### PR TITLE
feat: MCP host exposing prefab_diff tool

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -30,7 +30,7 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
 
 1. **Pick the version** `X.Y.Z` (semver; bump patch for fixes, minor for features).
 
-2. **Bump all four sources to `X.Y.Z`** on a branch:
+2. **Bump all five sources to `X.Y.Z`** on a branch:
    - `editor/Editor/Cli.cs` → `public const string Version = "X.Y.Z";`
    - `editor/package.json` → `"version": "X.Y.Z"`
    - `extension/package.json` → `"version": "X.Y.Z"`
@@ -71,7 +71,7 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
 |---|---|---|
 | Running `gh release create` yourself | The workflow's own `gh release create` then fails with "already exists" | Only push the tag; let the workflow publish |
 | Tagging before the version bump is on `main` | The released binary and package versions disagree; Editor downloads a version with no matching package | Merge the bump to `main`, then tag that commit |
-| `Cli.Version` ≠ the tag version | Editor requests `releases/download/v<Cli.Version>/…` → 404 | Keep all four sources and the tag identical (step 3 enforces this) |
+| `Cli.Version` ≠ the tag version | Editor requests `releases/download/v<Cli.Version>/…` → 404 | Keep all five sources and the tag identical (step 3 enforces this) |
 | Re-pushing / moving an existing tag to "redo" a release | Consumers cache the old asset; history becomes ambiguous | Delete the release **and** tag, or bump to the next patch and tag that |
 
 ## Verify the outcome, not the intent

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cut-release
-description: Use when cutting a new PrefabLens release, publishing a version, or pushing a vX.Y.Z tag. Bumps the four version sources in lockstep, tags main to trigger the release workflow, and verifies the GitHub Release with its four CLI zips. PrefabLens repo only. Explicit invocation only — pushes tags and publishes a public release.
+description: Use when cutting a new PrefabLens release, publishing a version, or pushing a vX.Y.Z tag. Bumps the five version sources in lockstep, tags main to trigger the release workflow, and verifies the GitHub Release with its four CLI zips. PrefabLens repo only. Explicit invocation only — pushes tags and publishes a public release.
 disable-model-invocation: true
 license: Proprietary
 metadata:
@@ -11,7 +11,7 @@ metadata:
 
 ## Overview
 
-PrefabLens ships three components on one version line: the Zig CLI, the Chrome extension, and the Unity Editor package. A release is triggered by **pushing a `vX.Y.Z` git tag** — `.github/workflows/release.yml` then cross-compiles the CLI for four targets, zips them, and runs `gh release create` automatically.
+PrefabLens ships four components on one version line: the Zig CLI, the Chrome extension, the Unity Editor package, and the MCP server (npm). A release is triggered by **pushing a `vX.Y.Z` git tag** — `.github/workflows/release.yml` then cross-compiles the CLI for four targets, zips them, and runs `gh release create` automatically. The release workflow then publishes `@hashiiiii/prefablens-mcp` to npm after the zip assets go live (Trusted Publishing — the npmjs.com side needs to be configured before the first publish).
 
 **Core principle: the human pushes exactly one thing — the tag. Everything downstream is automated. Never create the release by hand.**
 
@@ -35,6 +35,7 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
    - `editor/package.json` → `"version": "X.Y.Z"`
    - `extension/package.json` → `"version": "X.Y.Z"`
    - `extension/manifest.json` → `"version": "X.Y.Z"`
