### PR TITLE
feat: code search guid resolution, caches, 25MB render gate

### DIFF
--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -201,6 +201,28 @@ describe('createHandler', () => {
     expect(await createHandler(net.deps)(REQ)).toEqual({ ok: false, error: 'fetch-failed' });
   });
 
+  it('returns too-large above 25MB unless forced', async () => {
+    const big = new Uint8Array(13 * 1024 * 1024); // base+head で 26MB
+    const diff = vi.fn(() => DIFF);
+    const { deps, client } = makeDeps({ diff });
+    client.getFileAtRef.mockResolvedValue(big);
+    const handle = createHandler(deps);
+    expect(await handle(REQ)).toEqual({ ok: false, error: 'too-large', bytes: big.length * 2 });
+    expect(diff).not.toHaveBeenCalled();
+    // force で描画に進む。blob は sha キャッシュに乗っており再フェッチもない
+    const fetches = client.getFileAtRef.mock.calls.length;
+    expect((await handle({ ...REQ, force: true })).ok).toBe(true);
+    expect(diff).toHaveBeenCalledTimes(1);
+    expect(client.getFileAtRef.mock.calls.length).toBe(fetches);
+  });
+
+  it('renders exactly 25MB without the gate', async () => {
+    const half = new Uint8Array((25 * 1024 * 1024) / 2);
+    const { deps, client } = makeDeps();
+    client.getFileAtRef.mockResolvedValue(half);
+    expect((await createHandler(deps)(REQ)).ok).toBe(true);
+  });
+
   it('maps RateLimitError to rate-limited', async () => {
     const limited = makeDeps();
     limited.client.getPrRefs.mockRejectedValue(new RateLimitError('x'));

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -101,6 +101,32 @@ describe('createHandler', () => {
     expect(client.listPrFiles).toHaveBeenCalledTimes(1);
   });
 
+  it('refreshes PR context after 60s so new pushes are picked up', async () => {
+    vi.useFakeTimers();
+    try {
+      const { deps, client } = makeDeps();
+      const handle = createHandler(deps);
+      await handle(REQ);
+      vi.setSystemTime(Date.now() + 59_000);
+      await handle(REQ);
+      expect(client.getPrRefs).toHaveBeenCalledTimes(1);
+      vi.setSystemTime(Date.now() + 2_000); // 計 61 秒
+      await handle(REQ);
+      expect(client.getPrRefs).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fetches each sha+path blob only once (immutable content)', async () => {
+    const { deps, client } = makeDeps();
+    const handle = createHandler(deps);
+    await handle(REQ);
+    await handle(REQ);
+    const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === 'Assets/Foo.prefab');
+    expect(fooFetches).toHaveLength(2); // base + head の 2 回だけ(2 回目の handle では再フェッチしない)
+  });
+
   it('resolves remaining guids via code search and persists them', async () => {
     const { deps, guidCache } = makeDeps({ search: { g1: 'Assets/Scripts/S.cs' } });
     const res = await createHandler(deps)(REQ);

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -13,6 +13,8 @@ function makeDeps(overrides?: {
   contents?: Record<string, string>; // `${path}@${ref}` → text
   diff?: Differ['diff'];
   pat?: string | undefined;
+  search?: Record<string, string | null>; // guid → asset path(null = 未ヒット)
+  cached?: Record<string, string>; // guidCache の初期内容
 }) {
   const files = overrides?.files ?? [{ path: 'Assets/Foo.prefab', status: 'modified' }];
   const contents = overrides?.contents ?? { 'Assets/Foo.prefab@base-sha': 'b', 'Assets/Foo.prefab@head-sha': 'a' };
@@ -24,14 +26,25 @@ function makeDeps(overrides?: {
     getPrRefs: vi.fn(async () => ({ baseSha: 'base-sha', headSha: 'head-sha' })),
     listPrFiles: vi.fn(async () => files),
     getFileAtRef,
+    searchMetaByGuid: vi.fn(async (_o: string, _r: string, guid: string) => overrides?.search?.[guid] ?? null),
   };
   const differ: Differ = { diff: overrides?.diff ?? vi.fn(() => DIFF) };
+  const cacheData: Record<string, Record<string, string>> = {};
+  if (overrides?.cached) cacheData['https://api.github.com/o/r'] = { ...overrides.cached };
+  const guidCache = {
+    data: cacheData,
+    load: vi.fn(async (repo: string) => cacheData[repo] ?? {}),
+    save: vi.fn(async (repo: string, entries: Record<string, string>) => {
+      cacheData[repo] = { ...cacheData[repo], ...entries };
+    }),
+  };
   const deps: Deps = {
     getSettings: async () => ({ pat: 'pat' in (overrides ?? {}) ? overrides!.pat : 'tok', baseUrl: undefined }),
     makeClient: () => client,
     getDiffer: async () => differ,
+    guidCache,
   };
-  return { deps, client, differ };
+  return { deps, client, differ, guidCache };
 }
 
 describe('createHandler', () => {
@@ -86,6 +99,63 @@ describe('createHandler', () => {
     await handle({ ...REQ, path: 'Assets/Foo.prefab' });
     expect(client.getPrRefs).toHaveBeenCalledTimes(1);
     expect(client.listPrFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves remaining guids via code search and persists them', async () => {
+    const { deps, guidCache } = makeDeps({ search: { g1: 'Assets/Scripts/S.cs' } });
+    const res = await createHandler(deps)(REQ);
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/Scripts/S.cs' } } });
+    expect(guidCache.save).toHaveBeenCalledWith('https://api.github.com/o/r', { g1: 'Assets/Scripts/S.cs' });
+  });
+
+  it('prefers the in-PR meta index over code search', async () => {
+    const { deps, client } = makeDeps({
+      files: [
+        { path: 'Assets/Foo.prefab', status: 'modified' },
+        { path: 'Assets/S.cs.meta', status: 'modified' },
+      ],
+      contents: {
+        'Assets/Foo.prefab@base-sha': 'b',
+        'Assets/Foo.prefab@head-sha': 'a',
+        'Assets/S.cs.meta@head-sha': 'guid: g1\n',
+      },
+      search: { g1: 'Assets/Elsewhere.cs' },
+    });
+    const res = await createHandler(deps)(REQ);
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/S.cs' } } });
+    expect(client.searchMetaByGuid).not.toHaveBeenCalled();
+  });
+
+  it('serves cached guids without searching', async () => {
+    const { deps, client } = makeDeps({ cached: { g1: 'Assets/Cached.cs' } });
+    const res = await createHandler(deps)(REQ);
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/Cached.cs' } } });
+    expect(client.searchMetaByGuid).not.toHaveBeenCalled();
+  });
+
+  it('does not re-search a missed guid within the worker lifetime', async () => {
+    const { deps, client } = makeDeps(); // search 未ヒット
+    const handle = createHandler(deps);
+    await handle(REQ);
+    await handle(REQ);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the diff usable when code search hits the rate limit', async () => {
+    const twoGuids: DiffV2 = { ...DIFF, unresolvedGuids: ['g1', 'g2'] };
+    const { deps, client } = makeDeps({ diff: () => twoGuids });
+    client.searchMetaByGuid
+      .mockResolvedValueOnce('Assets/First.cs')
+      .mockRejectedValueOnce(new RateLimitError('x'));
+    const res = await createHandler(deps)(REQ);
+    expect(res).toEqual({ ok: true, json: { ...twoGuids, resolved: { g1: 'Assets/First.cs' } } });
+  });
+
+  it('caps code searches at 10 per request', async () => {
+    const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
+    const { deps, client } = makeDeps({ diff: () => many });
+    await createHandler(deps)(REQ);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
   });
 
   it('maps AuthError / DiffError / other failures to stable error codes', async () => {

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -177,6 +177,15 @@ describe('createHandler', () => {
     expect(res).toEqual({ ok: true, json: { ...twoGuids, resolved: { g1: 'Assets/First.cs' } } });
   });
 
+  it('does not treat Object.prototype members as cache hits (hostile guid)', async () => {
+    const proto: DiffV2 = { ...DIFF, unresolvedGuids: ['constructor'] };
+    const { deps, client } = makeDeps({ diff: () => proto, cached: { g9: 'Assets/X.cs' } });
+    const res = await createHandler(deps)(REQ);
+    // 'constructor' はキャッシュヒットではなく検索に回り、未ヒットで未解決のまま
+    expect(client.searchMetaByGuid).toHaveBeenCalledWith('o', 'r', 'constructor');
+    expect(res).toEqual({ ok: true, json: { ...proto, resolved: {} } });
+  });
+
   it('caps code searches at 10 per request', async () => {
     const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
     const { deps, client } = makeDeps({ diff: () => many });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -16,11 +16,14 @@ type PrContext = { refs: PrRefs; files: PrFile[]; guidIndex: Map<string, string>
 
 const EMPTY = new Uint8Array(0);
 const MAX_SEARCHES = 10; // Code Search は認証済み 10 req/min — 1 応答で使い切らない
+const CONTEXT_TTL_MS = 60_000; // push で headSha が変わるため PR コンテキストは短命
+const BLOB_CACHE_MAX = 32;
 
 export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise<SemanticDiffResponse> {
-  // PR 単位のコンテキストキャッシュ(follow-up の repo+sha キャッシュの差し込み口)。
-  // SW はいつ殺されてもよく、その場合は再取得するだけ。
-  const contexts = new Map<string, Promise<PrContext>>();
+  // PR 単位のコンテキストキャッシュ。SW はいつ殺されてもよく、その場合は再取得するだけ。
+  const contexts = new Map<string, { at: number; ctx: Promise<PrContext> }>();
+  // sha+path → bytes。内容は不変なので TTL 不要。25MB ガードの force 再要求もここに当たる
+  const blobs = new Map<string, Uint8Array | null>();
   // Code Search の未ヒット guid。索引遅延があるため永続化せず SW 生存期間のみ
   const misses = new Set<string>();
 
@@ -52,22 +55,31 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
     return { ...json, resolved };
   }
 
+  async function fetchBlob(client: ClientLike, owner: string, repo: string, path: string, sha: string): Promise<Uint8Array | null> {
+    const key = `${sha}:${path}`;
+    const hit = blobs.get(key); // 格納値は Uint8Array | null なので undefined = 未キャッシュ
+    if (hit !== undefined) return hit;
+    const bytes = await client.getFileAtRef(owner, repo, path, sha);
+    blobs.set(key, bytes);
+    if (blobs.size > BLOB_CACHE_MAX) blobs.delete(blobs.keys().next().value!);
+    return bytes;
+  }
+
   function loadContext(client: ClientLike, owner: string, repo: string, prNumber: number): Promise<PrContext> {
     const key = `${owner}/${repo}#${prNumber}`;
-    let ctx = contexts.get(key);
-    if (!ctx) {
-      ctx = (async () => {
-        const refs = await client.getPrRefs(owner, repo, prNumber);
-        const files = await client.listPrFiles(owner, repo, prNumber);
-        const guidIndex = await buildGuidIndex(files, async (path, side) => {
-          const bytes = await client.getFileAtRef(owner, repo, path, side === 'base' ? refs.baseSha : refs.headSha);
-          return bytes ? new TextDecoder().decode(bytes) : null;
-        });
-        return { refs, files, guidIndex };
-      })();
-      contexts.set(key, ctx);
-      ctx.catch(() => contexts.delete(key)); // 失敗はキャッシュしない
-    }
+    const entry = contexts.get(key);
+    if (entry && Date.now() - entry.at < CONTEXT_TTL_MS) return entry.ctx;
+    const ctx = (async () => {
+      const refs = await client.getPrRefs(owner, repo, prNumber);
+      const files = await client.listPrFiles(owner, repo, prNumber);
+      const guidIndex = await buildGuidIndex(files, async (path, side) => {
+        const bytes = await fetchBlob(client, owner, repo, path, side === 'base' ? refs.baseSha : refs.headSha);
+        return bytes ? new TextDecoder().decode(bytes) : null;
+      });
+      return { refs, files, guidIndex };
+    })();
+    contexts.set(key, { at: Date.now(), ctx });
+    ctx.catch(() => contexts.delete(key)); // 失敗はキャッシュしない
     return ctx;
   }
 
@@ -84,9 +96,9 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
       const beforePath = file?.previousPath ?? req.path;
 
       const before =
-        status === 'added' ? EMPTY : ((await client.getFileAtRef(req.owner, req.repo, beforePath, refs.baseSha)) ?? EMPTY);
+        status === 'added' ? EMPTY : ((await fetchBlob(client, req.owner, req.repo, beforePath, refs.baseSha)) ?? EMPTY);
       const after =
-        status === 'removed' ? EMPTY : ((await client.getFileAtRef(req.owner, req.repo, req.path, refs.headSha)) ?? EMPTY);
+        status === 'removed' ? EMPTY : ((await fetchBlob(client, req.owner, req.repo, req.path, refs.headSha)) ?? EMPTY);
 
       const differ = await deps.getDiffer();
       const json = differ.diff(before, after);

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -18,6 +18,7 @@ const EMPTY = new Uint8Array(0);
 const MAX_SEARCHES = 10; // Code Search は認証済み 10 req/min — 1 応答で使い切らない
 const CONTEXT_TTL_MS = 60_000; // push で headSha が変わるため PR コンテキストは短命
 const BLOB_CACHE_MAX = 32;
+const TOO_LARGE_BYTES = 25 * 1024 * 1024; // 親仕様 §5.7: 25MB 超はクリックで描画
 
 export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise<SemanticDiffResponse> {
   // PR 単位のコンテキストキャッシュ。SW はいつ殺されてもよく、その場合は再取得するだけ。
@@ -99,6 +100,10 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
         status === 'added' ? EMPTY : ((await fetchBlob(client, req.owner, req.repo, beforePath, refs.baseSha)) ?? EMPTY);
       const after =
         status === 'removed' ? EMPTY : ((await fetchBlob(client, req.owner, req.repo, req.path, refs.headSha)) ?? EMPTY);
+
+      if (!req.force && before.length + after.length > TOO_LARGE_BYTES) {
+        return { ok: false, error: 'too-large', bytes: before.length + after.length };
+      }
 
       const differ = await deps.getDiffer();
       const json = differ.diff(before, after);

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -32,7 +32,8 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
    *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ載せる。 */
   async function searchUnresolved(json: DiffV2, client: ClientLike, owner: string, repo: string, repoKey: string): Promise<DiffV2> {
     const resolved = { ...json.resolved };
-    const pending = json.unresolvedGuids.filter((g) => !(g in resolved) && !misses.has(`${repoKey}:${g}`));
+    // hasOwn: guid は任意文字列なので 'constructor' 等が in 演算子でプロトタイプに誤ヒットしない
+    const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g) && !misses.has(`${repoKey}:${g}`));
     if (!pending.length) return { ...json, resolved };
     const cached = await deps.guidCache.load(repoKey);
     const found: Record<string, string> = {};

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -38,8 +38,9 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
     const found: Record<string, string> = {};
     let searches = 0;
     for (const g of pending) {
-      if (cached[g] !== undefined) {
-        resolved[g] = cached[g];
+      // hasOwn: guid は任意文字列なので 'constructor' 等で Object.prototype を拾わない
+      if (Object.hasOwn(cached, g)) {
+        resolved[g] = cached[g]!;
         continue;
       }
       if (searches++ >= MAX_SEARCHES) continue;

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -1,24 +1,56 @@
 import { AuthError, RateLimitError, apiBase, type GithubClient, type PrFile, type PrRefs } from '../github/client';
-import { applyResolved, buildGuidIndex } from '../github/guids';
+import { applyResolved, buildGuidIndex, type GuidCache } from '../github/guids';
 import { DiffError, type Differ } from '../wasm/differ';
-import type { SemanticDiffRequest, SemanticDiffResponse } from '../types';
+import type { DiffV2, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
-type ClientLike = Pick<GithubClient, 'getPrRefs' | 'listPrFiles' | 'getFileAtRef'>;
+type ClientLike = Pick<GithubClient, 'getPrRefs' | 'listPrFiles' | 'getFileAtRef' | 'searchMetaByGuid'>;
 
 export type Deps = {
   getSettings(): Promise<{ pat?: string; baseUrl?: string }>;
   makeClient(base: string, token: string): ClientLike;
   getDiffer(): Promise<Differ>;
+  guidCache: GuidCache;
 };
 
 type PrContext = { refs: PrRefs; files: PrFile[]; guidIndex: Map<string, string> };
 
 const EMPTY = new Uint8Array(0);
+const MAX_SEARCHES = 10; // Code Search は認証済み 10 req/min — 1 応答で使い切らない
 
 export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise<SemanticDiffResponse> {
   // PR 単位のコンテキストキャッシュ(follow-up の repo+sha キャッシュの差し込み口)。
   // SW はいつ殺されてもよく、その場合は再取得するだけ。
   const contexts = new Map<string, Promise<PrContext>>();
+  // Code Search の未ヒット guid。索引遅延があるため永続化せず SW 生存期間のみ
+  const misses = new Set<string>();
+
+  /** PR 内 .meta で解決できなかった guid を キャッシュ → Code Search の順で解決する。
+   *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ載せる。 */
+  async function searchUnresolved(json: DiffV2, client: ClientLike, owner: string, repo: string, repoKey: string): Promise<DiffV2> {
+    const resolved = { ...json.resolved };
+    const pending = json.unresolvedGuids.filter((g) => !(g in resolved) && !misses.has(`${repoKey}:${g}`));
+    if (!pending.length) return { ...json, resolved };
+    const cached = await deps.guidCache.load(repoKey);
+    const found: Record<string, string> = {};
+    let searches = 0;
+    for (const g of pending) {
+      if (cached[g] !== undefined) {
+        resolved[g] = cached[g];
+        continue;
+      }
+      if (searches++ >= MAX_SEARCHES) continue;
+      try {
+        const path = await client.searchMetaByGuid(owner, repo, g);
+        if (path) resolved[g] = found[g] = path;
+        else misses.add(`${repoKey}:${g}`);
+      } catch (err) {
+        if (err instanceof RateLimitError) break;
+        misses.add(`${repoKey}:${g}`);
+      }
+    }
+    if (Object.keys(found).length) await deps.guidCache.save(repoKey, found);
+    return { ...json, resolved };
+  }
 
   function loadContext(client: ClientLike, owner: string, repo: string, prNumber: number): Promise<PrContext> {
     const key = `${owner}/${repo}#${prNumber}`;
@@ -43,7 +75,8 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
     try {
       const settings = await deps.getSettings();
       if (!settings.pat) return { ok: false, error: 'pat-missing' };
-      const client = deps.makeClient(apiBase(settings.baseUrl), settings.pat);
+      const base = apiBase(settings.baseUrl);
+      const client = deps.makeClient(base, settings.pat);
       const { refs, files, guidIndex } = await loadContext(client, req.owner, req.repo, req.prNumber);
 
       const file = files.find((f) => f.path === req.path);
@@ -57,7 +90,8 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
 
       const differ = await deps.getDiffer();
       const json = differ.diff(before, after);
-      return { ok: true, json: applyResolved(json, guidIndex) };
+      const withPr = applyResolved(json, guidIndex);
+      return { ok: true, json: await searchUnresolved(withPr, client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`) };
     } catch (err) {
       if (err instanceof RateLimitError) return { ok: false, error: 'rate-limited' };
       if (err instanceof AuthError) return { ok: false, error: 'auth-failed' };

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -18,6 +18,18 @@ const handle = createHandler({
       .then(createDiffer);
     return differ;
   },
+  guidCache: {
+    async load(repo) {
+      const key = `guids:${repo}`;
+      const stored = await chrome.storage.local.get([key]);
+      return (stored[key] as Record<string, string> | undefined) ?? {};
+    },
+    async save(repo, entries) {
+      const key = `guids:${repo}`;
+      const stored = await chrome.storage.local.get([key]);
+      await chrome.storage.local.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
+    },
+  },
 });
 
 chrome.runtime.onMessage.addListener((msg: SemanticDiffRequest, _sender, sendResponse) => {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,6 +1,6 @@
 import { parsePrUrl, scanUnityFiles, type FileEntry } from './detect';
 import { createToggle } from './toggle';
-import { render, renderError, renderLoading } from '../renderer/render';
+import { render, renderError, renderLoading, renderTooLarge } from '../renderer/render';
 import type { BackgroundError, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
@@ -39,17 +39,18 @@ function attachToggle(pr: { owner: string; repo: string; prNumber: number }, ent
     }
     host.style.display = '';
     if (requested) return; // 成功結果のみファイル単位でキャッシュ(再トグルで再フェッチしない)
-    requested = true;
     const root = host.shadowRoot!;
-    renderLoading(root);
-    void requestDiff({ type: 'semanticDiff', ...pr, path: entry.path }).then((res) => {
-      if (res.ok) {
-        render(root, res.json);
-      } else {
+    const request = (force?: boolean) => {
+      requested = true;
+      renderLoading(root);
+      void requestDiff({ type: 'semanticDiff', ...pr, path: entry.path, force }).then((res) => {
+        if (res.ok) return render(root, res.json);
         requested = false; // エラーはキャッシュしない: 次回トグルで再フェッチさせる
-        renderError(root, ERROR_TEXT[res.error]);
-      }
-    });
+        if (res.error === 'too-large') renderTooLarge(root, res.bytes, () => request(true));
+        else renderError(root, ERROR_TEXT[res.error]);
+      });
+    };
+    request();
   });
   entry.header.append(toggle);
 }

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -103,6 +103,34 @@ describe('GithubClient', () => {
     await expect(boom.getPrRefs('o', 'r', 1)).rejects.toBeInstanceOf(ApiError);
   });
 
+  it('searchMetaByGuid queries code search and strips .meta from the hit', async () => {
+    const { fn, calls } = fakeFetch({
+      '/search/code': () => json({ items: [{ path: 'Assets/Scripts/Player.cs.meta' }] }),
+    });
+    const client = new GithubClient('https://api.github.com', 'tok', fn);
+    expect(await client.searchMetaByGuid('o', 'r', 'abc123')).toBe('Assets/Scripts/Player.cs');
+    expect(calls[0]!.url).toContain(`/search/code?q=${encodeURIComponent('"abc123" repo:o/r extension:meta')}&per_page=1`);
+  });
+
+  it('searchMetaByGuid returns null on no hits, non-meta hits, and 422', async () => {
+    const empty = new GithubClient('https://api.github.com', 'tok', fakeFetch({ '/search/code': () => json({ items: [] }) }).fn);
+    expect(await empty.searchMetaByGuid('o', 'r', 'g')).toBeNull();
+    const odd = new GithubClient('https://api.github.com', 'tok', fakeFetch({ '/search/code': () => json({ items: [{ path: 'README.md' }] }) }).fn);
+    expect(await odd.searchMetaByGuid('o', 'r', 'g')).toBeNull();
+    // 422: リポジトリ未インデックス等。ApiError ではなく「未解決」として扱う
+    const unindexed = new GithubClient('https://api.github.com', 'tok', fakeFetch({ '/search/code': () => json({ message: 'Validation Failed' }, 422) }).fn);
+    expect(await unindexed.searchMetaByGuid('o', 'r', 'g')).toBeNull();
+  });
+
+  it('searchMetaByGuid propagates rate limiting', async () => {
+    const limited = new GithubClient(
+      'https://api.github.com',
+      'tok',
+      fakeFetch({ '/search/code': () => new Response('', { status: 403, headers: { 'retry-after': '60' } }) }).fn,
+    );
+    await expect(limited.searchMetaByGuid('o', 'r', 'g')).rejects.toBeInstanceOf(RateLimitError);
+  });
+
   it('maps rate-limit responses to RateLimitError, not AuthError', async () => {
     // GitHub の rate limit: primary は 403 + x-ratelimit-remaining: 0、
     // secondary は 403 + retry-after、新しめの API は 429。

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -83,6 +83,17 @@ export class GithubClient {
     }
   }
 
+  /** Code Search で guid → asset path(.meta を剥いだもの)を引く。未ヒット・未インデックス(422)は null。
+   *  legacy 構文(extension:meta)= GHES 互換。索引はデフォルトブランチのみ・認証済み 10 req/min。 */
+  async searchMetaByGuid(owner: string, repo: string, guid: string): Promise<string | null> {
+    const q = encodeURIComponent(`"${guid}" repo:${owner}/${repo} extension:meta`);
+    const res = await this.request(`/search/code?q=${q}&per_page=1`, 'application/vnd.github+json');
+    if (!res.ok) return null;
+    const body = (await res.json()) as { items?: Array<{ path?: string }> };
+    const path = body.items?.[0]?.path;
+    return path?.endsWith('.meta') ? path.slice(0, -'.meta'.length) : null;
+  }
+
   /** ref 時点の生バイト列。その側にファイルが無ければ null。 */
   async getFileAtRef(owner: string, repo: string, path: string, ref: string): Promise<Uint8Array | null> {
     const encoded = path.split('/').map(encodeURIComponent).join('/');

--- a/extension/src/github/guids.ts
+++ b/extension/src/github/guids.ts
@@ -12,6 +12,13 @@ export function parseGuidFromMeta(meta: string): string | undefined {
 
 export type MetaFetcher = (path: string, side: 'base' | 'head') => Promise<string | null>;
 
+/** Code Search で解決した guid→asset path の永続キャッシュ(repo キーは `<apiBase>/<owner>/<repo>`)。
+ *  guid→path は安定なので TTL なし。save はマージ。 */
+export type GuidCache = {
+  load(repo: string): Promise<Record<string, string>>;
+  save(repo: string, entries: Record<string, string>): Promise<void>;
+};
+
 const MAX_CONCURRENT_META_FETCHES = 8;
 
 /** PR 内で変更された .meta のみから guid → asset path 索引を作る(設計スコープ)。removed は base 側から読む。

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it } from 'vitest';
-import { detectTheme, render, renderError } from './render';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { detectTheme, render, renderError, renderTooLarge } from './render';
 import type { DiffV2 } from '../types';
 
 const DIFF: DiffV2 = {
@@ -132,6 +132,17 @@ describe('render', () => {
     render(root, { schema: 'prefablens.diff.v2', unresolvedGuids: [], roots: [], loose: [] });
     expect(root.querySelectorAll('details')).toHaveLength(0);
     expect(root.textContent).toContain('No semantic changes');
+  });
+
+  it('renderTooLarge shows the size and renders on click', () => {
+    const root = freshRoot();
+    const onRender = vi.fn();
+    renderTooLarge(root, 26 * 1024 * 1024, onRender);
+    expect(root.textContent).toContain('Large file (26 MB)');
+    const button = root.querySelector<HTMLButtonElement>('button.pl-render')!;
+    expect(button.textContent).toBe('Render anyway');
+    button.click();
+    expect(onRender).toHaveBeenCalledTimes(1);
   });
 
   it('renderError shows a clean one-line message', () => {

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -26,6 +26,7 @@ const STYLES = `
   .pl-arrow { color: var(--pl-muted); margin: 0 4px; }
   .pl-empty, .pl-error, .pl-loading { color: var(--pl-muted); margin: 0; }
   .pl-error { color: var(--pl-removed); }
+  .pl-render { font: inherit; margin-top: 4px; padding: 1px 8px; border: 1px solid var(--pl-border); background: transparent; color: inherit; cursor: pointer; }
   .pl-components { border-left: 1px solid var(--pl-border); margin: 2px 0 2px 4px; padding-left: 8px; }
   .pl-components-label { color: var(--pl-muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; user-select: none; }
 `;
@@ -54,6 +55,17 @@ export function renderError(root: ShadowRoot, message: string): void {
 
 export function renderLoading(root: ShadowRoot): void {
   mount(root).append(note('pl-loading', 'Computing semantic diff…'));
+}
+
+/** 25MB 超ガード(親仕様 §5.7): 自動描画せず明示クリックを待つ。 */
+export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => void): void {
+  const container = mount(root);
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'pl-render';
+  button.textContent = 'Render anyway';
+  button.addEventListener('click', onRender);
+  container.append(note('pl-empty', `Large file (${Math.round(bytes / 1048576)} MB).`), button);
 }
 
 function mount(root: ShadowRoot): HTMLElement {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -64,8 +64,12 @@ export type SemanticDiffRequest = {
   repo: string;
   prNumber: number;
   path: string;
+  force?: boolean; // 25MB ガードを越えて描画する(「Render anyway」クリック)
 };
 
 export type BackgroundError = 'pat-missing' | 'auth-failed' | 'rate-limited' | 'fetch-failed' | 'diff-failed';
 
-export type SemanticDiffResponse = { ok: true; json: DiffV2 } | { ok: false; error: BackgroundError };
+export type SemanticDiffResponse =
+  | { ok: true; json: DiffV2 }
+  | { ok: false; error: BackgroundError }
+  | { ok: false; error: 'too-large'; bytes: number };


### PR DESCRIPTION
## Summary

Phase 2 延期リストの本丸(spec A2+A3: `docs/superpowers/specs/2026-07-04-phase2-followups-design.md`)。

### guid 解決強化(A2)
- PR 内 `.meta` で解決できなかった guid を Code Search API(legacy 構文 `"<guid>" repo:o/r extension:meta`)で解決
- **PR 内索引 → 永続キャッシュ → Code Search の順で先勝ち**。検索は 1 応答あたり最大 10 件・逐次
- Code Search の失敗(レート制限含む)で diff は落とさず、解決できた分だけ載せる
- guid→path は `chrome.storage.local`(キー `guids:<apiBase>/<owner>/<repo>`)に TTL なしで永続、負結果は SW 生存期間のみ
- guid は任意文字列のため `Object.hasOwn` でプロトタイプ汚染系キー(`constructor` 等)を防御
- 制約(仕様通り): Code Search はデフォルトブランチのみ索引

### キャッシュ鮮度
- PR コンテキストに 60 秒 TTL(push 後の headSha 変化に追従)
- blob は `sha:path` キーで SW 内キャッシュ(不変、32 件 FIFO)

### 25MB クリック描画ガード(A3)
- base+head 合計 25MB 超は diff せず `too-large` 応答 → content が「Render anyway」ボタン表示 → `force: true` 再要求(blob キャッシュにより再フェッチなし)

## Test plan

- [x] `npm run typecheck && npm test`(77 tests、+12 追加)
- [x] `npm run build && npm run e2e`(smoke 2 本)
- [ ] 機能本体につきマージ前にユーザー確認(workflow-autonomy)