### PR TITLE
chore: mcp host follow-ups

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -76,4 +76,4 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
 
 ## Verify the outcome, not the intent
 
-A release is done only when `gh release view vX.Y.Z` lists all four zips. If the workflow failed, read `gh run view --log-failed`, fix on `main`, delete the partial tag/release, and re-tag — do not assume a pushed tag means a published release.
+A release is done only when `gh release view vX.Y.Z` lists all four zips **and** `npm view @hashiiiii/prefablens-mcp version` prints `X.Y.Z`. If the workflow failed, read `gh run view --log-failed`, fix on `main`, delete the partial tag/release, and re-tag — do not assume a pushed tag means a published release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             echo "mcp/package.json version $version does not match tag $GITHUB_REF_NAME" >&2
             exit 1
           fi
-          npm install -g npm@latest  # trusted publishing は npm >= 11.5.1 が必要(node 22 同梱は 10.x)
+          npm install -g 'npm@^11'  # trusted publishing は npm >= 11.5.1 が必要(node 22 同梱は 10.x)。将来 major の破壊的変更を避けて ^11 に固定
           npm ci
           npm run build
           npm publish --access public

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,50 @@
+# @hashiiiii/prefablens-mcp
+
+MCP server for [PrefabLens](https://github.com/hashiiiii/PrefabLens) — semantic diffs of Unity YAML assets (`.prefab` / `.unity` / `.asset`) between two git versions.
+
+Instead of reading raw YAML diffs, agents get a tree of added/removed/modified GameObjects, components, fields, and prefab overrides, with fileID-based object matching and names resolved via `.meta` guid scanning.
+
+## Setup
+
+Requires Node.js >= 22 and `git` on PATH.
+
+Claude Code:
+
+```sh
+claude mcp add prefablens -- npx -y @hashiiiii/prefablens-mcp
+```
+
+Generic MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "prefablens": {
+      "command": "npx",
+      "args": ["-y", "@hashiiiii/prefablens-mcp"]
+    }
+  }
+}
+```
+
+## Tool: `prefab_diff`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `path` | (required) | Asset path (`.prefab`/`.unity`/`.asset`), relative to `projectRoot` |
+| `before` | `HEAD` | Base git ref |
+| `after` | working tree | Target git ref; omit to compare against the working tree |
+| `projectRoot` | server cwd | Repository root (also the base for `.meta` guid resolution) |
+| `format` | `tree` | `tree` = readable text (truncated at 50k chars), `json` = `prefablens.diff.v2` |
+
+Example call:
+
+```json
+{ "path": "Assets/Prefabs/Player.prefab", "before": "main", "projectRoot": "/path/to/unity-project" }
+```
+
+## How the CLI is obtained
+
+The server drives the `prefablens` CLI as a subprocess. On first use it downloads the CLI matching this package's version from [GitHub Releases](https://github.com/hashiiiii/PrefabLens/releases) and caches it under `~/.cache/prefablens/<version>/`.
+
+To use a pre-installed binary instead (offline or restricted environments), set `PREFABLENS_CLI` to its path in the server's environment.

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -34,7 +34,11 @@ export function installFromZip(zipBytes: Uint8Array, dest: string, platform: Nod
   renameSync(tmp, dest);
 }
 
-/** env PREFABLENS_CLI → キャッシュ → GitHub Releases の順で CLI を確保する。 */
+/**
+ * env PREFABLENS_CLI → キャッシュ → GitHub Releases の順で CLI を確保する。
+ * PREFABLENS_CLI が存在しないパスを指す場合はエラーにせず次の候補へフォールスルーする
+ * (設定ミスでもキャッシュ/ダウンロードで動き続けることを優先)。
+ */
 export async function ensureCli(version: string): Promise<string> {
   const manual = process.env['PREFABLENS_CLI'];
   if (manual !== undefined && manual !== '' && existsSync(manual)) return manual;

--- a/mcp/src/diff.test.ts
+++ b/mcp/src/diff.test.ts
@@ -23,3 +23,11 @@ test('truncateTree truncates long text and appends a note', () => {
   expect(out.length).toBeLessThan(50_100);
   expect(out).toContain('[truncated: 60000 chars total]');
 });
+
+test('truncateTree keeps text exactly at the limit untouched', () => {
+  expect(truncateTree('x'.repeat(10), 10)).toBe('x'.repeat(10));
+});
+
+test('truncateTree cuts at the limit when one char over', () => {
+  expect(truncateTree('x'.repeat(11), 10)).toBe(`${'x'.repeat(10)}\n[truncated: 11 chars total]\n`);
+});

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -26,10 +26,10 @@ serveStdio(() => {
     {
       description: DESCRIPTION,
       inputSchema: z.object({
-        path: z.string().describe('Asset path (.prefab/.unity/.asset), relative to projectRoot'),
+        path: z.string().min(1).describe('Asset path (.prefab/.unity/.asset), relative to projectRoot'),
         before: z.string().default('HEAD').describe('Base git ref'),
         after: z.string().optional().describe('Target git ref; omit to compare against the working tree'),
-        projectRoot: z.string().optional().describe('Repository root; defaults to the server cwd'),
+        projectRoot: z.string().min(1).optional().describe('Repository root; defaults to the server cwd'),
         format: z.enum(['tree', 'json']).default('tree').describe('tree = readable text, json = prefablens.diff.v2'),
       }),
     },

--- a/mcp/src/server.test.ts
+++ b/mcp/src/server.test.ts
@@ -76,6 +76,24 @@ test('prefab_diff format:"json" returns prefablens.diff.v2', async () => {
   expect(parsed.schema).toBe('prefablens.diff.v2');
 });
 
+test('prefab_diff rejects an empty path before reaching the cli', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: '', projectRoot: fixtureRepo },
+  });
+  expect(res.isError).toBe(true);
+  expect(firstText(res)).toContain('Input validation error');
+});
+
+test('prefab_diff rejects an empty projectRoot before reaching the cli', async () => {
+  const res = await client.callTool({
+    name: 'prefab_diff',
+    arguments: { path: 'Plane.prefab', projectRoot: '' },
+  });
+  expect(res.isError).toBe(true);
+  expect(firstText(res)).toContain('Input validation error');
+});
+
 test('prefab_diff surfaces cli errors as tool errors', async () => {
   const res = await client.callTool({
     name: 'prefab_diff',

--- a/mcp/src/server.test.ts
+++ b/mcp/src/server.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { cpSync, mkdtempSync, rmSync } from 'node:fs';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -101,4 +101,25 @@ test('prefab_diff surfaces cli errors as tool errors', async () => {
   });
   expect(res.isError).toBe(true);
   expect(firstText(res)).toContain("git show failed for 'nosuchref:Plane.prefab'");
+});
+
+test('prefab_diff falls back to the exit code when stderr is empty', async () => {
+  const silentCli = path.join(fixtureRepo, 'silent-fail.sh');
+  writeFileSync(silentCli, '#!/bin/sh\nexit 3\n', { mode: 0o755 });
+  const silent = new Client({ name: 'test', version: '0.0.0' });
+  await silent.connect(new StdioClientTransport({
+    command: process.execPath,
+    args: [serverEntry],
+    env: { PREFABLENS_CLI: silentCli, PATH: process.env['PATH'] ?? '' },
+  }));
+  try {
+    const res = await silent.callTool({
+      name: 'prefab_diff',
+      arguments: { path: 'Plane.prefab', projectRoot: fixtureRepo },
+    });
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toBe('prefablens exited with code 3');
+  } finally {
+    await silent.close();
+  }
 });


### PR DESCRIPTION
## Summary

Follow-ups from the PR #13 final review triage (recommended before the v0.2.0 tag):

- **fix**: reject empty `path` / `projectRoot` with zod `.min(1)` — an empty `path` previously reached the CLI (`error: cannot read file ''`) and an empty `projectRoot` silently ran in the wrong cwd and returned an empty success
- **test**: empty-stderr exit-code fallback (`prefablens exited with code N`), via a `PREFABLENS_CLI` fake that exits silently
- **test**: `truncateTree` boundary cases (exactly at the limit / one char over), mutation-verified
- **docs**: `ensureCli` doc comment for the `PREFABLENS_CLI` missing-path fallthrough
- **ci**: pin `npm@^11` in release.yml (was `npm@latest`)
- **docs**: cut-release done definition now includes the npm publish check
- **docs**: README for the npm package page (`npm pack --dry-run` confirms inclusion)

## Verification

- mcp: typecheck / build / vitest 19/19 (14 → +5)
- zig build test: pass
- check-versions.sh 0.1.0: all five sources agree