+   - `mcp/package.json` → `"version": "X.Y.Z"`
 
 3. **Verify they agree** (this is the #1 failure mode):
 
@@ -61,6 +62,8 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
    ```
 
    Expect four assets: `prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip`.
+
+   Also verify `npm view @hashiiiii/prefablens-mcp version` matches the tag.
 
 ## Red flags — stop and reconsider
 

--- a/.claude/skills/cut-release/scripts/check-versions.sh
+++ b/.claude/skills/cut-release/scripts/check-versions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PrefabLens: verify the four release version strings agree before tagging.
+# PrefabLens: verify the five release version strings agree before tagging.
 # The Editor package downloads prefablens CLI from the release tagged v<Cli.Version>,
 # so a drift between these files silently ships a 404 or a version-mismatched binary.
 #
@@ -17,6 +17,7 @@ cli=$(sed -n 's/.*public const string Version = "\([^"]*\)".*/\1/p' editor/Edito
 epkg=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' editor/package.json | head -1)
 xpkg=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' extension/package.json | head -1)
 xman=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' extension/manifest.json | head -1)
+mpkg=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' mcp/package.json | head -1)
 
 fail=0
 check() {
@@ -33,9 +34,10 @@ check "editor/Editor/Cli.cs"      "$cli"
 check "editor/package.json"       "$epkg"
 check "extension/package.json"    "$xpkg"
 check "extension/manifest.json"   "$xman"
+check "mcp/package.json"          "$mpkg"
 
 if [[ "$fail" -ne 0 ]]; then
   echo "version mismatch: bump every source to $want before tagging v$want" >&2
   exit 1
 fi
-echo "all four version sources at $want"
+echo "all five version sources at $want"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,24 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: E2E smoke
         run: npm run e2e
+
+  mcp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tools
+        uses: jdx/mise-action@v4
+      - name: Build CLI
+        run: zig build
+        working-directory: ${{ github.workspace }}
+      - name: Install deps
+        run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Build
+        run: npm run build
+      - name: Tests
+        run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -32,3 +33,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create "$GITHUB_REF_NAME" dist/*.zip --generate-notes
+      - name: Publish MCP server to npm
+        working-directory: mcp
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "mcp/package.json version $version does not match tag $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+          npm install -g npm@latest  # trusted publishing は npm >= 11.5.1 が必要(node 22 同梱は 10.x)
+          npm ci
+          npm run build
+          npm publish --access public

--- a/docs/superpowers/plans/2026-07-04-phase4-mcp-host.md
+++ b/docs/superpowers/plans/2026-07-04-phase4-mcp-host.md
@@ -1,0 +1,740 @@
+# PrefabLens Phase 4: MCP ホスト Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 既存 CLI をサブプロセスで叩く薄い MCP サーバ(`@hashiiiii/prefablens-mcp`)を `/mcp` に作り、コーディングエージェントが Unity アセットの意味的 diff を `prefab_diff` ツールで取れるようにする。
+
+**Architecture:** stdio MCP サーバ(TypeScript)。git 調達・guid 解決・描画はすべて CLI 側で、MCP 層は「CLI の探索/自動取得 → サブプロセス実行 → 出力中継」のみ(spec: `docs/superpowers/specs/2026-07-04-phase4-mcp-host-design.md`)。CLI 取得は Editor `editor/Editor/Cli.cs` と同じ流儀の TS 版。
+
+**Tech Stack:** Node 22 / TypeScript(strict + noUncheckedIndexedAccess)/ `@modelcontextprotocol/server`(サーバ)+ `@modelcontextprotocol/client`(テスト)/ zod v4 / fflate(zip 展開)/ vitest。
+
+## Global Constraints
+
+- パッケージ名 `@hashiiiii/prefablens-mcp`、version `0.1.0`。**`mcp/package.json` の version が唯一のソース**(= ダウンロードする CLI の Releases タグ `v<version>`)
+- ランタイム依存は `@modelcontextprotocol/server` / `zod` / `fflate` の 3 つだけ。license フィールドは書かない(リポジトリに LICENSE なし、ユーザー判断待ち)
+- import は SDK ドキュメント準拠: `@modelcontextprotocol/server`、`@modelcontextprotocol/server/stdio`、`import * as z from 'zod/v4'`
+- tsc emit(NodeNext)なので相対 import は `./cli.js` のように **.js 拡張子必須**(extension の bundler 解決とは異なる)
+- コミットは 1 行英語 ≤50 字(git-conventions)。ブランチは作成済みの `feat/mcp-host` を継続
+- 検証コマンドを **パイプしない**(`cmd | tail` は exit code が化ける。Phase 2 の教訓)
+- 各タスクの検証は `mcp/` で `npm run typecheck` と `npx vitest run <file>` を素で実行する
+
+## File Structure
+
+```
+mcp/
+  package.json          … name/version/bin/scripts(build, typecheck, test)
+  tsconfig.json         … typecheck 用(src + vitest.config.ts、noEmit)
+  tsconfig.build.json   … build 用(src のみ、テスト除外、dist へ emit)
+  vitest.config.ts      … include src/**/*.test.ts、testTimeout 30s
+  src/diff.ts           … buildArgs / truncateTree(純関数)
+  src/cli.ts            … releaseAssetName / downloadUrl / binaryName / cachePath /
+                          installFromZip / ensureCli / runCli
+  src/index.ts          … bin エントリ(shebang)。serveStdio + prefab_diff 登録 + ハンドラ
+  src/diff.test.ts      … 純関数の単体
+  src/cli.test.ts       … 純関数 + installFromZip + runCli の単体
+  src/server.test.ts    … 統合(fixture git repo + StdioClientTransport + ゴールデン)
+```
+
+CI/リリース側: `.github/workflows/ci.yml`(mcp ジョブ追加)、`.github/workflows/release.yml`(npm publish 追加)、`.claude/skills/cut-release/`(bump 対象 4→5 箇所)。
+
+---
+
+### Task 1: パッケージ骨格 + diff.ts 純関数
+
+**Files:**
+- Create: `mcp/package.json` / `mcp/tsconfig.json` / `mcp/tsconfig.build.json` / `mcp/vitest.config.ts` / `mcp/.gitignore`
+- Create: `mcp/src/diff.ts`
+- Test: `mcp/src/diff.test.ts`
+
+**Interfaces:**
+- Produces: `buildArgs(a: DiffArgs): string[]`(DiffArgs = `{ path: string; before: string; after?: string; format: 'tree' | 'json' }`)/ `truncateTree(text: string, limit?: number): string` / `TREE_CHAR_LIMIT = 50_000`。Task 4 のハンドラが両方を使う
+
+- [ ] **Step 1: 骨格ファイルを書く**
+
+`mcp/package.json`(依存は Step 2 の npm install が追記する):
+
+```json
+{
+  "name": "@hashiiiii/prefablens-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for semantic diffs of Unity YAML assets (.prefab/.unity/.asset)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashiiiii/PrefabLens.git",
+    "directory": "mcp"
+  },
+  "type": "module",
+  "bin": { "prefablens-mcp": "dist/index.js" },
+  "files": ["dist"],
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  }
+}
+```
+
+`mcp/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}
+```
+
+`mcp/tsconfig.build.json`:
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false, "outDir": "dist" },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}
+```
+
+`mcp/vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { include: ['src/**/*.test.ts'], testTimeout: 30_000 },
+});
+```
+
+`mcp/.gitignore`:
+
+```
+node_modules/
+dist/
+```
+
+- [ ] **Step 2: 依存をインストール**
+
+```bash
+cd mcp
+npm install @modelcontextprotocol/server zod fflate
+npm install -D @modelcontextprotocol/client typescript vitest @types/node
+```
+
+インストール後、`node -p "require('@modelcontextprotocol/server/package.json').version"` でサーバ SDK が解決できることを確認(SDK のパッケージ名が異なる場合はここで発覚する。その場合は公式 README に従い読み替えて、以降のタスクの import も同じ名前に揃える)。
+
+- [ ] **Step 3: 失敗するテストを書く**
+
+`mcp/src/diff.test.ts`:
+
+```ts
+import { expect, test } from 'vitest';
+import { buildArgs, truncateTree } from './diff.js';
+
+test('buildArgs: tree + working-tree comparison', () => {
+  expect(buildArgs({ path: 'A.prefab', before: 'HEAD', format: 'tree' })).toEqual([
+    '--no-color', '--project', '.', '--git', 'HEAD', 'A.prefab',
+  ]);
+});
+
+test('buildArgs: json + two refs', () => {
+  expect(buildArgs({ path: 'A.prefab', before: 'main', after: 'HEAD', format: 'json' })).toEqual([
+    '--json', '--project', '.', '--git', 'main', 'HEAD', 'A.prefab',
+  ]);
+});
+
+test('truncateTree passes short text through', () => {
+  expect(truncateTree('short')).toBe('short');
+});
+
+test('truncateTree truncates long text and appends a note', () => {
+  const out = truncateTree('x'.repeat(60_000));
+  expect(out.startsWith('x'.repeat(100))).toBe(true);
+  expect(out.length).toBeLessThan(50_100);
+  expect(out).toContain('[truncated: 60000 chars total]');
+});
+```
+
+- [ ] **Step 4: 落ちることを確認**
+
+Run: `cd mcp && npx vitest run src/diff.test.ts`
+Expected: FAIL(`./diff.js` が存在しない)
+
+- [ ] **Step 5: 実装**
+
+`mcp/src/diff.ts`:
+
+```ts
+export const TREE_CHAR_LIMIT = 50_000;
+
+export interface DiffArgs {
+  path: string;
+  before: string;
+  after?: string;
+  format: 'tree' | 'json';
+}
+
+/** CLI 引数を組み立てる。--project . で cwd(= projectRoot)起点の .meta 走査による guid 解決を効かせる。 */
+export function buildArgs(a: DiffArgs): string[] {
+  const flags = a.format === 'json' ? ['--json'] : ['--no-color'];
+  const refs = a.after === undefined ? [a.before] : [a.before, a.after];
+  return [...flags, '--project', '.', '--git', ...refs, a.path];
+}
+
+/** LLM コンテキスト保護。tree 出力のみ対象(json は機械処理用途なので呼び出し側が使わない)。 */
+export function truncateTree(text: string, limit = TREE_CHAR_LIMIT): string {
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n[truncated: ${text.length} chars total]\n`;
+}
+```
+
+- [ ] **Step 6: 通ることを確認**
+
+Run: `cd mcp && npx vitest run src/diff.test.ts`
+Expected: PASS(4 tests)
+
+Run: `cd mcp && npm run typecheck`
+Expected: エラーなし
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mcp
+git commit -m "feat: scaffold mcp package with diff args"
+```
+
+---
+
+### Task 2: cli.ts — 探索・取得・実行
+
+**Files:**
+- Create: `mcp/src/cli.ts`
+- Test: `mcp/src/cli.test.ts`
+
+**Interfaces:**
+- Produces(Task 4 のハンドラと Task 3 の統合テストが使う):
+  - `releaseAssetName(platform: NodeJS.Platform, arch: string): string`
+  - `downloadUrl(version: string, assetName: string): string`
+  - `binaryName(platform: NodeJS.Platform): string`
+  - `cachePath(version: string, platform: NodeJS.Platform, home: string): string`
+  - `installFromZip(zipBytes: Uint8Array, dest: string, platform: NodeJS.Platform): void`
+  - `ensureCli(version: string): Promise<string>`(env `PREFABLENS_CLI` → キャッシュ → ダウンロード。戻り値は実行パス)
+  - `runCli(cliPath: string, args: string[], cwd: string): Promise<CliResult>`(CliResult = `{ code: number; stdout: string; stderr: string }`)
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`mcp/src/cli.test.ts`:
+
+```ts
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { zipSync } from 'fflate';
+import { afterAll, expect, test } from 'vitest';
+import { binaryName, cachePath, downloadUrl, installFromZip, releaseAssetName, runCli } from './cli.js';
+
+const dir = mkdtempSync(path.join(tmpdir(), 'prefablens-cli-test-'));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+test('releaseAssetName maps platform/arch to the four release zips', () => {
+  expect(releaseAssetName('win32', 'x64')).toBe('prefablens-windows-x64.zip');
+  expect(releaseAssetName('darwin', 'arm64')).toBe('prefablens-macos-arm64.zip');
+  expect(releaseAssetName('darwin', 'x64')).toBe('prefablens-macos-x64.zip');
+  expect(releaseAssetName('linux', 'x64')).toBe('prefablens-linux-x64.zip');
+});
+
+test('downloadUrl points at the tagged GitHub release', () => {
+  expect(downloadUrl('0.1.0', 'prefablens-macos-arm64.zip')).toBe(
+    'https://github.com/hashiiiii/PrefabLens/releases/download/v0.1.0/prefablens-macos-arm64.zip',
+  );
+});
+
+test('binaryName appends .exe only on windows', () => {
+  expect(binaryName('win32')).toBe('prefablens.exe');
+  expect(binaryName('darwin')).toBe('prefablens');
+});
+
+test('cachePath is versioned under <home>/.cache/prefablens', () => {
+  expect(cachePath('0.1.0', 'linux', '/home/u')).toBe(
+    path.join('/home/u', '.cache', 'prefablens', '0.1.0', 'prefablens'),
+  );
+});
+
+test('installFromZip extracts the binary atomically and marks it executable', () => {
+  const zip = zipSync({ prefablens: new TextEncoder().encode('#!/bin/sh\necho ok\n') });
+  const dest = path.join(dir, 'v1', 'prefablens');
+  installFromZip(zip, dest, 'linux');
+  expect(readFileSync(dest, 'utf8')).toContain('echo ok');
+  expect(statSync(dest).mode & 0o111).not.toBe(0);
+});
+
+test('installFromZip rejects a zip without the expected binary', () => {
+  const zip = zipSync({ other: new Uint8Array([1]) });
+  expect(() => installFromZip(zip, path.join(dir, 'v2', 'prefablens'), 'linux')).toThrow('not found');
+});
+
+test('runCli captures stdout and exit code', async () => {
+  const res = await runCli('git', ['--version'], process.cwd());
+  expect(res.code).toBe(0);
+  expect(res.stdout).toContain('git version');
+});
+```
+
+- [ ] **Step 2: 落ちることを確認**
+
+Run: `cd mcp && npx vitest run src/cli.test.ts`
+Expected: FAIL(`./cli.js` が存在しない)
+
+- [ ] **Step 3: 実装**
+
+`mcp/src/cli.ts`:
+
+```ts
+import { spawn } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { unzipSync } from 'fflate';
+
+/** Editor の Cli.ReleaseAssetName と同じ対応表(release.yml のアセット 4 種)。 */
+export function releaseAssetName(platform: NodeJS.Platform, arch: string): string {
+  if (platform === 'win32') return 'prefablens-windows-x64.zip';
+  if (platform === 'darwin') return arch === 'arm64' ? 'prefablens-macos-arm64.zip' : 'prefablens-macos-x64.zip';
+  return 'prefablens-linux-x64.zip';
+}
+
+export function downloadUrl(version: string, assetName: string): string {
+  return `https://github.com/hashiiiii/PrefabLens/releases/download/v${version}/${assetName}`;
+}
+
+export function binaryName(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'prefablens.exe' : 'prefablens';
+}
+
+export function cachePath(version: string, platform: NodeJS.Platform, home: string): string {
+  return path.join(home, '.cache', 'prefablens', version, binaryName(platform));
+}
+
+/** temp に書いて rename する原子的配置。同時起動の二重ダウンロードは後勝ちで無害。 */
+export function installFromZip(zipBytes: Uint8Array, dest: string, platform: NodeJS.Platform): void {
+  const body = unzipSync(zipBytes)[binaryName(platform)];
+  if (body === undefined) throw new Error(`${binaryName(platform)} not found in release zip`);
+  mkdirSync(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.tmp-${process.pid}`;
+  writeFileSync(tmp, body);
+  if (platform !== 'win32') chmodSync(tmp, 0o755);
+  renameSync(tmp, dest);
+}
+
+/** env PREFABLENS_CLI → キャッシュ → GitHub Releases の順で CLI を確保する。 */
+export async function ensureCli(version: string): Promise<string> {
+  const manual = process.env['PREFABLENS_CLI'];
+  if (manual !== undefined && manual !== '' && existsSync(manual)) return manual;
+  const dest = cachePath(version, process.platform, homedir());
+  if (existsSync(dest)) return dest;
+  const url = downloadUrl(version, releaseAssetName(process.platform, process.arch));
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`download failed: HTTP ${res.status} for ${url}`);
+  installFromZip(new Uint8Array(await res.arrayBuffer()), dest, process.platform);
+  return dest;
+}
+
+export interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export function runCli(cliPath: string, args: string[], cwd: string): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cliPath, args, { cwd });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => { stdout += c; });
+    child.stderr.on('data', (c: Buffer) => { stderr += c; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+```
+
+ダウンロード実路(fetch 分岐)はネットワーク依存のため単体テストしない(env 注入経路は Task 3 の統合テストが通す)。
+
+- [ ] **Step 4: 通ることを確認**
+
+Run: `cd mcp && npx vitest run src/cli.test.ts`
+Expected: PASS(7 tests)
+
+Run: `cd mcp && npm run typecheck`
+Expected: エラーなし
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mcp/src/cli.ts mcp/src/cli.test.ts
+git commit -m "feat: locate download and run cli from mcp"
+```
+
+---
+
+### Task 3: index.ts サーバ本体 + 統合テスト
+
+**Files:**
+- Create: `mcp/src/index.ts`
+- Test: `mcp/src/server.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1 の `buildArgs`/`truncateTree`、Task 2 の `ensureCli`/`runCli`
+- Produces: MCP ツール `prefab_diff`(引数 `path`/`before`(既定 HEAD)/`after`/`projectRoot`/`format`(tree|json))。bin `prefablens-mcp` → `dist/index.js`
+
+- [ ] **Step 1: 失敗する統合テストを書く**
+
+`mcp/src/server.test.ts`(fixture は既存の `core/src/testdata/plane_*.prefab` を temp git リポジトリにコピーして使う。サーバはビルド済み `dist/index.js` を Node 子プロセスで起動し、`PREFABLENS_CLI` でローカルビルドの CLI を注入するためネットワーク非依存):
+
+```ts
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const cliPath = path.join(repoRoot, 'zig-out', 'bin', process.platform === 'win32' ? 'prefablens.exe' : 'prefablens');
+const serverEntry = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+const testdata = path.join(repoRoot, 'core', 'src', 'testdata');
+
+let fixtureRepo: string;
+let client: Client;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], { cwd });
+}
+
+function firstText(res: { content?: unknown }): string {
+  const content = res.content as { type: string; text: string }[];
+  return content[0]?.text ?? '';
+}
+
+beforeAll(async () => {
+  fixtureRepo = mkdtempSync(path.join(tmpdir(), 'prefablens-mcp-'));
+  cpSync(path.join(testdata, 'plane_before.prefab'), path.join(fixtureRepo, 'Plane.prefab'));
+  git(fixtureRepo, 'init', '-q');
+  git(fixtureRepo, 'add', '.');
+  git(fixtureRepo, 'commit', '-q', '-m', 'init');
+  cpSync(path.join(testdata, 'plane_after.prefab'), path.join(fixtureRepo, 'Plane.prefab'));
+
+  client = new Client({ name: 'test', version: '0.0.0' });
+  await client.connect(new StdioClientTransport({
+    command: process.execPath,
+    args: [serverEntry],
+    env: { PREFABLENS_CLI: cliPath, PATH: process.env['PATH'] ?? '' },
+  }));
+});
+
+afterAll(async () => {
+  await client.close();
+  rmSync(fixtureRepo, { recursive: true, force: true });
+});
+
+test('prefab_diff returns the semantic tree for HEAD vs working tree', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', projectRoot: fixtureRepo },
+  });
+  expect(res.isError).toBeFalsy();
+  // ゴールデン。実装後に実出力を目視確認してからピンする(既存 golden の流儀)。
+  expect(firstText(res)).toBe([
+    '  Plane',
+    '  ~ Cylinder  <Prefab>',
+    '      components',
+    '        ~ Transform',
+    '          ~ Position.x: 0.41646004 -> 1',
+    '  + Cylinder Variant  <Prefab>',
+    '      components',
+    '        + Transform',
+    '          + Position: (2.03, 3.63, 1.11797)',
+    '',
+  ].join('\n'));
+});
+
+test('prefab_diff format:"json" returns prefablens.diff.v2', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', projectRoot: fixtureRepo, format: 'json' },
+  });
+  expect(res.isError).toBeFalsy();
+  const parsed = JSON.parse(firstText(res)) as { schema: string };
+  expect(parsed.schema).toBe('prefablens.diff.v2');
+});
+
+test('prefab_diff surfaces cli errors as tool errors', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', before: 'nosuchref', after: 'HEAD', projectRoot: fixtureRepo },
+  });
+  expect(res.isError).toBe(true);
+  expect(firstText(res)).toContain("git show failed for 'nosuchref:Plane.prefab'");
+});
+```
+
+- [ ] **Step 2: 落ちることを確認**
+
+Run(リポジトリルートで CLI を先にビルド): `zig build`
+Run: `cd mcp && npm run build`
+Expected: build が `src/index.ts` 不在で FAIL(または dist/index.js 不在でテスト FAIL)
+
+- [ ] **Step 3: 実装**
+
+`mcp/src/index.ts`:
+
+```ts
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { McpServer } from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import * as z from 'zod/v4';
+import { ensureCli, runCli } from './cli.js';
+import { buildArgs, truncateTree } from './diff.js';
+
+/** npm version = ダウンロードする CLI の Releases タグ(spec のバージョン規約)。 */
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+
+const DESCRIPTION =
+  'Semantic diff for Unity YAML assets (.prefab/.unity/.asset) between two git versions. ' +
+  'Use this instead of reading raw YAML diffs: it matches objects by fileID and reports ' +
+  'added/removed/modified GameObjects, components, fields, and prefab overrides with resolved names.';
+
+function message(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+serveStdio(() => {
+  const server = new McpServer({ name: 'prefablens', version: pkg.version });
+
+  server.registerTool(
+    'prefab_diff',
+    {
+      description: DESCRIPTION,
+      inputSchema: z.object({
+        path: z.string().describe('Asset path (.prefab/.unity/.asset), relative to projectRoot'),
+        before: z.string().default('HEAD').describe('Base git ref'),
+        after: z.string().optional().describe('Target git ref; omit to compare against the working tree'),
+        projectRoot: z.string().optional().describe('Repository root; defaults to the server cwd'),
+        format: z.enum(['tree', 'json']).default('tree').describe('tree = readable text, json = prefablens.diff.v2'),
+      }),
+    },
+    async ({ path: assetPath, before, after, projectRoot, format }) => {
+      try {
+        const cli = await ensureCli(pkg.version).catch((e: unknown) => {
+          throw new Error(
+            `prefablens CLI unavailable: ${message(e)}\n` +
+            'Place the binary manually and set PREFABLENS_CLI to its path.',
+          );
+        });
+        const res = await runCli(cli, buildArgs({ path: assetPath, before, after, format }), projectRoot ?? process.cwd());
+        if (res.code !== 0) {
+          return {
+            content: [{ type: 'text' as const, text: res.stderr.trim() || `prefablens exited with code ${res.code}` }],
+            isError: true,
+          };
+        }
+        const text = format === 'tree' ? truncateTree(res.stdout) : res.stdout;
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (e) {
+        return { content: [{ type: 'text' as const, text: message(e) }], isError: true };
+      }
+    },
+  );
+
+  return server;
+});
+```
+
+- [ ] **Step 4: ビルドして統合テストを通す**
+
+Run: `cd mcp && npm run typecheck`
+Expected: エラーなし
+
+Run: `cd mcp && npm run build`
+Expected: `dist/index.js` 生成(1 行目に shebang が残ることを確認)
+
+Run: `cd mcp && npx vitest run src/server.test.ts`
+Expected: PASS(3 tests)。tree ゴールデンが実出力と食い違ったら、`format:"tree"` の実出力を目視で妥当確認した上でテスト側をピンし直す(末尾改行の有無に注意)
+
+- [ ] **Step 5: 全テスト + Commit**
+
+Run: `cd mcp && npm test`
+Expected: PASS(diff 4 + cli 7 + server 3 = 14 tests)
+
+```bash
+git add mcp/src/index.ts mcp/src/server.test.ts
+git commit -m "feat: add prefab_diff mcp server"
+```
+
+---
+
+### Task 4: CI ジョブ + リリースパイプライン + cut-release 更新
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`(mcp ジョブ追加)
+- Modify: `.github/workflows/release.yml`(permissions + npm publish ステップ追加)
+- Modify: `.claude/skills/cut-release/scripts/check-versions.sh`(5 箇所目を追加)
+- Modify: `.claude/skills/cut-release/SKILL.md`(コンポーネント数・bump 対象の記述更新)
+
+**Interfaces:**
+- Consumes: Task 1-3 の `mcp/` パッケージ(scripts: typecheck / build / test)
+- Produces: tag `v*` push で「zip アセット公開 → npm publish」が 1 job 内でこの順に走る
+
+- [ ] **Step 1: ci.yml に mcp ジョブを追加**
+
+既存 `extension` ジョブの後に追記(同じ流儀: mise で zig/node を入れ、CLI を先にビルドして統合テストに使わせる):
+
+```yaml
+  mcp:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tools
+        uses: jdx/mise-action@v4
+      - name: Build CLI
+        run: zig build
+        working-directory: ${{ github.workspace }}
+      - name: Install deps
+        run: npm ci
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Build
+        run: npm run build
+      - name: Tests
+        run: npm test
+```
+
+- [ ] **Step 2: release.yml に npm publish を追加**
+
+`permissions:` ブロックを更新(Trusted Publishing の OIDC トークン用):
+
+```yaml
+permissions:
+  contents: write
+  id-token: write
+```
+
+`Create release` ステップの **後** に追記(npm が参照する CLI タグの Releases が先に存在する順序制約):
+
+```yaml
+      - name: Publish MCP server to npm
+        working-directory: mcp
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "mcp/package.json version $version does not match tag $GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+          npm install -g npm@latest  # trusted publishing は npm >= 11.5.1 が必要(node 22 同梱は 10.x)
+          npm ci
+          npm run build
+          npm publish --access public
+```
+
+- [ ] **Step 3: check-versions.sh に mcp を追加**
+
+`xman=` の行の下に追加:
+
+```bash
+mpkg=$(sed -n 's/.*"version": *"\([^"]*\)".*/\1/p' mcp/package.json | head -1)
+```
+
+`check "extension/manifest.json"` の行の下に追加:
+
+```bash
+check "mcp/package.json"          "$mpkg"
+```
+
+末尾のメッセージと冒頭コメントの「four」を「five」に更新:
+
+```bash
+echo "all five version sources at $want"
+```
+
+Run: `.claude/skills/cut-release/scripts/check-versions.sh 0.1.0`
+Expected: 5 行すべて `ok`(現行は全ソース 0.1.0 のため)
+
+- [ ] **Step 4: cut-release SKILL.md を更新**
+
+- description の「Bumps the four version sources」→「Bumps the five version sources」
+- Overview の「ships three components on one version line: the Zig CLI, the Chrome extension, and the Unity Editor package」→「ships four components on one version line: the Zig CLI, the Chrome extension, the Unity Editor package, and the MCP server (npm)」
+- Steps 2 の bump リストに追加: `mcp/package.json` → `"version": "X.Y.Z"`
+- リリース自動化の説明に追記: 「release workflow は zip アセット公開後に `@hashiiiii/prefablens-mcp` を npm publish する(Trusted Publishing。npmjs.com 側の設定が初回 publish 前に必要)」
+- Steps 6 の検証に追加: `npm view @hashiiiii/prefablens-mcp version` がタグと一致すること
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/release.yml .claude/skills/cut-release
+git commit -m "ci: build test and publish mcp package"
+```
+
+---
+
+### Task 5: 全体検証 + PR 作成
+
+**Files:** なし(検証のみ)
+
+- [ ] **Step 1: フレッシュ全検証**(パイプ禁止・各コマンドの exit code をそのまま見る)
+
+```bash
+zig build test
+zig build
+cd mcp
+npm ci
+npm run typecheck
+npm run build
+npm test
+cd ..
+.claude/skills/cut-release/scripts/check-versions.sh 0.1.0
+```
+
+Expected: すべて成功(zig test 96+ / mcp 14 tests / check-versions 5 ok)
+
+- [ ] **Step 2: 実機スモーク**(MCP クライアントとしての目視確認)
+
+```bash
+cd mcp
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | PREFABLENS_CLI=../zig-out/bin/prefablens node dist/index.js
+```
+
+Expected: `tools/list` 応答に `prefab_diff` が含まれる(JSON-RPC 生ログの目視。プロトコルバージョン文字列は SDK が違うものを要求したらエラーメッセージに従って合わせる)
+
+- [ ] **Step 3: push + PR 作成**
+
+```bash
+git push -u origin feat/mcp-host
+gh pr create --title "feat: MCP host exposing prefab_diff tool" --body "..."
+```
+
+PR body には以下を含める: spec/plan へのリンク / 検証結果 / **マージ前のユーザー作業 2 点**(npmjs.com で `@hashiiiii/prefablens-mcp` の Trusted Publisher を release.yml に対して設定する / license フィールド未設定の判断)。機能本体につき **マージはユーザー確認**([[workflow-autonomy]] の自己マージ対象外)
+
+- [ ] **Step 4: CI green を確認**
+
+Run: `gh run watch $(gh run list --branch feat/mcp-host --limit 1 --json databaseId -q '.[0].databaseId')`
+Expected: test / perf / extension / mcp の 4 ジョブすべて成功

--- a/docs/superpowers/specs/2026-07-04-phase4-mcp-host-design.md
+++ b/docs/superpowers/specs/2026-07-04-phase4-mcp-host-design.md
@@ -39,7 +39,7 @@ Claude Code などのコーディングエージェントが、作業中の Unit
 | `projectRoot` | string(省略可) | リポジトリルート。省略時はサーバプロセスの cwd |
 | `format` | `"tree"`(既定)\| `"json"` | tree = ANSI なしテキストツリー、json = diff.v2 |
 
-実行コマンド: `prefablens --no-color --git <before> [<after>] <path>`(cwd = projectRoot)。`format:"json"` 時は `--no-color` の代わりに `--json`。guid 解決は CLI のローカル `.meta` 走査がそのまま働く。
+実行コマンド: `prefablens --no-color --project . --git <before> [<after>] <path>`(cwd = projectRoot)。`format:"json"` 時は `--no-color` の代わりに `--json`。guid 解決は `--project .` によるローカル `.meta` 走査(cwd = projectRoot 起点)がそのまま働く。
 
 ツール説明文には「Unity YAML アセットの意味的 diff を返す。生の YAML diff を読む代わりに使う」旨をエージェント向けに書く(発見性がこのホストの UI に相当する)。
 

--- a/docs/superpowers/specs/2026-07-04-phase4-mcp-host-design.md
+++ b/docs/superpowers/specs/2026-07-04-phase4-mcp-host-design.md
@@ -1,0 +1,81 @@
+# PrefabLens Phase 4 設計 — AI / MCP ホスト(ウォーキングスケルトン)
+
+- **日付**: 2026-07-04
+- **ステータス**: ドラフト(ユーザーレビュー待ち)
+- **親仕様**: `2026-06-29-unity-prefab-diff-design.md` §6.4・§7・§8
+- **ユーザー決定(2026-07-04)**: 主ユースケースはローカルリポジトリのコーディングエージェント支援 / 配布は npm 公開 + npx 起動 / 出力はテキストツリー既定 + `format:"json"` で diff.v2 / 初回ツールは diff 1 つのみ / 実装は CLI サブプロセス方式(Editor ホストと同型)
+
+Claude Code などのコーディングエージェントが、作業中の Unity リポジトリで prefab/scene の変更を意味的に理解できるようにする最小の縦切りを作る。MCP サーバは薄いラッパで、git 調達・guid 解決・描画はすべて既存 CLI 側(親仕様 §6.3 と同じ責務分割)。要約・リスク指摘は LLM 側の仕事であり、サーバは構造化された事実だけを返す(親仕様 §6.4)。
+
+## スコープ
+
+### 初回に入れる
+
+1. **npm パッケージ `@hashiiiii/prefablens-mcp`**(`/mcp`、TypeScript + `@modelcontextprotocol/sdk`、stdio transport、bin `prefablens-mcp`)。利用者は `npx @hashiiiii/prefablens-mcp` を MCP クライアントに登録
+2. **MCP ツール `prefab_diff`** 1 つ(下記インターフェイス)
+3. **CLI の探索・自動取得**(Editor `Cli.cs` の TS 版)
+4. **release.yml への npm publish 追加**(tag `v*` で zip アセットと同時に出す)
+
+### 初回は延期
+
+- 複数ファイル一括 diff / 変更アセット列挙ツール(git で代替可能)
+- MCP resources・prompts 機能、要約プロンプトテンプレート
+- PR/GitHub API 入力(Phase 2 相当の複雑さ)、Unity AI Agents 連携
+- プラットフォーム別 npm パッケージ(optionalDependencies 方式)による初回ダウンロード排除
+
+## バージョン規約
+
+`mcp/package.json` の `version` が唯一のソース。npm パッケージの version = ダウンロードする CLI の Releases タグ(`v<version>`)。Editor の `Cli.Version` 定数と同じ規約で、サーバは実行時に自身の package.json を読む(定数の二重管理をしない)。
+
+**cut-release スキルの bump 対象が 4 → 5 箇所になる**(`mcp/package.json` 追加)。`check-versions.sh` も更新する。
+
+## MCP ツール: `prefab_diff`
+
+| 引数 | 型 | 説明 |
+|---|---|---|
+| `path` | string(必須) | 対象アセット(.prefab/.unity/.asset)のパス。projectRoot 相対(絶対パスも可、CLI は cwd = projectRoot で実行される) |
+| `before` | string、既定 `"HEAD"` | 比較元 git ref |
+| `after` | string(省略可) | 比較先 git ref。省略時は作業ツリー |
+| `projectRoot` | string(省略可) | リポジトリルート。省略時はサーバプロセスの cwd |
+| `format` | `"tree"`(既定)\| `"json"` | tree = ANSI なしテキストツリー、json = diff.v2 |
+
+実行コマンド: `prefablens --no-color --git <before> [<after>] <path>`(cwd = projectRoot)。`format:"json"` 時は `--no-color` の代わりに `--json`。guid 解決は CLI のローカル `.meta` 走査がそのまま働く。
+
+ツール説明文には「Unity YAML アセットの意味的 diff を返す。生の YAML diff を読む代わりに使う」旨をエージェント向けに書く(発見性がこのホストの UI に相当する)。
+
+## CLI の探索と取得
+
+1. 環境変数 `PREFABLENS_CLI`(明示指定。テストでのローカルビルド注入にも使う)
+2. キャッシュ `~/.cache/prefablens/<version>/prefablens(.exe)`(全 OS 統一でシンプルに)
+3. 無ければ `https://github.com/hashiiiii/PrefabLens/releases/download/v<version>/<asset>.zip` を取得 → 展開 → unix は chmod +x
+
+アセット名 4 種(`prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip`)は Editor と同一の対応表。配置は一時ファイルに展開して rename する原子的書き込みとし、同時起動の二重ダウンロードはロックせず「後勝ちでも壊れない」ことで無害化する。
+
+## エラーハンドリング
+
+- **CLI 不在 + ダウンロード失敗**: ツールエラー(`isError: true`)。手動配置 + `PREFABLENS_CLI` 指定の案内文を含める(ネットワーク遮断環境の逃げ道)
+- **CLI exit ≠ 0**: stderr をそのままツールエラーで返す(not a git repository / unknown ref 等は CLI のメッセージが既に具体的)
+- **巨大出力ガード**: tree 出力が 50,000 文字を超えたら切り詰め、末尾に `[truncated: N chars total]` を付記(LLM コンテキスト保護。Chrome 版 25MB 入力ガードの出力側版)。`format:"json"` は機械処理用途なので切り詰めない
+
+## テスト戦略(親仕様 §7)
+
+- **単体(vitest)**: 純関数 — アセット名解決 / ダウンロード URL / CLI 引数組み立て / truncate。Editor の EditMode テストと同じ対象の TS 版
+- **統合(vitest)**: MCP SDK のクライアントで stdio 接続し、fixture の git リポジトリに `prefab_diff` を実行 → 出力ゴールデン照合。CLI は `PREFABLENS_CLI` でローカルビルド(`zig-out/bin/prefablens`)を注入し、ネットワーク非依存
+- **CI**: ci.yml に mcp ジョブ追加(zig build → typecheck + vitest)
+
+## リリースパイプライン
+
+release.yml(tag `v*`)に npm publish を追加:
+
+- 既存 job 内で **zip アセットの `gh release create` 完了後**に publish(npm が参照する CLI タグの Releases が先に存在する、Phase 3 と同型の順序制約)
+- 認証は **npm Trusted Publishing(OIDC)**(シークレット管理不要)。npmjs.com 側の Trusted Publisher 設定はユーザー作業 1 回
+- publish 前に `mcp/package.json` の version と tag の一致を検証(不一致は fail)
+
+## PR 分割
+
+単一 PR(`feat/mcp-host`): `/mcp` パッケージ + release.yml/ci.yml 変更 + cut-release スキル更新。機能本体につきマージはユーザー確認。
+
+## 未決事項(レビューで確認)
+
+- npm パッケージ名: `@hashiiiii/prefablens-mcp` を仮置き(npm 上のスコープ確保状況はユーザー確認)
+- npm Trusted Publishing の設定タイミング(初回 publish 前に npmjs.com 側の設定が必要)

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hashiiiii/prefablens-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/server": "^2.0.0-beta.2",
+        "@modelcontextprotocol/server": "2.0.0-beta.2",
         "fflate": "^0.8.3",
         "zod": "^4.4.3"
       },
@@ -16,7 +16,7 @@
         "prefablens-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@modelcontextprotocol/client": "^2.0.0-beta.2",
+        "@modelcontextprotocol/client": "2.0.0-beta.2",
         "@types/node": "^26.1.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1468 @@
+{
+  "name": "@hashiiiii/prefablens-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@hashiiiii/prefablens-mcp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/server": "^2.0.0-beta.2",
+        "fflate": "^0.8.3",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "prefablens-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/client": "^2.0.0-beta.2",
+        "@types/node": "^26.1.0",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0-beta.2.tgz",
+      "integrity": "sha512-IKEJQmvM2g7HLSOofLXECjQyeryB1YWgjazHcYygyH3ERSe7b8cFS3WHlupMxees5URNXcqBLVlbDRgodaBQ9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-beta.2.tgz",
+      "integrity": "sha512-XK+sgFntT5ZzeqtTGpT9uti+Sqmq7YJZdx/N76eLJv9UA9vKvP04Qh9Hc45LCeIHGfTKRwDG6eh4C1Hs4omyIg==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -23,12 +23,12 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@modelcontextprotocol/server": "^2.0.0-beta.2",
+    "@modelcontextprotocol/server": "2.0.0-beta.2",
     "fflate": "^0.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@modelcontextprotocol/client": "^2.0.0-beta.2",
+    "@modelcontextprotocol/client": "2.0.0-beta.2",
     "@types/node": "^26.1.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@hashiiiii/prefablens-mcp",
+  "version": "0.1.0",
+  "description": "MCP server for semantic diffs of Unity YAML assets (.prefab/.unity/.asset)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hashiiiii/PrefabLens.git",
+    "directory": "mcp"
+  },
+  "type": "module",
+  "bin": {
+    "prefablens-mcp": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/server": "^2.0.0-beta.2",
+    "fflate": "^0.8.3",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/client": "^2.0.0-beta.2",
+    "@types/node": "^26.1.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/mcp/src/cli.test.ts
+++ b/mcp/src/cli.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { zipSync } from 'fflate';
+import { afterAll, expect, test } from 'vitest';
+import { binaryName, cachePath, downloadUrl, installFromZip, releaseAssetName, runCli } from './cli.js';
+
+const dir = mkdtempSync(path.join(tmpdir(), 'prefablens-cli-test-'));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+test('releaseAssetName maps platform/arch to the four release zips', () => {
+  expect(releaseAssetName('win32', 'x64')).toBe('prefablens-windows-x64.zip');
+  expect(releaseAssetName('darwin', 'arm64')).toBe('prefablens-macos-arm64.zip');
+  expect(releaseAssetName('darwin', 'x64')).toBe('prefablens-macos-x64.zip');
+  expect(releaseAssetName('linux', 'x64')).toBe('prefablens-linux-x64.zip');
+});
+
+test('downloadUrl points at the tagged GitHub release', () => {
+  expect(downloadUrl('0.1.0', 'prefablens-macos-arm64.zip')).toBe(
+    'https://github.com/hashiiiii/PrefabLens/releases/download/v0.1.0/prefablens-macos-arm64.zip',
+  );
+});
+
+test('binaryName appends .exe only on windows', () => {
+  expect(binaryName('win32')).toBe('prefablens.exe');
+  expect(binaryName('darwin')).toBe('prefablens');
+});
+
+test('cachePath is versioned under <home>/.cache/prefablens', () => {
+  expect(cachePath('0.1.0', 'linux', '/home/u')).toBe(
+    path.join('/home/u', '.cache', 'prefablens', '0.1.0', 'prefablens'),
+  );
+});
+
+test('installFromZip extracts the binary atomically and marks it executable', () => {
+  const zip = zipSync({ prefablens: new TextEncoder().encode('#!/bin/sh\necho ok\n') });
+  const dest = path.join(dir, 'v1', 'prefablens');
+  installFromZip(zip, dest, 'linux');
+  expect(readFileSync(dest, 'utf8')).toContain('echo ok');
+  expect(statSync(dest).mode & 0o111).not.toBe(0);
+});
+
+test('installFromZip rejects a zip without the expected binary', () => {
+  const zip = zipSync({ other: new Uint8Array([1]) });
+  expect(() => installFromZip(zip, path.join(dir, 'v2', 'prefablens'), 'linux')).toThrow('not found');
+});
+
+test('runCli captures stdout and exit code', async () => {
+  const res = await runCli('git', ['--version'], process.cwd());
+  expect(res.code).toBe(0);
+  expect(res.stdout).toContain('git version');
+});

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -1,0 +1,66 @@
+import { spawn } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { unzipSync } from 'fflate';
+
+/** Editor の Cli.ReleaseAssetName と同じ対応表(release.yml のアセット 4 種)。 */
+export function releaseAssetName(platform: NodeJS.Platform, arch: string): string {
+  if (platform === 'win32') return 'prefablens-windows-x64.zip';
+  if (platform === 'darwin') return arch === 'arm64' ? 'prefablens-macos-arm64.zip' : 'prefablens-macos-x64.zip';
+  return 'prefablens-linux-x64.zip';
+}
+
+export function downloadUrl(version: string, assetName: string): string {
+  return `https://github.com/hashiiiii/PrefabLens/releases/download/v${version}/${assetName}`;
+}
+
+export function binaryName(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'prefablens.exe' : 'prefablens';
+}
+
+export function cachePath(version: string, platform: NodeJS.Platform, home: string): string {
+  return path.join(home, '.cache', 'prefablens', version, binaryName(platform));
+}
+
+/** temp に書いて rename する原子的配置。同時起動の二重ダウンロードは後勝ちで無害。 */
+export function installFromZip(zipBytes: Uint8Array, dest: string, platform: NodeJS.Platform): void {
+  const body = unzipSync(zipBytes)[binaryName(platform)];
+  if (body === undefined) throw new Error(`${binaryName(platform)} not found in release zip`);
+  mkdirSync(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.tmp-${process.pid}`;
+  writeFileSync(tmp, body);
+  if (platform !== 'win32') chmodSync(tmp, 0o755);
+  renameSync(tmp, dest);
+}
+
+/** env PREFABLENS_CLI → キャッシュ → GitHub Releases の順で CLI を確保する。 */
+export async function ensureCli(version: string): Promise<string> {
+  const manual = process.env['PREFABLENS_CLI'];
+  if (manual !== undefined && manual !== '' && existsSync(manual)) return manual;
+  const dest = cachePath(version, process.platform, homedir());
+  if (existsSync(dest)) return dest;
+  const url = downloadUrl(version, releaseAssetName(process.platform, process.arch));
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`download failed: HTTP ${res.status} for ${url}`);
+  installFromZip(new Uint8Array(await res.arrayBuffer()), dest, process.platform);
+  return dest;
+}
+
+export interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export function runCli(cliPath: string, args: string[], cwd: string): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cliPath, args, { cwd });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => { stdout += c; });
+    child.stderr.on('data', (c: Buffer) => { stderr += c; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -58,8 +58,10 @@ export function runCli(cliPath: string, args: string[], cwd: string): Promise<Cl
     const child = spawn(cliPath, args, { cwd });
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', (c: Buffer) => { stdout += c; });
-    child.stderr.on('data', (c: Buffer) => { stderr += c; });
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (c: string) => { stdout += c; });
+    child.stderr.on('data', (c: string) => { stderr += c; });
     child.on('error', reject);
     child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
   });

--- a/mcp/src/diff.test.ts
+++ b/mcp/src/diff.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'vitest';
+import { buildArgs, truncateTree } from './diff.js';
+
+test('buildArgs: tree + working-tree comparison', () => {
+  expect(buildArgs({ path: 'A.prefab', before: 'HEAD', format: 'tree' })).toEqual([
+    '--no-color', '--project', '.', '--git', 'HEAD', 'A.prefab',
+  ]);
+});
+
+test('buildArgs: json + two refs', () => {
+  expect(buildArgs({ path: 'A.prefab', before: 'main', after: 'HEAD', format: 'json' })).toEqual([
+    '--json', '--project', '.', '--git', 'main', 'HEAD', 'A.prefab',
+  ]);
+});
+
+test('truncateTree passes short text through', () => {
+  expect(truncateTree('short')).toBe('short');
+});
+
+test('truncateTree truncates long text and appends a note', () => {
+  const out = truncateTree('x'.repeat(60_000));
+  expect(out.startsWith('x'.repeat(100))).toBe(true);
+  expect(out.length).toBeLessThan(50_100);
+  expect(out).toContain('[truncated: 60000 chars total]');
+});

--- a/mcp/src/diff.ts
+++ b/mcp/src/diff.ts
@@ -1,0 +1,21 @@
+export const TREE_CHAR_LIMIT = 50_000;
+
+export interface DiffArgs {
+  path: string;
+  before: string;
+  after?: string;
+  format: 'tree' | 'json';
+}
+
+/** CLI 引数を組み立てる。--project . で cwd(= projectRoot)起点の .meta 走査による guid 解決を効かせる。 */
+export function buildArgs(a: DiffArgs): string[] {
+  const flags = a.format === 'json' ? ['--json'] : ['--no-color'];
+  const refs = a.after === undefined ? [a.before] : [a.before, a.after];
+  return [...flags, '--project', '.', '--git', ...refs, a.path];
+}
+
+/** LLM コンテキスト保護。tree 出力のみ対象(json は機械処理用途なので呼び出し側が使わない)。 */
+export function truncateTree(text: string, limit = TREE_CHAR_LIMIT): string {
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit)}\n[truncated: ${text.length} chars total]\n`;
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { McpServer } from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import * as z from 'zod/v4';
+import { ensureCli, runCli } from './cli.js';
+import { buildArgs, truncateTree } from './diff.js';
+
+/** npm version = ダウンロードする CLI の Releases タグ(spec のバージョン規約)。 */
+const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+
+const DESCRIPTION =
+  'Semantic diff for Unity YAML assets (.prefab/.unity/.asset) between two git versions. ' +
+  'Use this instead of reading raw YAML diffs: it matches objects by fileID and reports ' +
+  'added/removed/modified GameObjects, components, fields, and prefab overrides with resolved names.';
+
+function message(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+serveStdio(() => {
+  const server = new McpServer({ name: 'prefablens', version: pkg.version });
+
+  server.registerTool(
+    'prefab_diff',
+    {
+      description: DESCRIPTION,
+      inputSchema: z.object({
+        path: z.string().describe('Asset path (.prefab/.unity/.asset), relative to projectRoot'),
+        before: z.string().default('HEAD').describe('Base git ref'),
+        after: z.string().optional().describe('Target git ref; omit to compare against the working tree'),
+        projectRoot: z.string().optional().describe('Repository root; defaults to the server cwd'),
+        format: z.enum(['tree', 'json']).default('tree').describe('tree = readable text, json = prefablens.diff.v2'),
+      }),
+    },
+    async ({ path: assetPath, before, after, projectRoot, format }) => {
+      try {
+        const cli = await ensureCli(pkg.version).catch((e: unknown) => {
+          throw new Error(
+            `prefablens CLI unavailable: ${message(e)}\n` +
+            'Place the binary manually and set PREFABLENS_CLI to its path.',
+          );
+        });
+        const res = await runCli(cli, buildArgs({ path: assetPath, before, after, format }), projectRoot ?? process.cwd());
+        if (res.code !== 0) {
+          return {
+            content: [{ type: 'text' as const, text: res.stderr.trim() || `prefablens exited with code ${res.code}` }],
+            isError: true,
+          };
+        }
+        const text = format === 'tree' ? truncateTree(res.stdout) : res.stdout;
+        return { content: [{ type: 'text' as const, text }] };
+      } catch (e) {
+        return { content: [{ type: 'text' as const, text: message(e) }], isError: true };
+      }
+    },
+  );
+
+  return server;
+});

--- a/mcp/src/server.test.ts
+++ b/mcp/src/server.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const cliPath = path.join(repoRoot, 'zig-out', 'bin', process.platform === 'win32' ? 'prefablens.exe' : 'prefablens');
+const serverEntry = fileURLToPath(new URL('../dist/index.js', import.meta.url));
+const testdata = path.join(repoRoot, 'core', 'src', 'testdata');
+
+let fixtureRepo: string;
+let client: Client;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-c', 'user.name=t', '-c', 'user.email=t@t', ...args], { cwd });
+}
+
+function firstText(res: { content?: unknown }): string {
+  const content = res.content as { type: string; text: string }[];
+  return content[0]?.text ?? '';
+}
+
+beforeAll(async () => {
+  fixtureRepo = mkdtempSync(path.join(tmpdir(), 'prefablens-mcp-'));
+  cpSync(path.join(testdata, 'plane_before.prefab'), path.join(fixtureRepo, 'Plane.prefab'));
+  git(fixtureRepo, 'init', '-q');
+  git(fixtureRepo, 'add', '.');
+  git(fixtureRepo, 'commit', '-q', '-m', 'init');
+  cpSync(path.join(testdata, 'plane_after.prefab'), path.join(fixtureRepo, 'Plane.prefab'));
+
+  client = new Client({ name: 'test', version: '0.0.0' });
+  await client.connect(new StdioClientTransport({
+    command: process.execPath,
+    args: [serverEntry],
+    env: { PREFABLENS_CLI: cliPath, PATH: process.env['PATH'] ?? '' },
+  }));
+});
+
+afterAll(async () => {
+  await client.close();
+  rmSync(fixtureRepo, { recursive: true, force: true });
+});
+
+test('prefab_diff returns the semantic tree for HEAD vs working tree', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', projectRoot: fixtureRepo },
+  });
+  expect(res.isError).toBeFalsy();
+  // ゴールデン。実装後に実出力を目視確認してからピンする(既存 golden の流儀)。
+  expect(firstText(res)).toBe([
+    '  Plane',
+    '  ~ Cylinder  <Prefab>',
+    '      components',
+    '        ~ Transform',
+    '          ~ Position.x: 0.41646004 -> 1',
+    '  + Cylinder Variant  <Prefab>',
+    '      components',
+    '        + Transform',
+    '          + Position: (2.03, 3.63, 1.11797)',
+    '',
+  ].join('\n'));
+});
+
+test('prefab_diff format:"json" returns prefablens.diff.v2', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', projectRoot: fixtureRepo, format: 'json' },
+  });
+  expect(res.isError).toBeFalsy();
+  const parsed = JSON.parse(firstText(res)) as { schema: string };
+  expect(parsed.schema).toBe('prefablens.diff.v2');
+});
+
+test('prefab_diff surfaces cli errors as tool errors', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', before: 'nosuchref', after: 'HEAD', projectRoot: fixtureRepo },
+  });
+  expect(res.isError).toBe(true);
+  expect(firstText(res)).toContain("git show failed for 'nosuchref:Plane.prefab'");
+});

