### PR TITLE
feat: Unity Editor host walking skeleton

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tools
+        uses: jdx/mise-action@v4
+      # zig は素でクロスコンパイルできるため 1 ランナーで全ターゲットを吐く。
+      # zig-out/bin はターゲットごとに上書きされるので都度 zip に退避する。
+      # アセットは zip 統一(Unity 側の System.IO.Compression.ZipFile が全 OS で扱える)。
+      - name: Build CLI for all targets
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          build() {
+            zig build -Dtarget="$1" -Doptimize=ReleaseSafe
+            (cd zig-out/bin && zip -j "../../dist/prefablens-$2.zip" "$3")
+          }
+          build aarch64-macos    macos-arm64  prefablens
+          build x86_64-macos     macos-x64    prefablens
+          build x86_64-linux-gnu linux-x64    prefablens
+          build x86_64-windows   windows-x64  prefablens.exe
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/*.zip --generate-notes

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -33,12 +33,36 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     }
 }
 
+/// 作業ツリー側(--git REF PATH の after)。ファイル不在は「削除済み」= 空側として扱う。
+pub fn readWorktree(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, path: []const u8) ![]u8 {
+    const full = try std.fs.path.join(arena, &.{ repo_dir, path });
+    return std.Io.Dir.cwd().readFileAlloc(io, full, arena, .limited(max_input_bytes)) catch |err| switch (err) {
+        error.FileNotFound => try arena.alloc(u8, 0),
+        else => err,
+    };
+}
+
 fn git(io: std.Io, arena: std.mem.Allocator, dir: []const u8, argv: []const []const u8) !void {
     var full: std.ArrayList([]const u8) = .empty;
     try full.append(arena, "git");
     try full.appendSlice(arena, argv);
     const res = try std.process.run(arena, io, .{ .argv = full.items, .cwd = .{ .path = dir } });
     if (res.term != .exited or res.term.exited != 0) return error.GitFailed;
+}
+
+test "readWorktree reads the file and treats absence as an empty side" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v2\n" });
+
+    try testing.expectEqualStrings("v2\n", try readWorktree(testing.io, arena, dir, "Foo.prefab"));
+    // 作業ツリーで削除済み = 空側(エラーにしない)
+    try testing.expectEqual(@as(usize, 0), (try readWorktree(testing.io, arena, dir, "Gone.prefab")).len);
 }
 
 test "showAtRef returns file contents at a commit" {

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -63,6 +63,21 @@ test "parseArgs: extra positional after --git operands is a parse error" {
     try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
 }
 
+test "parseArgs: --git with two operands means ref vs working tree" {
+    const args = [_][]const u8{ "--git", "HEAD", "Foo.prefab", "--json" };
+    const opt = try parseArgs(&args);
+    try testing.expect(opt.git_mode);
+    try testing.expectEqualStrings("HEAD", opt.git_ref_before);
+    try testing.expectEqualStrings("", opt.git_ref_after); // 空 = 作業ツリー側
+    try testing.expectEqualStrings("Foo.prefab", opt.git_path);
+    try testing.expectEqual(Format.json, opt.format);
+}
+
+test "parseArgs: --git with a single operand is missing operands" {
+    const args = [_][]const u8{ "--git", "HEAD" };
+    try testing.expectError(ArgError.MissingOperands, parseArgs(&args));
+}
+
 test "parseArgs: a third plain positional is too many arguments" {
     const args = [_][]const u8{ "a.prefab", "b.prefab", "c.prefab" };
     try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
@@ -401,14 +416,19 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             if (i >= args.len) return ArgError.MissingOperands;
             project_root = args[i];
         } else if (std.mem.eql(u8, a, "--git")) {
-            // Expect: --git <beforeRef> <afterRef> <path>, then keep parsing
-            // so flags following the operands (e.g. --json) still apply.
-            if (i + 3 >= args.len) return ArgError.MissingOperands;
+            // --git <beforeRef> [<afterRef>] <path>: 非フラグ operand を 2〜3 個消費し、
+            // 2 個なら after 側は作業ツリー(git_ref_after = "")。後続フラグは引き続き解釈する。
+            var ops: [3][]const u8 = undefined;
+            var n: usize = 0;
+            while (n < 3 and i + 1 < args.len and !std.mem.startsWith(u8, args[i + 1], "--")) : (n += 1) {
+                i += 1;
+                ops[n] = args[i];
+            }
+            if (n < 2) return ArgError.MissingOperands;
             git_mode = true;
-            git_ref_before = args[i + 1];
-            git_ref_after = args[i + 2];
-            git_path = args[i + 3];
-            i += 3;
+            git_ref_before = ops[0];
+            git_ref_after = if (n == 3) ops[1] else "";
+            git_path = ops[n - 1];
         } else if (std.mem.startsWith(u8, a, "--")) {
             return ArgError.UnknownFlag;
         } else if (git_mode) {
@@ -451,7 +471,7 @@ fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
 pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
-            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] [--no-color] (<before> <after> | --git <beforeRef> <afterRef> <path>)\n"),
+            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] [--no-color] (<before> <after> | --git <beforeRef> [<afterRef>] <path>)\n"),
             ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag\n"),
             ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments\n"),
         }
@@ -468,7 +488,13 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             try stderr.print("error: cannot read file '{s}'\n", .{opt.before});
             return 1;
         };
-    const after = if (opt.git_mode)
+    const after = if (opt.git_mode and opt.git_ref_after.len == 0)
+        // ref 1 個 = 作業ツリーとの比較(ファイル不在は削除 = 空側)
+        input.readWorktree(io, arena, ".", opt.git_path) catch {
+            try stderr.print("error: cannot read file '{s}'\n", .{opt.git_path});
+            return 1;
+        }
+    else if (opt.git_mode)
         input.showAtRef(io, arena, ".", opt.git_ref_after, opt.git_path) catch {
             try stderr.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_after, opt.git_path });
             return 1;

--- a/docs/superpowers/plans/2026-07-04-phase3-editor-host.md
+++ b/docs/superpowers/plans/2026-07-04-phase3-editor-host.md
@@ -1,0 +1,87 @@
+# Phase 3 Editor Host Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unity Editor 内で選択 prefab の「HEAD vs 作業ツリー」意味的 diff を表示する(spec: `docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md`、承認済み)。
+
+**Architecture:** CLI サブプロセス + stdout JSON(diff.v2)。CLI は GitHub Releases から自動取得。guid は AssetDatabase で完全解決。
+
+**Tech Stack:** Zig(CLI 拡張)/ GitHub Actions(release)/ C# + UIToolkit + Newtonsoft(editor package)
+
+## Global Constraints
+
+- コミットは 1 行英語 ≤50 字 / 実装は最小限(coding-preferences)/ Unity 2022.3 LTS+
+- package 名 `com.hashiiiii.prefablens` / 初回タグ `v0.1.0`(ユーザー確定)
+- 検証は exit code を殺さない形で(`cmd > /tmp/out; code=$?`)
+- Zig 検証: `zig build test`。C# は EditMode テストを書くが実行はローカル Unity(CI 化 backlog)
+
+---
+
+## PR a — `feat/editor-host`(CLI worktree エイリアス + release workflow)
+
+### Task 1: CLI `--git REF PATH`(REF vs 作業ツリー)
+
+**Files:** Modify `cli/src/main.zig`(parseArgs / run / usage 文言)
+
+**Interfaces:** `--git` は非フラグ operand を 2〜3 個消費。2 個なら `git_ref_after = ""`(空 = 作業ツリー側)。after 側の worktree 読みで FileNotFound は空(= 削除)扱い。
+
+- [ ] parseArgs テスト追加: 2-operand 形式 / 2-operand 直後のフラグ継続 / operand 1 個は MissingOperands → FAIL 確認
+- [ ] run テスト追加: 一時 git repo で commit(0.5)→ 作業ツリー変更(0.8)→ `--git HEAD <path> --json` が after 0.8 / 作業ツリーでファイル削除 → exit 0 で removed 出力 → FAIL 確認
+- [ ] parseArgs: `--git` の operand 消費を「`--` 始まりでない引数を最大 3 個」に変更、2 個なら worktree モード。usage を `--git <beforeRef> [<afterRef>] <path>` に
+- [ ] run: after 側を labeled block 化し、`git_ref_after.len == 0` なら readFile(FileNotFound → 空)
+- [ ] `zig build test` PASS → Commit `feat: diff a ref against the working tree`
+
+### Task 2: release workflow
+
+**Files:** Create `.github/workflows/release.yml`
+
+- [ ] tag `v*` push で: mise-action → 4 ターゲットを順に `zig build -Dtarget=<t> -Doptimize=ReleaseSafe` → `prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip` に zip -j → `gh release create "$GITHUB_REF_NAME" dist/*.zip --generate-notes`(`GH_TOKEN: ${{ github.token }}`、`permissions: contents: write`)
+- [ ] ローカル検証: 4 ターゲットのクロスコンパイルが通ることを実際に確認(`zig build -Dtarget=x86_64-windows` 等)
+- [ ] Commit `ci: build and attach cli binaries on tag push`
+
+### Task 3: PR a 作成 → CI green → ユーザー確認どおり自己判断可なら squash(機能本体のため原則ユーザー確認、ただし spec 承認済みのため PR 提示のみで続行可)
+
+- [ ] push、PR 作成、CI green 確認。マージ判断は PR b と合わせて最後にユーザーへ
+
+---
+
+## PR b — editor package(PR a の後、同ブランチ継続 or 分岐)
+
+### Task 4: package 骨格 + DiffModel
+
+**Files:** Create `editor/package.json` / `editor/Editor/PrefabLens.Editor.asmdef` / `editor/Editor/DiffModel.cs` / `editor/Tests/Editor/DiffModelTests.cs`(+ Tests asmdef)
+
+- [ ] package.json: name com.hashiiiii.prefablens、unity 2022.3、dependencies に com.unity.nuget.newtonsoft-json
+- [ ] DiffModel: diff.v2 の C# クラス群 + `DiffModel.Parse(string json)`(JObject 手書きマッピング、kind で NodeDiff 分岐)+ `ApplyAssetDatabaseResolution(Func<string,string> guidToPath)`(unresolvedGuids を完全解決して resolved を上書き)
+- [ ] EditMode テスト: wasm_golden と同じ JSON 文字列 → モデル / 未知 kind・欠損フィールドの耐性 / resolution 上書き
+- [ ] Commit `feat: add editor package skeleton and diff model`
+
+### Task 5: Cli.cs(探索・ダウンロード・実行)
+
+**Files:** Create `editor/Editor/Cli.cs` / Test `editor/Tests/Editor/CliTests.cs`
+
+- [ ] 純関数を分離: `ReleaseAssetName(OSPlatform, Architecture)` → `prefablens-macos-arm64.zip` 等 / `DownloadUrl(version, assetName)` / 引数組み立て `BuildArgs(assetPath)` → `--git HEAD "<path>" --json`
+- [ ] 探索: EditorPrefs `PrefabLens.CliPath` → `Library/PrefabLens/<VER>/prefablens(.exe)` → null
+- [ ] ダウンロード: UnityWebRequest で zip 取得 → ZipFile.ExtractToDirectory → unix chmod +x(Process)
+- [ ] 実行: Process(cwd = プロジェクトルート)、stdout/stderr 捕捉、exit≠0 は stderr を返す
+- [ ] EditMode テスト: 純関数 3 種
+- [ ] Commit `feat: locate download and run the cli`
+
+### Task 6: PrefabLensWindow.cs(UIToolkit)
+
+**Files:** Create `editor/Editor/PrefabLensWindow.cs`
+
+- [ ] `Window/PrefabLens` メニュー + `Assets/PrefabLens: Diff vs HEAD` コンテキスト(.prefab/.unity/.asset で有効)
+- [ ] TreeView: ノード → コンポーネント → フィールド(before → after、status 色分け。Chrome 版レンダラと同配色トーン)
+- [ ] 状態: CLI 不在(Download ボタン)/ 実行中 / stderr エラー / No semantic changes / Refresh ボタン
+- [ ] Commit `feat: add prefab diff editor window`
+
+### Task 7: 仕上げ
+
+- [ ] spec の未決事項欄を確定内容で更新、README 追記は不要(リポジトリ README は未追跡・ユーザー管理)
+- [ ] PR 作成 → CI green → ユーザーに PR a/b のマージと v0.1.0 タグ打ちを確認(タグは PR a マージ後でないと Releases が無く、Editor のダウンロードが 404 になる点を明記)
+
+## Self-Review 済み
+
+- spec の全節をタスクに対応付け(リリース=T2、CLI=T1、package=T4-6、テスト戦略=各タスク内)
+- 型・命名は spec と一致(CliVersion 定数、EditorPrefs キー、アセット名 4 種)

--- a/docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md
+++ b/docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md
@@ -1,0 +1,94 @@
+# PrefabLens Phase 3 設計 — Unity Editor ホスト(ウォーキングスケルトン)
+
+- **日付**: 2026-07-04
+- **ステータス**: ドラフト(ユーザーレビュー待ち)
+- **親仕様**: `2026-06-29-unity-prefab-diff-design.md` §6.3・§7・§8
+- **ユーザー決定(2026-07-04)**: CLI は GitHub Releases から取得(将来 homebrew tap、tap は別リポジトリ案)/ 初回スコープは git HEAD vs 作業ツリー / UIToolkit + Unity 2022.3 LTS+
+
+Editor を離れずに「選択した prefab の未コミット変更」を意味的 diff で確認できる最小の縦切りを作る。CLI をサブプロセスで叩き stdout の JSON(diff.v2)を描画する(親仕様 §6.3 の通り、ネイティブ連携なし)。
+
+## スコープ
+
+### 初回に入れる
+
+1. **リリースパイプライン**(前提インフラ): tag `v*` push で GitHub Actions が zig クロスコンパイル(macos-aarch64 / macos-x86_64 / linux-x86_64 / windows-x86_64)し、`prefablens-<target>.zip` を GitHub Release に添付。zig はクロスコンパイルが素で通るためビルドマトリクス不要(1 ランナーで 4 ターゲット)
+2. **CLI の薄い拡張**: `--git REF PATH`(operand 2 個)= 「REF vs 作業ツリー」。既存の `--git REF REF PATH` はそのまま。git ロジックを CLI に集約し、C# 側での `git show` 再実装を避ける(親仕様 §6.1 の「後続の薄いエイリアス」)
+3. **Unity package**(`/editor`、UPM): prefab を選択 → メニューで diff 表示
+
+### 初回は延期
+
+- homebrew tap(別リポジトリ `homebrew-prefablens` 案。Releases のアセットをそのまま参照できる)
+- 任意 2 ref 比較の UI、シーン内オブジェクトとの対応づけ、P/Invoke 化
+- Unity CI(game-ci)での EditMode テスト自動実行(テスト自体は書く。ローカル実行)
+
+## リリースパイプライン
+
+`.github/workflows/release.yml`(tag `v*` push):
+
+```
+zig build cli -Dtarget=aarch64-macos -Doptimize=ReleaseSafe  → zip → prefablens-macos-arm64.zip
+同様に x86_64-macos / x86_64-linux-gnu / x86_64-windows      → gh release upload
+```
+
+- アセットは **zip 統一**(C# の `System.IO.Compression.ZipFile` が全プラットフォームで扱えるため。tar.gz は Unity 側で展開手段がない)
+- 中身は単一バイナリ `prefablens`(win は `prefablens.exe`)
+- build.zig に `cli` ステップ(install 相当)が無ければ追加する(現状は default install のみ)
+
+## Unity package 構成
+
+```
+/editor
+  package.json                     com.hashiiiii.prefablens(Editor 専用、unity: 2022.3)
+  Editor/
+    PrefabLens.Editor.asmdef       Editor プラットフォームのみ、Newtonsoft 参照
+    PrefabLensWindow.cs            EditorWindow(UIToolkit)
+    Cli.cs                         探索・ダウンロード・実行(サブプロセス)
+    DiffModel.cs                   diff.v2 の C# モデル + Newtonsoft パース
+  Tests/Editor/                    EditMode テスト(パース・URL 選択の純関数)
+```
+
+- JSON は `com.unity.nuget.newtonsoft-json` 依存で読む(kind による NodeDiff の分岐は JObject 経由の手書きマッピング。JsonUtility はユニオン・null を扱えない)
+
+### Cli.cs(探索 → ダウンロード → 実行)
+
+1. **探索**: EditorPrefs `PrefabLens.CliPath`(手動指定、最優先)→ 既定ダウンロード先 `Library/PrefabLens/<VER>/prefablens(.exe)` → 無ければダウンロード提案
+2. **ダウンロード**: 固定バージョン定数 `CliVersion`(package と同時に更新)から
+   `https://github.com/hashiiiii/PrefabLens/releases/download/v<VER>/prefablens-<target>.zip`
+   を取得 → `Library/PrefabLens/<VER>/` に展開 → unix は実行権限付与。ターゲット判定は `RuntimeInformation`(Editor の OS/Arch)
+3. **実行**: プロジェクトルート(`Application.dataPath/..`)を cwd に
+   `prefablens --git HEAD "<assetPath>" --json` → stdout を parse。exit≠0 は stderr をそのまま表示
+4. **guid 解決**: CLI 単体実行では unresolvedGuids が残るため、Editor 側で `AssetDatabase.GUIDToAssetPath()` を使い **完全解決**して `resolved` を上書き(Chrome 版より強い解決が Editor の存在意義)
+
+### PrefabLensWindow.cs
+
+- メニュー: `Window/PrefabLens`、および Project ウィンドウのコンテキスト `Assets/PrefabLens: Diff vs HEAD`(.prefab / .unity / .asset で有効)
+- UIToolkit `TreeView` 1 本: ノード(GameObject / PrefabInstance)→ コンポーネント → フィールド行(label + before → after)。status で色分け(added/removed/modified)、Chrome 版レンダラと同じ配色トーン
+- 状態表示: CLI 未取得(Download ボタン)/ 実行中 / エラー(stderr)/ No semantic changes
+- 選択変更に自動追従はしない(明示的に Refresh ボタン。YAGNI)
+
+## エラーハンドリング
+
+| ケース | 挙動 |
+|---|---|
+| CLI 不在 | ウィンドウ内に Download ボタン + 手動パス設定への導線 |
+| ダウンロード失敗 | エラー表示(URL 付き)。手動配置の案内 |
+| 非 git リポジトリ / ref 不在 | CLI の stderr をそのまま表示(CLI 側のメッセージが一次情報)|
+| JSON パース失敗 | 「CLI バージョン不一致の可能性」+ 生 stdout 先頭を表示 |
+
+## テスト戦略(親仕様 §7)
+
+- **Zig**: `--git REF PATH`(worktree エイリアス)の parseArgs / run テストを既存 CLI テストに追加(CI で実行)
+- **C# EditMode**: DiffModel パース(golden JSON 文字列 → モデル)、release URL/ターゲット選択の純関数、Cli 引数組み立て。ローカルの Unity Test Runner で実行(CI 化は backlog)
+- **手動スモーク**: ユーザーの Unity プロジェクトで prefab を変更 → Diff vs HEAD 表示を確認
+
+## PR 分割
+
+| PR | 内容 | マージ |
+|---|---|---|
+| a | CLI worktree エイリアス + release workflow + 初回タグ手順 | 機能本体、ユーザー確認 |
+| b | editor package(Cli/DiffModel/Window + EditMode テスト) | 機能本体、ユーザー確認 |
+
+## 未決事項(レビューで確認)
+
+- package 名 `com.hashiiiii.prefablens` でよいか
+- 初回リリースタグは `v0.1.0` でよいか(拡張・CLI と同一バージョン系列)

--- a/editor/Editor.meta
+++ b/editor/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e45179a3111c4e66859c683359d2494e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using UnityEditor;
+
+namespace PrefabLens
+{
+    /// prefablens CLI の探索・ダウンロード・実行。git ロジックは全て CLI 側に置く(親仕様 §6.3)。
+    public static class Cli
+    {
+        /// ダウンロードする CLI のバージョン(GitHub Releases のタグ v{Version} と一致させる)。
+        public const string Version = "0.1.0";
+        public const string CliPathPref = "PrefabLens.CliPath";
+
+        // ---- 純関数(EditMode テスト対象) ----
+
+        public static string ReleaseAssetName(bool isWindows, bool isMac, bool isArm64)
+        {
+            if (isWindows) return "prefablens-windows-x64.zip";
+            if (isMac) return isArm64 ? "prefablens-macos-arm64.zip" : "prefablens-macos-x64.zip";
+            return "prefablens-linux-x64.zip";
+        }
+
+        public static string DownloadUrl(string version, string assetName) =>
+            $"https://github.com/hashiiiii/PrefabLens/releases/download/v{version}/{assetName}";
+
+        public static string[] BuildArgs(string assetPath) =>
+            new[] { "--git", "HEAD", assetPath, "--json" };
+
+        /// ProcessStartInfo.Arguments 用の最小クオート(スペース入りアセットパス対策)。
+        public static string QuoteArgs(string[] args)
+        {
+            var quoted = new string[args.Length];
+            for (var i = 0; i < args.Length; i++)
+                quoted[i] = "\"" + args[i].Replace("\"", "\\\"") + "\"";
+            return string.Join(" ", quoted);
+        }
+
+        // ---- Editor 連携 ----
+
+        public static string BinaryName =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "prefablens.exe" : "prefablens";
+
+        /// 既定の配置先。cwd(= Unity プロジェクトルート)相対の Library 配下。
+        public static string DefaultPath => Path.Combine("Library", "PrefabLens", Version, BinaryName);
+
+        /// EditorPrefs の手動指定が最優先。無ければ既定の配置先。どちらも無ければ null。
+        public static string Find()
+        {
+            var manual = EditorPrefs.GetString(CliPathPref, "");
+            if (!string.IsNullOrEmpty(manual) && File.Exists(manual)) return manual;
+            return File.Exists(DefaultPath) ? DefaultPath : null;
+        }
+
+        /// GitHub Releases から取得して Library 配下に展開する。成功時は実行パス、失敗時は throw。
+        public static string Download()
+        {
+            var asset = ReleaseAssetName(
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX),
+                RuntimeInformation.ProcessArchitecture == Architecture.Arm64);
+            var url = DownloadUrl(Version, asset);
+            var dir = Path.GetDirectoryName(DefaultPath);
+            Directory.CreateDirectory(dir);
+
+            try
+            {
+                EditorUtility.DisplayProgressBar("PrefabLens", $"Downloading {asset}…", 0.3f);
+                using (var http = new HttpClient())
+                using (var zip = new ZipArchive(new MemoryStream(http.GetByteArrayAsync(url).Result)))
+                {
+                    foreach (var entry in zip.Entries)
+                    {
+                        // ZipFileExtensions(ExtractToFile)は netstandard で参照できないため手動コピー
+                        var dest = Path.Combine(dir, entry.Name);
+                        using (var src = entry.Open())
+                        using (var dst = File.Create(dest))
+                            src.CopyTo(dst);
+                    }
+                }
+            }
+            finally
+            {
+                EditorUtility.ClearProgressBar();
+            }
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                RunProcess("chmod", "+x \"" + DefaultPath + "\"", ".");
+            return DefaultPath;
+        }
+
+        public struct Result
+        {
+            public int ExitCode;
+            public string Stdout;
+            public string Stderr;
+        }
+
+        /// プロジェクトルートを cwd に CLI を実行する(--git は cwd のリポジトリを見る)。
+        public static Result Run(string cliPath, string assetPath)
+        {
+            return RunProcess(cliPath, QuoteArgs(BuildArgs(assetPath)), Directory.GetCurrentDirectory());
+        }
+
+        static Result RunProcess(string file, string arguments, string workDir)
+        {
+            var psi = new ProcessStartInfo(file, arguments)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                WorkingDirectory = workDir,
+            };
+            using (var p = Process.Start(psi))
+            {
+                // 双方向 ReadToEnd のデッドロックを避ける: 片方は async で読む
+                var stdout = p.StandardOutput.ReadToEndAsync();
+                var stderr = p.StandardError.ReadToEndAsync();
+                p.WaitForExit();
+                return new Result { ExitCode = p.ExitCode, Stdout = stdout.Result, Stderr = stderr.Result };
+            }
+        }
+    }
+}

--- a/editor/Editor/Cli.cs.meta
+++ b/editor/Editor/Cli.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 462072f04c4448a395581c77660bd527
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/DiffModel.cs
+++ b/editor/Editor/DiffModel.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace PrefabLens
+{
+    public enum DiffStatus { Added, Removed, Modified, Unchanged }
+
+    /// diff.v2 のフィールド値: scalar / ref / null の 3 態。
+    public sealed class Value
+    {
+        public string Scalar;      // scalar のときのみ
+        public string RefFileId;   // ref のときのみ
+        public string RefGuid;     // ref かつ外部参照のときのみ
+        public bool IsRef;
+        public bool IsNull;
+
+        public static readonly Value Null = new Value { IsNull = true };
+    }
+
+    public sealed class FieldDiff
+    {
+        public string Path;
+        public DiffStatus Status;
+        public Value Before;
+        public Value After;
+    }
+
+    public sealed class OverrideDiff
+    {
+        public string Group;
+        public string Label;
+        public DiffStatus Status;
+        public Value Before;
+        public Value After;
+    }
+
+    public sealed class ComponentDiff
+    {
+        public string FileId;
+        public int ClassId;
+        public string TypeName;
+        public string ScriptGuid;
+        public string ClassName;
+        public DiffStatus Status;
+        public List<FieldDiff> Fields = new List<FieldDiff>();
+    }
+
+    public abstract class NodeDiff
+    {
+        public string FileId;
+        public string Name;
+        public DiffStatus Status;
+        public List<ComponentDiff> Components = new List<ComponentDiff>();
+        public List<NodeDiff> Children = new List<NodeDiff>();
+    }
+
+    public sealed class GameObjectDiff : NodeDiff { }
+
+    public sealed class PrefabInstanceDiff : NodeDiff
+    {
+        public string SourceGuid;
+        public List<OverrideDiff> Overrides = new List<OverrideDiff>();
+    }
+
+    /// prefablens.diff.v2(core/src/json.zig の出力)の読み取り側モデル。
+    /// 未知の kind やフィールド欠損は落とさず読み飛ばす(CLI が新しい場合に Editor 側が壊れない)。
+    public sealed class DiffModel
+    {
+        public List<string> UnresolvedGuids = new List<string>();
+        public Dictionary<string, string> Resolved = new Dictionary<string, string>();
+        public List<NodeDiff> Roots = new List<NodeDiff>();
+        public List<ComponentDiff> Loose = new List<ComponentDiff>();
+
+        public bool IsEmpty => Roots.Count == 0 && Loose.Count == 0;
+
+        public static DiffModel Parse(string json)
+        {
+            var o = JObject.Parse(json);
+            var m = new DiffModel();
+            foreach (var g in o["unresolvedGuids"] as JArray ?? new JArray())
+                m.UnresolvedGuids.Add((string)g);
+            if (o["resolved"] is JObject resolved)
+                foreach (var p in resolved.Properties())
+                    m.Resolved[p.Name] = (string)p.Value;
+            foreach (var r in o["roots"] as JArray ?? new JArray())
+                if (ParseNode(r as JObject) is NodeDiff n)
+                    m.Roots.Add(n);
+            foreach (var c in o["loose"] as JArray ?? new JArray())
+                if (c is JObject co)
+                    m.Loose.Add(ParseComponent(co));
+            return m;
+        }
+
+        /// Editor 内では AssetDatabase で guid を完全解決できる(Chrome 版より強い)。
+        public void ResolveWith(Func<string, string> guidToPath)
+        {
+            foreach (var g in UnresolvedGuids)
+            {
+                if (Resolved.ContainsKey(g)) continue;
+                var path = guidToPath(g);
+                if (!string.IsNullOrEmpty(path)) Resolved[g] = path;
+            }
+        }
+
+        static NodeDiff ParseNode(JObject o)
+        {
+            if (o == null) return null;
+            NodeDiff n;
+            switch ((string)o["kind"])
+            {
+                case "gameObject":
+                    n = new GameObjectDiff();
+                    break;
+                case "prefabInstance":
+                    var pi = new PrefabInstanceDiff { SourceGuid = (string)o["sourceGuid"] };
+                    foreach (var ov in o["overrides"] as JArray ?? new JArray())
+                        if (ov is JObject ovo)
+                            pi.Overrides.Add(new OverrideDiff
+                            {
+                                Group = (string)ovo["group"] ?? "",
+                                Label = (string)ovo["label"] ?? "",
+                                Status = ParseStatus((string)ovo["status"]),
+                                Before = ParseValue(ovo["before"]),
+                                After = ParseValue(ovo["after"]),
+                            });
+                    n = pi;
+                    break;
+                default:
+                    return null; // 未知の kind は読み飛ばす
+            }
+            n.FileId = (string)o["fileId"] ?? "";
+            n.Name = (string)o["name"] ?? "";
+            n.Status = ParseStatus((string)o["status"]);
+            foreach (var c in o["components"] as JArray ?? new JArray())
+                if (c is JObject co)
+                    n.Components.Add(ParseComponent(co));
+            foreach (var ch in o["children"] as JArray ?? new JArray())
+                if (ParseNode(ch as JObject) is NodeDiff child)
+                    n.Children.Add(child);
+            return n;
+        }
+
+        static ComponentDiff ParseComponent(JObject o)
+        {
+            var c = new ComponentDiff
+            {
+                FileId = (string)o["fileId"] ?? "",
+                ClassId = (int?)o["classId"] ?? 0,
+                TypeName = (string)o["typeName"] ?? "",
+                ScriptGuid = (string)o["scriptGuid"],
+                ClassName = (string)o["className"],
+                Status = ParseStatus((string)o["status"]),
+            };
+            foreach (var f in o["fields"] as JArray ?? new JArray())
+                if (f is JObject fo)
+                    c.Fields.Add(new FieldDiff
+                    {
+                        Path = (string)fo["path"] ?? "",
+                        Status = ParseStatus((string)fo["status"]),
+                        Before = ParseValue(fo["before"]),
+                        After = ParseValue(fo["after"]),
+                    });
+            return c;
+        }
+
+        static Value ParseValue(JToken t)
+        {
+            if (t == null || t.Type == JTokenType.Null) return Value.Null;
+            if (t is JObject o && o["ref"] is JObject r)
+                return new Value { IsRef = true, RefFileId = (string)r["fileId"] ?? "0", RefGuid = (string)r["guid"] };
+            return new Value { Scalar = (string)t };
+        }
+
+        static DiffStatus ParseStatus(string s)
+        {
+            switch (s)
+            {
+                case "added": return DiffStatus.Added;
+                case "removed": return DiffStatus.Removed;
+                case "modified": return DiffStatus.Modified;
+                default: return DiffStatus.Unchanged;
+            }
+        }
+    }
+}

--- a/editor/Editor/DiffModel.cs.meta
+++ b/editor/Editor/DiffModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7f401ccf6884adaaf08f3e762a4c64f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/PrefabLens.Editor.asmdef
+++ b/editor/Editor/PrefabLens.Editor.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "PrefabLens.Editor",
+    "rootNamespace": "PrefabLens",
+    "references": [],
+    "includePlatforms": ["Editor"],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": ["Newtonsoft.Json.dll"],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/editor/Editor/PrefabLens.Editor.asmdef.meta
+++ b/editor/Editor/PrefabLens.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 023a7750752d43ac8237e9617b9543e6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace PrefabLens
+{
+    /// 選択アセットの「HEAD vs 作業ツリー」意味的 diff を表示する(Phase 3 ウォーキングスケルトン)。
+    public sealed class PrefabLensWindow : EditorWindow
+    {
+        [SerializeField] string assetPath = "";
+
+        Label status;
+        VisualElement content;
+
+        [MenuItem("Window/PrefabLens")]
+        public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
+
+        [MenuItem("Assets/PrefabLens: Diff vs HEAD")]
+        static void DiffSelected()
+        {
+            var w = GetWindow<PrefabLensWindow>("PrefabLens");
+            w.assetPath = AssetDatabase.GetAssetPath(Selection.activeObject);
+            w.Refresh();
+        }
+
+        [MenuItem("Assets/PrefabLens: Diff vs HEAD", true)]
+        static bool ValidateDiffSelected()
+        {
+            var p = Selection.activeObject == null ? "" : AssetDatabase.GetAssetPath(Selection.activeObject);
+            return p.EndsWith(".prefab") || p.EndsWith(".unity") || p.EndsWith(".asset");
+        }
+
+        public void CreateGUI()
+        {
+            var toolbar = new VisualElement { style = { flexDirection = FlexDirection.Row, marginTop = 4, marginBottom = 4 } };
+            status = new Label { style = { flexGrow = 1, unityTextAlign = TextAnchor.MiddleLeft, marginLeft = 6 } };
+            toolbar.Add(status);
+            toolbar.Add(new Button(Refresh) { text = "Refresh" });
+            rootVisualElement.Add(toolbar);
+
+            content = new VisualElement { style = { flexGrow = 1 } };
+            rootVisualElement.Add(content);
+            Refresh();
+        }
+
+        void Refresh()
+        {
+            content.Clear();
+            if (string.IsNullOrEmpty(assetPath))
+            {
+                status.text = "Select a .prefab / .unity / .asset and run Assets → PrefabLens: Diff vs HEAD";
+                return;
+            }
+            status.text = assetPath;
+
+            var cli = Cli.Find();
+            if (cli == null)
+            {
+                Note($"prefablens CLI not found (v{Cli.Version}).");
+                content.Add(new Button(DownloadThenRefresh) { text = "Download from GitHub Releases", style = { alignSelf = Align.FlexStart, marginLeft = 6 } });
+                Note($"Or set a manual path via EditorPrefs key '{Cli.CliPathPref}'.");
+                return;
+            }
+
+            var res = Cli.Run(cli, assetPath);
+            if (res.ExitCode != 0)
+            {
+                // CLI の stderr が一次情報(非 git リポジトリ・不正 ref 等)
+                Note(string.IsNullOrEmpty(res.Stderr) ? $"prefablens exited with {res.ExitCode}" : res.Stderr.Trim());
+                return;
+            }
+
+            DiffModel model;
+            try
+            {
+                model = DiffModel.Parse(res.Stdout);
+            }
+            catch (Exception)
+            {
+                Note("Could not parse CLI output (CLI version mismatch?):");
+                Note(res.Stdout.Length > 200 ? res.Stdout.Substring(0, 200) + "…" : res.Stdout);
+                return;
+            }
+
+            model.ResolveWith(g => AssetDatabase.GUIDToAssetPath(g));
+            if (model.IsEmpty)
+            {
+                Note("No semantic changes");
+                return;
+            }
+            content.Add(BuildTree(model));
+        }
+
+        void DownloadThenRefresh()
+        {
+            try
+            {
+                Cli.Download();
+            }
+            catch (Exception e)
+            {
+                content.Clear();
+                Note($"Download failed: {e.Message}");
+                Note($"You can place the binary manually and set EditorPrefs '{Cli.CliPathPref}'.");
+                return;
+            }
+            Refresh();
+        }
+
+        void Note(string text)
+        {
+            content.Add(new Label(text) { style = { marginLeft = 6, marginTop = 2, whiteSpace = WhiteSpace.Normal } });
+        }
+
+        // ---- ツリー描画(Chrome 版レンダラと同じ配色トーン・記法) ----
+        // rich text は使わない: リポジトリ由来文字列をマークアップ解釈させない(Chrome 版の XSS テストと同じ思想)。
+
+        static class Palette
+        {
+            public static Color Added => Hex(EditorGUIUtility.isProSkin ? 0x3fb950 : 0x1a7f37);
+            public static Color Removed => Hex(EditorGUIUtility.isProSkin ? 0xf85149 : 0xcf222e);
+            public static Color Modified => Hex(EditorGUIUtility.isProSkin ? 0xd29922 : 0x9a6700);
+            public static Color Muted => Hex(EditorGUIUtility.isProSkin ? 0x9198a1 : 0x59636e);
+
+            static Color Hex(int rgb) => new Color(((rgb >> 16) & 0xff) / 255f, ((rgb >> 8) & 0xff) / 255f, (rgb & 0xff) / 255f);
+        }
+
+        readonly struct Span
+        {
+            public readonly string Text;
+            public readonly Color? Tint;
+
+            public Span(string text, Color? tint = null)
+            {
+                Text = text;
+                Tint = tint;
+            }
+        }
+
+        sealed class Row
+        {
+            public readonly List<Span> Spans = new List<Span>();
+
+            public Row Add(string text, Color? tint = null)
+            {
+                if (!string.IsNullOrEmpty(text)) Spans.Add(new Span(text, tint));
+                return this;
+            }
+        }
+
+        static TreeView BuildTree(DiffModel model)
+        {
+            var id = 0;
+            var items = new List<TreeViewItemData<Row>>();
+            foreach (var n in model.Roots) items.Add(NodeItem(n, model, ref id));
+            foreach (var c in model.Loose) items.Add(ComponentItem(c, model, ref id));
+
+            var tree = new TreeView { fixedItemHeight = 18, style = { flexGrow = 1 } };
+            tree.SetRootItems(items);
+            tree.makeItem = () => new VisualElement { style = { flexDirection = FlexDirection.Row, alignItems = Align.Center } };
+            tree.bindItem = (e, i) =>
+            {
+                e.Clear();
+                foreach (var span in tree.GetItemDataForIndex<Row>(i).Spans)
+                {
+                    var l = new Label(span.Text) { style = { marginLeft = 0, marginRight = 0, paddingLeft = 0, paddingRight = 0 } };
+                    if (span.Tint is Color tint) l.style.color = tint;
+                    e.Add(l);
+                }
+            };
+            tree.ExpandAll();
+            return tree;
+        }
+
+        static TreeViewItemData<Row> NodeItem(NodeDiff n, DiffModel m, ref int id)
+        {
+            var children = new List<TreeViewItemData<Row>>();
+            if (n is PrefabInstanceDiff pi)
+                foreach (var ov in pi.Overrides)
+                    children.Add(new TreeViewItemData<Row>(id++, OverrideRow(ov, m)));
+            foreach (var c in n.Components) children.Add(ComponentItem(c, m, ref id));
+            foreach (var ch in n.Children) children.Add(NodeItem(ch, m, ref id));
+
+            var row = Badge(n.Status).Add(n.Name);
+            if (n is PrefabInstanceDiff p && p.SourceGuid != null)
+                row.Add(" ‹Prefab: " + (m.Resolved.TryGetValue(p.SourceGuid, out var src) ? src : p.SourceGuid) + "›", Palette.Muted);
+            return new TreeViewItemData<Row>(id++, row, children);
+        }
+
+        static TreeViewItemData<Row> ComponentItem(ComponentDiff c, DiffModel m, ref int id)
+        {
+            var children = new List<TreeViewItemData<Row>>();
+            foreach (var f in c.Fields)
+                children.Add(new TreeViewItemData<Row>(id++, FieldRow(f.Path, f.Status, f.Before, f.After, m)));
+
+            var row = Badge(c.Status);
+            if (!string.IsNullOrEmpty(c.ClassName))
+                row.Add(c.ClassName).Add(" ‹Script›", Palette.Muted);
+            else if (c.ScriptGuid != null && m.Resolved.TryGetValue(c.ScriptGuid, out var p))
+                row.Add(Stem(p)).Add(" ‹Script›", Palette.Muted);
+            else
+                row.Add(c.TypeName);
+            return new TreeViewItemData<Row>(id++, row, children);
+        }
+
+        static Row OverrideRow(OverrideDiff ov, DiffModel m)
+        {
+            var label = ov.Group.Length > 0 && ov.Group != "Overrides" ? ov.Group + " / " + ov.Label : ov.Label;
+            return FieldRow(label, ov.Status, ov.Before, ov.After, m);
+        }
+
+        static Row FieldRow(string label, DiffStatus status, Value before, Value after, DiffModel m)
+        {
+            var row = Badge(status).Add(label + " ", Palette.Muted);
+            var b = Format(before, m);
+            var a = Format(after, m);
+            if (status == DiffStatus.Modified)
+                row.Add(b, Palette.Removed).Add(" → ", Palette.Muted).Add(a, Palette.Added);
+            else if (status == DiffStatus.Removed)
+                row.Add(b, Palette.Removed);
+            else
+                row.Add(a, status == DiffStatus.Added ? Palette.Added : (Color?)null);
+            return row;
+        }
+
+        static string Format(Value v, DiffModel m)
+        {
+            if (v == null || v.IsNull) return "";
+            if (!v.IsRef) return v.Scalar ?? "";
+            if (v.RefGuid != null)
+                return m.Resolved.TryGetValue(v.RefGuid, out var p) ? Stem(p) : v.RefGuid;
+            return v.RefFileId == "0" ? "None" : "#" + v.RefFileId;
+        }
+
+        static Row Badge(DiffStatus s)
+        {
+            switch (s)
+            {
+                case DiffStatus.Added: return new Row().Add("+ ", Palette.Added);
+                case DiffStatus.Removed: return new Row().Add("− ", Palette.Removed);
+                case DiffStatus.Modified: return new Row().Add("~ ", Palette.Modified);
+                default: return new Row().Add("  ");
+            }
+        }
+
+        static string Stem(string path)
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            return string.IsNullOrEmpty(name) ? path : name;
+        }
+    }
+}

--- a/editor/Editor/PrefabLensWindow.cs.meta
+++ b/editor/Editor/PrefabLensWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fe235a408b849f1a5d882c7d828b2a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests.meta
+++ b/editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbfe9622e83b4f63b61eda131f6f6db8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests/Editor.meta
+++ b/editor/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d63ffbb48863492aaff5bca5bb7715de
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+
+namespace PrefabLens.Tests
+{
+    public class CliTests
+    {
+        [Test]
+        public void ReleaseAssetNameCoversAllTargets()
+        {
+            Assert.AreEqual("prefablens-windows-x64.zip", Cli.ReleaseAssetName(isWindows: true, isMac: false, isArm64: false));
+            Assert.AreEqual("prefablens-macos-arm64.zip", Cli.ReleaseAssetName(isWindows: false, isMac: true, isArm64: true));
+            Assert.AreEqual("prefablens-macos-x64.zip", Cli.ReleaseAssetName(isWindows: false, isMac: true, isArm64: false));
+            Assert.AreEqual("prefablens-linux-x64.zip", Cli.ReleaseAssetName(isWindows: false, isMac: false, isArm64: false));
+        }
+
+        [Test]
+        public void DownloadUrlPointsAtTheVersionedRelease()
+        {
+            Assert.AreEqual(
+                "https://github.com/hashiiiii/PrefabLens/releases/download/v0.1.0/prefablens-macos-arm64.zip",
+                Cli.DownloadUrl("0.1.0", "prefablens-macos-arm64.zip"));
+        }
+
+        [Test]
+        public void BuildArgsDiffsHeadAgainstTheWorktreeAsJson()
+        {
+            Assert.AreEqual(new[] { "--git", "HEAD", "Assets/Foo.prefab", "--json" }, Cli.BuildArgs("Assets/Foo.prefab"));
+        }
+
+        [Test]
+        public void QuoteArgsSurvivesSpacesAndQuotes()
+        {
+            Assert.AreEqual("\"--git\" \"HEAD\" \"Assets/My Prefab.prefab\" \"--json\"", Cli.QuoteArgs(Cli.BuildArgs("Assets/My Prefab.prefab")));
+            Assert.AreEqual("\"a\\\"b\"", Cli.QuoteArgs(new[] { "a\"b" }));
+        }
+    }
+}

--- a/editor/Tests/Editor/CliTests.cs.meta
+++ b/editor/Tests/Editor/CliTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0d284def005e4ed799d4dce56f62c638
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -1,0 +1,97 @@
+using NUnit.Framework;
+
+namespace PrefabLens.Tests
+{
+    public class DiffModelTests
+    {
+        // core/tests/wasm_golden.test.mjs の GOLDEN と同一(スキーマ互換の回帰点)
+        const string Golden =
+            "{\"schema\":\"prefablens.diff.v2\",\"unresolvedGuids\":[\"def\"],\"roots\":[],\"loose\":[{\"kind\":\"component\",\"fileId\":\"11400000\",\"classId\":114,\"typeName\":\"MonoBehaviour\",\"scriptGuid\":\"def\",\"className\":null,\"status\":\"modified\",\"fields\":[{\"path\":\"Volume\",\"status\":\"modified\",\"before\":\"0.5\",\"after\":\"0.8\"}]}]}";
+
+        [Test]
+        public void ParsesTheWasmGolden()
+        {
+            var m = DiffModel.Parse(Golden);
+            Assert.AreEqual(new[] { "def" }, m.UnresolvedGuids);
+            Assert.AreEqual(0, m.Roots.Count);
+            Assert.AreEqual(1, m.Loose.Count);
+            var c = m.Loose[0];
+            Assert.AreEqual("MonoBehaviour", c.TypeName);
+            Assert.AreEqual("def", c.ScriptGuid);
+            Assert.IsNull(c.ClassName);
+            Assert.AreEqual(DiffStatus.Modified, c.Status);
+            Assert.AreEqual(1, c.Fields.Count);
+            Assert.AreEqual("Volume", c.Fields[0].Path);
+            Assert.AreEqual("0.5", c.Fields[0].Before.Scalar);
+            Assert.AreEqual("0.8", c.Fields[0].After.Scalar);
+            Assert.IsFalse(m.IsEmpty);
+        }
+
+        [Test]
+        public void ParsesNodesInstancesAndRefValues()
+        {
+            const string json = @"{
+                ""schema"":""prefablens.diff.v2"",""unresolvedGuids"":[""aaa""],""resolved"":{},
+                ""roots"":[{
+                    ""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""unchanged"",""components"":[],
+                    ""children"":[{
+                        ""kind"":""prefabInstance"",""fileId"":""1001"",""name"":""Cylinder"",""status"":""added"",""sourceGuid"":""aaa"",
+                        ""overrides"":[{""group"":""Transform"",""label"":""Position"",""status"":""added"",""before"":null,""after"":""(1, 2, 3)""}],
+                        ""components"":[],
+                        ""children"":[]
+                    }]
+                }],
+                ""loose"":[{""kind"":""component"",""fileId"":""2"",""classId"":114,""typeName"":""MonoBehaviour"",""scriptGuid"":null,""className"":null,""status"":""modified"",
+                    ""fields"":[{""path"":""Target"",""status"":""modified"",""before"":{""ref"":{""fileId"":""100"",""guid"":null,""type"":null}},""after"":{""ref"":{""fileId"":""0"",""guid"":""bbb"",""type"":2}}}]}]
+            }";
+            var m = DiffModel.Parse(json);
+            var root = (GameObjectDiff)m.Roots[0];
+            var inst = (PrefabInstanceDiff)root.Children[0];
+            Assert.AreEqual("aaa", inst.SourceGuid);
+            Assert.AreEqual(DiffStatus.Added, inst.Status);
+            Assert.AreEqual("Transform", inst.Overrides[0].Group);
+            Assert.IsTrue(inst.Overrides[0].Before.IsNull);
+            Assert.AreEqual("(1, 2, 3)", inst.Overrides[0].After.Scalar);
+
+            var field = m.Loose[0].Fields[0];
+            Assert.IsTrue(field.Before.IsRef);
+            Assert.AreEqual("100", field.Before.RefFileId);
+            Assert.IsNull(field.Before.RefGuid);
+            Assert.AreEqual("bbb", field.After.RefGuid);
+        }
+
+        [Test]
+        public void SkipsUnknownNodeKindsAndToleratesMissingFields()
+        {
+            const string json = @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[
+                    {""kind"":""hologram"",""fileId"":""9"",""name"":""Future"",""status"":""added""},
+                    {""kind"":""gameObject""}
+                ],
+                ""loose"":[]
+            }";
+            var m = DiffModel.Parse(json);
+            Assert.AreEqual(1, m.Roots.Count); // 未知 kind は読み飛ばし、欠損フィールドは既定値
+            Assert.AreEqual("", m.Roots[0].Name);
+            Assert.AreEqual(DiffStatus.Unchanged, m.Roots[0].Status);
+        }
+
+        [Test]
+        public void ResolveWithFillsOnlyUnresolvedGuids()
+        {
+            var m = DiffModel.Parse(Golden);
+            m.Resolved["def"] = "Assets/Preexisting.cs";
+            m.ResolveWith(_ => "Assets/FromAssetDatabase.cs");
+            Assert.AreEqual("Assets/Preexisting.cs", m.Resolved["def"]); // 既存の解決が先勝ち
+
+            var fresh = DiffModel.Parse(Golden);
+            fresh.ResolveWith(g => g == "def" ? "Assets/Scripts/Sound.cs" : "");
+            Assert.AreEqual("Assets/Scripts/Sound.cs", fresh.Resolved["def"]);
+
+            var none = DiffModel.Parse(Golden);
+            none.ResolveWith(_ => ""); // AssetDatabase が空を返したら未解決のまま
+            Assert.IsFalse(none.Resolved.ContainsKey("def"));
+        }
+    }
+}

--- a/editor/Tests/Editor/DiffModelTests.cs.meta
+++ b/editor/Tests/Editor/DiffModelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bcc49b6caa0f409aabf8e08f4d1a315a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests/Editor/PrefabLens.Editor.Tests.asmdef
+++ b/editor/Tests/Editor/PrefabLens.Editor.Tests.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "PrefabLens.Editor.Tests",
+    "rootNamespace": "PrefabLens.Tests",
+    "references": [
+        "PrefabLens.Editor",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": ["Editor"],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": ["nunit.framework.dll", "Newtonsoft.Json.dll"],
+    "autoReferenced": false,
+    "defineConstraints": ["UNITY_INCLUDE_TESTS"],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/editor/Tests/Editor/PrefabLens.Editor.Tests.asmdef.meta
+++ b/editor/Tests/Editor/PrefabLens.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2a29a5d92cc4434c86fb13a668dd1c8e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "com.hashiiiii.prefablens",
+  "version": "0.1.0",
+  "displayName": "PrefabLens",
+  "description": "Semantic diffs for Unity YAML assets (prefab / scene / asset) against git, rendered inside the Editor.",
+  "unity": "2022.3",
+  "dependencies": {
+    "com.unity.nuget.newtonsoft-json": "3.2.1"
+  }
+}

--- a/editor/package.json.meta
+++ b/editor/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c0b61ad6436542cc91536eeeb3f7e1d0
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Phase 3 本体(spec: `docs/superpowers/specs/2026-07-04-phase3-editor-host-design.md` 承認済み)。**#10 の上に積んだスタック PR**(base: `feat/editor-host`)。

- **UPM package `com.hashiiiii.prefablens`**(`/editor`、Editor 専用、Unity 2022.3+、Newtonsoft 依存、.meta 同梱で git URL 配布可能: `?path=/editor`)
- **DiffModel**: diff.v2 の読み取りモデル。未知 kind・欠損フィールドは読み飛ばし(新しい CLI で壊れない)。`ResolveWith(AssetDatabase.GUIDToAssetPath)` で guid を完全解決(Chrome 版より強い解決が Editor の存在意義)
- **Cli**: EditorPrefs 手動パス → `Library/PrefabLens/<VER>/` → GitHub Releases から zip 自動取得(#10 の release pipeline が前提)。実行は project root を cwd に `prefablens --git HEAD <path> --json`
- **PrefabLensWindow**: UIToolkit TreeView。`Window/PrefabLens` + `Assets/PrefabLens: Diff vs HEAD` コンテキストメニュー。**rich text 不使用**(リポジトリ由来文字列を Span+Label で描画、Chrome 版の XSS テストと同じ思想)。配色は Chrome レンダラと同トーン(light/dark 追従)
- EditMode テスト: DiffModel パース(WASM golden と同一 JSON を回帰点に)/ release asset 選択・URL・引数組み立ての純関数

## Test plan

- [x] CLI worktree エイリアスの実機スモーク(このリポジトリの fixture を一時変更 → `~ Position.y: 0.5 -> 9.9` を確認)
- [x] `zig build test` green(CI)
- [ ] EditMode テストと Window の実機確認はユーザーの Unity プロジェクトで(CI 化は backlog)
- [ ] マージ順: #10 → 本 PR → `v0.1.0` タグ(タグが先にないと Editor のダウンロードが 404)