### PR TITLE
test: full-stack E2E through the real extension

### DIFF
--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -1,5 +1,5 @@
 import { build } from 'esbuild';
-import { cpSync, mkdirSync } from 'node:fs';
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 
 mkdirSync('dist', { recursive: true });
 
@@ -16,6 +16,11 @@ await build({
   outdir: 'dist',
 });
 
-cpSync('manifest.json', 'dist/manifest.json');
+// --e2e: full-stack E2E がローカル HTTP サーバを「GHES」として使えるよう 127.0.0.1 を事前許可する
+// (permissions.request は許可済みオリジンならプロンプトなしで true を返す)
+const manifest = JSON.parse(readFileSync('manifest.json', 'utf8'));
+if (process.argv.includes('--e2e')) manifest.host_permissions.push('http://127.0.0.1/*');
+writeFileSync('dist/manifest.json', JSON.stringify(manifest, null, 2));
+
 cpSync('src/options/options.html', 'dist/options.html');
 cpSync('../zig-out/bin/prefablens.wasm', 'dist/prefablens.wasm');

--- a/extension/e2e/fixtures/pr-files.html
+++ b/extension/e2e/fixtures/pr-files.html
@@ -9,6 +9,12 @@
       <div class="js-file-content">raw github diff table</div>
     </div>
     <div class="file">
+      <div class="file-header" data-path="Assets/Big.unity">
+        <span class="file-info">Assets/Big.unity</span>
+      </div>
+      <div class="js-file-content">raw github diff table</div>
+    </div>
+    <div class="file">
       <div class="file-header" data-path="README.md">
         <span class="file-info">README.md</span>
       </div>

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -1,0 +1,117 @@
+/// <reference types="node" />
+// 本物の拡張(--load-extension)で 検出 → 実 background → 実 WASM → 描画 を端から端まで通す。
+// ローカル HTTP サーバを A1 の GHES 動的登録経由で「GitHub」として使う(--e2e build が 127.0.0.1 を事前許可)。
+import { chromium, expect, test, type BrowserContext } from '@playwright/test';
+import { createServer, type Server } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const DIST = fileURLToPath(new URL('../dist', import.meta.url));
+const fixture = readFileSync(new URL('./fixtures/pr-files.html', import.meta.url), 'utf8');
+
+// core/tests/wasm_golden.test.mjs と同じミニマル prefab: 出力が golden で確定している
+const BEFORE = `--- !u!114 &11400000
+MonoBehaviour:
+  m_Script: {fileID: 0, guid: def, type: 3}
+  volume: 0.5
+`;
+const AFTER = BEFORE.replace('0.5', '0.8');
+// ドキュメントなしの 26MB = 25MB ガードを踏み、force 後は空 diff で軽く終わる
+const BIG = 'x'.repeat(26 * 1024 * 1024);
+
+function startServer(): Promise<{ server: Server; port: number }> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url!, 'http://127.0.0.1');
+    const send = (body: string, type: string): void => {
+      res.writeHead(200, { 'content-type': type });
+      res.end(body);
+    };
+    const json = (body: unknown): void => send(JSON.stringify(body), 'application/json');
+    switch (url.pathname) {
+      case '/o/r/pull/1/files':
+        return send(fixture, 'text/html');
+      case '/api/v3/repos/o/r/pulls/1/files':
+        return json([
+          { filename: 'Assets/Foo.prefab', status: 'modified' },
+          { filename: 'Assets/Big.unity', status: 'modified' },
+        ]);
+      case '/api/v3/repos/o/r/pulls/1':
+        return json({ base: { sha: 'B' }, head: { sha: 'H' } });
+      case '/api/v3/repos/o/r/compare/B...H':
+        return json({ merge_base_commit: { sha: 'MB' } });
+      case '/api/v3/repos/o/r/contents/Assets/Foo.prefab':
+        return send(url.searchParams.get('ref') === 'MB' ? BEFORE : AFTER, 'application/vnd.github.raw+json');
+      case '/api/v3/repos/o/r/contents/Assets/Big.unity':
+        return send(BIG, 'application/vnd.github.raw+json');
+      case '/api/v3/search/code':
+        return json({ items: [{ path: 'Assets/Scripts/Sound.cs.meta' }] });
+      default:
+        res.writeHead(404);
+        res.end();
+    }
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, port: (server.address() as { port: number }).port });
+    });
+  });
+}
+
+let context: BrowserContext;
+let server: Server;
+let port: number;
+
+test.beforeAll(async () => {
+  ({ server, port } = await startServer());
+  context = await chromium.launchPersistentContext('', {
+    channel: 'chromium', // headless で拡張を使うには chromium channel が必要
+    args: [`--disable-extensions-except=${DIST}`, `--load-extension=${DIST}`],
+  });
+  let sw = context.serviceWorkers()[0];
+  sw ??= await context.waitForEvent('serviceworker');
+  const extensionId = new URL(sw.url()).host;
+
+  // Options で PAT とローカルサーバを保存 → applyGhes が 127.0.0.1 を動的登録する
+  const options = await context.newPage();
+  await options.goto(`chrome-extension://${extensionId}/options.html`);
+  await options.fill('#pat', 'tok');
+  await options.fill('#baseUrl', `http://127.0.0.1:${port}`);
+  await options.click('#save');
+  await expect(options.locator('#status')).toHaveText('Saved');
+  await options.close();
+});
+
+test.afterAll(async () => {
+  await context?.close();
+  server?.close();
+});
+
+test('renders a real wasm diff with code-search guid resolution', async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${port}/o/r/pull/1/files`);
+
+  const header = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await header.getByRole('button', { name: 'Semantic' }).click();
+
+  const view = page.locator('[data-prefablens-view]');
+  // Code Search 経由で guid def → Sound.cs に実名解決され、型名ではなくスクリプト名が出る
+  await expect(view).toContainText('Sound');
+  await expect(view).toContainText('Volume');
+  await expect(view).toContainText('0.5');
+  await expect(view).toContainText('0.8');
+  await page.close();
+});
+
+test('gates oversized files behind an explicit render click', async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${port}/o/r/pull/1/files`);
+
+  const header = page.locator('.file-header[data-path="Assets/Big.unity"]');
+  await header.getByRole('button', { name: 'Semantic' }).click();
+
+  const view = page.locator('[data-prefablens-view]');
+  await expect(view).toContainText('Large file (52 MB)', { timeout: 30_000 });
+  await view.getByRole('button', { name: 'Render anyway' }).click();
+  await expect(view).toContainText('No semantic changes', { timeout: 30_000 });
+  await page.close();
+});

