### PR TITLE
chore: Phase 1 follow-up polish (cleanup, tests, stderr, color)

### DIFF
--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -1,6 +1,11 @@
 const std = @import("std");
 const testing = std.testing;
 
+/// Shared input-size ceiling for both file reads (main.zig) and `git show`
+/// output (here), so the two acquisition paths reject oversized input the
+/// same way instead of diverging on an arbitrary limit.
+pub const max_input_bytes: usize = 64 * 1024 * 1024; // 64 MiB guard
+
 pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref: []const u8, path: []const u8) ![]u8 {
     const spec = try std.fmt.allocPrint(arena, "{s}:{s}", .{ ref, path });
     // Force the C locale so the stderr substrings matched below are always
@@ -11,7 +16,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     const res = try std.process.run(arena, io, .{
         .argv = &.{ "git", "show", "--end-of-options", spec },
         .cwd = .{ .path = repo_dir },
-        .stdout_limit = .limited(256 * 1024 * 1024),
+        .stdout_limit = .limited(max_input_bytes),
         .environ_map = &env,
     });
     switch (res.term) {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -3,10 +3,16 @@ const testing = std.testing;
 
 pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref: []const u8, path: []const u8) ![]u8 {
     const spec = try std.fmt.allocPrint(arena, "{s}:{s}", .{ ref, path });
+    // Force the C locale so the stderr substrings matched below are always
+    // English, regardless of the caller's own LC_ALL/LANG.
+    var env = std.process.Environ.Map.init(arena);
+    try env.put("LC_ALL", "C");
+    try env.put("LANG", "C");
     const res = try std.process.run(arena, io, .{
         .argv = &.{ "git", "show", "--end-of-options", spec },
         .cwd = .{ .path = repo_dir },
         .stdout_limit = .limited(256 * 1024 * 1024),
+        .environ_map = &env,
     });
     switch (res.term) {
         .exited => |c| {

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -65,10 +65,12 @@ test "run: extra positional after --git operands exits 2, not silently accepted"
     // arg-error contract as any other unrecognized positional.
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
-    try testing.expect(std.mem.indexOf(u8, output.items, "unknown flag") != null);
+    try testing.expect(std.mem.indexOf(u8, err_output.items, "unknown flag") != null);
 }
 
 test "run: --json with two real files prints core JSON" {
@@ -96,7 +98,9 @@ test "run: --json with two real files prints core JSON" {
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--json", before_path, after_path }, &aw.writer);
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--json", before_path, after_path }, &aw.writer, &aw_err.writer);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"schema\":\"prefablens.diff.v1\"") != null);
@@ -110,11 +114,13 @@ test "run: unreadable input file reports error and exits 1" {
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--json", "/no/such/file.asset", "/no/such/other.asset" }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--json", "/no/such/file.asset", "/no/such/other.asset" }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
-    try testing.expectEqualStrings("error: cannot read file '/no/such/file.asset'\n", output.items);
+    try testing.expectEqualStrings("error: cannot read file '/no/such/file.asset'\n", err_output.items);
 }
 
 test "run: hostile deeply-nested input reports a clean error and exits 1" {
@@ -145,11 +151,13 @@ test "run: hostile deeply-nested input reports a clean error and exits 1" {
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ hostile_path, other_path }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ hostile_path, other_path }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
-    try testing.expectEqualStrings("error: input nested too deeply\n", output.items);
+    try testing.expectEqualStrings("error: input nested too deeply\n", err_output.items);
 }
 
 test "run: unreadable --project directory reports error and exits 1" {
@@ -175,11 +183,13 @@ test "run: unreadable --project directory reports error and exits 1" {
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--json", "--project", "/no/such/project", before_path, after_path }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
-    try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", output.items);
+    try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", err_output.items);
 }
 
 test "run: unreadable --project directory reports error and exits 1 in tree mode" {
@@ -205,12 +215,14 @@ test "run: unreadable --project directory reports error and exits 1 in tree mode
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
     // No --json: the default tree format must honor the same error contract.
-    const code = try run(testing.io, arena, &.{ "--project", "/no/such/project", before_path, after_path }, &aw.writer);
-    const output = aw.toArrayList();
+    const code = try run(testing.io, arena, &.{ "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
-    try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", output.items);
+    try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", err_output.items);
 }
 
 test "run: unreadable --project directory reports error and exits 1 in html mode" {
@@ -236,11 +248,13 @@ test "run: unreadable --project directory reports error and exits 1 in html mode
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--html", "--project", "/no/such/project", before_path, after_path }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--html", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
-    try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", output.items);
+    try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", err_output.items);
 }
 
 test "run: --git with bad ref reports error and exits 1" {
@@ -252,11 +266,13 @@ test "run: --git with bad ref reports error and exits 1" {
     // git show fails for a bogus ref -- both must surface as a clean error.
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--json", "--git", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--json", "--git", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
-    try testing.expectEqualStrings("error: git show failed for 'bogus-ref:Foo.prefab'\n", output.items);
+    try testing.expectEqualStrings("error: git show failed for 'bogus-ref:Foo.prefab'\n", err_output.items);
 }
 
 test "run: no operands prints usage and exits 2" {
@@ -266,10 +282,12 @@ test "run: no operands prints usage and exits 2" {
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{}, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{}, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
-    try testing.expect(std.mem.indexOf(u8, output.items, "usage:") != null);
+    try testing.expect(std.mem.indexOf(u8, err_output.items, "usage:") != null);
 }
 
 test "run: unknown flag prints error and exits 2" {
@@ -279,10 +297,12 @@ test "run: unknown flag prints error and exits 2" {
 
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    const code = try run(testing.io, arena, &.{ "--bogus", "a.prefab", "b.prefab" }, &aw.writer);
-    const output = aw.toArrayList();
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--bogus", "a.prefab", "b.prefab" }, &aw.writer, &aw_err.writer);
+    const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
-    try testing.expect(std.mem.indexOf(u8, output.items, "unknown flag") != null);
+    try testing.expect(std.mem.indexOf(u8, err_output.items, "unknown flag") != null);
 }
 
 pub const Format = enum { tree, json, html };
@@ -369,33 +389,33 @@ fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
     return std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(max_file_bytes));
 }
 
-pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer) !u8 {
+pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
-            ArgError.MissingOperands => try stdout.writeAll("usage: prefablens [--json|--html] [--project DIR] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
-            ArgError.UnknownFlag => try stdout.writeAll("error: unknown flag\n"),
+            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
+            ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag\n"),
         }
         return 2;
     };
 
     const before = if (opt.git_mode)
         input.showAtRef(io, arena, ".", opt.git_ref_before, opt.git_path) catch {
-            try stdout.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_before, opt.git_path });
+            try stderr.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_before, opt.git_path });
             return 1;
         }
     else
         readFile(io, arena, opt.before) catch {
-            try stdout.print("error: cannot read file '{s}'\n", .{opt.before});
+            try stderr.print("error: cannot read file '{s}'\n", .{opt.before});
             return 1;
         };
     const after = if (opt.git_mode)
         input.showAtRef(io, arena, ".", opt.git_ref_after, opt.git_path) catch {
-            try stdout.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_after, opt.git_path });
+            try stderr.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_after, opt.git_path });
             return 1;
         }
     else
         readFile(io, arena, opt.after) catch {
-            try stdout.print("error: cannot read file '{s}'\n", .{opt.after});
+            try stderr.print("error: cannot read file '{s}'\n", .{opt.after});
             return 1;
         };
 
