### PR TITLE
perf: parallelize fetches and clean up extension

### DIFF
--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -58,6 +58,29 @@ test('detects a Unity file, toggles to Semantic, renders the tree', async ({ pag
   await expect(view).toBeHidden();
 });
 
+test('attaches toggles to files added after the initial scan (SPA lazy loading)', async ({ page }) => {
+  await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
+  await page.addInitScript((res) => {
+    (window as unknown as Record<string, unknown>)['chrome'] = {
+      runtime: { sendMessage: () => Promise.resolve(res) },
+    };
+  }, cannedResponse);
+
+  await page.goto('https://prefablens.test/owner/repo/pull/1/files');
+  await page.addScriptTag({ path: 'dist/content.js' });
+
+  // GitHub は Files changed をスクロールで遅延ロードする: 初回スキャン後の追加を MutationObserver が拾う
+  await page.evaluate(() => {
+    const file = document.createElement('div');
+    file.className = 'file';
+    file.innerHTML =
+      '<div class="file-header" data-path="Assets/Late.prefab"></div><div class="js-file-content">raw diff</div>';
+    document.body.append(file);
+  });
+  const lateHeader = page.locator('.file-header[data-path="Assets/Late.prefab"]');
+  await expect(lateHeader.getByRole('button', { name: 'Semantic' })).toBeVisible();
+});
+
 test('recovers after an error response', async ({ page }) => {
   await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
   // 1回目は pat-missing エラー、2回目以降は正常応答を返す(エラーはキャッシュされず再フェッチされることを確認)

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -39,7 +39,7 @@ function makeDeps(overrides?: {
     }),
   };
   const deps: Deps = {
-    getSettings: async () => ({ pat: 'pat' in (overrides ?? {}) ? overrides!.pat : 'tok', baseUrl: undefined }),
+    getSettings: async () => ({ pat: Object.hasOwn(overrides ?? {}, 'pat') ? overrides!.pat : 'tok', baseUrl: undefined }),
     makeClient: () => client,
     getDiffer: async () => differ,
     guidCache,
@@ -72,14 +72,50 @@ describe('createHandler', () => {
   });
 
   it('uses an empty before for added files without fetching the base side', async () => {
-    const diff = vi.fn(() => DIFF);
+    const diff = vi.fn<Differ['diff']>(() => DIFF);
     const { deps, client } = makeDeps({ files: [{ path: 'Assets/Foo.prefab', status: 'added' }], diff });
     await createHandler(deps)(REQ);
     const baseFetches = client.getFileAtRef.mock.calls.filter(
       (c) => c[2] === 'Assets/Foo.prefab' && c[3] === 'base-sha',
     );
     expect(baseFetches).toHaveLength(0);
-    expect((diff.mock.calls[0] as any[])?.[0]).toHaveLength(0); // before は空
+    expect(diff.mock.calls[0]?.[0]).toHaveLength(0); // before は空
+  });
+
+  it('uses an empty after for removed files without fetching the head side', async () => {
+    const diff = vi.fn<Differ['diff']>(() => DIFF);
+    const { deps, client } = makeDeps({ files: [{ path: 'Assets/Foo.prefab', status: 'removed' }], diff });
+    await createHandler(deps)(REQ);
+    const headFetches = client.getFileAtRef.mock.calls.filter(
+      (c) => c[2] === 'Assets/Foo.prefab' && c[3] === 'head-sha',
+    );
+    expect(headFetches).toHaveLength(0);
+    expect(diff.mock.calls[0]?.[1]).toHaveLength(0); // after は空
+  });
+
+  it('diffs a file missing from the PR list as modified (files API caps at 3000)', async () => {
+    // 3000 ファイル超の PR では一覧 API が打ち切られ、UI にあるファイルが一覧に無いことがある
+    const { deps, client } = makeDeps({ files: [{ path: 'Assets/Other.prefab', status: 'modified' }] });
+    const res = await createHandler(deps)(REQ);
+    expect(res.ok).toBe(true);
+    expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Foo.prefab', 'base-sha');
+    expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Foo.prefab', 'head-sha');
+  });
+
+  it('fetches the base and head blobs in parallel', async () => {
+    // 初回トグルのレイテンシは blob フェッチ 2 本が支配的なので、直列化への退行を固定する
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const { deps, client } = makeDeps();
+    client.getFileAtRef.mockImplementation(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 0));
+      inFlight--;
+      return new TextEncoder().encode('x');
+    });
+    await createHandler(deps)(REQ);
+    expect(maxInFlight).toBe(2);
   });
 
   it('reads renamed files from previousPath on the base side', async () => {
@@ -116,6 +152,15 @@ describe('createHandler', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('retries the PR context after a failed load instead of caching the failure', async () => {
+    // 一時的なネットワーク失敗が 60 秒キャッシュに乗ると、再トグルしても直らなくなる
+    const { deps, client } = makeDeps();
+    client.listPrFiles.mockRejectedValueOnce(new Error('socket'));
+    const handle = createHandler(deps);
+    expect(await handle(REQ)).toEqual({ ok: false, error: 'fetch-failed' });
+    expect((await handle(REQ)).ok).toBe(true);
   });
 
   it('fetches each sha+path blob only once (immutable content)', async () => {
@@ -191,6 +236,15 @@ describe('createHandler', () => {
     const { deps, client } = makeDeps({ diff: () => many });
     await createHandler(deps)(REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
+  });
+
+  it('does not count cached guids against the search cap', async () => {
+    // 12 guid 中 2 つがキャッシュ済みなら、検索枠 10 は未知の 10 guid にまるごと使える
+    const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
+    const { deps, client } = makeDeps({ diff: () => many, cached: { g0: 'Assets/A.cs', g1: 'Assets/B.cs' } });
+    const res = await createHandler(deps)(REQ);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
+    expect(res).toEqual({ ok: true, json: { ...many, resolved: { g0: 'Assets/A.cs', g1: 'Assets/B.cs' } } });
   });
 
   it('maps AuthError / DiffError / other failures to stable error codes', async () => {

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -32,19 +32,17 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
    *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ載せる。 */
   async function searchUnresolved(json: DiffV2, client: ClientLike, owner: string, repo: string, repoKey: string): Promise<DiffV2> {
     const resolved = { ...json.resolved };
-    // hasOwn: guid は任意文字列なので 'constructor' 等が in 演算子でプロトタイプに誤ヒットしない
+    // hasOwn: guid は任意文字列なので 'constructor' 等が Object.prototype に誤ヒットしない(cached も同様)
     const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g) && !misses.has(`${repoKey}:${g}`));
     if (!pending.length) return { ...json, resolved };
     const cached = await deps.guidCache.load(repoKey);
-    const found: Record<string, string> = {};
-    let searches = 0;
+    const unknown: string[] = [];
     for (const g of pending) {
-      // hasOwn: guid は任意文字列なので 'constructor' 等で Object.prototype を拾わない
-      if (Object.hasOwn(cached, g)) {
-        resolved[g] = cached[g]!;
-        continue;
-      }
-      if (searches++ >= MAX_SEARCHES) continue;
+      if (Object.hasOwn(cached, g)) resolved[g] = cached[g]!;
+      else unknown.push(g);
+    }
+    const found: Record<string, string> = {};
+    for (const g of unknown.slice(0, MAX_SEARCHES)) {
       try {
         const path = await client.searchMetaByGuid(owner, repo, g);
         if (path) resolved[g] = found[g] = path;
@@ -73,8 +71,10 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
     const entry = contexts.get(key);
     if (entry && Date.now() - entry.at < CONTEXT_TTL_MS) return entry.ctx;
     const ctx = (async () => {
-      const refs = await client.getPrRefs(owner, repo, prNumber);
-      const files = await client.listPrFiles(owner, repo, prNumber);
+      const [refs, files] = await Promise.all([
+        client.getPrRefs(owner, repo, prNumber),
+        client.listPrFiles(owner, repo, prNumber),
+      ]);
       const guidIndex = await buildGuidIndex(files, async (path, side) => {
         const bytes = await fetchBlob(client, owner, repo, path, side === 'base' ? refs.baseSha : refs.headSha);
         return bytes ? new TextDecoder().decode(bytes) : null;
@@ -95,13 +95,16 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
       const { refs, files, guidIndex } = await loadContext(client, req.owner, req.repo, req.prNumber);
 
       const file = files.find((f) => f.path === req.path);
+      // 一覧に無い場合(files API は 3000 件で打ち切り)は modified 扱い: 無い側は 404 → EMPTY に落ちるだけ
       const status = file?.status ?? 'modified';
       const beforePath = file?.previousPath ?? req.path;
 
-      const before =
-        status === 'added' ? EMPTY : ((await fetchBlob(client, req.owner, req.repo, beforePath, refs.baseSha)) ?? EMPTY);
-      const after =
-        status === 'removed' ? EMPTY : ((await fetchBlob(client, req.owner, req.repo, req.path, refs.headSha)) ?? EMPTY);
+      const fetchSide = (path: string, sha: string) =>
+        fetchBlob(client, req.owner, req.repo, path, sha).then((bytes) => bytes ?? EMPTY);
+      const [before, after] = await Promise.all([
+        status === 'added' ? EMPTY : fetchSide(beforePath, refs.baseSha),
+        status === 'removed' ? EMPTY : fetchSide(req.path, refs.headSha),
+      ]);
 
       if (!req.force && before.length + after.length > TOO_LARGE_BYTES) {
         return { ok: false, error: 'too-large', bytes: before.length + after.length };

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -12,6 +12,10 @@ const FIXTURE = `
     <div class="js-file-content">raw diff</div>
   </div>
   <div class="file">
+    <div class="file-header" data-path="Assets/Data/Config.asset"></div>
+    <div class="js-file-content">raw diff</div>
+  </div>
+  <div class="file">
     <div class="file-header" data-path="src/main.cs"></div>
     <div class="js-file-content">raw diff</div>
   </div>
@@ -33,7 +37,7 @@ describe('scanUnityFiles', () => {
   it('finds .prefab/.unity/.asset containers and skips other files', () => {
     document.body.innerHTML = FIXTURE;
     const entries = scanUnityFiles(document);
-    expect(entries.map((e) => e.path)).toEqual(['Assets/Foo.prefab', 'Assets/Scenes/Main.unity']);
+    expect(entries.map((e) => e.path)).toEqual(['Assets/Foo.prefab', 'Assets/Scenes/Main.unity', 'Assets/Data/Config.asset']);
     expect(entries[0]!.content.classList.contains('js-file-content')).toBe(true);
   });
 

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -16,6 +16,19 @@ function fakeStorage(initial: Record<string, unknown> = {}) {
   };
 }
 
+function fakeGhes(granted = true) {
+  return {
+    permissions: { request: vi.fn(async () => granted) },
+    scripting: {
+      registerContentScripts: vi.fn(async () => {}),
+      unregisterContentScripts: vi.fn(async () => {}),
+    },
+  } satisfies ChromeGhes;
+}
+
+// click ハンドラの async チェーンが status を書き終わるまで待つ(マクロタスクで flush)
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
 describe('initOptions', () => {
   it('loads stored values into the form', async () => {
     document.body.innerHTML = OPTIONS_BODY;
@@ -30,24 +43,18 @@ describe('initOptions', () => {
     await initOptions(document, storage);
     document.querySelector<HTMLInputElement>('#pat')!.value = '  tok  ';
     document.querySelector<HTMLButtonElement>('#save')!.click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     expect(storage.data['pat']).toBe('tok');
     expect(document.querySelector('#status')!.textContent).toBe('Saved');
   });
 
   it('applies ghes registration with the trimmed base url on save', async () => {
     document.body.innerHTML = OPTIONS_BODY;
-    const ghes: ChromeGhes = {
-      permissions: { request: vi.fn(async () => true) },
-      scripting: {
-        registerContentScripts: vi.fn(async () => {}),
-        unregisterContentScripts: vi.fn(async () => {}),
-      },
-    };
+    const ghes = fakeGhes();
     await initOptions(document, fakeStorage(), ghes);
     document.querySelector<HTMLInputElement>('#baseUrl')!.value = '  ghe.corp.com  ';
     document.querySelector<HTMLButtonElement>('#save')!.click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     expect(ghes.permissions.request).toHaveBeenCalledWith({ origins: ['https://ghe.corp.com/*'] });
     expect(document.querySelector('#status')!.textContent).toBe('Saved');
   });
@@ -55,17 +62,10 @@ describe('initOptions', () => {
   it('saves but reports when the host permission is declined', async () => {
     document.body.innerHTML = OPTIONS_BODY;
     const storage = fakeStorage();
-    const ghes: ChromeGhes = {
-      permissions: { request: vi.fn(async () => false) },
-      scripting: {
-        registerContentScripts: vi.fn(async () => {}),
-        unregisterContentScripts: vi.fn(async () => {}),
-      },
-    };
-    await initOptions(document, storage, ghes);
+    await initOptions(document, storage, fakeGhes(false));
     document.querySelector<HTMLInputElement>('#baseUrl')!.value = 'ghe.corp.com';
     document.querySelector<HTMLButtonElement>('#save')!.click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     expect(storage.data['baseUrl']).toBe('ghe.corp.com');
     expect(document.querySelector('#status')!.textContent).toBe('Saved (host permission declined)');
   });
@@ -73,18 +73,11 @@ describe('initOptions', () => {
   it('still saves settings when ghes setup itself fails', async () => {
     document.body.innerHTML = OPTIONS_BODY;
     const storage = fakeStorage();
-    const ghes: ChromeGhes = {
-      permissions: { request: vi.fn(async () => true) },
-      scripting: {
-        registerContentScripts: vi.fn(async () => {}),
-        unregisterContentScripts: vi.fn(async () => {}),
-      },
-    };
-    await initOptions(document, storage, ghes);
+    await initOptions(document, storage, fakeGhes());
     document.querySelector<HTMLInputElement>('#pat')!.value = 'tok';
     document.querySelector<HTMLInputElement>('#baseUrl')!.value = 'https://'; // originOf が throw する不正 URL
     document.querySelector<HTMLButtonElement>('#save')!.click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     expect(storage.data['pat']).toBe('tok'); // PAT は捨てない
     expect(document.querySelector('#status')!.textContent).toBe('Saved (GHES setup failed)');
   });
@@ -95,17 +88,11 @@ describe('initOptions', () => {
     storage.set = async () => {
       throw new Error('quota exceeded');
     };
-    const ghes: ChromeGhes = {
-      permissions: { request: vi.fn(async () => true) },
-      scripting: {
-        registerContentScripts: vi.fn(async () => {}),
-        unregisterContentScripts: vi.fn(async () => {}),
-      },
-    };
+    const ghes = fakeGhes();
     await initOptions(document, storage, ghes);
     document.querySelector<HTMLInputElement>('#baseUrl')!.value = 'ghe.corp.com';
     document.querySelector<HTMLButtonElement>('#save')!.click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     // 保存に失敗したのに登録だけ進む中途半端な状態を作らない
     expect(ghes.scripting.registerContentScripts).not.toHaveBeenCalled();
     expect(document.querySelector('#status')!.textContent).toBe('Save failed');
@@ -119,7 +106,7 @@ describe('initOptions', () => {
     };
     await initOptions(document, storage);
     document.querySelector<HTMLButtonElement>('#save')!.click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flush();
     expect(document.querySelector('#status')!.textContent).toBe('Save failed');
   });
 });

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -1,3 +1,5 @@
+import { applyGhes, type ChromeGhes } from './ghes';
+
 // フォーム本体を TS 側に持つ: options.html と jsdom テストで同一マークアップを共有する。
 export const OPTIONS_BODY = `
   <h1>PrefabLens</h1>
@@ -14,8 +16,6 @@ export const OPTIONS_BODY = `
   <button id="save" type="button">Save</button>
   <span id="status" role="status"></span>
 `;
-
-import { applyGhes, type ChromeGhes } from './ghes';
 
 type StorageLike = {
   get(keys: string[]): Promise<Record<string, unknown>>;

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -320,4 +320,19 @@ describe('detectTheme', () => {
     document.documentElement.setAttribute('data-color-mode', 'light');
     expect(detectTheme(document)).toBe('light');
   });
+
+  it('follows the OS scheme via matchMedia when data-color-mode is auto', () => {
+    // GitHub の既定は auto: dark/light どちらでもない値は matchMedia に委ねる
+    document.documentElement.setAttribute('data-color-mode', 'auto');
+    expect(detectTheme(document)).toBe('light'); // jsdom に matchMedia は無い → light に倒す
+    const win = document.defaultView!;
+    win.matchMedia = ((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)',
+    })) as unknown as typeof win.matchMedia;
+    try {
+      expect(detectTheme(document)).toBe('dark');
+    } finally {
+      delete (win as { matchMedia?: unknown }).matchMedia;
+    }
+  });
 });

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -65,16 +65,15 @@ export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => 
   button.className = 'pl-render';
   button.textContent = 'Render anyway';
   button.addEventListener('click', onRender);
-  container.append(note('pl-empty', `Large file (${Math.round(bytes / 1048576)} MB).`), button);
+  container.append(note('pl-empty', `Large file (${Math.round(bytes / (1024 * 1024))} MB).`), button);
 }
 
 function mount(root: ShadowRoot): HTMLElement {
   root.replaceChildren();
-  const doc = root.host.ownerDocument;
-  const style = doc.createElement('style');
+  const style = document.createElement('style');
   style.textContent = STYLES;
-  const container = doc.createElement('div');
-  container.className = `pl-root pl-${detectTheme(doc)}`;
+  const container = document.createElement('div');
+  container.className = `pl-root pl-${detectTheme(document)}`;
   root.append(style, container);
   return container;
 }
@@ -87,7 +86,7 @@ function note(className: string, text: string): HTMLElement {
 }
 
 function stem(path: string): string {
-  const base = path.split('/').pop() ?? path;
+  const base = path.split('/').at(-1) ?? path;
   const dot = base.lastIndexOf('.');
   return dot > 0 ? base.slice(0, dot) : base;
 }
@@ -133,7 +132,7 @@ function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
 function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElement[] {
   const groups: { name: string; rows: OverrideDiff[] }[] = [];
   for (const ov of overrides) {
-    const last = groups[groups.length - 1];
+    const last = groups.at(-1);
     if (last && last.name === ov.group) last.rows.push(ov);
     else groups.push({ name: ov.group, rows: [ov] });
   }


### PR DESCRIPTION
## Summary

Code review pass over `extension/` (performance, modern syntax, fallback discipline, simplicity, WHY comments) with the resulting fixes.

### Performance
- `handler.ts`: `getPrRefs` and `listPrFiles` are independent API calls — fetch them with `Promise.all`, and do the same for the base/head blob fetches. Removes two serialized network round-trips from the first-toggle critical path.

### Simplicity
- `handler.ts` `searchUnresolved`: replaced the `searches++` counter with an implicit `continue` (cache hits kept resolving past the search cap, which was easy to misread) with an explicit two-phase structure: resolve from cache first, then search the first `MAX_SEARCHES` unknowns. Also deduplicates the twice-repeated `hasOwn` comment.
- `render.ts` `mount()`: was the only helper going through `root.host.ownerDocument` while every other helper uses the global `document` — unified to `document`.
- `options.ts`: moved the `import` to the top of the file (it sat below `OPTIONS_BODY`).

### Modern syntax
- `render.ts`: `groups[groups.length - 1]` → `groups.at(-1)`, `split('/').pop()` → `.at(-1)`, `1048576` → `1024 * 1024` (matches `handler.ts`'s `25 * 1024 * 1024`).

### WHY comments
- `handler.ts`: documented why a file missing from the PR file list falls back to `modified` (the files API caps at 3000 entries; the missing side degrades to 404 → EMPTY).

### Review findings with no code change
- No excessive fallbacks found: every defensive branch (scheme-less base URL, rate-limit propagation in `buildGuidIndex`, `requestDiff` catch for SW restarts) is either load-bearing or already documented and pinned by tests.

## Test plan
- `npm run typecheck` — clean
- `npm test` — 77/77 passed (includes the wasm golden tests against a fresh `zig build wasm`)
- `npm run e2e` — 4/4 passed (real extension, real background, real WASM)