### PR TITLE
chore: add cut-release skill for both agents

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: cut-release
+description: Use when cutting a new PrefabLens release, publishing a version, or pushing a vX.Y.Z tag. Bumps the four version sources in lockstep, tags main to trigger the release workflow, and verifies the GitHub Release with its four CLI zips. PrefabLens repo only. Explicit invocation only — pushes tags and publishes a public release.
+disable-model-invocation: true
+license: Proprietary
+metadata:
+  project: PrefabLens
+---
+
+# Cut a PrefabLens release
+
+## Overview
+
+PrefabLens ships three components on one version line: the Zig CLI, the Chrome extension, and the Unity Editor package. A release is triggered by **pushing a `vX.Y.Z` git tag** — `.github/workflows/release.yml` then cross-compiles the CLI for four targets, zips them, and runs `gh release create` automatically.
+
+**Core principle: the human pushes exactly one thing — the tag. Everything downstream is automated. Never create the release by hand.**
+
+The Editor package downloads the CLI from `releases/download/v<Cli.Version>/prefablens-<target>.zip`, so the tag, `Cli.Version`, and the package versions must be the *same* string, and the tag must point at a commit that already carries that version.
+
+## When to use
+
+- Publishing a new version (feature/bugfix already merged to `main`)
+- Re-cutting after a failed release workflow
+
+Do **not** use to: re-point an existing tag, or hotfix a shipped binary in place (bump a new patch instead).
+
+## Steps
+
+Run from a clean `main` that is up to date (`git switch main && git pull`).
+
+1. **Pick the version** `X.Y.Z` (semver; bump patch for fixes, minor for features).
+
+2. **Bump all four sources to `X.Y.Z`** on a branch:
+   - `editor/Editor/Cli.cs` → `public const string Version = "X.Y.Z";`
+   - `editor/package.json` → `"version": "X.Y.Z"`
+   - `extension/package.json` → `"version": "X.Y.Z"`
+   - `extension/manifest.json` → `"version": "X.Y.Z"`
+
+3. **Verify they agree** (this is the #1 failure mode):
+
+   ```
+   .claude/skills/cut-release/scripts/check-versions.sh X.Y.Z
+   ```
+
+   Fix any `DIFF` line before continuing.
+
+4. **Land the bump on main first.** Branch `chore/release-vX.Y.Z`, commit `chore: bump version to X.Y.Z`, open a PR, wait for CI green, squash-merge. Then `git switch main && git pull`.
+
+5. **Tag the merged commit and push** (the push is the trigger):
+
+   ```
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+6. **Verify the release** — the workflow takes a few minutes:
+
+   ```
+   gh run watch $(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')
+   gh release view vX.Y.Z --json tagName,assets -q '.tagName + ": " + ([.assets[].name] | join(", "))'
+   ```
+
+   Expect four assets: `prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip`.
+
+## Red flags — stop and reconsider
+
+| Situation | Why it breaks | Do instead |
+|---|---|---|
+| Running `gh release create` yourself | The workflow's own `gh release create` then fails with "already exists" | Only push the tag; let the workflow publish |
+| Tagging before the version bump is on `main` | The released binary and package versions disagree; Editor downloads a version with no matching package | Merge the bump to `main`, then tag that commit |
+| `Cli.Version` ≠ the tag version | Editor requests `releases/download/v<Cli.Version>/…` → 404 | Keep all four sources and the tag identical (step 3 enforces this) |
+| Re-pushing / moving an existing tag to "redo" a release | Consumers cache the old asset; history becomes ambiguous | Delete the release **and** tag, or bump to the next patch and tag that |
+
+## Verify the outcome, not the intent
+
+A release is done only when `gh release view vX.Y.Z` lists all four zips. If the workflow failed, read `gh run view --log-failed`, fix on `main`, delete the partial tag/release, and re-tag — do not assume a pushed tag means a published release.

--- a/.claude/skills/cut-release/scripts/check-versions.sh
+++ b/.claude/skills/cut-release/scripts/check-versions.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# PrefabLens: verify the four release version strings agree before tagging.
+# The Editor package downloads prefablens CLI from the release tagged v<Cli.Version>,
+# so a drift between these files silently ships a 404 or a version-mismatched binary.
+#
+# Usage (from repo root): .claude/skills/cut-release/scripts/check-versions.sh <X.Y.Z>
+set -euo pipefail
+
+want="${1:-}"
+if [[ -z "$want" ]]; then
+  echo "usage: $0 <version>   e.g. $0 0.2.0" >&2
+  exit 2
+fi
+
+# Each source's current version, extracted by its own surrounding syntax.
+cli=$(sed -n 's/.*public const string Version = "\([^"]*\)".*/\1/p' editor/Editor/Cli.cs | head -1)
+epkg=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' editor/package.json | head -1)
+xpkg=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' extension/package.json | head -1)
+xman=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' extension/manifest.json | head -1)
+
+fail=0
+check() {
+  local label="$1" got="$2"
+  if [[ "$got" == "$want" ]]; then
+    printf '  ok    %-26s %s\n' "$label" "$got"
+  else
+    printf '  DIFF  %-26s %s (want %s)\n' "$label" "${got:-<none>}" "$want"
+    fail=1
+  fi
+}
+
+check "editor/Editor/Cli.cs"      "$cli"
+check "editor/package.json"       "$epkg"
+check "extension/package.json"    "$xpkg"
+check "extension/manifest.json"   "$xman"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "version mismatch: bump every source to $want before tagging v$want" >&2
+  exit 1
+fi
+echo "all four version sources at $want"


### PR DESCRIPTION
## Summary

タグ打ち(リリース)の定型作業を **Claude Code / Cursor 両対応の Agent Skill** として追加。

調査で確定した事実: Agent Skills(SKILL.md)は 2025-12 にオープン標準化済みで、**Cursor は互換性のため `.claude/skills/` も走査する**(公式 doc)。よって `.claude/skills/cut-release/` の 1 実体を両ツールが `/cut-release` で呼べる。二重管理不要。

- `SKILL.md`: 前提 → 4 バージョン源の同期 → `main` にマージ後にタグ push → Release 検証、の手順。非自明な落とし穴(手動 `gh release create` 禁止 / bump 前タグ禁止 / `Cli.Version`≠タグで Editor 404 / タグ再 push 禁止)を赤旗表で明示
- `scripts/check-versions.sh`: `Cli.Version` / editor・extension の `package.json` / `manifest.json` の 4 つが一致するか検査(ドリフトが最大の事故要因なので機械化)
- `disable-model-invocation: true`: 副作用(タグ push → 実 Release 発行)があるため明示呼び出し専用。両ツール対応フィールド

## Test plan

- [x] `check-versions.sh` を実リポジトリで検証(0.1.0=全 ok/exit0、0.2.0=全 DIFF/exit1、引数なし=usage/exit2)
- [x] SKILL.md 手順が実 `release.yml` の挙動と一致することを確認