@@ -403,7 +423,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         .json => {
             const res = core.diffBytes(arena, before, after) catch |err| {
                 if (err == error.NestingTooDeep) {
-                    try stdout.writeAll("error: input nested too deeply\n");
+                    try stderr.writeAll("error: input nested too deeply\n");
                     return 1;
                 }
                 return err;
@@ -412,7 +432,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             var idx: core.json.Resolver = undefined;
             if (opt.project_root) |proj| {
                 const built = resolve.buildIndex(io, arena, proj) catch {
-                    try stdout.print("error: cannot read project directory '{s}'\n", .{proj});
+                    try stderr.print("error: cannot read project directory '{s}'\n", .{proj});
                     return 1;
                 };
                 idx = built; // Index and Resolver are both StringHashMap([]const u8)
@@ -425,7 +445,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         .tree => {
             const res = core.diffBytes(arena, before, after) catch |err| {
                 if (err == error.NestingTooDeep) {
-                    try stdout.writeAll("error: input nested too deeply\n");
+                    try stderr.writeAll("error: input nested too deeply\n");
                     return 1;
                 }
                 return err;
@@ -434,7 +454,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             var idx: core.json.Resolver = undefined;
             if (opt.project_root) |proj| {
                 idx = resolve.buildIndex(io, arena, proj) catch {
-                    try stdout.print("error: cannot read project directory '{s}'\n", .{proj});
+                    try stderr.print("error: cannot read project directory '{s}'\n", .{proj});
                     return 1;
                 };
                 resolver_ptr = &idx;
@@ -445,7 +465,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         .html => {
             const res = core.diffBytes(arena, before, after) catch |err| {
                 if (err == error.NestingTooDeep) {
-                    try stdout.writeAll("error: input nested too deeply\n");
+                    try stderr.writeAll("error: input nested too deeply\n");
                     return 1;
                 }
                 return err;
@@ -454,7 +474,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             var idx: core.json.Resolver = undefined;
             if (opt.project_root) |proj| {
                 idx = resolve.buildIndex(io, arena, proj) catch {
-                    try stdout.print("error: cannot read project directory '{s}'\n", .{proj});
+                    try stderr.print("error: cannot read project directory '{s}'\n", .{proj});
                     return 1;
                 };
                 resolver_ptr = &idx;
@@ -471,13 +491,18 @@ pub fn main(init: std.process.Init) !u8 {
     const arena = arena_state.allocator();
 
     const args = try init.minimal.args.toSlice(arena);
-    const user_args = args[1..];
+    const user_args = if (args.len > 1) args[1..] else args[0..0];
 
     var stdout_buffer: [4096]u8 = undefined;
     var stdout_file_writer: std.Io.File.Writer = .init(.stdout(), init.io, &stdout_buffer);
     const stdout = &stdout_file_writer.interface;
 
-    const code = try run(init.io, arena, user_args, stdout);
+    var stderr_buffer: [4096]u8 = undefined;
+    var stderr_file_writer: std.Io.File.Writer = .init(.stderr(), init.io, &stderr_buffer);
+    const stderr = &stderr_file_writer.interface;
+
+    const code = try run(init.io, arena, user_args, stdout, stderr);
     try stdout.flush();
+    try stderr.flush();
     return code;
 }

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -388,10 +388,8 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
     };
 }
 
-const max_file_bytes = 64 * 1024 * 1024; // 64 MB guard
-
 fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
-    return std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(max_file_bytes));
+    return std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(input.max_input_bytes));
 }
 
 pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer) !u8 {

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -51,7 +51,12 @@ test "parseArgs: flags after --git operands are honored, not dropped" {
 
 test "parseArgs: extra positional after --git operands is a parse error" {
     const args = [_][]const u8{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" };
-    try testing.expectError(ArgError.UnknownFlag, parseArgs(&args));
+    try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
+}
+
+test "parseArgs: a third plain positional is too many arguments" {
+    const args = [_][]const u8{ "a.prefab", "b.prefab", "c.prefab" };
+    try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
 }
 
 test "run: extra positional after --git operands exits 2, not silently accepted" {
@@ -70,7 +75,7 @@ test "run: extra positional after --git operands exits 2, not silently accepted"
     const code = try run(testing.io, arena, &.{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" }, &aw.writer, &aw_err.writer);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
-    try testing.expect(std.mem.indexOf(u8, err_output.items, "unknown flag") != null);
+    try testing.expect(std.mem.indexOf(u8, err_output.items, "too many arguments") != null);
 }
 
 test "run: --json with two real files prints core JSON" {
@@ -318,7 +323,7 @@ pub const Options = struct {
     git_path: []const u8 = "",
 };
 
-pub const ArgError = error{ MissingOperands, UnknownFlag };
+pub const ArgError = error{ MissingOperands, UnknownFlag, TooManyArguments };
 
 pub fn parseArgs(args: []const []const u8) ArgError!Options {
     var format: Format = .tree;
@@ -354,10 +359,10 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             return ArgError.UnknownFlag;
         } else if (git_mode) {
             // --git already consumed its three operands; a bare positional
-            // afterward is an unrecognized extra argument.
-            return ArgError.UnknownFlag;
+            // afterward is an extra operand, not an unrecognized flag.
+            return ArgError.TooManyArguments;
         } else {
-            if (pos_count >= 2) return ArgError.UnknownFlag;
+            if (pos_count >= 2) return ArgError.TooManyArguments;
             positionals[pos_count] = a;
             pos_count += 1;
         }
@@ -394,6 +399,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         switch (err) {
             ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
             ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag\n"),
+            ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments\n"),
         }
         return 2;
     };

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -29,6 +29,15 @@ test "parseArgs: --json sets json format" {
     try testing.expectEqual(Format.json, opt.format);
 }
 
+test "parseArgs: --no-color sets no_color, off by default" {
+    const default_args = [_][]const u8{ "a.prefab", "b.prefab" };
+    try testing.expect(!(try parseArgs(&default_args)).no_color);
+
+    const args = [_][]const u8{ "--no-color", "a.prefab", "b.prefab" };
+    const opt = try parseArgs(&args);
+    try testing.expect(opt.no_color);
+}
+
 test "parseArgs: --git captures refs and path" {
     const args = [_][]const u8{ "--json", "--git", "HEAD~1", "HEAD", "Foo.prefab" };
     const opt = try parseArgs(&args);
@@ -72,7 +81,7 @@ test "run: extra positional after --git operands exits 2, not silently accepted"
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
     try testing.expect(std.mem.indexOf(u8, err_output.items, "too many arguments") != null);
@@ -105,7 +114,7 @@ test "run: --json with two real files prints core JSON" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--json", before_path, after_path }, &aw.writer, &aw_err.writer, false);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"schema\":\"prefablens.diff.v1\"") != null);
@@ -121,7 +130,7 @@ test "run: unreadable input file reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "/no/such/file.asset", "/no/such/other.asset" }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--json", "/no/such/file.asset", "/no/such/other.asset" }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -158,7 +167,7 @@ test "run: hostile deeply-nested input reports a clean error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ hostile_path, other_path }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ hostile_path, other_path }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -190,7 +199,7 @@ test "run: unreadable --project directory reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -223,7 +232,7 @@ test "run: unreadable --project directory reports error and exits 1 in tree mode
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
     // No --json: the default tree format must honor the same error contract.
-    const code = try run(testing.io, arena, &.{ "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -255,7 +264,7 @@ test "run: unreadable --project directory reports error and exits 1 in html mode
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--html", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--html", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -273,7 +282,7 @@ test "run: --git with bad ref reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "--git", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--json", "--git", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -289,7 +298,7 @@ test "run: no operands prints usage and exits 2" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{}, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{}, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
     try testing.expect(std.mem.indexOf(u8, err_output.items, "usage:") != null);
@@ -304,10 +313,51 @@ test "run: unknown flag prints error and exits 2" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--bogus", "a.prefab", "b.prefab" }, &aw.writer, &aw_err.writer);
+    const code = try run(testing.io, arena, &.{ "--bogus", "a.prefab", "b.prefab" }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
     try testing.expect(std.mem.indexOf(u8, err_output.items, "unknown flag") != null);
+}
+
+test "run: color=true colors tree output, --no-color forces it back off" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "before.asset", .data =
+        \\--- !u!114 &11400000
+        \\MonoBehaviour:
+        \\  volume: 0.5
+    });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "after.asset", .data =
+        \\--- !u!114 &11400000
+        \\MonoBehaviour:
+        \\  volume: 0.8
+    });
+    const before_path = try tmp.dir.realPathFileAlloc(testing.io, "before.asset", arena);
+    const after_path = try tmp.dir.realPathFileAlloc(testing.io, "after.asset", arena);
+
+    // color=true (the TTY-detected default) paints the tree output.
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ before_path, after_path }, &aw.writer, &aw_err.writer, true);
+    const output = aw.toArrayList();
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expect(std.mem.indexOf(u8, output.items, "\x1b[") != null);
+
+    // --no-color forces it off even though color=true was passed in.
+    var out2: std.ArrayList(u8) = .empty;
+    var aw2 = std.Io.Writer.Allocating.fromArrayList(arena, &out2);
+    var errbuf2: std.ArrayList(u8) = .empty;
+    var aw_err2 = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf2);
+    const code2 = try run(testing.io, arena, &.{ "--no-color", before_path, after_path }, &aw2.writer, &aw_err2.writer, true);
+    const output2 = aw2.toArrayList();
+    try testing.expectEqual(@as(u8, 0), code2);
+    try testing.expect(std.mem.indexOf(u8, output2.items, "\x1b[") == null);
 }
 
 pub const Format = enum { tree, json, html };
