### PR TITLE
docs: document mcp checksum and timeout behavior

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -47,4 +47,6 @@ Example call:
 
 The server drives the `prefablens` CLI as a subprocess. On first use it downloads the CLI matching this package's version from [GitHub Releases](https://github.com/hashiiiii/PrefabLens/releases) and caches it under `~/.cache/prefablens/<version>/`.
 
+Downloads are verified against the release's `SHA256SUMS` asset before the binary is cached; a mismatch aborts the install. Releases that predate `SHA256SUMS` (v0.2.0 and earlier) skip verification with a note on stderr. Both the download and each CLI run are bounded by a 60 s timeout so a stalled network or hung subprocess cannot block the MCP call indefinitely.
+
 To use a pre-installed binary instead (offline or restricted environments), set `PREFABLENS_CLI` to its path in the server's environment.


### PR DESCRIPTION
## Summary

PR #18(タイムアウト)と PR #19(SHA256 検証)で入った挙動を mcp README の「How the CLI is obtained」に反映する。ドキュメントのみ。

## Test plan

- [x] 記述が実装(mcp/src/cli.ts の ensureCli / download / runCli)と一致することを確認
- [x] CI green 確認後にセルフマージ(workflow-autonomy)