### PR TITLE
fix: add timeouts to mcp download and cli run

### DIFF
--- a/mcp/src/cli.test.ts
+++ b/mcp/src/cli.test.ts
@@ -1,9 +1,11 @@
 import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { zipSync } from 'fflate';
 import { afterAll, expect, test } from 'vitest';
-import { binaryName, cachePath, downloadUrl, installFromZip, releaseAssetName, runCli } from './cli.js';
+import { binaryName, cachePath, download, downloadUrl, installFromZip, releaseAssetName, runCli } from './cli.js';
 
 const dir = mkdtempSync(path.join(tmpdir(), 'prefablens-cli-test-'));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
@@ -49,4 +51,92 @@ test('runCli captures stdout and exit code', async () => {
   const res = await runCli('git', ['--version'], process.cwd());
   expect(res.code).toBe(0);
   expect(res.stdout).toContain('git version');
+});
+
+test('runCli kills a hung process and rejects after the timeout', async () => {
+  // 実プロセス(60 秒 sleep する node)を 200ms タイムアウトで打ち切る。
+  await expect(
+    runCli(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], process.cwd(), 200),
+  ).rejects.toThrow('timed out after 200ms');
+});
+
+test('runCli rejects on timeout even when a grandchild keeps stdio open', async () => {
+  // SIGKILL が殺せるのは直接の子だけ。stdio を継承した孫がパイプを掴んだままだと
+  // 'close' はパイプ全閉塞まで発火しないので、close を待たずに reject できることを確認する。
+  const script =
+    "const{spawn}=require('node:child_process');" +
+    "spawn(process.execPath,['-e','setTimeout(()=>{},3000)'],{stdio:['ignore','inherit','inherit']});" +
+    'setTimeout(()=>{},3000);';
+  await expect(
+    runCli(process.execPath, ['-e', script], process.cwd(), 200),
+  ).rejects.toThrow('timed out after 200ms');
+}, 2000);
+
+test('runCli includes captured stderr in the timeout error', async () => {
+  // ハング原因の手がかり(例: git の lock 待ち)を timeout エラーでも失わない。
+  const script = "process.stderr.write('lock held');setTimeout(()=>{},3000);";
+  await expect(
+    runCli(process.execPath, ['-e', script], process.cwd(), 300),
+  ).rejects.toThrow('lock held');
+});
+
+/** 実 HTTP サーバーを空きポートで起動し、テスト後に閉じるための最小ヘルパー。 */
+async function withServer(
+  handler: Parameters<typeof createServer>[1],
+  run: (baseUrl: string) => Promise<void>,
+): Promise<void> {
+  const srv: Server = createServer(handler);
+  await new Promise<void>((resolve) => srv.listen(0, '127.0.0.1', resolve));
+  try {
+    await run(`http://127.0.0.1:${(srv.address() as AddressInfo).port}`);
+  } finally {
+    srv.closeAllConnections();
+    srv.close();
+  }
+}
+
+test('download returns the response body bytes', async () => {
+  await withServer(
+    (_req, res) => res.end('zip-bytes'),
+    async (base) => {
+      const bytes = await download(`${base}/asset.zip`);
+      expect(new TextDecoder().decode(bytes)).toBe('zip-bytes');
+    },
+  );
+});
+
+test('download surfaces HTTP errors with status and url', async () => {
+  await withServer(
+    (_req, res) => {
+      res.statusCode = 404;
+      res.end();
+    },
+    async (base) => {
+      await expect(download(`${base}/missing.zip`)).rejects.toThrow('download failed: HTTP 404');
+    },
+  );
+});
+
+test('download rejects when the body stalls past the timeout', async () => {
+  // ヘッダーは返すが body を完結させないサーバー。body 読み取り中の abort が
+  // 'TypeError: terminated' 等に化けず timeout エラーに正規化されることを確認する。
+  await withServer(
+    (_req, res) => {
+      res.writeHead(200, { 'content-length': '10' });
+      res.write('abc');
+    },
+    async (base) => {
+      await expect(download(`${base}/slow.zip`, 200)).rejects.toThrow('download timed out after 200ms');
+    },
+  );
+});
+
+test('download rejects when the server never responds within the timeout', async () => {
+  // リクエストを受け付けるがレスポンスを一切書かない実サーバーでハングを再現する。
+  await withServer(
+    () => {},
+    async (base) => {
+      await expect(download(`${base}/hang.zip`, 200)).rejects.toThrow('download timed out after 200ms');
+    },
+  );
 });

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -34,6 +34,23 @@ export function installFromZip(zipBytes: Uint8Array, dest: string, platform: Nod
   renameSync(tmp, dest);
 }
 
