### PR TITLE
feat: add timeout and sha256 check to editor cli

### DIFF
--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -2,8 +2,11 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using UnityEditor;
 
 namespace PrefabLens
@@ -14,6 +17,10 @@ namespace PrefabLens
         /// ダウンロードする CLI のバージョン(GitHub Releases のタグ v{Version} と一致させる)。
         public const string Version = "0.2.0";
         public const string CliPathPref = "PrefabLens.CliPath";
+
+        /// CLI 実行の上限。CLI 内部の git タイムアウト(60 秒)より長く取り、git ハング時は
+        /// CLI 自身の具体的なエラーを先に出させる。ここは Unity メインスレッド凍結の最終安全網。
+        public const int RunTimeoutMs = 90_000;
 
         // ---- 純関数(EditMode テスト対象) ----
 
@@ -37,6 +44,31 @@ namespace PrefabLens
             for (var i = 0; i < args.Length; i++)
                 quoted[i] = "\"" + args[i].Replace("\"", "\\\"") + "\"";
             return string.Join(" ", quoted);
+        }
+
+        /// `sha256sum` 形式("<hex>  <name>"、バイナリモードは "<hex> *<name>")から
+        /// assetName の行のハッシュを取り出す。見つからなければ null。
+        public static string ParseSha256Sums(string sums, string assetName)
+        {
+            foreach (var raw in sums.Split('\n'))
+            {
+                var line = raw.Trim();
+                var sep = line.IndexOf(' ');
+                if (sep <= 0) continue;
+                var name = line.Substring(sep).Trim().TrimStart('*');
+                if (name == assetName) return line.Substring(0, sep);
+            }
+            return null;
+        }
+
+        public static string Sha256Hex(byte[] bytes)
+        {
+            using (var sha = SHA256.Create())
+            {
+                var sb = new StringBuilder();
+                foreach (var b in sha.ComputeHash(bytes)) sb.Append(b.ToString("x2"));
+                return sb.ToString();
+            }
         }
 
         // ---- Editor 連携 ----
@@ -70,15 +102,19 @@ namespace PrefabLens
             {
                 EditorUtility.DisplayProgressBar("PrefabLens", $"Downloading {asset}…", 0.3f);
                 using (var http = new HttpClient())
-                using (var zip = new ZipArchive(new MemoryStream(http.GetByteArrayAsync(url).Result)))
                 {
-                    foreach (var entry in zip.Entries)
+                    var bytes = http.GetByteArrayAsync(url).Result;
+                    VerifyChecksum(http, asset, bytes);
+                    using (var zip = new ZipArchive(new MemoryStream(bytes)))
                     {
-                        // ZipFileExtensions(ExtractToFile)は netstandard で参照できないため手動コピー
-                        var dest = Path.Combine(dir, entry.Name);
-                        using (var src = entry.Open())
-                        using (var dst = File.Create(dest))
-                            src.CopyTo(dst);
+                        foreach (var entry in zip.Entries)
+                        {
+                            // ZipFileExtensions(ExtractToFile)は netstandard で参照できないため手動コピー
+                            var dest = Path.Combine(dir, entry.Name);
+                            using (var src = entry.Open())
+                            using (var dst = File.Create(dest))
+                                src.CopyTo(dst);
+                        }
                     }
                 }
             }
@@ -88,8 +124,23 @@ namespace PrefabLens
             }
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                RunProcess("chmod", "+x \"" + DefaultPath + "\"", ".");
+                RunProcess("chmod", "+x \"" + DefaultPath + "\"", ".", RunTimeoutMs);
             return DefaultPath;
