### PR TITLE
fix: harden core parser and adopt zig 0.16 idioms

### DIFF
--- a/core/src/classid.zig
+++ b/core/src/classid.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 
 const Pair = struct { id: u32, name: []const u8 };
 
-// Common Unity classIDs (subset sufficient for prefab/scene/asset diffing).
-// Source: Unity "YAML Class ID Reference".
+// 頻出の Unity classID(prefab/scene/asset の diff に十分なサブセット)。
+// 出典: Unity "YAML Class ID Reference"。
 const table = [_]Pair{
     .{ .id = 1, .name = "GameObject" },
     .{ .id = 2, .name = "Component" },

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -579,8 +579,7 @@ fn editorClassName(doc: *const model.Document) ?[]const u8 {
         .scalar => |s| s,
         else => return null,
     };
-    const idx = std.mem.lastIndexOfScalar(u8, s, ':') orelse (if (s.len != 0) return s else return null);
-    const tail = s[idx + 1 ..];
+    const tail = if (std.mem.lastIndexOfScalar(u8, s, ':')) |idx| s[idx + 1 ..] else s;
     return if (tail.len != 0) tail else null;
 }
 
@@ -607,7 +606,9 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
     const after = try parser.parse(arena, after_src);
 
     var docs: std.ArrayList(DocDiff) = .empty;
-    var guids = GuidSet.init(arena);
+    // Array hash map: preserves first-insertion order so unresolvedGuids
+    // serializes deterministically in reference order.
+    var guids: std.StringArrayHashMapUnmanaged(void) = .empty;
 
     // fileID -> *Document indices so the union walk below is O(n) instead of
     // O(n^2) linear scans (matters at scene scale: tens of thousands of docs).
@@ -618,10 +619,10 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
     // then `before`-only documents.
     for (after) |*ad| {
         if (ad.stripped) continue;
-        try collectGuids(&guids, ad.body);
+        try collectGuids(arena, &guids, ad.body);
         const bd = before_idx.get(ad.file_id);
         if (bd) |b| {
-            try collectGuids(&guids, b.body);
+            try collectGuids(arena, &guids, b.body);
             if (ad.class_id == 1001) {
                 const overrides = try diffOverrides(arena, b, ad);
                 try docs.append(arena, .{
@@ -630,13 +631,13 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
                     .type_name = resolvedTypeName(ad),
                     .script_guid = scriptGuid(ad),
                     .status = if (overrides.len == 0) .unchanged else .modified,
-                    .fields = &[_]FieldDiff{},
+                    .fields = &.{},
                     .overrides = overrides,
                 });
             } else {
                 var raw: std.ArrayList(FieldDiff) = .empty;
                 try diffNode(arena, &raw, "", b.body, ad.body);
-                const fields = try presentFields(arena, try raw.toOwnedSlice(arena));
+                const fields = try presentFields(arena, raw.items);
                 try docs.append(arena, .{
                     .file_id = ad.file_id,
                     .class_id = ad.class_id,
@@ -655,7 +656,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
                     .type_name = resolvedTypeName(ad),
                     .script_guid = scriptGuid(ad),
                     .status = .added,
-                    .fields = &[_]FieldDiff{},
+                    .fields = &.{},
                     .overrides = try addedInstanceOverrides(arena, ad),
                 });
             } else {
@@ -668,7 +669,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
                     .script_guid = scriptGuid(ad),
                     .class_name = editorClassName(ad),
                     .status = .added,
-                    .fields = try presentFields(arena, try raw.toOwnedSlice(arena)),
+                    .fields = try presentFields(arena, raw.items),
                 });
             }
         }
@@ -676,7 +677,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
     for (before) |*bd| {
         if (bd.stripped) continue;
         if (after_idx.contains(bd.file_id)) continue;
-        try collectGuids(&guids, bd.body);
+        try collectGuids(arena, &guids, bd.body);
         try docs.append(arena, .{
             .file_id = bd.file_id,
             .class_id = bd.class_id,
@@ -684,13 +685,13 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
             .script_guid = scriptGuid(bd),
             .class_name = editorClassName(bd),
             .status = .removed,
-            .fields = &[_]FieldDiff{},
+            .fields = &.{},
         });
     }
 
     return .{
         .docs = try docs.toOwnedSlice(arena),
-        .unresolved_guids = try guids.toSlice(),
+        .unresolved_guids = guids.keys(),
         .before = before,
         .after = after,
     };
