### PR TITLE
refactor: modernize editor C# and trim allocations

### DIFF
--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -63,12 +63,10 @@ namespace PrefabLens
 
         public static string Sha256Hex(byte[] bytes)
         {
-            using (var sha = SHA256.Create())
-            {
-                var sb = new StringBuilder();
-                foreach (var b in sha.ComputeHash(bytes)) sb.Append(b.ToString("x2"));
-                return sb.ToString();
-            }
+            using var sha = SHA256.Create();
+            var sb = new StringBuilder();
+            foreach (var b in sha.ComputeHash(bytes)) sb.Append(b.ToString("x2"));
+            return sb.ToString();
         }
 
         // ---- Editor 連携 ----
@@ -101,21 +99,17 @@ namespace PrefabLens
             try
             {
                 EditorUtility.DisplayProgressBar("PrefabLens", $"Downloading {asset}…", 0.3f);
-                using (var http = new HttpClient())
+                using var http = new HttpClient();
+                var bytes = http.GetByteArrayAsync(url).Result;
+                VerifyChecksum(http, asset, bytes);
+                using var zip = new ZipArchive(new MemoryStream(bytes));
+                foreach (var entry in zip.Entries)
                 {
-                    var bytes = http.GetByteArrayAsync(url).Result;
-                    VerifyChecksum(http, asset, bytes);
-                    using (var zip = new ZipArchive(new MemoryStream(bytes)))
-                    {
-                        foreach (var entry in zip.Entries)
-                        {
-                            // ZipFileExtensions(ExtractToFile)は netstandard で参照できないため手動コピー
-                            var dest = Path.Combine(dir, entry.Name);
-                            using (var src = entry.Open())
-                            using (var dst = File.Create(dest))
-                                src.CopyTo(dst);
-                        }
-                    }
+                    // ZipFileExtensions(ExtractToFile)は netstandard で参照できないため手動コピー
+                    var dest = Path.Combine(dir, entry.Name);
+                    using var src = entry.Open();
+                    using var dst = File.Create(dest);
+                    src.CopyTo(dst);
                 }
             }
             finally
@@ -167,28 +161,26 @@ namespace PrefabLens
                 CreateNoWindow = true,
                 WorkingDirectory = workDir,
             };
-            using (var p = Process.Start(psi))
+            using var p = Process.Start(psi);
+            // 双方向 ReadToEnd のデッドロックを避ける: 片方は async で読む
+            var stdout = p.StandardOutput.ReadToEndAsync();
+            var stderr = p.StandardError.ReadToEndAsync();
+            if (!p.WaitForExit(timeoutMs))
             {
-                // 双方向 ReadToEnd のデッドロックを避ける: 片方は async で読む
-                var stdout = p.StandardOutput.ReadToEndAsync();
-                var stderr = p.StandardError.ReadToEndAsync();
-                if (!p.WaitForExit(timeoutMs))
+                // ハングした CLI から Unity メインスレッドを守る。Kill 後も stdio を掴む
+                // 孫プロセスが残ると Read タスクは完了しないため、読み残しは待たない。
+                try { p.Kill(); }
+                catch (InvalidOperationException) { /* タイムアウトと終了の競合 */ }
+                catch (System.ComponentModel.Win32Exception) { /* 既に終了処理中 */ }
+                return new Result
                 {
-                    // ハングした CLI から Unity メインスレッドを守る。Kill 後も stdio を掴む
-                    // 孫プロセスが残ると Read タスクは完了しないため、読み残しは待たない。
-                    try { p.Kill(); }
-                    catch (InvalidOperationException) { /* タイムアウトと終了の競合 */ }
-                    catch (System.ComponentModel.Win32Exception) { /* 既に終了処理中 */ }
-                    return new Result
-                    {
-                        ExitCode = -1,
-                        Stdout = "",
-                        Stderr = $"prefablens timed out after {timeoutMs / 1000}s and was killed",
-                        TimedOut = true,
-                    };
-                }
-                return new Result { ExitCode = p.ExitCode, Stdout = stdout.Result, Stderr = stderr.Result };
+                    ExitCode = -1,
+                    Stdout = "",
+                    Stderr = $"prefablens timed out after {timeoutMs / 1000}s and was killed",
+                    TimedOut = true,
+                };
             }