@@ -321,6 +371,7 @@ pub const Options = struct {
     git_ref_before: []const u8 = "",
     git_ref_after: []const u8 = "",
     git_path: []const u8 = "",
+    no_color: bool = false,
 };
 
 pub const ArgError = error{ MissingOperands, UnknownFlag, TooManyArguments };
@@ -334,6 +385,7 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
     var git_ref_before: []const u8 = "";
     var git_ref_after: []const u8 = "";
     var git_path: []const u8 = "";
+    var no_color = false;
 
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -342,6 +394,8 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             format = .json;
         } else if (std.mem.eql(u8, a, "--html")) {
             format = .html;
+        } else if (std.mem.eql(u8, a, "--no-color")) {
+            no_color = true;
         } else if (std.mem.eql(u8, a, "--project")) {
             i += 1;
             if (i >= args.len) return ArgError.MissingOperands;
@@ -377,6 +431,7 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             .git_ref_before = git_ref_before,
             .git_ref_after = git_ref_after,
             .git_path = git_path,
+            .no_color = no_color,
         };
     }
     if (pos_count != 2) return ArgError.MissingOperands;
@@ -385,6 +440,7 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
         .after = positionals[1].?,
         .format = format,
         .project_root = project_root,
+        .no_color = no_color,
     };
 }
 