--- a/extension/package.json
+++ b/extension/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "size": "node scripts/check-wasm-size.mjs",
-    "e2e": "playwright test"
+    "e2e": "node build.mjs --e2e && playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",


### PR DESCRIPTION
## Summary

spec A4(`docs/superpowers/specs/2026-07-04-phase2-followups-design.md`)。**#8 の上に積んだスタック PR**(base: `feat/code-search-guid-resolution`)。#8 マージ後に base を main に付け替えてからマージする。

- `--load-extension` で本物の拡張をロードし、ローカル HTTP サーバ(canned GitHub API + PR ページ fixture)を **A1 の GHES 動的登録経由で「GitHub」として使う** full-stack E2E を追加
  - 検出 → 実 background(実 fetch)→ 実 WASM diff → Code Search guid 実名解決 → Shadow DOM 描画 まで一気通貫
  - 25MB ガード: `Large file (52 MB)` → `Render anyway` クリック → 描画、まで実機検証
- `build.mjs --e2e` で manifest の host_permissions に `http://127.0.0.1/*` を追加(許可済みオリジンへの permissions.request はプロンプトなしで通る)
- フィクスチャは core の WASM golden と同一のミニマル prefab を使い、期待値を golden に固定

## Test plan

- [x] `npm run typecheck && npm run e2e`(full 2 本 + 既存 smoke 2 本 = 4 本 PASS)
- [x] #8 マージ後に base 付け替え → CI green → 自己マージ可(polish、workflow-autonomy)