### PR TITLE
ci: run mcp job on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Unity YAML fixtures are byte-exact test inputs (golden tests parse them as-is).
+# Keep them out of CRLF conversion on Windows checkouts.
+*.prefab -text
+*.unity -text
+*.asset -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,11 @@ jobs:
         run: npm run e2e
 
   mcp:
-    runs-on: ubuntu-latest
+    # npm パッケージは全 OS 向けに配布し、プロセス kill・タイムアウト・spawn はプラットフォーム差が出やすいので windows でも回す。
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: mcp

--- a/mcp/src/cli.test.ts
+++ b/mcp/src/cli.test.ts
@@ -49,7 +49,8 @@ test('installFromZip extracts the binary atomically and marks it executable', ()
   const dest = path.join(dir, 'v1', 'prefablens');
   installFromZip(zip, dest, 'linux');
   expect(readFileSync(dest, 'utf8')).toContain('echo ok');
-  expect(statSync(dest).mode & 0o111).not.toBe(0);
+  // Windows のファイルシステムに unix の実行ビットは無い(実装も win32 では chmod しない)。
+  if (process.platform !== 'win32') expect(statSync(dest).mode & 0o111).not.toBe(0);
 });
 
 test('installFromZip rejects a zip without the expected binary', () => {

--- a/mcp/src/server.test.ts
+++ b/mcp/src/server.test.ts
@@ -24,6 +24,14 @@ function firstText(res: { content?: unknown }): string {
   return content[0]?.text ?? '';
 }
 
+/** 親の環境を丸ごと引き継いで PREFABLENS_CLI だけ上書きする。置換式だと Windows で SystemRoot 等が欠落して子 node が壊れる。 */
+function envWith(cli: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) if (v !== undefined) env[k] = v;
+  env['PREFABLENS_CLI'] = cli;
+  return env;
+}
+
 beforeAll(async () => {
   fixtureRepo = mkdtempSync(path.join(tmpdir(), 'prefablens-mcp-'));
   cpSync(path.join(testdata, 'plane_before.prefab'), path.join(fixtureRepo, 'Plane.prefab'));
@@ -36,7 +44,7 @@ beforeAll(async () => {
   await client.connect(new StdioClientTransport({
     command: process.execPath,
     args: [serverEntry],
-    env: { PREFABLENS_CLI: cliPath, PATH: process.env['PATH'] ?? '' },
+    env: envWith(cliPath),
   }));
 });
 
@@ -103,14 +111,15 @@ test('prefab_diff surfaces cli errors as tool errors', async () => {
   expect(firstText(res)).toContain("git show failed for 'nosuchref:Plane.prefab'");
 });
 
-test('prefab_diff falls back to the exit code when stderr is empty', async () => {
+// シェルスクリプトの fixture CLI は Windows では起動できない(検証対象の fallback 自体はプラットフォーム非依存の JS)。
+test.skipIf(process.platform === 'win32')('prefab_diff falls back to the exit code when stderr is empty', async () => {
   const silentCli = path.join(fixtureRepo, 'silent-fail.sh');
   writeFileSync(silentCli, '#!/bin/sh\nexit 3\n', { mode: 0o755 });
   const silent = new Client({ name: 'test', version: '0.0.0' });
   await silent.connect(new StdioClientTransport({
     command: process.execPath,
     args: [serverEntry],
-    env: { PREFABLENS_CLI: silentCli, PATH: process.env['PATH'] ?? '' },
+    env: envWith(silentCli),
   }));
   try {
     const res = await silent.callTool({


### PR DESCRIPTION
## Summary

mcp は npm パッケージとして全 OS 向けに配布しており、PR #18 で入れたプロセス kill・タイムアウト・spawn 周りはプラットフォーム差が出やすいのに Windows のテストカバレッジがゼロだった。ci.yml の mcp ジョブを `ubuntu-latest / windows-latest` の matrix にする。

Windows 対応の随伴修正:

- `server.test.ts` の子プロセス env を置換式 → 親 env 引き継ぎ + `PREFABLENS_CLI` 上書きに変更(Phase 4 トリアージ持ち越し。置換式は Windows で `SystemRoot` 等が欠落し子 node が壊れる)
- `silent-fail.sh` フィクスチャの 1 テストは `skipIf(win32)`(シェルスクリプトは Windows で起動不可。検証対象の fallback ロジック自体はプラットフォーム非依存)
- `.gitattributes` 新設: `*.prefab` / `*.unity` / `*.asset` を `-text` に(Windows checkout の CRLF 変換から golden テストのバイト列を守る)

## Test plan

- [x] ローカル(macOS): mcp 30/30 / typecheck / build green
- [x] ci.yml YAML 妥当性
- [ ] CI: windows-latest の mcp ジョブ green(この PR 自体が検証。mise-action の Windows 挙動含む)
- [x] CI green 確認後にセルフマージ(workflow-autonomy)