### PR TITLE
ci: trim jobs, scope tool installs, add caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           install_args: zig
       - name: Cache Zig artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .zig-cache
@@ -49,7 +49,7 @@ jobs:
         with:
           install_args: zig node
       - name: Cache Zig artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             .zig-cache
@@ -74,7 +74,7 @@ jobs:
         run: npm run build
       - name: Cache Playwright browser
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('extension/package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
           path: |
             .zig-cache
             .zig-cache-global
-          key: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ github.sha }}
-          restore-keys: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
+          key: zig-${{ github.job }}-${{ hashFiles('mise.toml') }}-${{ github.sha }}
+          restore-keys: zig-${{ github.job }}-${{ hashFiles('mise.toml') }}-
       - name: Test
         run: zig build test
       - name: Performance budget
@@ -40,12 +40,22 @@ jobs:
     defaults:
       run:
         working-directory: extension
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
     steps:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
         with:
           install_args: zig node
+      - name: Cache Zig artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            .zig-cache-global
+          key: zig-${{ github.job }}-${{ hashFiles('mise.toml') }}-${{ github.sha }}
+          restore-keys: zig-${{ github.job }}-${{ hashFiles('mise.toml') }}-
       - name: Build WASM core
         run: zig build wasm
         working-directory: ${{ github.workspace }}
@@ -73,26 +83,3 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: E2E smoke
         run: npm run e2e
-
-  windows:
-    # 旧 mcp(TS ホスト)ジョブの後継。プロセス spawn・パス・改行のプラットフォーム差を
-    # zig 側テスト(mcp サブコマンド含む)で押さえる。
-    runs-on: windows-latest
-    env:
-      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install tools
-        uses: jdx/mise-action@v4
-        with:
-          install_args: zig
-      - name: Cache Zig artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            .zig-cache
-            .zig-cache-global
-          key: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ github.sha }}
-          restore-keys: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
-      - name: Test
-        run: zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,34 @@ on:
     branches: [main]
   pull_request:
 
+# PR への force-push で旧ランを打ち切る。main は履歴として全ランを残す。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  test:
+  linux:
+    # perf の計測自体は 1 秒未満で、旧 perf ジョブの所要時間はほぼ ReleaseFast の
+    # コンパイルとランナーのセットアップだった。独立ジョブにする意味がないので同居させる。
     runs-on: ubuntu-latest
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
     steps:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+        with:
+          install_args: zig
+      - name: Cache Zig artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            .zig-cache-global
+          key: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ github.sha }}
+          restore-keys: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
       - name: Test
         run: zig build test
-
-  perf:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install tools
-        uses: jdx/mise-action@v4
       - name: Performance budget
         run: zig build perf
 
@@ -32,6 +44,8 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+        with:
+          install_args: zig node
       - name: Build WASM core
         run: zig build wasm
         working-directory: ${{ github.workspace }}
@@ -48,7 +62,14 @@ jobs:
         run: npm test
       - name: Build extension
         run: npm run build
+      - name: Cache Playwright browser
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('extension/package-lock.json') }}
       - name: Install Playwright browser
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
       - name: E2E smoke
         run: npm run e2e
@@ -57,11 +78,21 @@ jobs:
     # 旧 mcp(TS ホスト)ジョブの後継。プロセス spawn・パス・改行のプラットフォーム差を
     # zig 側テスト(mcp サブコマンド含む)で押さえる。
     runs-on: windows-latest
+    env:
+      ZIG_GLOBAL_CACHE_DIR: ${{ github.workspace }}/.zig-cache-global
     steps:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+        with:
+          install_args: zig
+      - name: Cache Zig artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .zig-cache
+            .zig-cache-global
+          key: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-${{ github.sha }}
+          restore-keys: zig-${{ runner.os }}-${{ hashFiles('mise.toml') }}-
       - name: Test
         run: zig build test
-      - name: Build
-        run: zig build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,33 @@
+name: Windows
+# 旧 mcp(TS ホスト)ジョブの後継。プロセス spawn・パス・改行のプラットフォーム差を
+# zig 側テスト(mcp サブコマンド含む)で押さえる。
+# Windows ランナーは tool 展開とファイル I/O が遅く 1 分を切れないため、
+# zig 側に影響し得る変更(ソース・埋め込みファイル・toolchain)の PR だけで走らせる。
+# main への push では無条件に走らせて、フィルタ漏れの安全網とする。
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '**/*.zig'
+      - 'build.zig.zon'
+      - 'mise.toml'
+      - 'core/src/testdata/**'
+      - 'cli/src/tools_list.json'
+      - '.github/workflows/windows.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tools
+        uses: jdx/mise-action@v4
+        with:
+          install_args: zig
+      - name: Test
+        run: zig build test


### PR DESCRIPTION
## What

CI の再設計。「そもそもその step / job が必要か」から見直した。

- **perf ジョブを linux に統合**: perf の計測自体は 1 秒未満(実測 143-170 ms)。旧ジョブの 39 秒はほぼ ReleaseFast コンパイルとランナーセットアップだったので、独立ジョブの意味がなかった
- **windows を paths フィルタ付きの別ワークフローに分離**: windows ジョブの存在理由は zig 側のプラットフォーム差(spawn・パス・改行)の検出。zig に触れない PR では原理的に壊れないので、zig ソース・埋め込みファイル・toolchain に触れた PR だけで走らせる。main への push では無条件に走らせて安全網を維持
- **windows の Build ステップ削除**: `zig build test` の mcp_smoke が同じ exe をリンク・実行するため冗長
- **mise install を tool 単位に限定**: zls は CI で不要、node は extension ジョブのみ
- **Zig キャッシュ(linux / extension)**: ウォームで Test 8s→0s、perf 22s→1s、wasm 10s→0s。windows は実測で 9 秒しか縮まず restore/save コストと相殺のため採用せず
- **Playwright ブラウザキャッシュ**: 毎回 26 秒のダウンロードを排除
- **concurrency 追加**: PR への force-push で旧ランをキャンセル(main は全ラン保持)
- actions/cache を v6 に更新(Node 20 非推奨警告の解消)

## 計測

Baseline(run 28737987815): wall-clock 73s(windows がクリティカルパス)

| job | before | after (warm) |
|---|---|---|
| test + perf | 18s + 39s(2 ジョブ) | linux 10-16s(1 ジョブ) |
| extension | 53s | 23-30s |
| windows | 73s | ~67s、ただし zig 非依存 PR ではスキップ |

- zig に触れる PR: wall-clock 73s → **~67s**(Windows ランナーの tool 展開 ~25s とファイル I/O が床。これ以上は YAML では縮まない)
- extension / docs / editor のみの PR: 73s → **~30s**
- キャッシュ全ヒット時(docs 等): linux 10s / extension 23s