--- a/mcp/tsconfig.build.json
+++ b/mcp/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false, "outDir": "dist" },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/mcp/tsconfig.build.json
+++ b/mcp/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": { "noEmit": false, "outDir": "dist" },
+  "compilerOptions": { "noEmit": false, "outDir": "dist", "rootDir": "src" },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { include: ['src/**/*.test.ts'], testTimeout: 30_000 },
+});


### PR DESCRIPTION
## Summary

Phase 4 (AI/MCP ホスト) のウォーキングスケルトン。`/mcp` に薄い stdio MCP サーバ `@hashiiiii/prefablens-mcp` を追加し、コーディングエージェントが Unity YAML アセットの意味的 diff を `prefab_diff` ツールで取得できるようにする。

- Spec: `docs/superpowers/specs/2026-07-04-phase4-mcp-host-design.md`
- Plan: `docs/superpowers/plans/2026-07-04-phase4-mcp-host.md`

## 中身

- **`mcp/src/diff.ts`** — CLI 引数組み立て(`--project .` で guid 解決を有効化)+ 50k 文字 truncate(tree のみ)
- **`mcp/src/cli.ts`** — CLI の探索(env `PREFABLENS_CLI` → `~/.cache/prefablens/<ver>/` → GitHub Releases zip 自動取得)、fflate 展開 + 原子的配置、サブプロセス実行(UTF-8 チャンク境界セーフ)
- **`mcp/src/index.ts`** — `prefab_diff` ツール(`path` / `before`=HEAD / `after` 省略=作業ツリー / `projectRoot` / `format`=tree|json)。SDK は `@modelcontextprotocol/server` 2.0.0-beta.2 に exact pin
- **テスト 14 本** — 純関数単体 + 実 CLI・実 git repo・実 stdio クライアントでの E2E ゴールデン(ネットワーク非依存)
- **CI** — `mcp` ジョブ追加(zig build → typecheck → build → test)
- **release.yml** — zip アセット公開後に npm publish(OIDC Trusted Publishing、tag と package.json version の一致検証付き)。初回 publish は次の cut-release(v0.2.0)で走る
- **cut-release スキル** — バージョンソース 4 → 5 箇所(`mcp/package.json` 追加)、check-versions.sh 更新