+            return new Result { ExitCode = p.ExitCode, Stdout = stdout.Result, Stderr = stderr.Result };
         }
     }
 }

--- a/editor/Editor/DiffModel.cs
+++ b/editor/Editor/DiffModel.cs
@@ -15,7 +15,7 @@ namespace PrefabLens
         public bool IsRef;
         public bool IsNull;
 
-        public static readonly Value Null = new Value { IsNull = true };
+        public static readonly Value Null = new() { IsNull = true };
     }
 
     public sealed class FieldDiff
@@ -43,7 +43,7 @@ namespace PrefabLens
         public string ScriptGuid;
         public string ClassName;
         public DiffStatus Status;
-        public List<FieldDiff> Fields = new List<FieldDiff>();
+        public List<FieldDiff> Fields = new();
     }
 
     public abstract class NodeDiff
@@ -51,8 +51,8 @@ namespace PrefabLens
         public string FileId;
         public string Name;
         public DiffStatus Status;
-        public List<ComponentDiff> Components = new List<ComponentDiff>();
-        public List<NodeDiff> Children = new List<NodeDiff>();
+        public List<ComponentDiff> Components = new();
+        public List<NodeDiff> Children = new();
     }
 
     public sealed class GameObjectDiff : NodeDiff { }
@@ -60,17 +60,17 @@ namespace PrefabLens
     public sealed class PrefabInstanceDiff : NodeDiff
     {
         public string SourceGuid;
-        public List<OverrideDiff> Overrides = new List<OverrideDiff>();
+        public List<OverrideDiff> Overrides = new();
     }
 
     /// prefablens.diff.v2(core/src/json.zig の出力)の読み取り側モデル。
     /// 未知の kind やフィールド欠損は落とさず読み飛ばす(CLI が新しい場合に Editor 側が壊れない)。
     public sealed class DiffModel
     {
-        public List<string> UnresolvedGuids = new List<string>();
-        public Dictionary<string, string> Resolved = new Dictionary<string, string>();
-        public List<NodeDiff> Roots = new List<NodeDiff>();
-        public List<ComponentDiff> Loose = new List<ComponentDiff>();
+        public List<string> UnresolvedGuids = new();
+        public Dictionary<string, string> Resolved = new();
+        public List<NodeDiff> Roots = new();
+        public List<ComponentDiff> Loose = new();
 
         public bool IsEmpty => Roots.Count == 0 && Loose.Count == 0;
 
@@ -78,15 +78,15 @@ namespace PrefabLens
         {
             var o = JObject.Parse(json);
             var m = new DiffModel();
-            foreach (var g in o["unresolvedGuids"] as JArray ?? new JArray())
+            foreach (var g in Items(o["unresolvedGuids"]))
                 m.UnresolvedGuids.Add((string)g);
             if (o["resolved"] is JObject resolved)
                 foreach (var p in resolved.Properties())
                     m.Resolved[p.Name] = (string)p.Value;
-            foreach (var r in o["roots"] as JArray ?? new JArray())
+            foreach (var r in Items(o["roots"]))
                 if (ParseNode(r as JObject) is NodeDiff n)
                     m.Roots.Add(n);
-            foreach (var c in o["loose"] as JArray ?? new JArray())
+            foreach (var c in Items(o["loose"]))
                 if (c is JObject co)
                     m.Loose.Add(ParseComponent(co));
             return m;
@@ -106,39 +106,39 @@ namespace PrefabLens
         static NodeDiff ParseNode(JObject o)
         {
             if (o == null) return null;
-            NodeDiff n;
-            switch ((string)o["kind"])
+            NodeDiff n = (string)o["kind"] switch
             {
-                case "gameObject":
-                    n = new GameObjectDiff();
-                    break;
-                case "prefabInstance":
-                    var pi = new PrefabInstanceDiff { SourceGuid = (string)o["sourceGuid"] };
-                    foreach (var ov in o["overrides"] as JArray ?? new JArray())
-                        if (ov is JObject ovo)
-                            pi.Overrides.Add(new OverrideDiff
-                            {
-                                Group = (string)ovo["group"] ?? "",
-                                Label = (string)ovo["label"] ?? "",
-                                Status = ParseStatus((string)ovo["status"]),
-                                Before = ParseValue(ovo["before"]),
-                                After = ParseValue(ovo["after"]),
-                            });
-                    n = pi;
-                    break;
-                default:
-                    return null; // 未知の kind は読み飛ばす
-            }
+                "gameObject" => new GameObjectDiff(),
+                "prefabInstance" => ParsePrefabInstance(o),
+                _ => null, // 未知の kind は読み飛ばす
+            };
+            if (n == null) return null;
             n.FileId = (string)o["fileId"] ?? "";
             n.Name = (string)o["name"] ?? "";
             n.Status = ParseStatus((string)o["status"]);
-            foreach (var c in o["components"] as JArray ?? new JArray())
+            foreach (var c in Items(o["components"]))
                 if (c is JObject co)
                     n.Components.Add(ParseComponent(co));
-            foreach (var ch in o["children"] as JArray ?? new JArray())
+            foreach (var ch in Items(o["children"]))
                 if (ParseNode(ch as JObject) is NodeDiff child)
                     n.Children.Add(child);
             return n;
+        }
+
+        static PrefabInstanceDiff ParsePrefabInstance(JObject o)
+        {
+            var pi = new PrefabInstanceDiff { SourceGuid = (string)o["sourceGuid"] };
+            foreach (var ov in Items(o["overrides"]))
+                if (ov is JObject ovo)
+                    pi.Overrides.Add(new OverrideDiff
+                    {
+                        Group = (string)ovo["group"] ?? "",
+                        Label = (string)ovo["label"] ?? "",
+                        Status = ParseStatus((string)ovo["status"]),
+                        Before = ParseValue(ovo["before"]),
+                        After = ParseValue(ovo["after"]),
+                    });
+            return pi;
         }
 
         static ComponentDiff ParseComponent(JObject o)
@@ -152,7 +152,7 @@ namespace PrefabLens
                 ClassName = (string)o["className"],
                 Status = ParseStatus((string)o["status"]),
             };