@@ -392,10 +448,10 @@ fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
     return std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(input.max_input_bytes));
 }
 
-pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer) !u8 {
+pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
-            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
+            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] [--no-color] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
             ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag\n"),
             ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments\n"),
         }
@@ -463,8 +519,8 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                 };
                 resolver_ptr = &idx;
             }
-            // Color when stdout is a TTY is decided in main(); tests pass color=false.
-            try render_tree.render(arena, stdout, res, resolver_ptr, false);
+            // Color when stdout is a TTY is decided in main(); --no-color forces it off.
+            try render_tree.render(arena, stdout, res, resolver_ptr, color and !opt.no_color);
         },
         .html => {
             const res = core.diffBytes(arena, before, after) catch |err| {
@@ -505,7 +561,9 @@ pub fn main(init: std.process.Init) !u8 {
     var stderr_file_writer: std.Io.File.Writer = .init(.stderr(), init.io, &stderr_buffer);
     const stderr = &stderr_file_writer.interface;
 
-    const code = try run(init.io, arena, user_args, stdout, stderr);
+    const color = std.Io.File.stdout().isTty(init.io) catch false;
+
+    const code = try run(init.io, arena, user_args, stdout, stderr, color);
     try stdout.flush();
     try stderr.flush();
     return code;

--- a/cli/src/render_html.zig
+++ b/cli/src/render_html.zig
@@ -66,6 +66,145 @@ test "html: ref guid with markup is escaped" {
     try testing.expect(std.mem.indexOf(u8, html, "&lt;img") != null);
 }
 
+test "html: resolved script guid renders the resolved script name, not the raw type" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 11500000, guid: abc123, type: 3}
+        \\  hp: 1
+    ;
+    const after =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 11500000, guid: abc123, type: 3}
+        \\  hp: 2
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    var resolver = core.json.Resolver.init(arena);
+    try resolver.put("abc123", "Assets/Scripts/PlayerController.cs");
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    try render(arena, &aw.writer, res, &resolver);
+    const html = aw.toArrayList().items;
+    try testing.expect(std.mem.indexOf(u8, html, "PlayerController.cs") != null);
+    // The resolved basename replaces the raw type name entirely.
+    try testing.expect(std.mem.indexOf(u8, html, "MonoBehaviour") == null);
+}
+
+test "html: nested child GameObject renders indented one level under its parent" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Child
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+    ;
+    const after =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: ChildRenamed
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    try render(arena, &aw.writer, res, null);
+    const html = aw.toArrayList().items;
+    // Parent (depth 0, unchanged) has no leading pad before its span.
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"unchanged go\">  Parent</span>") != null);
+    // Child (depth 1, modified) is indented two spaces under it.
+    try testing.expect(std.mem.indexOf(u8, html, "  <span class=\"modified go\">~ ChildRenamed</span>") != null);
+}
+
+test "html: loose component renders without a GameObject wrapper" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!114 &11400000
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 0, guid: def, type: 3}
+        \\  volume: 0.5
+    ;
+    const after =
+        \\--- !u!114 &11400000
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 0, guid: def, type: 3}
+        \\  volume: 0.8
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    try render(arena, &aw.writer, res, null);
+    const html = aw.toArrayList().items;
+    try testing.expect(std.mem.indexOf(u8, html, "volume") != null);
+    // Loose components render at depth 0 with a plain (non-"go") span class.
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"modified\">~ MonoBehaviour</span>") != null);
+    try testing.expect(std.mem.indexOf(u8, html, " go\">") == null);
+}
+
+test "html: added and removed fields render only their one side" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_LocalPosition: {x: 0, y: 0, z: 0}
+        \\  m_OldField: 1
+    ;
+    const after =
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_LocalPosition: {x: 0, y: 0, z: 0}
+        \\  m_NewField: 2
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    try render(arena, &aw.writer, res, null);
+    const html = aw.toArrayList().items;
+    // Added field: only the "new" span, no paired "old" value.
+    try testing.expect(std.mem.indexOf(u8, html, "m_NewField") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"new\">2</span>") != null);
+    // Removed field: only the "old" span, no paired "new" value.
+    try testing.expect(std.mem.indexOf(u8, html, "m_OldField") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"old\">1</span>") != null);
+}
+
 const model = core.model;
 
 const head =

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -191,10 +191,9 @@ fn scriptGuid(doc: *const model.Document) ?[]const u8 {
     };
 }
 
