### PR TITLE
feat: verify release zip sha256 in mcp

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cut-release
-description: Use when cutting a new PrefabLens release, publishing a version, or pushing a vX.Y.Z tag. Bumps the five version sources in lockstep, tags main to trigger the release workflow, and verifies the GitHub Release with its four CLI zips. PrefabLens repo only. Explicit invocation only — pushes tags and publishes a public release.
+description: Use when cutting a new PrefabLens release, publishing a version, or pushing a vX.Y.Z tag. Bumps the five version sources in lockstep, tags main to trigger the release workflow, and verifies the GitHub Release with its four CLI zips plus SHA256SUMS. PrefabLens repo only. Explicit invocation only — pushes tags and publishes a public release.
 disable-model-invocation: true
 license: Proprietary
 metadata:
@@ -61,7 +61,7 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
    gh release view vX.Y.Z --json tagName,assets -q '.tagName + ": " + ([.assets[].name] | join(", "))'
    ```
 
-   Expect four assets: `prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip`.
+   Expect five assets: `prefablens-{macos-arm64,macos-x64,linux-x64,windows-x64}.zip` and `SHA256SUMS` (the MCP server verifies downloads against it — a release without it silently skips verification).
 
    Also verify `npm view @hashiiiii/prefablens-mcp version` matches the tag (skip while npm publishing is paused).
 
@@ -76,4 +76,4 @@ Run from a clean `main` that is up to date (`git switch main && git pull`).
 
 ## Verify the outcome, not the intent
 
-A release is done only when `gh release view vX.Y.Z` lists all four zips **and**, once npm publishing is re-enabled, `npm view @hashiiiii/prefablens-mcp version` prints `X.Y.Z`. If the workflow failed, read `gh run view --log-failed`, fix on `main`, delete the partial tag/release, and re-tag — do not assume a pushed tag means a published release.
+A release is done only when `gh release view vX.Y.Z` lists all four zips plus `SHA256SUMS` **and**, once npm publishing is re-enabled, `npm view @hashiiiii/prefablens-mcp version` prints `X.Y.Z`. If the workflow failed, read `gh run view --log-failed`, fix on `main`, delete the partial tag/release, and re-tag — do not assume a pushed tag means a published release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,12 @@ jobs:
           build x86_64-macos     macos-x64    prefablens
           build x86_64-linux-gnu linux-x64    prefablens
           build x86_64-windows   windows-x64  prefablens.exe
+          # ダウンロード側(mcp の ensureCli)が整合性検証に使う。sha256sum 形式で全 zip をカバーする。
+          (cd dist && sha256sum *.zip > SHA256SUMS)
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" dist/*.zip --generate-notes
+        run: gh release create "$GITHUB_REF_NAME" dist/*.zip dist/SHA256SUMS --generate-notes
       # npm publish は保留中(npmjs.com の Trusted Publisher 未設定)。設定後に if 条件を外して再開する。
       - name: Publish MCP server to npm
         if: ${{ false }}

--- a/mcp/src/cli.test.ts
+++ b/mcp/src/cli.test.ts
@@ -5,7 +5,17 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { zipSync } from 'fflate';
 import { afterAll, expect, test } from 'vitest';
-import { binaryName, cachePath, download, downloadUrl, installFromZip, releaseAssetName, runCli } from './cli.js';
+import {
+  binaryName,
+  cachePath,
+  download,
+  downloadUrl,
+  expectedSha256,
+  installFromZip,
+  releaseAssetName,
+  runCli,
+  verifySha256,
+} from './cli.js';
 
 const dir = mkdtempSync(path.join(tmpdir(), 'prefablens-cli-test-'));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
@@ -45,6 +55,30 @@ test('installFromZip extracts the binary atomically and marks it executable', ()
 test('installFromZip rejects a zip without the expected binary', () => {
   const zip = zipSync({ other: new Uint8Array([1]) });
   expect(() => installFromZip(zip, path.join(dir, 'v2', 'prefablens'), 'linux')).toThrow('not found');
+});
+
+// sha256("hello") の既知値。ツール(sha256sum)出力との一致を固定するため文字列リテラルでピンする。
+const HELLO_SHA256 = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+const HELLO = new TextEncoder().encode('hello');
+
+test('expectedSha256 parses sha256sum output lines', () => {
+  const sums = `${HELLO_SHA256}  prefablens-macos-arm64.zip\naaaa  garbage\n${'0'.repeat(64)}  prefablens-linux-x64.zip\n`;
+  expect(expectedSha256(sums, 'prefablens-macos-arm64.zip')).toBe(HELLO_SHA256);
+  expect(expectedSha256(sums, 'prefablens-linux-x64.zip')).toBe('0'.repeat(64));
+  expect(expectedSha256(sums, 'prefablens-windows-x64.zip')).toBeUndefined();
+});
+
+test('verifySha256 accepts a matching zip', () => {
+  expect(() => verifySha256(HELLO, `${HELLO_SHA256}  asset.zip`, 'asset.zip')).not.toThrow();
+});
+
+test('verifySha256 rejects a tampered zip', () => {
+  const tampered = new TextEncoder().encode('hellO');
+  expect(() => verifySha256(tampered, `${HELLO_SHA256}  asset.zip`, 'asset.zip')).toThrow('checksum mismatch');
+});
+
+test('verifySha256 rejects a checksum file without the asset entry', () => {
+  expect(() => verifySha256(HELLO, `${HELLO_SHA256}  other.zip`, 'asset.zip')).toThrow('no checksum entry');
 });
 
 test('runCli captures stdout and exit code', async () => {
@@ -112,7 +146,11 @@ test('download surfaces HTTP errors with status and url', async () => {
       res.end();
     },
     async (base) => {
-      await expect(download(`${base}/missing.zip`)).rejects.toThrow('download failed: HTTP 404');
+      // ensureCli が「404 = SHA256SUMS 未同梱の旧リリース」だけを skip 対象にできるよう status を載せる。
+      await expect(download(`${base}/missing.zip`)).rejects.toMatchObject({
+        message: expect.stringContaining('download failed: HTTP 404'),
+        status: 404,
+      });
     },
   );
 });

--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { chmodSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
@@ -40,7 +41,8 @@ const TIMEOUT_MS = 60_000;
 export async function download(url: string, timeoutMs = TIMEOUT_MS): Promise<Uint8Array> {
   try {
     const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
-    if (!res.ok) throw new Error(`download failed: HTTP ${res.status} for ${url}`);
+    // status は呼び出し側の分岐用(404 = アセット不在)。message 文字列の解析に依存させない。
+    if (!res.ok) throw Object.assign(new Error(`download failed: HTTP ${res.status} for ${url}`), { status: res.status });
     return new Uint8Array(await res.arrayBuffer());
   } catch (e) {
     // AbortSignal.timeout の reason は DOMException(name: TimeoutError)。ヘッダー待ちと body 読み取り中のどちらの abort もこれで捕捉できる。
@@ -49,6 +51,23 @@ export async function download(url: string, timeoutMs = TIMEOUT_MS): Promise<Uin
     }
     throw e;
   }
+}
+
+/** sha256sum 形式(`‹64hex›  ‹filename›`、binary モードの `*` 前置も許容)から assetName の期待値を引く。 */
+export function expectedSha256(sums: string, assetName: string): string | undefined {
+  for (const line of sums.split('\n')) {
+    const m = /^([0-9a-f]{64})\s+\*?(.+)$/.exec(line.trim());
+    if (m !== null && m[2] === assetName) return m[1];
+  }
+  return undefined;
+}
+
+/** SHA256SUMS と照合する。エントリ欠落・ハッシュ不一致は throw(破損 zip を実行しない)。 */
+export function verifySha256(zipBytes: Uint8Array, sums: string, assetName: string): void {
+  const want = expectedSha256(sums, assetName);
+  if (want === undefined) throw new Error(`no checksum entry for ${assetName} in SHA256SUMS`);
+  const got = createHash('sha256').update(zipBytes).digest('hex');
+  if (got !== want) throw new Error(`checksum mismatch for ${assetName}: expected ${want}, got ${got}`);
 }
 
 /**
@@ -61,8 +80,19 @@ export async function ensureCli(version: string): Promise<string> {
   if (manual !== undefined && manual !== '' && existsSync(manual)) return manual;
   const dest = cachePath(version, process.platform, homedir());
   if (existsSync(dest)) return dest;
-  const url = downloadUrl(version, releaseAssetName(process.platform, process.arch));
-  installFromZip(await download(url), dest, process.platform);
+  const assetName = releaseAssetName(process.platform, process.arch);
+  const zip = await download(downloadUrl(version, assetName));
+  // SHA256SUMS を持たない旧リリース(v0.2.0 以前)= 404 のときだけ検証をスキップする。
+  // タイムアウトや 5xx で黙ってスキップすると、チェックサムだけ妨害された場合に検証が無効化されるため伝播させる。
+  let sums: string | undefined;
+  try {
+    sums = new TextDecoder().decode(await download(downloadUrl(version, 'SHA256SUMS')));
+  } catch (e) {
+    if ((e as { status?: unknown }).status !== 404) throw e;
+    console.error(`prefablens-mcp: no SHA256SUMS for v${version}, skipping checksum verification`);
+  }
+  if (sums !== undefined) verifySha256(zip, sums, assetName);
+  installFromZip(zip, dest, process.platform);
   return dest;
 }
 


### PR DESCRIPTION
## Summary

Phase 4 最終レビューの将来 hardening 残件「バイナリ SHA256 検証」を実装する。

- release.yml: 4 zip の `SHA256SUMS`(sha256sum 形式)を生成し、5 個目のリリースアセットとして公開
- mcp `ensureCli`: zip ダウンロード後に同リリースの `SHA256SUMS` と照合。不一致・エントリ欠落は throw し、破損 zip をキャッシュ・実行しない
  - スキップは **404(SHA256SUMS 未同梱の旧リリース)のみ**。タイムアウトや 5xx で黙ってスキップすると、チェックサムだけ妨害された場合に検証が無効化されるため伝播させる(`download` のエラーに `status` を付与して message 文字列解析を回避)
- cut-release スキル: 期待アセット数を 5 に更新(SHA256SUMS の存在確認を done 定義に追加)

v0.2.0 リリースには SHA256SUMS が無いため、検証が効き始めるのは次のリリースから(それまでは 404 skip + stderr ログ)。Editor(C#)側のダウンローダは未検証のまま — 将来の parity 課題。

## Test plan

- [x] mcp: vitest 30/30(新規: sha256sum 形式パース / 一致・改竄・エントリ欠落 / download エラーの status)
- [x] 実 `shasum -a 256` 出力に対する end-to-end 照合をローカル確認(dist ビルド経由)
- [x] release.yml の YAML 妥当性確認(release はタグ push まで CI 対象外)
- [x] typecheck / build green
- [x] CI green 確認後にセルフマージ(workflow-autonomy)