### PR TITLE
feat: worktree diff alias and release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tools
+        uses: jdx/mise-action@v4
+      # zig は素でクロスコンパイルできるため 1 ランナーで全ターゲットを吐く。
+      # zig-out/bin はターゲットごとに上書きされるので都度 zip に退避する。
+      # アセットは zip 統一(Unity 側の System.IO.Compression.ZipFile が全 OS で扱える)。
+      - name: Build CLI for all targets
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          build() {
+            zig build -Dtarget="$1" -Doptimize=ReleaseSafe
+            (cd zig-out/bin && zip -j "../../dist/prefablens-$2.zip" "$3")
+          }
+          build aarch64-macos    macos-arm64  prefablens
+          build x86_64-macos     macos-x64    prefablens
+          build x86_64-linux-gnu linux-x64    prefablens
+          build x86_64-windows   windows-x64  prefablens.exe
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/*.zip --generate-notes

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -33,12 +33,36 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     }
 }
 
+/// 作業ツリー側(--git REF PATH の after)。ファイル不在は「削除済み」= 空側として扱う。
+pub fn readWorktree(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, path: []const u8) ![]u8 {
+    const full = try std.fs.path.join(arena, &.{ repo_dir, path });
+    return std.Io.Dir.cwd().readFileAlloc(io, full, arena, .limited(max_input_bytes)) catch |err| switch (err) {
+        error.FileNotFound => try arena.alloc(u8, 0),
+        else => err,
+    };
+}
+
 fn git(io: std.Io, arena: std.mem.Allocator, dir: []const u8, argv: []const []const u8) !void {
     var full: std.ArrayList([]const u8) = .empty;
     try full.append(arena, "git");
     try full.appendSlice(arena, argv);
     const res = try std.process.run(arena, io, .{ .argv = full.items, .cwd = .{ .path = dir } });
     if (res.term != .exited or res.term.exited != 0) return error.GitFailed;
+}
+
+test "readWorktree reads the file and treats absence as an empty side" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v2\n" });
+
+    try testing.expectEqualStrings("v2\n", try readWorktree(testing.io, arena, dir, "Foo.prefab"));
+    // 作業ツリーで削除済み = 空側(エラーにしない)
+    try testing.expectEqual(@as(usize, 0), (try readWorktree(testing.io, arena, dir, "Gone.prefab")).len);
 }
 
 test "showAtRef returns file contents at a commit" {

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -63,6 +63,21 @@ test "parseArgs: extra positional after --git operands is a parse error" {
     try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
 }
 
+test "parseArgs: --git with two operands means ref vs working tree" {
+    const args = [_][]const u8{ "--git", "HEAD", "Foo.prefab", "--json" };
+    const opt = try parseArgs(&args);
+    try testing.expect(opt.git_mode);
+    try testing.expectEqualStrings("HEAD", opt.git_ref_before);
+    try testing.expectEqualStrings("", opt.git_ref_after); // 空 = 作業ツリー側
+    try testing.expectEqualStrings("Foo.prefab", opt.git_path);
+    try testing.expectEqual(Format.json, opt.format);
+}
+
+test "parseArgs: --git with a single operand is missing operands" {
+    const args = [_][]const u8{ "--git", "HEAD" };
+    try testing.expectError(ArgError.MissingOperands, parseArgs(&args));
+}
+
 test "parseArgs: a third plain positional is too many arguments" {
     const args = [_][]const u8{ "a.prefab", "b.prefab", "c.prefab" };
     try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
@@ -401,14 +416,19 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             if (i >= args.len) return ArgError.MissingOperands;
             project_root = args[i];
         } else if (std.mem.eql(u8, a, "--git")) {
-            // Expect: --git <beforeRef> <afterRef> <path>, then keep parsing
-            // so flags following the operands (e.g. --json) still apply.
-            if (i + 3 >= args.len) return ArgError.MissingOperands;
+            // --git <beforeRef> [<afterRef>] <path>: 非フラグ operand を 2〜3 個消費し、
+            // 2 個なら after 側は作業ツリー(git_ref_after = "")。後続フラグは引き続き解釈する。
+            var ops: [3][]const u8 = undefined;
+            var n: usize = 0;
+            while (n < 3 and i + 1 < args.len and !std.mem.startsWith(u8, args[i + 1], "--")) : (n += 1) {
+                i += 1;
+                ops[n] = args[i];
+            }
+            if (n < 2) return ArgError.MissingOperands;
             git_mode = true;
-            git_ref_before = args[i + 1];
-            git_ref_after = args[i + 2];
-            git_path = args[i + 3];
-            i += 3;
+            git_ref_before = ops[0];
+            git_ref_after = if (n == 3) ops[1] else "";
+            git_path = ops[n - 1];
         } else if (std.mem.startsWith(u8, a, "--")) {
             return ArgError.UnknownFlag;
         } else if (git_mode) {
@@ -451,7 +471,7 @@ fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
 pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
-            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] [--no-color] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
+            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] [--no-color] (<before> <after> | --git <beforeRef> [<afterRef>] <path>)\n"),
             ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag\n"),
             ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments\n"),
         }
@@ -468,7 +488,13 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             try stderr.print("error: cannot read file '{s}'\n", .{opt.before});
             return 1;
         };
-    const after = if (opt.git_mode)
+    const after = if (opt.git_mode and opt.git_ref_after.len == 0)
+        // ref 1 個 = 作業ツリーとの比較(ファイル不在は削除 = 空側)
+        input.readWorktree(io, arena, ".", opt.git_path) catch {
+            try stderr.print("error: cannot read file '{s}'\n", .{opt.git_path});
+            return 1;
+        }
+    else if (opt.git_mode)
         input.showAtRef(io, arena, ".", opt.git_ref_after, opt.git_path) catch {
             try stderr.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_after, opt.git_path });
             return 1;

--- a/docs/superpowers/plans/2026-07-04-phase3-editor-host.md
+++ b/docs/superpowers/plans/2026-07-04-phase3-editor-host.md
@@ -1,0 +1,87 @@
+# Phase 3 Editor Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unity Editor 内で選択 prefab の「HEAD vs 作業ツリー」意味的 diff を表示する(spec: `docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md`、承認済み)。
+
+**Architecture:** CLI サブプロセス + stdout JSON(diff.v2)。CLI は GitHub Releases から自動取得。guid は AssetDatabase で完全解決。
+
+**Tech Stack:** Zig(CLI 拡張)/ GitHub Actions(release)/ C# + UIToolkit + Newtonsoft(editor package)
+
+## Global Constraints
+
+- コミットは 1 行英語 ≤50 字 / 実装は最小限(coding-preferences)/ Unity 2022.3 LTS+
+- package 名 `com.hashiiiii.prefablens` / 初回タグ `v0.1.0`(ユーザー確定)
+- 検証は exit code を殺さない形で(`cmd > /tmp/out; code=$?`)
+- Zig 検証: `zig build test`。C# は EditMode テストを書くが実行はローカル Unity(CI 化 backlog)
+
+---
+
+## PR a — `feat/editor-host`(CLI worktree エイリアス + release workflow)
+
+### Task 1: CLI `--git REF PATH`(REF vs 作業ツリー)
+
+**Files:** Modify `cli/src/main.zig`(parseArgs / run / usage 文言)
+
+**Interfaces:** `--git` は非フラグ operand を 2〜3 個消費。2 個なら `git_ref_after = ""`(空 = 作業ツリー側)。after 側の worktree 読みで FileNotFound は空(= 削除)扱い。
+
+- [ ] parseArgs テスト追加: 2-operand 形式 / 2-operand 直後のフラグ継続 / operand 1 個は MissingOperands → FAIL 確認
+- [ ] run テスト追加: 一時 git repo で commit(0.5)→ 作業ツリー変更(0.8)→ `--git HEAD <path> --json` が after 0.8 / 作業ツリーでファイル削除 → exit 0 で removed 出力 → FAIL 確認
+- [ ] parseArgs: `--git` の operand 消費を「`--` 始まりでない引数を最大 3 個」に変更、2 個なら worktree モード。usage を `--git <beforeRef> [<afterRef>] <path>` に
+- [ ] run: after 側を labeled block 化し、`git_ref_after.len == 0` なら readFile(FileNotFound → 空)
+- [ ] `zig build test` PASS → Commit `feat: diff a ref against the working tree`
+
+### Task 2: release workflow
+
+**Files:** Create `.github/workflows/release.yml`
+
+- [ ] tag `v*` push で: mise-action → 4 ターゲットを順に `zig build -Dtarget=<t> -Doptimize=ReleaseSafe` → `prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip` に zip -j → `gh release create "$GITHUB_REF_NAME" dist/*.zip --generate-notes`(`GH_TOKEN: ${{ github.token }}`、`permissions: contents: write`)
+- [ ] ローカル検証: 4 ターゲットのクロスコンパイルが通ることを実際に確認(`zig build -Dtarget=x86_64-windows` 等)
+- [ ] Commit `ci: build and attach cli binaries on tag push`
+
+### Task 3: PR a 作成 → CI green → ユーザー確認どおり自己判断可なら squash(機能本体のため原則ユーザー確認、ただし spec 承認済みのため PR 提示のみで続行可)
+
+- [ ] push、PR 作成、CI green 確認。マージ判断は PR b と合わせて最後にユーザーへ
+
+---
+
+## PR b — editor package(PR a の後、同ブランチ継続 or 分岐)
+
+### Task 4: package 骨格 + DiffModel
+
+**Files:** Create `editor/package.json` / `editor/Editor/PrefabLens.Editor.asmdef` / `editor/Editor/DiffModel.cs` / `editor/Tests/Editor/DiffModelTests.cs`(+ Tests asmdef)
+
+- [ ] package.json: name com.hashiiiii.prefablens、unity 2022.3、dependencies に com.unity.nuget.newtonsoft-json
+- [ ] DiffModel: diff.v2 の C# クラス群 + `DiffModel.Parse(string json)`(JObject 手書きマッピング、kind で NodeDiff 分岐)+ `ApplyAssetDatabaseResolution(Func<string,string> guidToPath)`(unresolvedGuids を完全解決して resolved を上書き)
+- [ ] EditMode テスト: wasm_golden と同じ JSON 文字列 → モデル / 未知 kind・欠損フィールドの耐性 / resolution 上書き
+- [ ] Commit `feat: add editor package skeleton and diff model`
+
+### Task 5: Cli.cs(探索・ダウンロード・実行)
+
+**Files:** Create `editor/Editor/Cli.cs` / Test `editor/Tests/Editor/CliTests.cs`
+
+- [ ] 純関数を分離: `ReleaseAssetName(OSPlatform, Architecture)` → `prefablens-macos-arm64.zip` 等 / `DownloadUrl(version, assetName)` / 引数組み立て `BuildArgs(assetPath)` → `--git HEAD "<path>" --json`
+- [ ] 探索: EditorPrefs `PrefabLens.CliPath` → `Library/PrefabLens/<VER>/prefablens(.exe)` → null
+- [ ] ダウンロード: UnityWebRequest で zip 取得 → ZipFile.ExtractToDirectory → unix chmod +x(Process)
+- [ ] 実行: Process(cwd = プロジェクトルート)、stdout/stderr 捕捉、exit≠0 は stderr を返す
+- [ ] EditMode テスト: 純関数 3 種
+- [ ] Commit `feat: locate download and run the cli`
+
+### Task 6: PrefabLensWindow.cs(UIToolkit)
+
+**Files:** Create `editor/Editor/PrefabLensWindow.cs`
+
+- [ ] `Window/PrefabLens` メニュー + `Assets/PrefabLens: Diff vs HEAD` コンテキスト(.prefab/.unity/.asset で有効)
+- [ ] TreeView: ノード → コンポーネント → フィールド(before → after、status 色分け。Chrome 版レンダラと同配色トーン)
+- [ ] 状態: CLI 不在(Download ボタン)/ 実行中 / stderr エラー / No semantic changes / Refresh ボタン
+- [ ] Commit `feat: add prefab diff editor window`
+
+### Task 7: 仕上げ
+
+- [ ] spec の未決事項欄を確定内容で更新、README 追記は不要(リポジトリ README は未追跡・ユーザー管理)
+- [ ] PR 作成 → CI green → ユーザーに PR a/b のマージと v0.1.0 タグ打ちを確認(タグは PR a マージ後でないと Releases が無く、Editor のダウンロードが 404 になる点を明記)
+
+## Self-Review 済み
+
+- spec の全節をタスクに対応付け(リリース=T2、CLI=T1、package=T4-6、テスト戦略=各タスク内)
+- 型・命名は spec と一致(CliVersion 定数、EditorPrefs キー、アセット名 4 種)

--- a/docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md
+++ b/docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md
@@ -1,0 +1,94 @@
+# PrefabLens Phase 3 設計 — Unity Editor ホスト(ウォーキングスケルトン)
+
+- **日付**: 2026-07-04
+- **ステータス**: ドラフト(ユーザーレビュー待ち)
+- **親仕様**: `2026-06-29-unity-prefab-diff-design.md` §6.3・§7・§8
+- **ユーザー決定(2026-07-04)**: CLI は GitHub Releases から取得(将来 homebrew tap、tap は別リポジトリ案)/ 初回スコープは git HEAD vs 作業ツリー / UIToolkit + Unity 2022.3 LTS+
+
+Editor を離れずに「選択した prefab の未コミット変更」を意味的 diff で確認できる最小の縦切りを作る。CLI をサブプロセスで叩き stdout の JSON(diff.v2)を描画する(親仕様 §6.3 の通り、ネイティブ連携なし)。
+
+## スコープ
+
+### 初回に入れる
+
+1. **リリースパイプライン**(前提インフラ): tag `v*` push で GitHub Actions が zig クロスコンパイル(macos-aarch64 / macos-x86_64 / linux-x86_64 / windows-x86_64)し、`prefablens-<target>.zip` を GitHub Release に添付。zig はクロスコンパイルが素で通るためビルドマトリクス不要(1 ランナーで 4 ターゲット)
+2. **CLI の薄い拡張**: `--git REF PATH`(operand 2 個)= 「REF vs 作業ツリー」。既存の `--git REF REF PATH` はそのまま。git ロジックを CLI に集約し、C# 側での `git show` 再実装を避ける(親仕様 §6.1 の「後続の薄いエイリアス」)
+3. **Unity package**(`/editor`、UPM): prefab を選択 → メニューで diff 表示
+
+### 初回は延期
+
+- homebrew tap(別リポジトリ `homebrew-prefablens` 案。Releases のアセットをそのまま参照できる)
+- 任意 2 ref 比較の UI、シーン内オブジェクトとの対応づけ、P/Invoke 化
+- Unity CI(game-ci)での EditMode テスト自動実行(テスト自体は書く。ローカル実行)
+
+## リリースパイプライン
+
+`.github/workflows/release.yml`(tag `v*` push):
+
+```
+zig build cli -Dtarget=aarch64-macos -Doptimize=ReleaseSafe  → zip → prefablens-macos-arm64.zip
+同様に x86_64-macos / x86_64-linux-gnu / x86_64-windows      → gh release upload
+```
+
+- アセットは **zip 統一**(C# の `System.IO.Compression.ZipFile` が全プラットフォームで扱えるため。tar.gz は Unity 側で展開手段がない)
+- 中身は単一バイナリ `prefablens`(win は `prefablens.exe`)
+- build.zig に `cli` ステップ(install 相当)が無ければ追加する(現状は default install のみ)
+
+## Unity package 構成
+
+```
+/editor
+  package.json                     com.hashiiiii.prefablens(Editor 専用、unity: 2022.3)
+  Editor/
+    PrefabLens.Editor.asmdef       Editor プラットフォームのみ、Newtonsoft 参照
+    PrefabLensWindow.cs            EditorWindow(UIToolkit)
+    Cli.cs                         探索・ダウンロード・実行(サブプロセス)
+    DiffModel.cs                   diff.v2 の C# モデル + Newtonsoft パース
+  Tests/Editor/                    EditMode テスト(パース・URL 選択の純関数)
+```
+
+- JSON は `com.unity.nuget.newtonsoft-json` 依存で読む(kind による NodeDiff の分岐は JObject 経由の手書きマッピング。JsonUtility はユニオン・null を扱えない)
+
+### Cli.cs(探索 → ダウンロード → 実行)
+
+1. **探索**: EditorPrefs `PrefabLens.CliPath`(手動指定、最優先)→ 既定ダウンロード先 `Library/PrefabLens/<VER>/prefablens(.exe)` → 無ければダウンロード提案
+2. **ダウンロード**: 固定バージョン定数 `CliVersion`(package と同時に更新)から
+   `https://github.com/hashiiiii/PrefabLens/releases/download/v<VER>/prefablens-<target>.zip`
+   を取得 → `Library/PrefabLens/<VER>/` に展開 → unix は実行権限付与。ターゲット判定は `RuntimeInformation`(Editor の OS/Arch)
+3. **実行**: プロジェクトルート(`Application.dataPath/..`)を cwd に
+   `prefablens --git HEAD "<assetPath>" --json` → stdout を parse。exit≠0 は stderr をそのまま表示
+4. **guid 解決**: CLI 単体実行では unresolvedGuids が残るため、Editor 側で `AssetDatabase.GUIDToAssetPath()` を使い **完全解決**して `resolved` を上書き(Chrome 版より強い解決が Editor の存在意義)
+
+### PrefabLensWindow.cs
+
+- メニュー: `Window/PrefabLens`、および Project ウィンドウのコンテキスト `Assets/PrefabLens: Diff vs HEAD`(.prefab / .unity / .asset で有効)
+- UIToolkit `TreeView` 1 本: ノード(GameObject / PrefabInstance)→ コンポーネント → フィールド行(label + before → after)。status で色分け(added/removed/modified)、Chrome 版レンダラと同じ配色トーン
+- 状態表示: CLI 未取得(Download ボタン)/ 実行中 / エラー(stderr)/ No semantic changes
+- 選択変更に自動追従はしない(明示的に Refresh ボタン。YAGNI)
+
+## エラーハンドリング
+
+| ケース | 挙動 |
+|---|---|
+| CLI 不在 | ウィンドウ内に Download ボタン + 手動パス設定への導線 |
+| ダウンロード失敗 | エラー表示(URL 付き)。手動配置の案内 |
+| 非 git リポジトリ / ref 不在 | CLI の stderr をそのまま表示(CLI 側のメッセージが一次情報)|
+| JSON パース失敗 | 「CLI バージョン不一致の可能性」+ 生 stdout 先頭を表示 |
+
+## テスト戦略(親仕様 §7)
+
+- **Zig**: `--git REF PATH`(worktree エイリアス)の parseArgs / run テストを既存 CLI テストに追加(CI で実行)
+- **C# EditMode**: DiffModel パース(golden JSON 文字列 → モデル)、release URL/ターゲット選択の純関数、Cli 引数組み立て。ローカルの Unity Test Runner で実行(CI 化は backlog)
+- **手動スモーク**: ユーザーの Unity プロジェクトで prefab を変更 → Diff vs HEAD 表示を確認
+
+## PR 分割
+
+| PR | 内容 | マージ |
+|---|---|---|
+| a | CLI worktree エイリアス + release workflow + 初回タグ手順 | 機能本体、ユーザー確認 |
+| b | editor package(Cli/DiffModel/Window + EditMode テスト) | 機能本体、ユーザー確認 |
+
+## 未決事項(レビューで確認)
+
+- package 名 `com.hashiiiii.prefablens` でよいか
+- 初回リリースタグは `v0.1.0` でよいか(拡張・CLI と同一バージョン系列)


### PR DESCRIPTION
## Summary

Phase 3(Unity Editor ホスト)の前提部分。spec: `docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md`(承認済み)、plan 同日付。

- **CLI**: `--git <ref> <path>`(operand 2 個)= ref vs **作業ツリー** の薄いエイリアス(親仕様 §6.1 の後続分)。作業ツリー側のファイル不在は「削除 = 空側」として扱う。既存の 2-ref 形式は不変
- **Release pipeline**: tag `v*` push で zig クロスコンパイル(macos-arm64/x64, linux-x64, windows-x64)→ `prefablens-<target>.zip` を GitHub Release に添付。4 ターゲットのクロスビルドはローカルで実証済み
- Editor package(PR 続編)はこの Release からバイナリを自動取得する

## Test plan

- [x] `zig build test`(readWorktree / parseArgs 2-operand 形式のテスト追加、99 tests)
- [x] 4 ターゲットのクロスコンパイルをローカル実証
- [ ] マージ後に `v0.1.0` タグを打って release workflow を実走確認(ユーザー確認済みのタグ)