## 検証

- `zig build test` 99/99 / mcp `npm run typecheck` + `npm run build` + `npm test` 14/14 / `check-versions.sh 0.1.0` 5/5 ok
- JSON-RPC stdio スモーク: `tools/list` に `prefab_diff`
- 最終ブランチレビュー(SDD): Critical 0 / Important 1(beta SDK caret)→ exact pin で解消、再レビューで **Ready to merge: Yes**

## マージ前後のユーザー作業

1. **npmjs.com の Trusted Publisher 設定**(初回 publish 前に必須): パッケージ `@hashiiiii/prefablens-mcp` に対し repository `hashiiiii/PrefabLens` / workflow `release.yml` を Trusted Publisher として登録。未設定だと次のタグの npm publish ステップが失敗します
2. **license の判断**: リポジトリに LICENSE がないため `mcp/package.json` に license フィールドを入れていません(npm publish 時に警告は出るが成功はする)。公開パッケージとしてはライセンス明示を推奨

## Follow-up(別 PR、v0.2.0 タグ前推奨)

zod `.min(1)` / `ensureCli` の doc コメント / 空 stderr フォールバックのテスト / truncateTree 境界テスト / `npm@^11` pin / SKILL.md の done 定義に npm 追記 / mcp README。将来 hardening: バイナリ SHA256 検証、fetch/runCli タイムアウト