+        }
+
+        /// リリースの SHA256SUMS と zip を照合する。SHA256SUMS が無い(404 = v0.2.0 以前の
+        /// リリース)場合のみスキップし、それ以外の取得失敗と不一致は throw。
+        static void VerifyChecksum(HttpClient http, string assetName, byte[] zipBytes)
+        {
+            var res = http.GetAsync(DownloadUrl(Version, "SHA256SUMS")).Result;
+            if (res.StatusCode == HttpStatusCode.NotFound) return;
+            res.EnsureSuccessStatusCode();
+            var want = ParseSha256Sums(res.Content.ReadAsStringAsync().Result, assetName);
+            if (want == null)
+                throw new InvalidOperationException($"SHA256SUMS has no entry for {assetName}");
+            var got = Sha256Hex(zipBytes);
+            if (!string.Equals(want, got, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException($"SHA256 mismatch for {assetName}: expected {want}, got {got}");
         }
 
         public struct Result
@@ -97,15 +148,16 @@ namespace PrefabLens
             public int ExitCode;
             public string Stdout;
             public string Stderr;
+            public bool TimedOut;
         }
 
         /// プロジェクトルートを cwd に CLI を実行する(--git は cwd のリポジトリを見る)。
         public static Result Run(string cliPath, string assetPath)
         {
-            return RunProcess(cliPath, QuoteArgs(BuildArgs(assetPath)), Directory.GetCurrentDirectory());
+            return RunProcess(cliPath, QuoteArgs(BuildArgs(assetPath)), Directory.GetCurrentDirectory(), RunTimeoutMs);
         }
 
-        static Result RunProcess(string file, string arguments, string workDir)
+        public static Result RunProcess(string file, string arguments, string workDir, int timeoutMs)
         {
             var psi = new ProcessStartInfo(file, arguments)
             {
@@ -120,7 +172,21 @@ namespace PrefabLens
                 // 双方向 ReadToEnd のデッドロックを避ける: 片方は async で読む
                 var stdout = p.StandardOutput.ReadToEndAsync();
                 var stderr = p.StandardError.ReadToEndAsync();
-                p.WaitForExit();
+                if (!p.WaitForExit(timeoutMs))
+                {
+                    // ハングした CLI から Unity メインスレッドを守る。Kill 後も stdio を掴む
+                    // 孫プロセスが残ると Read タスクは完了しないため、読み残しは待たない。
+                    try { p.Kill(); }
+                    catch (InvalidOperationException) { /* タイムアウトと終了の競合 */ }
+                    catch (System.ComponentModel.Win32Exception) { /* 既に終了処理中 */ }
+                    return new Result
+                    {
+                        ExitCode = -1,
+                        Stdout = "",
+                        Stderr = $"prefablens timed out after {timeoutMs / 1000}s and was killed",
+                        TimedOut = true,
+                    };
+                }
                 return new Result { ExitCode = p.ExitCode, Stdout = stdout.Result, Stderr = stderr.Result };
             }
         }

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
 using NUnit.Framework;
 
 namespace PrefabLens.Tests
@@ -32,6 +35,64 @@ namespace PrefabLens.Tests
         {
             Assert.AreEqual("\"--git\" \"HEAD\" \"Assets/My Prefab.prefab\" \"--json\"", Cli.QuoteArgs(Cli.BuildArgs("Assets/My Prefab.prefab")));
             Assert.AreEqual("\"a\\\"b\"", Cli.QuoteArgs(new[] { "a\"b" }));
+        }
+
+        [Test]
+        public void ParseSha256SumsFindsTheAssetLine()
+        {
+            // release.yml の `sha256sum *.zip` が生成するそのままの形。
+            var sums =
+                "1111111111111111111111111111111111111111111111111111111111111111  prefablens-linux-x64.zip\n" +
+                "2222222222222222222222222222222222222222222222222222222222222222  prefablens-macos-arm64.zip\n";
+            Assert.AreEqual(
+                "2222222222222222222222222222222222222222222222222222222222222222",
+                Cli.ParseSha256Sums(sums, "prefablens-macos-arm64.zip"));
+            Assert.IsNull(Cli.ParseSha256Sums(sums, "prefablens-windows-x64.zip"));
+        }
+
+        [Test]
+        public void ParseSha256SumsHandlesCrlfAndBinaryMarker()
+        {
+            // CRLF 改行と、sha256sum バイナリモードの "*" 前置も受理する。
+            var sums = "cafe01 *prefablens-windows-x64.zip\r\n";
+            Assert.AreEqual("cafe01", Cli.ParseSha256Sums(sums, "prefablens-windows-x64.zip"));
+        }
+
+        [Test]
+        public void Sha256HexMatchesTheStandardTestVector()
+        {
+            // FIPS 180-2 の既知ベクタ: sha256("abc")
+            Assert.AreEqual(
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                Cli.Sha256Hex(Encoding.ASCII.GetBytes("abc")));
+        }
+
+        [Test]
+        public void RunProcessKillsAHungProcessAndReportsTimeout()
+        {
+            // 実プロセス(sleep)で検証: タイムアウトで殺され、60 秒待たされないこと。
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c ping -n 60 127.0.0.1 > NUL" : "-c \"sleep 60\"";
+            var sw = Stopwatch.StartNew();
+            var res = Cli.RunProcess(file, args, ".", timeoutMs: 500);
+            sw.Stop();
+            Assert.IsTrue(res.TimedOut, "expected the hung process to be reported as timed out");
+            Assert.AreNotEqual(0, res.ExitCode);
+            StringAssert.Contains("timed out", res.Stderr);
+            Assert.Less(sw.ElapsedMilliseconds, 30_000, "timeout must not degrade into waiting for the child");
+        }
+
+        [Test]
+        public void RunProcessReturnsOutputWhenTheProcessExitsInTime()
+        {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c echo hello" : "-c \"echo hello\"";
+            var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs);
+            Assert.IsFalse(res.TimedOut);
+            Assert.AreEqual(0, res.ExitCode);
+            StringAssert.Contains("hello", res.Stdout);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes the last remaining parity gap: the Unity Editor host now matches the hardening the CLI (PR #24) and the former TS MCP host (PR #18/#19) already had.

- **Run timeout**: `Cli.RunProcess` now uses `WaitForExit(90s)` and kills the process on expiry instead of blocking the Unity main thread forever. 90s sits deliberately above the CLI's internal 60s git timeout, so a hung git surfaces as the CLI's own specific error first; the Editor timeout is the last-resort net. On timeout the abandoned stdout/stderr read tasks are not awaited (a grandchild holding the inherited pipes would otherwise hang the wait — the same lesson PR #18 established for the TS host). The synthetic result carries `TimedOut = true` and a message in `Stderr`, which the window already displays via its nonzero-exit path, so no window changes are needed.
- **SHA256 verification**: `Cli.Download` fetches the release's `SHA256SUMS` (published since PR #19), parses the `sha256sum` format (including CRLF and the `*` binary-mode marker), and compares against the downloaded zip. Skip only on 404 (releases up to v0.2.0 predate SHA256SUMS); any other fetch failure or a mismatch throws, which the window reports as "Download failed: …".

## Test plan

Unity EditMode cannot run in this environment, so the changed logic was verified for real with a scratch dotnet harness: `Cli.cs` + `CliTests.cs` compiled at **LangVersion 9** (Unity 2022.3) with compile-only `UnityEditor` stand-ins (never executed — the tests don't touch `Find`/`Download`), run under NUnit on net8.0:

- 9/9 pass (4 existing + 5 new)
- The timeout test spawns a real `sleep 60` / `ping -n 60` process and asserts it is killed at 500 ms with `TimedOut` set
- `Sha256Hex` checked against the FIPS 180-2 `sha256("abc")` vector; `ParseSha256Sums` against the exact `sha256sum *.zip` output shape release.yml produces

Please give it one EditMode run in a local Unity when convenient — the suite is self-contained (no fixtures needed).