### PR TITLE
test: cover resolved map, stderr, and pipe drain

### DIFF
--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -94,5 +94,38 @@ namespace PrefabLens.Tests
             Assert.AreEqual(0, res.ExitCode);
             StringAssert.Contains("hello", res.Stdout);
         }
+
+        [Test]
+        public void RunProcessCapturesStderrAndExitCode()
+        {
+            // ExitCode != 0 のとき Window は stderr を一次情報として表示する。その配線の検証。
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c echo boom 1>&2 & exit 3" : "-c \"echo boom 1>&2; exit 3\"";
+            var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs);
+            Assert.IsFalse(res.TimedOut);
+            Assert.AreEqual(3, res.ExitCode);
+            StringAssert.Contains("boom", res.Stderr);
+        }
+
+        [Test]
+        public void RunProcessDrainsBothPipesPastTheOsBuffer()
+        {
+            // stdout / stderr の両方を OS のパイプバッファ(通常 64KB)より多く書く子でも
+            // デッドロックせず全量読めること。RunProcess の非同期読みを同期 ReadToEnd ×2 に
+            // 「単純化」すると、子が stderr 書き込みでブロックしたままタイムアウトして fail する。
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var line = new string('x', 40);
+            var args = isWindows
+                ? $"/c for /L %i in (1,1,4000) do @(echo {line}& echo {line} 1>&2)"
+                : $"-c \"i=0; while [ $i -lt 4000 ]; do echo {line}; echo {line} 1>&2; i=$((i+1)); done\"";
+            var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs);
+            Assert.IsFalse(res.TimedOut);
+            Assert.AreEqual(0, res.ExitCode);
+            // 4000 行 × 41 バイト ≈ 160KB。バッファ超えを確実にしつつ取りこぼしも検出する。
+            Assert.Greater(res.Stdout.Length, 100_000);
+            Assert.Greater(res.Stderr.Length, 100_000);
+        }
     }
 }

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -78,6 +78,35 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void EmptyDiffIsEmpty()
+        {
+            // 変更なしのとき Window は IsEmpty を見て "No semantic changes" を出す。その分岐の根拠。
+            var m = DiffModel.Parse(@"{""schema"":""prefablens.diff.v2"",""unresolvedGuids"":[],""roots"":[],""loose"":[]}");
+            Assert.IsTrue(m.IsEmpty);
+        }
+
+        [Test]
+        public void ParsesResolvedMapAndRemovedStatus()
+        {
+            // resolved は CLI 側で解決済みの guid -> パス(ResolveWith が上書きしないのは別テストで検証)。
+            // removed は 4 status のうち他テストが通っていない残り 1 つ。
+            const string json = @"{
+                ""unresolvedGuids"":[],
+                ""resolved"":{""ccc"":""Assets/Textures/Grass.png""},
+                ""roots"":[],
+                ""loose"":[{""kind"":""component"",""fileId"":""3"",""classId"":135,""typeName"":""SphereCollider"",""scriptGuid"":null,""className"":null,""status"":""removed"",
+                    ""fields"":[{""path"":""m_Radius"",""status"":""removed"",""before"":""0.5"",""after"":null}]}]
+            }";
+            var m = DiffModel.Parse(json);
+            Assert.AreEqual("Assets/Textures/Grass.png", m.Resolved["ccc"]);
+            Assert.AreEqual(DiffStatus.Removed, m.Loose[0].Status);
+            var f = m.Loose[0].Fields[0];
+            Assert.AreEqual(DiffStatus.Removed, f.Status);
+            Assert.AreEqual("0.5", f.Before.Scalar);
+            Assert.IsTrue(f.After.IsNull);
+        }
+
+        [Test]
         public void ResolveWithFillsOnlyUnresolvedGuids()
         {
             var m = DiffModel.Parse(Golden);


### PR DESCRIPTION
## 概要

PR #32 のフォローアップ。editor/ のテストを「必要十分か」の観点で見直した結果、冗長なテストはなし、不足が 4 点あったので追加する(+62 行、テストのみ)。

### 追加したテスト

- `EmptyDiffIsEmpty` — 変更なし diff で `IsEmpty` が true になること。Window の "No semantic changes" 分岐の根拠なのに未検証だった
- `ParsesResolvedMapAndRemovedStatus` — `resolved` マップの読み取り(既存テストは空オブジェクトのみ)と、4 status のうち唯一未検証だった `removed`
- `RunProcessCapturesStderrAndExitCode` — 非ゼロ exit code と stderr の伝搬。「CLI の stderr が一次情報」という Window のエラー表示設計の配線を保証する
- `RunProcessDrainsBothPipesPastTheOsBuffer` — 両ストリームが OS パイプバッファ(64KB)を超えても deadlock せず全量読めること。`RunProcess` の非同期読みを同期 `ReadToEnd` ×2 に「単純化」する回帰への唯一のガード

### 検証

- netstandard2.1 + C# 9 ハーネス(PR #32 と同じ方式)で 17/17 パス
- deadlock ガードの実効性を実証済み: 同期 `ReadToEnd` ×2 に退行させた再現プログラムは同じ子プロセスで 20 秒以内に返らずデッドロックする

### テストしないと判断した領域

- `PrefabLensWindow` の `Format` / `Stem` — private のテストには可視性変更が必要で、UI 層を薄く保つ設計を優先
- `Download` / `VerifyChecksum` のネットワーク経路 — モック禁止のため、抽出済み純関数(`ParseSha256Sums` / `Sha256Hex` / `DownloadUrl`)の既存テストでカバー