-            foreach (var f in o["fields"] as JArray ?? new JArray())
+            foreach (var f in Items(o["fields"]))
                 if (f is JObject fo)
                     c.Fields.Add(new FieldDiff
                     {
@@ -172,15 +172,15 @@ namespace PrefabLens
             return new Value { Scalar = (string)t };
         }
 
-        static DiffStatus ParseStatus(string s)
+        static IEnumerable<JToken> Items(JToken t) =>
+            t is JArray a ? a : (IEnumerable<JToken>)Array.Empty<JToken>();
+
+        static DiffStatus ParseStatus(string s) => s switch
         {
-            switch (s)
-            {
-                case "added": return DiffStatus.Added;
-                case "removed": return DiffStatus.Removed;
-                case "modified": return DiffStatus.Modified;
-                default: return DiffStatus.Unchanged;
-            }
-        }
+            "added" => DiffStatus.Added,
+            "removed" => DiffStatus.Removed,
+            "modified" => DiffStatus.Modified,
+            _ => DiffStatus.Unchanged,
+        };
     }
 }

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -30,7 +30,9 @@ namespace PrefabLens
         static bool ValidateDiffSelected()
         {
             var p = Selection.activeObject == null ? "" : AssetDatabase.GetAssetPath(Selection.activeObject);
-            return p.EndsWith(".prefab") || p.EndsWith(".unity") || p.EndsWith(".asset");
+            return p.EndsWith(".prefab", StringComparison.Ordinal)
+                || p.EndsWith(".unity", StringComparison.Ordinal)
+                || p.EndsWith(".asset", StringComparison.Ordinal);
         }
 
         public void CreateGUI()
@@ -85,7 +87,7 @@ namespace PrefabLens
                 return;
             }
 