+/** ハング防止の上限。release zip は数 MB、CLI diff は通常 1 秒未満なので 60 秒は十分に保守的。 */
+const TIMEOUT_MS = 60_000;
+
+export async function download(url: string, timeoutMs = TIMEOUT_MS): Promise<Uint8Array> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) throw new Error(`download failed: HTTP ${res.status} for ${url}`);
+    return new Uint8Array(await res.arrayBuffer());
+  } catch (e) {
+    // AbortSignal.timeout の reason は DOMException(name: TimeoutError)。ヘッダー待ちと body 読み取り中のどちらの abort もこれで捕捉できる。
+    if (e instanceof DOMException && e.name === 'TimeoutError') {
+      throw new Error(`download timed out after ${timeoutMs}ms for ${url}`);
+    }
+    throw e;
+  }
+}
+
 /**
  * env PREFABLENS_CLI → キャッシュ → GitHub Releases の順で CLI を確保する。
  * PREFABLENS_CLI が存在しないパスを指す場合はエラーにせず次の候補へフォールスルーする
@@ -45,9 +62,7 @@ export async function ensureCli(version: string): Promise<string> {
   const dest = cachePath(version, process.platform, homedir());
   if (existsSync(dest)) return dest;
   const url = downloadUrl(version, releaseAssetName(process.platform, process.arch));
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`download failed: HTTP ${res.status} for ${url}`);
-  installFromZip(new Uint8Array(await res.arrayBuffer()), dest, process.platform);
+  installFromZip(await download(url), dest, process.platform);
   return dest;
 }
 
@@ -57,16 +72,34 @@ export interface CliResult {
   stderr: string;
 }
 
-export function runCli(cliPath: string, args: string[], cwd: string): Promise<CliResult> {
+export function runCli(cliPath: string, args: string[], cwd: string, timeoutMs = TIMEOUT_MS): Promise<CliResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(cliPath, args, { cwd });
     let stdout = '';
     let stderr = '';
+    // タイマー内で直接 reject する。'close' 待ちにすると、SIGKILL 後も stdio パイプを
+    // 継承した孫プロセス(git 等)が掴んでいる間 'close' が発火せずハングしたままになる。
+    const timer = setTimeout(() => {
+      // すでに終了済みなら timeout 扱いにしない(exit と 'close' の隙間で発火したレース)。
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill('SIGKILL');
+      // 読み取り側ハンドルを閉じ、孫プロセスが残ってもイベントループを塞がないようにする。
+      child.stdout.destroy();
+      child.stderr.destroy();
+      const hint = stderr.trim() === '' ? '' : `\nstderr: ${stderr.trim()}`;
+      reject(new Error(`prefablens CLI timed out after ${timeoutMs}ms${hint}`));
+    }, timeoutMs);
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
     child.stdout.on('data', (c: string) => { stdout += c; });
     child.stderr.on('data', (c: string) => { stderr += c; });
-    child.on('error', reject);
-    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
   });
 }


### PR DESCRIPTION
## Summary

Phase 4 最終レビューの持ち越し hardening(fetch・runCli タイムアウト)を実装する。

- `ensureCli` の fetch を `download(url, timeoutMs)` として抽出し、`AbortSignal.timeout`(既定 60 秒)を適用。timeout は明確なメッセージ(`download timed out after ...`)に正規化
- `runCli` に timeout(既定 60 秒)を追加。タイマー内で SIGKILL + 直接 reject する
  - `close` イベント待ちだと、stdio を継承した孫プロセス(git 等)がパイプを掴んでいる間 `close` が発火せず、タイムアウト後もハングしたままになる(テストで実証済み)
  - 終了済みプロセスへのレース(exit と close の隙間)は `exitCode` ガードで timeout 誤判定を回避
  - timeout エラーに捕捉済み stderr を含め、ハング原因の手がかりを残す

## Test plan

- [x] mcp: vitest 26/26(新規 6 本: hung process kill / 孫プロセスの stdio 保持 / stderr 引き継ぎ / download の bytes・HTTP エラー・ヘッダー停滞・body 停滞)— 全てモックなしの実プロセス・実 HTTP サーバー
- [x] typecheck / build green
- [x] CI green を確認後にセルフマージ(workflow-autonomy)