@@ -705,11 +706,11 @@ fn diffNode(
     b: *const Node,
 ) anyerror!void {
     // Same kind?
-    if (std.meta.activeTag(a.*) == .map and std.meta.activeTag(b.*) == .map) {
+    if (a.* == .map and b.* == .map) {
         try diffMap(arena, out, prefix, a.map, b.map);
         return;
     }
-    if (std.meta.activeTag(a.*) == .seq and std.meta.activeTag(b.*) == .seq) {
+    if (a.* == .seq and b.* == .seq) {
         try diffSeq(arena, out, prefix, a.seq, b.seq);
         return;
     }
@@ -752,18 +753,17 @@ fn diffSeq(
     b: []*Node,
 ) anyerror!void {
     const n = @min(a.len, b.len);
-    var i: usize = 0;
-    while (i < n) : (i += 1) {
+    for (a[0..n], b[0..n], 0..) |ea, eb, i| {
         const path = try std.fmt.allocPrint(arena, "{s}[{d}]", .{ prefix, i });
-        try diffNode(arena, out, path, a[i], b[i]);
+        try diffNode(arena, out, path, ea, eb);
     }
-    while (i < a.len) : (i += 1) {
+    for (a[n..], n..) |ea, i| {
         const path = try std.fmt.allocPrint(arena, "{s}[{d}]", .{ prefix, i });
-        try flattenSubtree(arena, out, path, a[i], .removed);
+        try flattenSubtree(arena, out, path, ea, .removed);
     }
-    while (i < b.len) : (i += 1) {
+    for (b[n..], n..) |eb, i| {
         const path = try std.fmt.allocPrint(arena, "{s}[{d}]", .{ prefix, i });
-        try flattenSubtree(arena, out, path, b[i], .added);
+        try flattenSubtree(arena, out, path, eb, .added);
     }
 }
 
@@ -951,7 +951,7 @@ fn sortByGroup(overrides: []model.OverrideDiff) void {
             return std.mem.order(u8, a.group, b.group) == .lt;
         }
     };
-    std.sort.insertion(model.OverrideDiff, overrides, {}, Ctx.lessThan);
+    std.sort.block(model.OverrideDiff, overrides, {}, Ctx.lessThan);
 }
 
 const Placement = struct { prefix: []const u8, label: []const u8, comps: []const []const u8 };
@@ -969,6 +969,8 @@ fn scalarOf(n: ?*Node) ?[]const u8 {
     };
 }
 
+/// Exact equality on purpose: near-default values are real overrides and must
+/// stay visible (epsilon matching was evaluated and rejected).
 fn numEql(s: []const u8, want: f64) bool {
     const v = std.fmt.parseFloat(f64, std.mem.trim(u8, s, " ")) catch return false;
     return v == want;
@@ -1068,29 +1070,11 @@ fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model
 
 // ---- guid collection ----
 
-const GuidSet = struct {
-    arena: std.mem.Allocator,
-    map: std.StringHashMap(void),
-    order: std.ArrayList([]const u8),
-
-    fn init(arena: std.mem.Allocator) GuidSet {
-        return .{ .arena = arena, .map = std.StringHashMap(void).init(arena), .order = .empty };
-    }
-    fn add(self: *GuidSet, guid: []const u8) !void {
-        if (self.map.contains(guid)) return;
-        try self.map.put(guid, {});
-        try self.order.append(self.arena, guid);
-    }
-    fn toSlice(self: *GuidSet) ![][]const u8 {
-        return self.order.toOwnedSlice(self.arena);
-    }
-};
-
-fn collectGuids(set: *GuidSet, node: *const Node) anyerror!void {
+fn collectGuids(arena: std.mem.Allocator, set: *std.StringArrayHashMapUnmanaged(void), node: *const Node) anyerror!void {
     switch (node.*) {
-        .ref => |r| if (r.guid) |g| try set.add(g),
-        .map => |entries| for (entries) |e| try collectGuids(set, e.value),
-        .seq => |items| for (items) |it| try collectGuids(set, it),
+        .ref => |r| if (r.guid) |g| try set.put(arena, g, {}),
+        .map => |entries| for (entries) |e| try collectGuids(arena, set, e.value),
+        .seq => |items| for (items) |it| try collectGuids(arena, set, it),
         .scalar => {},
     }
 }

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -77,7 +77,7 @@ test "diff: nested field path and added field" {
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
     try testing.expectEqual(model.Status.modified, d.status);
-    // Expect one modified leaf (m_LocalPosition.y) plus added subtree (m_LocalScale.*).
+    // 期待: modified な leaf(m_LocalPosition.y)+ added なサブツリー(m_LocalScale)。
     var saw_y = false;
     var saw_added_scale = false;
     for (d.fields) |f| {
@@ -99,9 +99,9 @@ test "diff: duplicate before fileIDs match the first occurrence" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Malformed anchors default file_id to 0 in the parser, so genuine
-    // duplicates occur; the linear scan this index replaced matched the
-    // FIRST document, and that semantics must be preserved.
+    // 不正な anchor は parser が file_id を 0 に落とすため、重複は実際に
+    // 起こる。index 導入前の線形探索は「最初の」ドキュメントに一致して
+    // いたので、そのセマンティクスを維持しなければならない。
     const before =
         \\--- !u!114 &5
         \\MonoBehaviour:
@@ -119,7 +119,7 @@ test "diff: duplicate before fileIDs match the first occurrence" {
     const d = findDoc(fd, 5).?;
     try testing.expectEqual(model.Status.modified, d.status);
     try testing.expectEqual(@as(usize, 1), d.fields.len);
-    // First occurrence wins: before must be 100, not the duplicate's 999.
+    // 最初の出現が勝つ: before は重複側の 999 ではなく 100。
     try testing.expectEqualStrings("100", d.fields[0].before.?.scalar);
     try testing.expectEqualStrings("150", d.fields[0].after.?.scalar);
 }
@@ -139,7 +139,7 @@ test "diff: unresolved guids collected from external refs" {
         \\  m_Script: {fileID: 1, guid: bbbb, type: 3}
     ;
     const fd = try compute(arena, before, after);
-    // Both aaaa and bbbb are external guids referenced; both should appear.
+    // aaaa と bbbb はどちらも参照された外部 guid なので両方現れる。
     var saw_a = false;
     var saw_b = false;
     for (fd.unresolved_guids) |g| {
@@ -556,8 +556,8 @@ fn buildIndex(arena: std.mem.Allocator, docs: []model.Document) !std.AutoHashMap
     var idx = std.AutoHashMap(i64, *model.Document).init(arena);
     try idx.ensureTotalCapacity(@intCast(docs.len));
     for (docs) |*d| {
-        // First occurrence wins on duplicate fileIDs, matching the linear
-        // scan this index replaced (duplicates occur with malformed anchors).
+        // fileID 重複は最初の出現が勝つ(不正な anchor で発生する)。
+        // index 導入前の線形探索と同じセマンティクス。
         const gop = idx.getOrPutAssumeCapacity(d.file_id);
         if (!gop.found_existing) gop.value_ptr.* = d;
     }
@@ -572,7 +572,7 @@ fn scriptGuid(doc: *const model.Document) ?[]const u8 {
     };
 }
 
-/// "Assembly-CSharp::Cylinder1" -> "Cylinder1"(最後の ':' より後)。
+// "Assembly-CSharp::Cylinder1" -> "Cylinder1"(最後の ':' より後)。
 fn editorClassName(doc: *const model.Document) ?[]const u8 {
     const v = model.findValue(doc.body.map, "m_EditorClassIdentifier") orelse return null;
     const s = switch (v.*) {
@@ -583,7 +583,7 @@ fn editorClassName(doc: *const model.Document) ?[]const u8 {
     return if (tail.len != 0) tail else null;
 }
 
-/// 生の field diff から Inspector 非表示を落とし、path を表示名に置換する。
+// 生の field diff から Inspector 非表示を落とし、path を表示名に置換する。
 fn presentFields(arena: std.mem.Allocator, raw: []FieldDiff) ![]FieldDiff {
     var kept: std.ArrayList(FieldDiff) = .empty;
     for (raw) |f| {
@@ -597,7 +597,7 @@ fn presentFields(arena: std.mem.Allocator, raw: []FieldDiff) ![]FieldDiff {
 
 fn resolvedTypeName(doc: *const model.Document) []const u8 {
     if (classid.typeName(doc.class_id)) |n| return n;
-    // Unknown classID: fall back to the document's own top key.
+    // 未知の classID はドキュメント自身のトップレベルキーに fallback。
     return doc.type_name;
 }
 
@@ -606,17 +606,17 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
     const after = try parser.parse(arena, after_src);
 
     var docs: std.ArrayList(DocDiff) = .empty;
-    // Array hash map: preserves first-insertion order so unresolvedGuids
-    // serializes deterministically in reference order.
+    // array hash map は初回挿入順を保持するので、unresolvedGuids が
+    // 参照順で決定的にシリアライズされる。
     var guids: std.StringArrayHashMapUnmanaged(void) = .empty;
 
-    // fileID -> *Document indices so the union walk below is O(n) instead of
-    // O(n^2) linear scans (matters at scene scale: tens of thousands of docs).
+    // fileID -> *Document の索引。以降の和集合の走査を O(n^2) の線形探索
+    // ではなく O(n) にする(数万 doc のシーン規模で効く)。
     var before_idx = try buildIndex(arena, before);
     var after_idx = try buildIndex(arena, after);
 
-    // Walk the union of file_ids: iterate `after` first (preserves after order),
-    // then `before`-only documents.
+    // file_id の和集合を歩く: まず `after` を順に(after の順序を保つ)、
+    // 次に `before` にしかないドキュメントを処理する。
     for (after) |*ad| {
         if (ad.stripped) continue;
         try collectGuids(arena, &guids, ad.body);
@@ -697,7 +697,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
     };
 }
 
-/// Recursive field diff. `prefix` is the dotted/indexed path to `a`/`b`.
+// 再帰的な field diff。`prefix` は `a`/`b` へのドット/添字区切りパス。
 fn diffNode(
     arena: std.mem.Allocator,
     out: *std.ArrayList(FieldDiff),
@@ -705,7 +705,7 @@ fn diffNode(
     a: *const Node,
     b: *const Node,
 ) anyerror!void {
-    // Same kind?
+    // 同じ種別なら再帰。
     if (a.* == .map and b.* == .map) {
         try diffMap(arena, out, prefix, a.map, b.map);
         return;
@@ -714,7 +714,7 @@ fn diffNode(
         try diffSeq(arena, out, prefix, a.seq, b.seq);
         return;
     }
-    // Leaf (scalar/ref) or kind change.
+    // leaf(scalar/ref)または種別の変化。
     if (!Node.eql(a, b)) {
         try out.append(arena, .{ .path = prefix, .status = .modified, .before = a, .after = b });
     }
@@ -727,7 +727,7 @@ fn diffMap(
     a: []model.Entry,
     b: []model.Entry,
 ) anyerror!void {
-    // keys in a: modified/removed/recurse
+    // a にあるキー: modified/removed または再帰
     for (a) |ea| {
         const path = try joinKey(arena, prefix, ea.key);
         if (model.findValue(b, ea.key)) |bv| {
@@ -736,7 +736,7 @@ fn diffMap(
             try flattenSubtree(arena, out, path, ea.value, .removed);
         }
     }
-    // keys only in b: added
+    // b にしかないキー: added
     for (b) |eb| {
         if (model.findValue(a, eb.key) == null) {
             const path = try joinKey(arena, prefix, eb.key);
@@ -782,7 +782,7 @@ fn isVectorMap(entries: []model.Entry) bool {
     return true;
 }
 
-/// "(a, b, c)" 形の合成スカラー Node("Position: (2, 3, 1)" 等の 1 行表示用)。
+// "(a, b, c)" 形の合成スカラー Node("Position: (2, 3, 1)" 等の 1 行表示用)。
 fn parenJoinNode(arena: std.mem.Allocator, vals: []const []const u8) !*Node {
     var out: std.ArrayList(u8) = .empty;
     try out.append(arena, '(');
@@ -810,7 +810,7 @@ fn appendLeaf(arena: std.mem.Allocator, out: *std.ArrayList(FieldDiff), path: []
     });
 }
 
-/// added/removed サブツリーを leaf 単位に展開する。ベクトル風 map は 1 行に縮約。
+// added/removed サブツリーを leaf 単位に展開する。ベクトル風 map は 1 行に縮約。
 fn flattenSubtree(
     arena: std.mem.Allocator,
     out: *std.ArrayList(FieldDiff),
@@ -873,7 +873,7 @@ fn objRefIfSet(n: ?*Node) ?*Node {
     };
 }
 
-/// objectReference が設定されていればそれ、なければ value。
+// objectReference が設定されていればそれ、なければ value。
 fn modValue(m: Mod) ?*Node {
     return m.obj_ref orelse m.value;
 }
@@ -931,9 +931,9 @@ fn diffOverrides(arena: std.mem.Allocator, before_doc: ?*const model.Document, a
     return out.toOwnedSlice(arena);
 }
 
-/// group 単位で安定ソート(Transform → GameObject → Overrides)。
-/// レンダラは同一グループの行が連続することを前提に見出しを出すため、
-/// 生の m_Modifications 順を group ごとに束ね直す。
+// group 単位で安定ソート(Transform → GameObject → Overrides)。
+// レンダラは同一グループの行が連続することを前提に見出しを出すため、
+// 生の m_Modifications 順を group ごとに束ね直す。
 fn groupRank(group: []const u8) u2 {
     if (std.mem.eql(u8, group, "Transform")) return 0;
     if (std.mem.eql(u8, group, "GameObject")) return 1;
@@ -969,8 +969,8 @@ fn scalarOf(n: ?*Node) ?[]const u8 {
     };
 }
 
-/// Exact equality on purpose: near-default values are real overrides and must
-/// stay visible (epsilon matching was evaluated and rejected).
+// 意図的な厳密一致: ほぼデフォルトに近い値も実在する override であり、
+// 表示され続けるべき(epsilon 比較は検討のうえ見送り済み)。
 fn numEql(s: []const u8, want: f64) bool {
     const v = std.fmt.parseFloat(f64, std.mem.trim(u8, s, " ")) catch return false;
     return v == want;
@@ -1046,7 +1046,7 @@ fn modificationSeqLen(doc: *const model.Document, key: []const u8) usize {
     };
 }
 
-/// m_Added*/m_Removed* の完全展開はスコープ外。件数の要約 1 行で情報が黙って消えるのを防ぐ。
+// m_Added*/m_Removed* の完全展開はスコープ外。件数の要約 1 行で情報が黙って消えるのを防ぐ。
 fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model.OverrideDiff), before_doc: ?*const model.Document, after_doc: *const model.Document) !void {
     const keys = [_]struct { key: []const u8, label: []const u8 }{
         .{ .key = "m_AddedGameObjects", .label = "Added GameObjects" },

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -77,7 +77,8 @@ test "diff: nested field path and added field" {
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
     try testing.expectEqual(model.Status.modified, d.status);
-    // 期待: modified な leaf(m_LocalPosition.y)+ added なサブツリー(m_LocalScale)。
+    // 期待: modified な leaf(m_LocalPosition.y)と、added な m_LocalScale が
+    // ベクトル縮約されて "Scale" 1 行になること。
     var saw_y = false;
     var saw_added_scale = false;
     for (d.fields) |f| {
@@ -87,9 +88,10 @@ test "diff: nested field path and added field" {
             try testing.expectEqualStrings("0", f.before.?.scalar);
             try testing.expectEqualStrings("5", f.after.?.scalar);
         }
-        if (std.mem.startsWith(u8, f.path, "Scale")) {
+        if (std.mem.eql(u8, f.path, "Scale")) {
             saw_added_scale = true;
             try testing.expectEqual(model.Status.added, f.status);
+            try testing.expectEqualStrings("(1, 1, 1)", f.after.?.scalar);
         }
     }
     try testing.expect(saw_y and saw_added_scale);
@@ -260,6 +262,47 @@ test "diff: editor class identifier tail is extracted" {
     try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.class_name.?);
 }
 
+test "diff: editor class identifier without separator or with empty tail" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  m_EditorClassIdentifier: Cylinder1
+        \\--- !u!114 &6
+        \\MonoBehaviour:
+        \\  m_EditorClassIdentifier: Assembly-CSharp::
+    ;
+    const fd = try compute(arena, src, src);
+    // 区切りなしは全体をクラス名として使い、末尾が空なら class_name なし。
+    try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.class_name.?);
+    try testing.expect(findDoc(fd, 6).?.class_name == null);
+}
+
+test "diff: unresolved guids are deduplicated in first-reference order" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const after =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 1, guid: bbb, type: 3}
+        \\--- !u!114 &6
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 1, guid: aaa, type: 3}
+        \\--- !u!114 &7
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 1, guid: bbb, type: 3}
+    ;
+    const fd = try compute(arena, "", after);
+    // 重複する bbb は 1 回だけ、初回参照順(bbb, aaa)で並ぶ。
+    // JSON の unresolvedGuids/resolved の決定的な順序はこれに依存する。
+    try testing.expectEqual(@as(usize, 2), fd.unresolved_guids.len);
+    try testing.expectEqualStrings("bbb", fd.unresolved_guids[0]);
+    try testing.expectEqualStrings("aaa", fd.unresolved_guids[1]);
+}
+
 test "diff: sortByGroup keeps same-group rows contiguous beyond known ranks" {
     // レンダラは「同一グループの行は連続」を core の不変条件として前提にする。
     // groupOf が将来 4 つ目のグループ名を返しても壊れないことを直接固定する。
@@ -297,34 +340,6 @@ test "diff: added document enumerates fields with vector collapse" {
     try testing.expectEqualStrings("Position", d.fields[0].path);
     try testing.expectEqualStrings("(4, 0, 0)", d.fields[0].after.?.scalar);
     try testing.expectEqualStrings("Max Hp", d.fields[1].path);
-}
-
-test "diff: added map field inside a modified document is flattened" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const before =
-        \\--- !u!4 &4
-        \\Transform:
-        \\  m_LocalPosition: {x: 0, y: 0, z: 0}
-    ;
-    const after =
-        \\--- !u!4 &4
-        \\Transform:
-        \\  m_LocalPosition: {x: 0, y: 5, z: 0}
-        \\  m_LocalScale: {x: 1, y: 1, z: 1}
-    ;
-    const fd = try compute(arena, before, after);
-    const d = findDoc(fd, 4).?;
-    var saw_scale = false;
-    for (d.fields) |f| {
-        if (std.mem.eql(u8, f.path, "Scale")) {
-            saw_scale = true;
-            try testing.expectEqual(model.Status.added, f.status);
-            try testing.expectEqualStrings("(1, 1, 1)", f.after.?.scalar);
-        }
-    }
-    try testing.expect(saw_scale);
 }
 
 test "diff: prefab instance override keyed by target+propertyPath" {

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -1,5 +1,5 @@
-//! 検証 PR (hashiiiii/unity-yaml-playground#1) の実データに対する統合テスト。
-//! 期待値は spec の承認済みモック(docs/superpowers/specs/2026-07-03-semantic-diff-inspector-model-design.md)。
+// 検証 PR (hashiiiii/unity-yaml-playground#1) の実データに対する統合テスト。
+// 期待値は spec の承認済みモック(docs/superpowers/specs/2026-07-03-semantic-diff-inspector-model-design.md)。
 const std = @import("std");
 const root = @import("root.zig");
 const model = @import("model.zig");

--- a/core/src/inspector.zig
+++ b/core/src/inspector.zig
@@ -125,8 +125,7 @@ fn appendNicified(arena: std.mem.Allocator, out: *std.ArrayList(u8), name: []con
 }
 
 const transform_props = [_][]const u8{
-    "m_LocalPosition", "m_LocalRotation", "m_LocalScale",
-    "m_LocalEulerAnglesHint", "m_ConstrainProportionsScale",
+    "m_LocalPosition", "m_LocalRotation", "m_LocalScale", "m_LocalEulerAnglesHint", "m_ConstrainProportionsScale",
 };
 const game_object_props = [_][]const u8{
     "m_Name", "m_IsActive", "m_TagString", "m_Layer", "m_StaticEditorFlags", "m_Icon",

--- a/core/src/inspector.zig
+++ b/core/src/inspector.zig
@@ -33,7 +33,7 @@ test "inspector: groupOf infers pseudo component from propertyPath" {
     try testing.expectEqualStrings("Overrides", groupOf("maxHp"));
 }
 
-/// Inspector に表示されないフィールド(パス先頭セグメントで判定)。
+// Inspector に表示されないフィールド(パス先頭セグメントで判定)。
 const hidden = [_][]const u8{
     "m_ObjectHideFlags",
     "m_CorrespondingSourceObject",
@@ -50,7 +50,7 @@ const hidden = [_][]const u8{
     "m_RootOrder",
 };
 
-/// 主要ビルトインの Inspector 表示名(先頭セグメント単位)。
+// 主要ビルトインの Inspector 表示名(先頭セグメント単位)。
 const display = [_]struct { raw: []const u8, shown: []const u8 }{
     .{ .raw = "m_LocalPosition", .shown = "Position" },
     .{ .raw = "m_LocalRotation", .shown = "Rotation" },
@@ -88,15 +88,15 @@ pub fn displayPath(arena: std.mem.Allocator, path: []const u8) ![]const u8 {
     return out.toOwnedSlice(arena);
 }
 
-/// "[N]" 添字は名前部の後ろにそのまま残す。
+// "[N]" 添字は名前部の後ろにそのまま残す。
 fn appendSegment(arena: std.mem.Allocator, out: *std.ArrayList(u8), seg: []const u8) !void {
     const br = std.mem.indexOfScalar(u8, seg, '[') orelse seg.len;
     try appendNicified(arena, out, seg[0..br]);
     try out.appendSlice(arena, seg[br..]);
 }
 
-/// Unity の ObjectNames.NicifyVariableName 相当: 固定テーブル →
-/// "m_" 除去 + 先頭大文字化 + 小文字/数字→大文字境界に空白挿入。
+// Unity の ObjectNames.NicifyVariableName 相当: 固定テーブル →
+// "m_" 除去 + 先頭大文字化 + 小文字/数字→大文字境界に空白挿入。
 fn appendNicified(arena: std.mem.Allocator, out: *std.ArrayList(u8), name: []const u8) !void {
     for (display) |d| if (std.mem.eql(u8, name, d.raw)) {
         try out.appendSlice(arena, d.shown);

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -22,8 +22,8 @@ pub fn serialize(arena: std.mem.Allocator, res: model.DiffResult, resolved: ?*co
     try w.writeByte(']');
 
     if (resolved) |r| {
-        // Scope to guids the diff actually references (not the whole project
-        // index), in the same deterministic order as unresolvedGuids.
+        // diff が実際に参照した guid だけに絞る(プロジェクト index 全体を
+        // 出さない)。順序は unresolvedGuids と同じで決定的。
         try w.writeAll(",\"resolved\":{");
         var first = true;
         for (res.unresolved_guids) |g| {
@@ -155,7 +155,7 @@ fn writeValue(w: *std.Io.Writer, node: ?*const Node) !void {
             if (r.type_id) |t| try w.print("{d}", .{t}) else try w.writeAll("null");
             try w.writeAll("}}");
         },
-        // Maps/seqs as field leaves are uncommon (they recurse), but render compactly.
+        // map/seq が leaf に来るのは稀(通常は再帰される)。コンパクトに表現する。
         .map => try w.writeAll("\"<map>\""),
         .seq => try w.writeAll("\"<seq>\""),
     }
@@ -349,8 +349,8 @@ test "json: resolved is scoped to referenced guids, ordered like unresolvedGuids
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // A project index built from 2 .meta files -- guidA and guidC are both
-    // resolvable, but only guidA is actually referenced by the diff.
+    // 2 つの .meta から構築したプロジェクト index。guidA と guidC はどちらも
+    // 解決可能だが、diff が参照するのは guidA のみ。
     var resolver = Resolver.init(arena);
     try resolver.put("guidA", "Assets/Scripts/A.cs");
     try resolver.put("guidC", "Assets/Scripts/C.cs");
@@ -363,9 +363,9 @@ test "json: resolved is scoped to referenced guids, ordered like unresolvedGuids
     };
 
     const out = try serialize(arena, res, &resolver);
-    // Only the referenced guid is present in "resolved" ...
+    // "resolved" には参照された guid だけが載り、
     try testing.expect(std.mem.indexOf(u8, out, "\"resolved\":{\"guidA\":\"Assets/Scripts/A.cs\"}") != null);
-    // ... the unreferenced-but-resolvable guidC must not leak into the dump.
+    // 参照されていない guidC は解決可能でも出力に漏れない。
     try testing.expect(std.mem.indexOf(u8, out, "guidC") == null);
 }
 
@@ -378,7 +378,7 @@ test "json: resolved follows unresolvedGuids order, skipping guids the resolver 
     try resolver.put("guidA", "Assets/Scripts/A.cs");
     try resolver.put("guidB", "Assets/Scripts/B.cs");
 
-    // Referenced order is B, A; guidX is referenced but not in the project index.
+    // 参照順は B, A。guidX は参照されているがプロジェクト index に存在しない。
     var unresolved_guids = [_][]const u8{ "guidB", "guidA", "guidX" };
     const res: model.DiffResult = .{
         .roots = &.{},
@@ -389,7 +389,7 @@ test "json: resolved follows unresolvedGuids order, skipping guids the resolver 
     const out = try serialize(arena, res, &resolver);
     try testing.expect(std.mem.indexOf(u8, out, "\"resolved\":{\"guidB\":\"Assets/Scripts/B.cs\",\"guidA\":\"Assets/Scripts/A.cs\"}") != null);
     try testing.expect(std.mem.indexOf(u8, out, "guidX\":") == null);
-    // guidX stays listed as unresolved.
+    // guidX は unresolved のまま残る。
     try testing.expect(std.mem.indexOf(u8, out, "\"unresolvedGuids\":[\"guidB\",\"guidA\",\"guidX\"]") != null);
 }
 
@@ -408,6 +408,6 @@ test "json: string escaping" {
         \\  m_Name: "a\"b"
     ;
     const out = try root.diffToJson(arena, before, after);
-    // The quote inside the value must be escaped in JSON output.
+    // 値の中の引用符は JSON 出力でエスケープされる。
     try testing.expect(std.mem.indexOf(u8, out, "a\\\"b") != null);
 }

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -9,8 +9,7 @@ const Status = model.Status;
 pub const Resolver = std.StringHashMap([]const u8);
 
 pub fn serialize(arena: std.mem.Allocator, res: model.DiffResult, resolved: ?*const Resolver) ![]u8 {
-    var buf: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &buf);
+    var aw: std.Io.Writer.Allocating = .init(arena);
     const w = &aw.writer;
 
     try w.writeAll("{\"schema\":\"prefablens.diff.v2\"");
@@ -50,8 +49,7 @@ pub fn serialize(arena: std.mem.Allocator, res: model.DiffResult, resolved: ?*co
     }
     try w.writeAll("]}");
 
-    var list = aw.toArrayList();
-    return list.toOwnedSlice(arena);
+    return aw.toOwnedSlice();
 }
 
 fn writeObject(w: *std.Io.Writer, o: model.ObjectDiff, resolved: ?*const Resolver) !void {

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -393,6 +393,16 @@ test "json: resolved follows unresolvedGuids order, skipping guids the resolver 
     try testing.expect(std.mem.indexOf(u8, out, "\"unresolvedGuids\":[\"guidB\",\"guidA\",\"guidX\"]") != null);
 }
 
+test "json: control characters are escaped" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var aw: std.Io.Writer.Allocating = .init(arena);
+    // 名前つきエスケープ(\n 等)はそれを、その他の制御文字は \u00XX を使う。
+    try writeJsonString(&aw.writer, "a\nb\x01c");
+    try testing.expectEqualStrings("\"a\\nb\\u0001c\"", aw.written());
+}
+
 test "json: string escaping" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -150,4 +150,9 @@ test "Node.eql: scalars, refs, seqs, maps" {
     var m1 = Node{ .map = &e_a };
     var m2 = Node{ .map = &e_b };
     try std.testing.expect(Node.eql(&m1, &m2));
+
+    // 要素数が同じでもキー集合が異なるマップは不等。
+    var e_c = [_]Entry{ .{ .key = "x", .value = &s1 }, .{ .key = "z", .value = &s3 } };
+    var m3 = Node{ .map = &e_c };
+    try std.testing.expect(!Node.eql(&m1, &m3));
 }

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-/// External or local reference: `{fileID: N}` or `{fileID: N, guid: ..., type: N}`.
+// 外部または内部への参照: `{fileID: N}` または `{fileID: N, guid: ..., type: N}`。
 pub const Ref = struct {
     file_id: i64,
     guid: ?[]const u8 = null,
@@ -8,11 +8,11 @@ pub const Ref = struct {
 };
 
 pub const Entry = struct {
-    key: []const u8, // slice into source
+    key: []const u8, // 入力バッファへのスライス
     value: *Node,
 };
 
-/// A parsed Unity-YAML value. Scalars/keys/guids are slices into the input buffer.
+// パース済み Unity YAML の値。scalar/key/guid は入力バッファへのスライス。
 pub const Node = union(enum) {
     map: []Entry,
     seq: []*Node,
@@ -54,26 +54,26 @@ fn strEqOpt(a: ?[]const u8, b: ?[]const u8) bool {
     return std.mem.eql(u8, a.?, b.?);
 }
 
-/// Look up a value by key in a map's entries (linear; Unity maps are small).
+// map のエントリからキーで値を引く(線形探索。Unity の map は小さい)。
 pub fn findValue(entries: []const Entry, key: []const u8) ?*Node {
     for (entries) |e| if (std.mem.eql(u8, e.key, key)) return e.value;
     return null;
 }
 
-/// One Unity document: `--- !u!<class_id> &<file_id>` + a body mapping.
+// Unity の 1 ドキュメント: `--- !u!<class_id> &<file_id>` + 本体の mapping。
 pub const Document = struct {
     class_id: u32,
     file_id: i64,
-    type_name: []const u8, // the single top-level key, e.g. "GameObject"
+    type_name: []const u8, // 唯一のトップレベルキー("GameObject" 等)
     stripped: bool = false,
-    body: *Node, // a .map node of the document's fields
+    body: *Node, // ドキュメントのフィールドを持つ .map ノード
 };
 
 pub const Status = enum { added, removed, modified, unchanged };
 
 pub const ObjectKind = enum { game_object, prefab_instance };
 
-/// PrefabInstance の (target, propertyPath) 単位の override diff。
+// PrefabInstance の (target, propertyPath) 単位の override diff。
 pub const OverrideDiff = struct {
     group: []const u8, // "Transform" | "GameObject" | "Overrides"
     label: []const u8, // humanize 済み ("Position.x")
@@ -83,7 +83,7 @@ pub const OverrideDiff = struct {
 };
 
 pub const FieldDiff = struct {
-    path: []const u8, // dotted/indexed path, arena-built
+    path: []const u8, // ドット/添字区切りのパス(arena 上に構築)
     status: Status,
     before: ?*const Node = null,
     after: ?*const Node = null,
@@ -94,7 +94,7 @@ pub const ComponentDiff = struct {
     class_id: u32,
     type_name: []const u8,
     script_guid: ?[]const u8 = null,
-    /// m_EditorClassIdentifier 末尾のクラス名 ("Cylinder1")。guid 解決の第 2 候補。
+    // m_EditorClassIdentifier 末尾のクラス名 ("Cylinder1")。guid 解決の第 2 候補。
     class_name: ?[]const u8 = null,
     status: Status,
     fields: []FieldDiff,
@@ -105,9 +105,9 @@ pub const ObjectDiff = struct {
     file_id: i64,
     name: []const u8,
     status: Status,
-    /// prefab_instance のみ: m_SourcePrefab の guid。
+    // prefab_instance のみ: m_SourcePrefab の guid。
     source_guid: ?[]const u8 = null,
-    /// prefab_instance のみ: (target, propertyPath) キーの override diff。
+    // prefab_instance のみ: (target, propertyPath) キーの override diff。
     overrides: []OverrideDiff = &.{},
     components: []ComponentDiff,
     children: []ObjectDiff,
@@ -120,31 +120,31 @@ pub const DiffResult = struct {
 };
 
 test "Node.eql: scalars, refs, seqs, maps" {
-    // Scalars
+    // スカラー
     var s1 = Node{ .scalar = "100" };
     var s2 = Node{ .scalar = "100" };
     var s3 = Node{ .scalar = "150" };
     try std.testing.expect(Node.eql(&s1, &s2));
     try std.testing.expect(!Node.eql(&s1, &s3));
 
-    // Refs
+    // 参照
     var r1 = Node{ .ref = .{ .file_id = 234, .guid = "abc", .type_id = 3 } };
     var r2 = Node{ .ref = .{ .file_id = 234, .guid = "abc", .type_id = 3 } };
     var r3 = Node{ .ref = .{ .file_id = 234, .guid = "xyz", .type_id = 3 } };
     try std.testing.expect(Node.eql(&r1, &r2));
     try std.testing.expect(!Node.eql(&r1, &r3));
 
-    // Cross-kind is never equal
+    // 種別が異なるノードは常に不等
     try std.testing.expect(!Node.eql(&s1, &r1));
 
-    // Seqs
+    // シーケンス(順序込みで比較)
     var seq_a = [_]*Node{ &s1, &s3 };
     var seq_b = [_]*Node{ &s2, &s3 };
     var q1 = Node{ .seq = &seq_a };
     var q2 = Node{ .seq = &seq_b };
     try std.testing.expect(Node.eql(&q1, &q2));
 
-    // Maps
+    // マップ(キー順序は不問)
     var e_a = [_]Entry{ .{ .key = "x", .value = &s1 }, .{ .key = "y", .value = &s3 } };
     var e_b = [_]Entry{ .{ .key = "y", .value = &s3 }, .{ .key = "x", .value = &s2 } };
     var m1 = Node{ .map = &e_a };

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -120,9 +120,6 @@ pub const DiffResult = struct {
 };
 
 test "Node.eql: scalars, refs, seqs, maps" {
-    const a = std.testing.allocator;
-    _ = a;
-
     // Scalars
     var s1 = Node{ .scalar = "100" };
     var s2 = Node{ .scalar = "100" };

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -105,7 +105,7 @@ test "parse: ref with guid and type, and a non-ref flow map (vector)" {
     try testing.expectEqual(@as(i64, 3), script.ref.type_id.?);
 
     const pos = model.findValue(doc.body.map, "m_LocalPosition").?;
-    // A flow map without fileID stays a .map, not a .ref.
+    // fileID を持たない flow map は .ref にならず .map のまま。
     const x = model.findValue(pos.map, "x").?;
     try testing.expectEqualStrings("1", x.scalar);
 
@@ -202,8 +202,8 @@ test "parse: deeply nested flow value is rejected instead of overflowing the sta
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // Enough nesting to previously blow the stack (~14000 levels crashes);
-    // 5000 is well past any sane cap and well within the 200 KB file budget.
+    // かつてスタックを溢れさせた深さ(~14000 段でクラッシュ)を再現する規模。
+    // 5000 は正気な上限をはるかに超え、かつ 200 KB のファイル予算には収まる。
     const depth = 5000;
     var src: std.ArrayList(u8) = .empty;
     try src.appendSlice(arena, "--- !u!114 &1\nMonoBehaviour:\n  m_Field: ");
@@ -218,8 +218,8 @@ test "parse: sequence document body degrades to an empty map instead of crashing
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Unity never writes a sequence as a document body, but hostile input can;
-    // downstream reads body.map unconditionally, so it must stay a map.
+    // Unity はドキュメント本体にシーケンスを書かないが、敵対的入力では起こり得る。
+    // 下流は body.map を無条件に読むため、body は常に map でなければならない。
     const src =
         \\--- !u!1 &1
         \\GameObject:
@@ -305,8 +305,8 @@ const Parser = struct {
     }
 };
 
-/// Tokenize into significant logical lines (indent + content), dropping
-/// blanks, `%` directives, and `#` comments.
+// 意味のある論理行(インデント + 内容)に分解する。空行・`%` ディレクティブ・
+// `#` コメントは落とす。
 fn tokenize(arena: std.mem.Allocator, source: []const u8) ![]Line {
     var lines: std.ArrayList(Line) = .empty;
     var it = std.mem.splitScalar(u8, source, '\n');
@@ -357,11 +357,11 @@ fn parseDocument(p: *Parser) !Document {
     var body: *Node = undefined;
     if (p.peek()) |first| {
         if (!std.mem.startsWith(u8, first.text, "---")) {
-            _ = p.advance(); // the "TypeName:" line at indent 0
+            _ = p.advance(); // indent 0 の "TypeName:" 行
             type_name = stripTrailingColon(first.text);
             body = try parseBlock(p, indentOfNext(p, 2), 0);
-            // Downstream reads body.map unconditionally; a malformed body
-            // that parses as a sequence must not escape as a non-map node.
+            // 下流は body.map を無条件に読む。シーケンスとして parse された
+            // 不正な body を map 以外のノードとして外に出してはならない。
             if (body.* != .map) body = try emptyMap(p.arena);
         } else {
             body = try emptyMap(p.arena);
@@ -379,18 +379,18 @@ fn parseDocument(p: *Parser) !Document {
     };
 }
 
-/// The body's first field indent (Unity uses 2, but be tolerant): peek the
-/// next line; if it's deeper than 0, use its indent, else default.
+// 本体の最初のフィールドのインデント(Unity は 2 だが寛容に扱う): 次の行を
+// 覗き、0 より深ければそのインデント、そうでなければ default。
 fn indentOfNext(p: *const Parser, default_indent: usize) usize {
     if (p.peek()) |l| if (l.indent > 0 and !std.mem.startsWith(u8, l.text, "---")) return l.indent;
     return default_indent;
 }
 
-/// Unity YAML never nests more than a handful of levels deep; this is a
-/// generous cap that rejects hostile input before it can overflow the stack.
+// Unity YAML の入れ子は高々数段。スタックを溢れさせる敵対的入力を
+// 事前に拒否するための、十分に余裕を持った上限。
 const max_nesting_depth: usize = 128;
 
-/// Parse a block (mapping or sequence) whose entries sit at exactly `indent`.
+// エントリがちょうど `indent` に並ぶブロック(mapping または sequence)を parse する。
 fn parseBlock(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
     if (depth > max_nesting_depth) return error.NestingTooDeep;
     const first = p.peek() orelse return emptyMap(p.arena);
@@ -418,10 +418,10 @@ fn parseMap(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
     return makeNode(p.arena, .{ .map = try entries.toOwnedSlice(p.arena) });
 }
 
-/// Value of a "key:" line with nothing after the colon: a nested block at a
-/// deeper indent, or a block sequence whose dash items are aligned with the
-/// key's own indent (Unity's convention, e.g. `m_Component:` followed by
-/// `- component: {...}` at the same column); otherwise an empty map.
+// コロンの後に何もない "key:" 行の値: より深いインデントの入れ子ブロック、
+// またはキー自身のインデントにダッシュが揃うブロックシーケンス(Unity の
+// 慣習。`m_Component:` の直後に同じ桁で `- component: {...}` が続く形)。
+// どちらでもなければ空 map。
 fn parseNestedValue(p: *Parser, key_indent: usize, depth: usize) anyerror!*Node {
     if (p.peek()) |next| {
         const is_dash = std.mem.startsWith(u8, next.text, "- ") or std.mem.eql(u8, next.text, "-");
@@ -440,11 +440,11 @@ fn parseSeq(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
         _ = p.advance();
         const rest = if (line.text.len >= 2) std.mem.trimStart(u8, line.text[1..], " ") else "";
         if (rest.len == 0) {
-            // "-" alone: nested block belongs to this item at deeper indent.
+            // "-" 単独: この項目の入れ子ブロックがより深いインデントに続く。
             const ci = indentOfNext(p, indent + 2);
             try items.append(p.arena, try parseBlock(p, ci, depth + 1));
         } else if (looksLikeMapEntry(rest)) {
-            // compact map item: first entry on the dash line, continuation at indent+2.
+            // コンパクトな map 項目: 先頭エントリはダッシュ行、続きは indent+2。
             try items.append(p.arena, try parseSeqMapItem(p, indent, rest, depth));
         } else {
             try items.append(p.arena, try parseValue(p.arena, rest, depth));
@@ -453,13 +453,13 @@ fn parseSeq(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
     return makeNode(p.arena, .{ .seq = try items.toOwnedSlice(p.arena) });
 }
 
-/// A sequence item that is a mapping, e.g.
-///   - target: {fileID: 0}
-///     propertyPath: m_Name
-///     value: Foo
+// mapping であるシーケンス項目。例:
+//   - target: {fileID: 0}
+//     propertyPath: m_Name
+//     value: Foo
 fn parseSeqMapItem(p: *Parser, dash_indent: usize, first_line: []const u8, depth: usize) anyerror!*Node {
     var entries: std.ArrayList(Entry) = .empty;
-    // All keys of the item sit at the column just past "- ".
+    // 項目のキーはすべて "- " の直後の桁に並ぶ。
     const key_indent = dash_indent + 2;
     const kv = splitKeyValue(first_line);
     if (kv.value.len == 0) {
@@ -467,7 +467,7 @@ fn parseSeqMapItem(p: *Parser, dash_indent: usize, first_line: []const u8, depth
     } else {
         try entries.append(p.arena, .{ .key = kv.key, .value = try parseValue(p.arena, kv.value, depth) });
     }
-    // Continuation entries are indented two past the dash (aligned after "- ").
+    // 継続エントリはダッシュより 2 つ深い("- " の直後に揃う)。
     while (p.peek()) |line| {
         if (line.indent != key_indent) break;
         if (std.mem.startsWith(u8, line.text, "- ") or std.mem.eql(u8, line.text, "-")) break;
@@ -502,10 +502,10 @@ fn stripTrailingColon(s: []const u8) []const u8 {
 
 const KV = struct { key: []const u8, value: []const u8, has_colon: bool };
 
-/// Split "key: value" / "key:" at the first ": " or trailing ":".
-/// Does not split inside a flow value (the value starts after the first colon).
+// "key: value" / "key:" を最初の ": " または末尾の ":" で分割する。
+// flow 値の内側では分割しない(値は最初のコロンの後から始まる)。
 fn splitKeyValue(line: []const u8) KV {
-    // Find the first ":" that is followed by a space or end-of-line.
+    // 空白または行末が続く最初の ":" を探す。
     var i: usize = 0;
     while (i < line.len) : (i += 1) {
         if (line[i] == ':' and (i + 1 == line.len or line[i + 1] == ' ')) {
@@ -518,7 +518,7 @@ fn splitKeyValue(line: []const u8) KV {
 }
 
 fn looksLikeMapEntry(s: []const u8) bool {
-    if (s.len > 0 and s[0] == '{') return false; // flow value, not a map entry
+    if (s.len > 0 and s[0] == '{') return false; // flow 値であって map エントリではない
     const kv = splitKeyValue(s);
     return kv.has_colon and kv.key.len > 0;
 }
@@ -532,7 +532,7 @@ fn parseValue(arena: std.mem.Allocator, raw: []const u8, depth: usize) anyerror!
     return makeNode(arena, .{ .scalar = try unquote(arena, s) });
 }
 
-/// Parse a flow mapping `{a: b, c: d}`. If it has a `fileID` key, return a Ref node.
+// flow mapping `{a: b, c: d}` を parse する。`fileID` キーを持てば Ref ノードを返す。
 fn parseFlow(arena: std.mem.Allocator, s: []const u8, depth: usize) anyerror!*Node {
     const inner = stripBrackets(s, '{', '}');
     var entries: std.ArrayList(Entry) = .empty;
@@ -586,9 +586,9 @@ fn stripBrackets(s: []const u8, open: u8, close: u8) []const u8 {
     return t;
 }
 
-/// Strip enclosing quotes. Double-quoted scalars also resolve YAML's
-/// backslash escapes for `\"` and `\\` (the only escapes Unity emits),
-/// so the raw scalar holds the literal value rather than the source text.
+// 囲みの引用符を外す。double-quote のスカラーは YAML のバックスラッシュ
+// エスケープ `\"` と `\\`(Unity が出力する唯一のエスケープ)も解決し、
+// scalar がソース表記ではなくリテラル値を持つようにする。
 fn unquote(arena: std.mem.Allocator, s: []const u8) anyerror![]const u8 {
     if (s.len >= 2 and s[0] == '\'' and s[s.len - 1] == '\'') {
         return s[1 .. s.len - 1];
@@ -612,7 +612,7 @@ fn unquote(arena: std.mem.Allocator, s: []const u8) anyerror![]const u8 {
     return s;
 }
 
-/// Iterator over comma-separated parts at brace/bracket depth 0.
+// brace/bracket の深さ 0 にあるカンマで区切られた部分のイテレータ。
 const TopLevelIter = struct {
     s: []const u8,
     i: usize = 0,

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -216,6 +216,36 @@ test "parse: deeply nested flow value is rejected instead of overflowing the sta
     try testing.expectError(error.NestingTooDeep, parse(arena, src.items));
 }
 
+test "parse: sequence document body degrades to an empty map instead of crashing" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // Unity never writes a sequence as a document body, but hostile input can;
+    // downstream reads body.map unconditionally, so it must stay a map.
+    const src =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  - rogue
+    ;
+    const doc = try parseOne(arena, src);
+    try testing.expectEqual(@as(usize, 0), doc.body.map.len);
+}
+
+test "parse: non-scalar guid in a ref degrades to null instead of crashing" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\--- !u!114 &1
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 1, guid: {x: 1}, type: 3}
+    ;
+    const doc = try parseOne(arena, src);
+    const script = model.findValue(doc.body.map, "m_Script").?;
+    try testing.expectEqual(@as(i64, 1), script.ref.file_id);
+    try testing.expect(script.ref.guid == null);
+}
+
 test "parse: CRLF line endings parse identically to LF" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -332,6 +362,9 @@ fn parseDocument(p: *Parser) !Document {
             _ = p.advance(); // the "TypeName:" line at indent 0
             type_name = stripTrailingColon(first.text);
             body = try parseBlock(p, indentOfNext(p, 2), 0);
+            // Downstream reads body.map unconditionally; a malformed body
+            // that parses as a sequence must not escape as a non-map node.
+            if (body.* != .map) body = try emptyMap(p.arena);
         } else {
             body = try emptyMap(p.arena);
         }
@@ -516,11 +549,18 @@ fn parseFlow(arena: std.mem.Allocator, s: []const u8, depth: usize) anyerror!*No
     if (model.findValue(es, "fileID")) |fid_node| {
         return makeNode(arena, .{ .ref = .{
             .file_id = scalarToInt(i64, fid_node) orelse 0,
-            .guid = if (model.findValue(es, "guid")) |g| g.scalar else null,
+            .guid = if (model.findValue(es, "guid")) |g| scalarString(g) else null,
             .type_id = if (model.findValue(es, "type")) |t| scalarToInt(i64, t) else null,
         } });
     }
     return makeNode(arena, .{ .map = es });
+}
+
+fn scalarString(n: *const Node) ?[]const u8 {
+    return switch (n.*) {
+        .scalar => |s| s,
+        else => null,
+    };
 }
 
 fn parseFlowSeq(arena: std.mem.Allocator, s: []const u8, depth: usize) anyerror!*Node {

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -137,6 +137,24 @@ test "parse: multi-entry sequence map (modifications)" {
     try testing.expectEqual(@as(i64, 7), model.findValue(item.map, "target").?.ref.file_id);
 }
 
+test "parse: non-empty flow sequence of refs and scalars" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_List: [{fileID: 7}, 2]
+    ;
+    // parseFlowSeq の非空経路: 入れ子の flow map があってもトップレベルの
+    // カンマだけで分割され、要素ごとに ref/scalar として parse される。
+    const doc = try parseOne(arena, src);
+    const list = model.findValue(doc.body.map, "m_List").?;
+    try testing.expectEqual(@as(usize, 2), list.seq.len);
+    try testing.expectEqual(@as(i64, 7), list.seq[0].ref.file_id);
+    try testing.expectEqualStrings("2", list.seq[1].scalar);
+}
+
 test "parse: quoted scalar and empty flow seq" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -273,6 +291,36 @@ test "parse: comment lines are skipped" {
     const doc = try parseOne(arena, src);
     try testing.expectEqualStrings("Player", model.findValue(doc.body.map, "m_Name").?.scalar);
     try testing.expectEqualStrings("1", model.findValue(doc.body.map, "m_IsActive").?.scalar);
+}
+
+test "parse: double-quoted scalar resolves backslash escapes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: "a\"b\\c"
+    ;
+    // scalar はソース表記ではなくリテラル値を持つ(\" -> "、\\ -> \)。
+    const doc = try parseOne(arena, src);
+    try testing.expectEqualStrings("a\"b\\c", model.findValue(doc.body.map, "m_Name").?.scalar);
+}
+
+test "parse: malformed class id and anchor default to 0" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const src =
+        \\--- !u!xx &yy
+        \\GameObject:
+        \\  m_Name: A
+    ;
+    // diff の first-occurrence-wins(重複 fileID)はこの 0 への縮退を前提と
+    // するため、parse エラーではなく 0 に落ちることを固定する。
+    const doc = try parseOne(arena, src);
+    try testing.expectEqual(@as(u32, 0), doc.class_id);
+    try testing.expectEqual(@as(i64, 0), doc.file_id);
 }
 
 test "parse: single-quoted scalar is unquoted" {

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -207,11 +207,9 @@ test "parse: deeply nested flow value is rejected instead of overflowing the sta
     const depth = 5000;
     var src: std.ArrayList(u8) = .empty;
     try src.appendSlice(arena, "--- !u!114 &1\nMonoBehaviour:\n  m_Field: ");
-    var i: usize = 0;
-    while (i < depth) : (i += 1) try src.appendSlice(arena, "{a: ");
+    for (0..depth) |_| try src.appendSlice(arena, "{a: ");
     try src.appendSlice(arena, "1");
-    i = 0;
-    while (i < depth) : (i += 1) try src.append(arena, '}');
+    for (0..depth) |_| try src.append(arena, '}');
 
     try testing.expectError(error.NestingTooDeep, parse(arena, src.items));
 }
@@ -548,9 +546,9 @@ fn parseFlow(arena: std.mem.Allocator, s: []const u8, depth: usize) anyerror!*No
     const es = try entries.toOwnedSlice(arena);
     if (model.findValue(es, "fileID")) |fid_node| {
         return makeNode(arena, .{ .ref = .{
-            .file_id = scalarToInt(i64, fid_node) orelse 0,
+            .file_id = scalarToI64(fid_node) orelse 0,
             .guid = if (model.findValue(es, "guid")) |g| scalarString(g) else null,
-            .type_id = if (model.findValue(es, "type")) |t| scalarToInt(i64, t) else null,
+            .type_id = if (model.findValue(es, "type")) |t| scalarToI64(t) else null,
         } });
     }
     return makeNode(arena, .{ .map = es });
@@ -576,11 +574,9 @@ fn parseFlowSeq(arena: std.mem.Allocator, s: []const u8, depth: usize) anyerror!
     return makeNode(arena, .{ .seq = try items.toOwnedSlice(arena) });
 }
 
-fn scalarToInt(comptime T: type, n: *const Node) ?T {
-    return switch (n.*) {
-        .scalar => |s| std.fmt.parseInt(T, std.mem.trim(u8, s, " "), 10) catch null,
-        else => null,
-    };
+fn scalarToI64(n: *const Node) ?i64 {
+    const s = scalarString(n) orelse return null;
+    return std.fmt.parseInt(i64, std.mem.trim(u8, s, " "), 10) catch null;
 }
 
 fn stripBrackets(s: []const u8, open: u8, close: u8) []const u8 {

--- a/core/src/perf.zig
+++ b/core/src/perf.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const root = @import("root.zig");
 
-/// Build a synthetic scene with `n` GameObjects, each with a Transform and a
-/// MonoBehaviour, as a single YAML byte buffer.
+// n 個の GameObject(各 Transform + MonoBehaviour つき)からなる合成シーンを
+// 1 つの YAML バッファとして生成する。
 fn buildScene(arena: std.mem.Allocator, n: usize, hp: usize) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(arena);
     const w = &aw.writer;
@@ -32,7 +32,7 @@ fn buildScene(arena: std.mem.Allocator, n: usize, hp: usize) ![]u8 {
     return aw.toOwnedSlice();
 }
 
-/// Returns nanoseconds for one before/after diff over `n` objects.
+// n オブジェクトの before/after diff 1 回の所要ナノ秒を返す。
 pub fn timeDiff(io: std.Io, arena: std.mem.Allocator, n: usize) !u64 {
     const before = try buildScene(arena, n, 1);
     const after = try buildScene(arena, n, 2);
@@ -47,7 +47,7 @@ test "perf: small scene diff completes well under budget" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    const ns = try timeDiff(std.testing.io, arena, 200); // ~200 objects ~= a small prefab
-    // Generous sanity bound for a debug test build (real budget enforced by `zig build perf`).
+    const ns = try timeDiff(std.testing.io, arena, 200); // 200 オブジェクト ≒ 小さめの prefab
+    // debug ビルドのテスト向けの緩い上限(本来の予算は `zig build perf` が強制する)。
     try std.testing.expect(ns < 500 * std.time.ns_per_ms);
 }

--- a/core/src/perf.zig
+++ b/core/src/perf.zig
@@ -4,11 +4,9 @@ const root = @import("root.zig");
 /// Build a synthetic scene with `n` GameObjects, each with a Transform and a
 /// MonoBehaviour, as a single YAML byte buffer.
 fn buildScene(arena: std.mem.Allocator, n: usize, hp: usize) ![]u8 {
-    var buf: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &buf);
+    var aw: std.Io.Writer.Allocating = .init(arena);
     const w = &aw.writer;
-    var i: usize = 0;
-    while (i < n) : (i += 1) {
+    for (0..n) |i| {
         const go: i64 = @intCast(1 + i * 3);
         const tr: i64 = go + 1;
         const mb: i64 = go + 2;
@@ -31,8 +29,7 @@ fn buildScene(arena: std.mem.Allocator, n: usize, hp: usize) ![]u8 {
             \\
         , .{ go, i, tr, mb, tr, go, mb, go, hp });
     }
-    var list = aw.toArrayList();
-    return list.toOwnedSlice(arena);
+    return aw.toOwnedSlice();
 }
 
 /// Returns nanoseconds for one before/after diff over `n` objects.

--- a/core/src/perf_main.zig
+++ b/core/src/perf_main.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 const perf = @import("perf.zig");
 
-// Budget multipliers leave headroom for CI runner noise; nominal targets are
-// spec §5.7 (typical < 5ms, ~10MB scene < 150ms). We size a ~10MB scene and
-// assert it diffs under a generous CI ceiling.
-const big_objects = 50_000; // ~10 MB of YAML at ~200 bytes/object
-const ci_ceiling_ms = 600; // 4x the 150ms nominal; fails only on real regressions
+// 予算は CI ランナーのノイズを見込んで名目値より緩めてある。名目値は
+// spec §5.7(通常 < 5ms、~10MB シーン < 150ms)。~10MB 相当のシーンを
+// 生成し、CI 上限内で diff できることを検証する。
+const big_objects = 50_000; // 1 オブジェクト ~200 bytes として YAML ~10 MB
+const ci_ceiling_ms = 600; // 名目 150ms の 4 倍。真の退行でのみ失敗する
 
 pub fn main(init: std.process.Init) !void {
     var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -1,4 +1,3 @@
-//! By convention, root.zig is the root source file when making a package.
 const std = @import("std");
 pub const model = @import("model.zig");
 pub const classid = @import("classid.zig");

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -8,11 +8,11 @@ const diffmod = @import("diff.zig");
 const ComponentDiff = model.ComponentDiff;
 const ObjectDiff = model.ObjectDiff;
 
-/// Index helpers over the parsed documents (use the union of before+after).
+// パース済みドキュメント(before+after の和集合)への索引。
 const Index = struct {
-    // file_id -> DocDiff (status + fields), for quick component construction.
+    // file_id -> DocDiff(status + fields)。コンポーネント構築を速くする。
     diff_by_id: std.AutoHashMap(i64, diffmod.DocDiff),
-    // file_id -> *Document for the *structural* (after-preferred) version.
+    // file_id -> 構造解決用(after 優先)の *Document。
     doc_by_id: std.AutoHashMap(i64, *model.Document),
 
     fn structuralDoc(self: *Index, file_id: i64) ?*model.Document {
@@ -33,7 +33,7 @@ fn gameObjectIdOfComponent(doc: *model.Document) ?i64 {
 }
 
 fn transformOf(idx: *Index, go_id: i64) ?*model.Document {
-    // The GameObject lists its components; find the one whose doc is a Transform/RectTransform.
+    // GameObject が列挙するコンポーネントから Transform/RectTransform のものを探す。
     const go = idx.structuralDoc(go_id) orelse return null;
     const comps = model.findValue(go.body.map, "m_Component") orelse return null;
     if (comps.* != .seq) return null;
@@ -58,7 +58,7 @@ fn sourcePrefabGuid(doc: *const model.Document) ?[]const u8 {
     };
 }
 
-/// m_Name override をインスタンス名として拾う(after 優先の structural doc から)。
+// m_Name override をインスタンス名として拾う(after 優先の structural doc から)。
 fn instanceName(idx: *Index, pi_id: i64) []const u8 {
     const doc = idx.structuralDoc(pi_id) orelse return "";
     const m = model.findValue(doc.body.map, "m_Modification") orelse return "";
@@ -78,12 +78,12 @@ fn instanceName(idx: *Index, pi_id: i64) []const u8 {
     return "";
 }
 
-/// 入れ子チェーン歩行の hop 上限。壊れたファイルで stripped PrefabInstance
-/// 同士が循環参照しても停止する(実プロジェクトの入れ子深度は数段)。
+// 入れ子チェーン歩行の hop 上限。壊れたファイルで stripped PrefabInstance
+// 同士が循環参照しても停止する(実プロジェクトの入れ子深度は数段)。
 const max_instance_hops = 8;
 
-/// stripped な PrefabInstance の m_PrefabInstance チェーンを外側へ辿り、
-/// 実体(非 stripped)の PrefabInstance の file_id を返す。
+// stripped な PrefabInstance の m_PrefabInstance チェーンを外側へ辿り、
+// 実体(非 stripped)の PrefabInstance の file_id を返す。
 fn resolveInstanceChain(idx: *Index, start_id: i64) ?i64 {
     var id = start_id;
     var hops: usize = 0;
@@ -96,8 +96,8 @@ fn resolveInstanceChain(idx: *Index, start_id: i64) ?i64 {
     return null;
 }
 
-/// Transform の file_id から親ノード(GameObject または PrefabInstance)の id。
-/// stripped Transform は m_PrefabInstance を辿って所属インスタンスに橋渡し。
+// Transform の file_id から親ノード(GameObject または PrefabInstance)の id。
+// stripped Transform は m_PrefabInstance を辿って所属インスタンスに橋渡し。
 fn ownerNodeIdOfTransform(idx: *Index, tr_id: i64) ?i64 {
     if (tr_id == 0) return null;
     const tr = idx.structuralDoc(tr_id) orelse return null;
@@ -150,14 +150,14 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         .doc_by_id = std.AutoHashMap(i64, *model.Document).init(arena),
     };
     for (fd.docs) |d| try idx.diff_by_id.put(d.file_id, d);
-    // Structural docs: prefer after, fall back to before (for removed objects).
+    // 構造解決用 doc: after 優先、removed オブジェクトは before に fallback。
     for (fd.before) |*d| try idx.doc_by_id.put(d.file_id, d);
-    for (fd.after) |*d| try idx.doc_by_id.put(d.file_id, d); // overwrites -> after wins
+    for (fd.after) |*d| try idx.doc_by_id.put(d.file_id, d); // 上書きにより after が勝つ
 
-    // Partition documents: GameObjects, PrefabInstances, their components, and loose docs.
+    // ドキュメントを仕分ける: GameObject、PrefabInstance、その所属コンポーネント、loose。
     var go_ids: std.ArrayList(i64) = .empty;
     var pi_ids: std.ArrayList(i64) = .empty;
-    // components grouped by owning GameObject/PrefabInstance id
+    // 所属先 GameObject/PrefabInstance の id でグループ化したコンポーネント
     var comps_by_owner = std.AutoHashMap(i64, std.ArrayList(ComponentDiff)).init(arena);
     var loose: std.ArrayList(ComponentDiff) = .empty;
 
@@ -173,36 +173,36 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         const owner = blk: {
             const doc = idx.structuralDoc(d.file_id) orelse break :blk null;
             const go_id = gameObjectIdOfComponent(doc) orelse break :blk null;
-            // Only a confirmed GameObject document owns components; an
-            // unresolvable ref ({fileID: 0} or dangling) would otherwise
-            // bucket the component under a phantom id and drop it.
+            // 所有者になれるのは GameObject と確認できた doc のみ。解決不能な
+            // 参照({fileID: 0} や宙ぶらりん)を許すと、コンポーネントが
+            // 幻の id の下に仕分けられて消えてしまう。
             const go_doc = idx.structuralDoc(go_id) orelse break :blk null;
             if (go_doc.class_id != 1) break :blk null;
-            // stripped GameObject (nested prefab instance's root, placed in
-            // the outer document) never becomes a node itself; bridge to its
-            // owning PrefabInstance so the component isn't silently dropped.
-            // The owning instance may itself be stripped (nested prefab), so
-            // walk the chain out to the nearest materialized instance.
+            // stripped GameObject(入れ子インスタンスの root が外側ドキュメントに
+            // 置かれたもの)はノードにならない。所属 PrefabInstance に橋渡しして
+            // コンポーネントが黙って消えないようにする。所属インスタンス自体も
+            // stripped の場合(入れ子 prefab)があるため、チェーンを実体化される
+            // 最寄りのインスタンスまで辿る。
             const owner_id = if (go_doc.stripped) inner: {
                 const pi_id = refFileId(model.findValue(go_doc.body.map, "m_PrefabInstance")) orelse break :blk null;
                 break :inner resolveInstanceChain(&idx, pi_id) orelse break :blk null;
             } else go_id;
-            // Stripped docs are excluded from fd.docs and never become nodes;
-            // only an owner that materializes may claim the component.
+            // stripped doc は fd.docs から除外されノードにならない。
+            // コンポーネントを引き取れるのは実体化する所有者だけ。
             break :blk if (idx.diff_by_id.contains(owner_id)) owner_id else null;
         };
         if (owner) |owner_id| {
             const gop = try comps_by_owner.getOrPut(owner_id);
             if (!gop.found_existing) gop.value_ptr.* = .empty;
-            // Collapse unchanged components with no fields.
+            // fields を持たない unchanged コンポーネントは畳む。
             if (d.status != .unchanged) try gop.value_ptr.append(arena, makeComponent(d));
         } else {
-            // No owning GameObject/PrefabInstance -> loose (e.g. ScriptableObject).
+            // 所属 GameObject/PrefabInstance なし -> loose(ScriptableObject 等)。
             if (d.status != .unchanged) try loose.append(arena, makeComponent(d));
         }
     }
 
-    // Build ObjectDiff per GameObject (without children yet).
+    // GameObject ごとの ObjectDiff を構築する(children はまだ空)。
     var obj_by_id = std.AutoHashMap(i64, ObjectDiff).init(arena);
     for (go_ids.items) |go_id| {
         const gd = idx.diff_by_id.get(go_id).?;
@@ -231,7 +231,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         });
     }
 
-    // Assemble parent/child links.
+    // 親子リンクを組み立てる。
     var children_of = std.AutoHashMap(i64, std.ArrayList(i64)).init(arena);
     var roots_ids: std.ArrayList(i64) = .empty;
     for (go_ids.items) |go_id|
@@ -239,7 +239,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     for (pi_ids.items) |pi_id|
         try linkToParent(arena, &obj_by_id, &children_of, &roots_ids, instanceParentId(&idx, pi_id), pi_id);
 
-    // Recursively materialize, pruning unchanged subtrees with no changed descendants.
+    // 再帰的に実体化し、変更された子孫を持たない unchanged な部分木を刈る。
     var roots: std.ArrayList(ObjectDiff) = .empty;
     for (roots_ids.items) |rid| {
         if (try materialize(arena, &obj_by_id, &children_of, rid)) |node| {
@@ -254,7 +254,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     };
 }
 
-/// 親が実在ノードなら children_of へ、そうでなければ root へ振り分ける。
+// 親が実在ノードなら children_of へ、そうでなければ root へ振り分ける。
 fn linkToParent(
     arena: std.mem.Allocator,
     obj_by_id: *std.AutoHashMap(i64, ObjectDiff),
@@ -274,8 +274,8 @@ fn linkToParent(
     try roots_ids.append(arena, id);
 }
 
-/// Build the ObjectDiff for `go_id` with its kept children. Returns null if the
-/// node and its entire subtree are unchanged with no kept components.
+// `go_id` の ObjectDiff を残った children ごと構築する。ノードと部分木全体が
+// unchanged で残すコンポーネントもなければ null を返す。
 fn materialize(
     arena: std.mem.Allocator,
     obj_by_id: *std.AutoHashMap(i64, ObjectDiff),
@@ -344,9 +344,9 @@ test "tree: GameObject groups its components; modified component bubbles up" {
     const res = try root.diffBytes(arena, before, after);
     const go = findRoot(res, 1).?;
     try testing.expectEqualStrings("Player", go.name);
-    // Player itself is structurally unchanged but kept because a child component changed.
+    // Player 自体は unchanged だが、子コンポーネントに変更があるので残る。
     try testing.expectEqual(model.Status.unchanged, go.status);
-    // Components: the Transform (unchanged, no fields) is collapsed; MonoBehaviour kept.
+    // コンポーネント: unchanged で fields もない Transform は畳まれ、MonoBehaviour は残る。
     var saw_modified_mb = false;
     for (go.components) |c| {
         if (c.file_id == 5) {
@@ -382,7 +382,7 @@ test "tree: child GameObject nests under parent via Transform m_Father" {
         \\  m_GameObject: {fileID: 2}
         \\  m_Father: {fileID: 4}
     ;
-    // after: child renamed
+    // after: 子をリネーム
     const src_after =
         \\--- !u!1 &1
         \\GameObject:
@@ -607,8 +607,8 @@ test "tree: component whose m_GameObject resolves to a non-GameObject document b
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // fileID 999 exists but is a MonoBehaviour, not a GameObject: a dangling
-    // reference in spirit (no GameObject there), distinct from fileID: 0.
+    // fileID 999 は存在するが GameObject ではなく MonoBehaviour。fileID: 0 とは
+    // 別種の、実質的に宙ぶらりんな参照(そこに GameObject はいない)。
     const before =
         \\--- !u!114 &7
         \\MonoBehaviour:
@@ -629,7 +629,7 @@ test "tree: component whose m_GameObject resolves to a non-GameObject document b
     ;
     const res = try root.diffBytes(arena, before, after);
     try testing.expectEqual(@as(usize, 0), res.roots.len);
-    // Component 999 is unchanged (collapsed); component 7 is loose, not dropped.
+    // コンポーネント 999 は unchanged で畳まれ、7 は消えずに loose へ。
     try testing.expectEqual(@as(usize, 1), res.loose.len);
     try testing.expectEqual(@as(i64, 7), res.loose[0].file_id);
     try testing.expectEqual(model.Status.modified, res.loose[0].status);
@@ -639,9 +639,9 @@ test "tree: component of a stripped GameObject attaches to the owning prefab ins
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // A component added to a prefab instance's placed GameObject: the
-    // instance's root GameObject is `stripped` in the outer document, and
-    // the real MonoBehaviour doc points m_GameObject at it.
+    // prefab インスタンスが配置した GameObject に追加されたコンポーネント:
+    // インスタンスの root GameObject は外側ドキュメントでは stripped で、
+    // 実体の MonoBehaviour doc が m_GameObject でそれを指す。
     const before =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -698,8 +698,8 @@ test "tree: component of a stripped GameObject with unresolvable m_PrefabInstanc
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // The stripped GameObject's m_PrefabInstance points nowhere resolvable
-    // (fileID 9999 doesn't exist): the component must not be dropped.
+    // stripped GameObject の m_PrefabInstance が解決不能な先(存在しない
+    // fileID 9999)を指す: それでもコンポーネントを消してはならない。
     const before =
         \\--- !u!1 &2 stripped
         \\GameObject:
@@ -731,9 +731,9 @@ test "tree: component bridged to a stripped nested prefab instance becomes loose
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Component bridged to a stripped nested PrefabInstance that carries NO
-    // m_PrefabInstance ref of its own: the chain out to the outer instance
-    // is broken, so the component must fall back to loose, not vanish.
+    // 橋渡し先の stripped な入れ子 PrefabInstance が自身の m_PrefabInstance
+    // 参照を持たないケース: 外側インスタンスへのチェーンが切れているので、
+    // コンポーネントは消えるのではなく loose に落ちる。
     const before =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -783,7 +783,7 @@ test "tree: component bridged to a stripped nested prefab instance becomes loose
         \\  hp: 2
     ;
     const res = try root.diffBytes(arena, before, after);
-    // Outer instance is unchanged -> pruned as usual; the component stays visible.
+    // 外側インスタンスは unchanged なので通常どおり刈られ、コンポーネントは見え続ける。
     try testing.expectEqual(@as(usize, 0), res.roots.len);
     try testing.expectEqual(@as(usize, 1), res.loose.len);
     try testing.expectEqual(@as(i64, 3), res.loose[0].file_id);
@@ -794,11 +794,10 @@ test "tree: component of a nested stripped chain attaches to the outer prefab in
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Component added to a GameObject inside a NESTED instance: the inner
-    // PrefabInstance is stripped in the outer document and carries its own
-    // m_PrefabInstance ref to the outer instance. Walking that chain must
-    // attach the component to the outer (materialized) instance node
-    // instead of dropping it to loose.
+    // 入れ子インスタンス内の GameObject に追加されたコンポーネント: 内側の
+    // PrefabInstance は外側ドキュメントでは stripped で、外側インスタンスへの
+    // m_PrefabInstance 参照を自身が持つ。このチェーンを辿って、loose に落とす
+    // のではなく外側の(実体化される)インスタンスノードに付け替える。
     const before =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -866,8 +865,8 @@ test "tree: cyclic stripped instance chain falls back to loose, not an infinite 
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Corrupt file: two stripped PrefabInstances reference each other. The
-    // hop cap must break the cycle and the component keeps the loose floor.
+    // 壊れたファイル: stripped な PrefabInstance 2 つが互いを参照する。
+    // hop 上限が循環を断ち切り、コンポーネントは loose の床を維持する。
     const before =
         \\--- !u!1001 &2002 stripped
         \\PrefabInstance:
@@ -911,9 +910,9 @@ test "tree: instance parented inside a nested instance nests under the outer ins
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // A real PrefabInstance whose m_TransformParent is a stripped Transform
-    // belonging to a stripped NESTED instance: the chain walks out to the
-    // outer real instance instead of flattening the child to a root.
+    // 実体の PrefabInstance の m_TransformParent が、stripped な入れ子
+    // インスタンスに属する stripped Transform を指すケース: チェーンを外側の
+    // 実体インスタンスまで辿り、子を root に平坦化しない。
     const after =
         \\--- !u!1001 &1001
         \\PrefabInstance:

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -41,7 +41,7 @@ fn transformOf(idx: *Index, go_id: i64) ?*model.Document {
         const cref = if (item.* == .map) model.findValue(item.map, "component") else null;
         const cid = refFileId(cref) orelse continue;
         const cdoc = idx.structuralDoc(cid) orelse continue;
-        if (cdoc.class_id == 4 or cdoc.class_id == 224) return cdoc;
+        if (isTransformClass(cdoc.class_id)) return cdoc;
     }
     return null;
 }
@@ -206,19 +206,19 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     var obj_by_id = std.AutoHashMap(i64, ObjectDiff).init(arena);
     for (go_ids.items) |go_id| {
         const gd = idx.diff_by_id.get(go_id).?;
-        const comps: []ComponentDiff = if (comps_by_owner.get(go_id)) |list| list.items else &[_]ComponentDiff{};
+        const comps: []ComponentDiff = if (comps_by_owner.get(go_id)) |list| list.items else &.{};
         try obj_by_id.put(go_id, .{
             .file_id = go_id,
             .name = goName(&idx, go_id),
             .status = gd.status,
             .components = comps,
-            .children = &[_]ObjectDiff{},
+            .children = &.{},
         });
     }
     for (pi_ids.items) |pi_id| {
         const dd = idx.diff_by_id.get(pi_id).?;
         const doc = idx.structuralDoc(pi_id);
-        const comps: []ComponentDiff = if (comps_by_owner.get(pi_id)) |list| list.items else &[_]ComponentDiff{};
+        const comps: []ComponentDiff = if (comps_by_owner.get(pi_id)) |list| list.items else &.{};
         try obj_by_id.put(pi_id, .{
             .kind = .prefab_instance,
             .file_id = pi_id,
@@ -227,7 +227,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
             .status = dd.status,
             .overrides = dd.overrides,
             .components = comps,
-            .children = &[_]ObjectDiff{},
+            .children = &.{},
         });
     }
 

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -409,6 +409,30 @@ test "tree: child GameObject nests under parent via Transform m_Father" {
     try testing.expectEqual(@as(i64, 2), parent.children[0].file_id);
 }
 
+test "tree: removed GameObject surfaces as a removed root with its name" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Player
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    // after 側に doc がなくても、構造解決が before に fallback するので
+    // 名前解決とコンポーネントの帰属が機能する(loose に漏れない)。
+    const res = try root.diffBytes(arena, before, "");
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    try testing.expectEqual(@as(usize, 0), res.loose.len);
+    try testing.expectEqualStrings("Player", res.roots[0].name);
+    try testing.expectEqual(model.Status.removed, res.roots[0].status);
+}
+
 test "tree: ScriptableObject .asset becomes a loose component" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/core/src/wasm.zig
+++ b/core/src/wasm.zig
@@ -1,5 +1,5 @@
-//! WASM C ABI ラッパ(親仕様 §5.6)。diff 1 回 = 1 arena、グローバル可変状態なし。
-//! 戻り値は u32(LE)長さ前置の JSON バイト列。呼び出し側が free(ptr, 4 + len) で解放する。
+// WASM C ABI ラッパ(親仕様 §5.6)。diff 1 回 = 1 arena、グローバル可変状態なし。
+// 戻り値は u32(LE)長さ前置の JSON バイト列。呼び出し側が free(ptr, 4 + len) で解放する。
 const std = @import("std");
 const core = @import("root.zig");
 


### PR DESCRIPTION
## Summary

Review pass over `core/` for performance, Zig 0.16 idioms, fallback policy, simplicity, and WHY comments — plus a follow-up aligning comments with the resolved locale (comments=ja_JP) and truing up test coverage. Two hostile-input panics fixed. No behavior change for well-formed Unity YAML (golden tests unchanged).

## Fixes (crash on malformed input)

- `parseDocument` now guarantees `Document.body` is a `.map`. A document body that parses as a sequence previously escaped as a `.seq` node and panicked downstream on `body.map` access (UB in ReleaseFast/wasm).
- `parseFlow` no longer assumes a `guid` value is a scalar; `guid: {x: 1}` panicked on `g.scalar`. Non-scalar guids degrade to `null`.

Both pinned by new parser tests (TDD: reproduced the panics first).

## Refactors

- `GuidSet` (map + separate order list) replaced with `std.StringArrayHashMapUnmanaged(void)`, which preserves first-insertion order natively.
- `std.Io.Writer.Allocating`: `init` + `toOwnedSlice()` instead of the `fromArrayList`/`toArrayList` round-trip.
- `a.* == .map` instead of `std.meta.activeTag`; ranged `for` loops instead of counter `while`; `&.{}` instead of `&[_]T{}`.
- `presentFields` consumes `raw.items` directly (drops a needless `toOwnedSlice`).
- `sortByGroup`: `std.sort.insertion` -> `std.sort.block` (same stability, O(n log n) worst case).
- `editorClassName` untangled, `scalarToInt` de-generalized to `scalarToI64`, `transformOf` reuses `isTransformClass`.

## Comments (locale alignment)

- All comments rewritten in Japanese per the user-level locale (comments=ja_JP); log/test-log strings stay English (logs=en_US, test-logs=en_US).
- Doc comments (`///`, `//!`) converted to plain `//` — the project generates no API docs, so the special syntax carried no value.
- Added a WHY note to `numEql` (exact equality is deliberate; epsilon matching was evaluated and rejected).

## Tests trued up

Added coverage for previously untested paths:

- parser: non-empty flow sequences, double-quoted backslash escapes, malformed header -> 0 (the semantics first-occurrence-wins relies on), sequence body degradation, non-scalar guid
- diff: `editorClassName` edges (no separator / empty tail), guid dedup + first-reference order (JSON determinism relies on it)
- tree: removed GameObject surfaces as a removed root via the before-side structural fallback
- model: same-length maps with different key sets are unequal
- json: control-character escaping (`\n`, `\u0001`)

Removed one redundant test (`added map field inside a modified document` duplicated the input of `nested field path and added field`; its one extra assertion was folded into the latter).

## Review findings with no change needed

- Performance: hash indexes, arena allocation, and the CI perf gate are in place; no O(n^2) hot paths found.
- Fallbacks: `catch 0` header parsing, the loose-component floor, and the wasm error JSON are all deliberate and test-pinned — nothing excessive to remove.

## Verification

- `zig build test` (75 tests) / `zig build perf`: 50k objects in 147 ms (ceiling 600 ms)
- `zig build wasm` + `node --test core/tests/wasm_golden.test.mjs` (4/4)
- `zig fmt --check core/src` clean
