### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -12,7 +12,7 @@ namespace PrefabLens
     public static class Cli
     {
         /// ダウンロードする CLI のバージョン(GitHub Releases のタグ v{Version} と一致させる)。
-        public const string Version = "0.1.0";
+        public const string Version = "0.2.0";
         public const string CliPathPref = "PrefabLens.CliPath";
 
         // ---- 純関数(EditMode テスト対象) ----

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hashiiiii.prefablens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "displayName": "PrefabLens",
   "description": "Semantic diffs for Unity YAML assets (prefab / scene / asset) against git, rendered inside the Editor.",
   "unity": "2022.3",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PrefabLens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Semantic diffs for Unity YAML files in GitHub pull requests",
   "permissions": ["storage", "scripting"],
   "host_permissions": ["https://api.github.com/*"],

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prefablens-extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prefablens-extension",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@types/chrome": "^0.2.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prefablens-extension",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "build": "node build.mjs",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashiiiii/prefablens-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashiiiii/prefablens-mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0-beta.2",
         "fflate": "^0.8.3",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashiiiii/prefablens-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for semantic diffs of Unity YAML assets (.prefab/.unity/.asset)",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Version bump for the v0.2.0 release (Phase 4: MCP host + Apache 2.0 license since v0.1.0).

- All five version sources bumped in lockstep (`check-versions.sh 0.2.0` passes)
- Lockfile root versions updated by hand to avoid npm-version-dependent metadata churn

After squash-merge, `v0.2.0` will be tagged on main to trigger the release workflow. The npm publish step is paused (`if: false`), so the workflow ships the four CLI zips only.