### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -380,7 +380,7 @@ test "run: color=true colors tree output, --no-color forces it back off" {
 }
 
 /// リリースタグ v<version> と lockstep(cut-release の 5 ソースの一員)。
-pub const version = "0.2.0";
+pub const version = "0.3.0";
 
 test "run: --project points git mode at a repo outside the cwd" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
@@ -428,7 +428,7 @@ test "run: --project points git mode at a repo outside the cwd" {
 }
 
 test "version constant exists for serverInfo and release lockstep" {
-    try testing.expectEqualStrings("0.2.0", version);
+    try testing.expectEqualStrings("0.3.0", version);
 }
 
 pub const Format = enum { tree, json, html };

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -15,7 +15,7 @@ namespace PrefabLens
     public static class Cli
     {
         /// ダウンロードする CLI のバージョン(GitHub Releases のタグ v{Version} と一致させる)。
-        public const string Version = "0.2.0";
+        public const string Version = "0.3.0";
         public const string CliPathPref = "PrefabLens.CliPath";
 
         /// CLI 実行の上限。CLI 内部の git タイムアウト(60 秒)より長く取り、git ハング時は

--- a/editor/package.json
+++ b/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hashiiiii.prefablens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "displayName": "PrefabLens",
   "description": "Semantic diffs for Unity YAML assets (prefab / scene / asset) against git, rendered inside the Editor.",
   "unity": "2022.3",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PrefabLens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Semantic diffs for Unity YAML files in GitHub pull requests",
   "permissions": ["storage", "scripting"],
   "host_permissions": ["https://api.github.com/*"],

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prefablens-extension",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prefablens-extension",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@playwright/test": "^1.61.1",
         "@types/chrome": "^0.2.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prefablens-extension",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "build": "node build.mjs",


### PR DESCRIPTION
## Summary

Version bump for the v0.3.0 release (cut-release step 4). All five version sources move in lockstep, plus the two hand-edited root version fields in extension/package-lock.json and the lockstep pin test in cli/src/main.zig.

Release contents since v0.2.0: native `prefablens mcp` subcommand replacing the TS host (#22/#23), git subprocess timeout (#24), codebase simplification (#25), and Editor CLI hardening — run timeout + SHA256 verification (#26). This is also the first release the Editor's new SHA256SUMS verification will actually exercise.

## Test plan

- `.claude/skills/cut-release/scripts/check-versions.sh 0.3.0` — all five ok
- `zig build test` green (includes the version pin test)