-fn resolvedTypeName(arena: std.mem.Allocator, doc: *const model.Document) ![]const u8 {
+fn resolvedTypeName(doc: *const model.Document) ![]const u8 {
     if (classid.typeName(doc.class_id)) |n| return n;
     // Unknown classID: fall back to the document's own top key.
-    _ = arena;
     return doc.type_name;
 }
 
@@ -222,7 +221,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
             try docs.append(arena, .{
                 .file_id = ad.file_id,
                 .class_id = ad.class_id,
-                .type_name = try resolvedTypeName(arena, ad),
+                .type_name = try resolvedTypeName(ad),
                 .script_guid = scriptGuid(ad),
                 .status = if (fields.items.len == 0) .unchanged else .modified,
                 .fields = try fields.toOwnedSlice(arena),
@@ -231,7 +230,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
             try docs.append(arena, .{
                 .file_id = ad.file_id,
                 .class_id = ad.class_id,
-                .type_name = try resolvedTypeName(arena, ad),
+                .type_name = try resolvedTypeName(ad),
                 .script_guid = scriptGuid(ad),
                 .status = .added,
                 .fields = &[_]FieldDiff{},
@@ -244,7 +243,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
         try docs.append(arena, .{
             .file_id = bd.file_id,
             .class_id = bd.class_id,
-            .type_name = try resolvedTypeName(arena, bd),
+            .type_name = try resolvedTypeName(bd),
             .script_guid = scriptGuid(bd),
             .status = .removed,
             .fields = &[_]FieldDiff{},

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -216,8 +216,6 @@ test "parse: deeply nested flow value is rejected instead of overflowing the sta
     try testing.expectError(error.NestingTooDeep, parse(arena, src.items));
 }
 
-const Ref = model.Ref;
-
 const Line = struct { indent: usize, text: []const u8 };
 
 const Parser = struct {

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -216,6 +216,50 @@ test "parse: deeply nested flow value is rejected instead of overflowing the sta
     try testing.expectError(error.NestingTooDeep, parse(arena, src.items));
 }
 
+test "parse: CRLF line endings parse identically to LF" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src = "--- !u!1 &123\r\nGameObject:\r\n  m_Name: Player\r\n  m_IsActive: 1\r\n";
+    const doc = try parseOne(arena, src);
+    try testing.expectEqual(@as(u32, 1), doc.class_id);
+    try testing.expectEqual(@as(i64, 123), doc.file_id);
+    try testing.expectEqualStrings("GameObject", doc.type_name);
+    try testing.expectEqualStrings("Player", model.findValue(doc.body.map, "m_Name").?.scalar);
+    try testing.expectEqualStrings("1", model.findValue(doc.body.map, "m_IsActive").?.scalar);
+}
+
+test "parse: comment lines are skipped" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\# leading comment before any document
+        \\--- !u!1 &1
+        \\# a comment at the document's top level
+        \\GameObject:
+        \\  # a comment among fields
+        \\  m_Name: Player
+        \\  m_IsActive: 1
+    ;
+    const doc = try parseOne(arena, src);
+    try testing.expectEqualStrings("Player", model.findValue(doc.body.map, "m_Name").?.scalar);
+    try testing.expectEqualStrings("1", model.findValue(doc.body.map, "m_IsActive").?.scalar);
+}
+
+test "parse: single-quoted scalar is unquoted" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: 'Hello: World'
+    ;
+    const doc = try parseOne(arena, src);
+    try testing.expectEqualStrings("Hello: World", model.findValue(doc.body.map, "m_Name").?.scalar);
+}
+
 const Line = struct { indent: usize, text: []const u8 };
 
 const Parser = struct {

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -7,12 +7,9 @@ const diffmod = @import("diff.zig");
 
 const ComponentDiff = model.ComponentDiff;
 const ObjectDiff = model.ObjectDiff;
-const Status = model.Status;
 
 /// Index helpers over the parsed documents (use the union of before+after).
 const Index = struct {
-    arena: std.mem.Allocator,
-    fd: diffmod.FlatDiff,
     // file_id -> DocDiff (status + fields), for quick component construction.
     diff_by_id: std.AutoHashMap(i64, diffmod.DocDiff),
     // file_id -> *Document for the *structural* (after-preferred) version.
@@ -79,8 +76,6 @@ fn makeComponent(dd: diffmod.DocDiff) ComponentDiff {
 
 pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     var idx = Index{
-        .arena = arena,
-        .fd = fd,
         .diff_by_id = std.AutoHashMap(i64, diffmod.DocDiff).init(arena),
         .doc_by_id = std.AutoHashMap(i64, *model.Document).init(arena),
     };

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -339,3 +339,35 @@ test "tree: component with unresolvable m_GameObject ref becomes loose, not drop
     try testing.expectEqual(@as(i64, 7), res.loose[0].file_id);
     try testing.expectEqual(model.Status.modified, res.loose[0].status);
 }
+
+test "tree: component whose m_GameObject resolves to a non-GameObject document becomes loose, not dropped" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // fileID 999 exists but is a MonoBehaviour, not a GameObject: a dangling
+    // reference in spirit (no GameObject there), distinct from fileID: 0.
+    const before =
+        \\--- !u!114 &7
+        \\MonoBehaviour:
+        \\  m_GameObject: {fileID: 999}
+        \\  speed: 1
+        \\--- !u!114 &999
+        \\MonoBehaviour:
+        \\  hp: 1
+    ;
+    const after =
+        \\--- !u!114 &7
+        \\MonoBehaviour:
+        \\  m_GameObject: {fileID: 999}
+        \\  speed: 2
+        \\--- !u!114 &999
+        \\MonoBehaviour:
+        \\  hp: 1
+    ;
+    const res = try root.diffBytes(arena, before, after);
+    try testing.expectEqual(@as(usize, 0), res.roots.len);
+    // Component 999 is unchanged (collapsed); component 7 is loose, not dropped.
+    try testing.expectEqual(@as(usize, 1), res.loose.len);
+    try testing.expectEqual(@as(i64, 7), res.loose[0].file_id);
+    try testing.expectEqual(model.Status.modified, res.loose[0].status);
+}


### PR DESCRIPTION
## 概要

Phase 1 のレビューで follow-up として整理した非ブロッキング項目をまとめて対応しました。挙動の本質は変えず、デッドコード除去・テストカバレッジ・小さな正しさ修正が中心です。実装は最小限に保っています。

## 変更内容

**デッドコード除去** (`refactor`)
- `parser.zig` の未使用 `Ref` エイリアス、`diff.zig` `resolvedTypeName` の未使用 `arena`、`tree.zig` の未使用 `Index.arena`/`Index.fd`/`Status` を削除。

**テストカバレッジ追加** (`test`) — 既存挙動をロックイン
- パーサ: CRLF 改行 / `#` コメント / シングルクォートスカラー
- tree: 非 GameObject を指す孤立コンポーネントが `loose` に回る(従来 fileID:0 のみ)
- render_html: 解決済み script 名 / ネスト子 / loose / added・removed アーム

**小さな正しさ修正** (`fix`)
- usage・エラー出力を **stderr** へ(diff 本体は stdout のまま)。`run` に `stderr` 引数を追加。
- 余剰オペランドを `error: too many arguments`(exit 2)に(従来は "unknown flag")。
- `main()` の `args[1..]` を防御的にガード。
- git サブプロセスを `LC_ALL=C`/`LANG=C` で起動し、stderr 判別をロケール非依存に。
- 入力サイズ上限を 64 MiB に統一(git-show は従来 256 MiB)。

**色のデフォルト** (`feat`)
- 既定のツリー出力を stdout が TTY のとき色付きに(spec §6.1)。`run` に `color` 引数、`--no-color` フラグを追加。ゴールデンは color=false のまま不変。

## テスト

```
zig build test   # 62 tests (51 → 62), all green
zig build perf   # 128 ms (ceiling 600 ms)
zig fmt --check   # clean
```

## 既知の Minor(将来 polish、実害なし)
- `input.zig`: git の環境を完全置換しているが、`argv[0]` 解決は親 PATH を使うため機能上は安全(将来 HOME/PATH 依存が増えるなら継承+上書きが保守的)。
- TTY 判定は `isTty`。Windows のレガシーコンソール対応が目標になれば `supportsAnsiEscapeCodes` がより堅牢。