-            model.ResolveWith(g => AssetDatabase.GUIDToAssetPath(g));
+            model.ResolveWith(AssetDatabase.GUIDToAssetPath);
             if (model.IsEmpty)
             {
                 Note("No semantic changes");
@@ -142,7 +144,7 @@ namespace PrefabLens
 
         sealed class Row
         {
-            public readonly List<Span> Spans = new List<Span>();
+            public readonly List<Span> Spans = new();
 
             public Row Add(string text, Color? tint = null)
             {
@@ -177,16 +179,17 @@ namespace PrefabLens
 
         static TreeViewItemData<Row> NodeItem(NodeDiff n, DiffModel m, ref int id)
         {
+            var pi = n as PrefabInstanceDiff;
             var children = new List<TreeViewItemData<Row>>();
-            if (n is PrefabInstanceDiff pi)
+            if (pi != null)
                 foreach (var ov in pi.Overrides)
                     children.Add(new TreeViewItemData<Row>(id++, OverrideRow(ov, m)));
             foreach (var c in n.Components) children.Add(ComponentItem(c, m, ref id));
             foreach (var ch in n.Children) children.Add(NodeItem(ch, m, ref id));
 
             var row = Badge(n.Status).Add(n.Name);
-            if (n is PrefabInstanceDiff p && p.SourceGuid != null)
-                row.Add(" ‹Prefab: " + (m.Resolved.TryGetValue(p.SourceGuid, out var src) ? src : p.SourceGuid) + "›", Palette.Muted);
+            if (pi?.SourceGuid != null)
+                row.Add(" ‹Prefab: " + (m.Resolved.TryGetValue(pi.SourceGuid, out var src) ? src : pi.SourceGuid) + "›", Palette.Muted);
             return new TreeViewItemData<Row>(id++, row, children);
         }
 
@@ -235,16 +238,13 @@ namespace PrefabLens
             return v.RefFileId == "0" ? "None" : "#" + v.RefFileId;
         }
 
-        static Row Badge(DiffStatus s)
+        static Row Badge(DiffStatus s) => s switch
         {
-            switch (s)
-            {
-                case DiffStatus.Added: return new Row().Add("+ ", Palette.Added);
-                case DiffStatus.Removed: return new Row().Add("− ", Palette.Removed);
-                case DiffStatus.Modified: return new Row().Add("~ ", Palette.Modified);
-                default: return new Row().Add("  ");
-            }
-        }
+            DiffStatus.Added => new Row().Add("+ ", Palette.Added),
+            DiffStatus.Removed => new Row().Add("− ", Palette.Removed),
+            DiffStatus.Modified => new Row().Add("~ ", Palette.Modified),
+            _ => new Row().Add("  "),
+        };
 
         static string Stem(string path)
         {


### PR DESCRIPTION
## Summary

Review pass over `editor/` for performance, modern C# (Unity 2022.3 = C# 9), fallback hygiene, simplicity, and comments.

- **Perf**: `DiffModel` no longer allocates a fresh `JArray` for every missing array field (6 sites) — a shared `Items` helper returns `Array.Empty<JToken>()` instead. Menu validation in `PrefabLensWindow` now uses `StringComparison.Ordinal` instead of culture-sensitive `EndsWith`.
- **Modern syntax**: switch expressions (`ParseStatus`, `Badge`, node `kind` dispatch), `using var` declarations in `Cli`, target-typed `new()` for field initializers, method group for `AssetDatabase.GUIDToAssetPath`.
- **Simplicity**: extracted `ParsePrefabInstance` so override parsing mirrors `ParseComponent` instead of living inline in a switch case; collapsed the double `PrefabInstanceDiff` pattern match in `NodeItem`.
- **Fallbacks**: the null-tolerant parsing in `DiffModel` is intentional forward-compat (documented and tested), so it stays; only the repeated `?? new JArray()` pattern was consolidated.
- **Comments**: existing comments are already WHY-focused (deadlock avoidance, netstandard limits, timeout rationale) and were kept as is.

No behavior change.

## Verification

Compiled the production sources as `netstandard2.1` / `LangVersion 9` (Unity 2022.3 equivalent) with minimal Unity API stubs, and ran the EditMode test suite under NUnit on dotnet: 13/13 passed. Unity EditMode in the actual Editor not run.