### PR TITLE
refactor: vendor MiniJSON and drop newtonsoft

### DIFF
--- a/editor/Editor/DiffModel.cs
+++ b/editor/Editor/DiffModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
+using System.Globalization;
+using PrefabLens.MiniJson;
 
 namespace PrefabLens
 {
@@ -76,18 +77,23 @@ namespace PrefabLens
 
         public static DiffModel Parse(string json)
         {
-            var o = JObject.Parse(json);
+            // MiniJSON は不正入力で throw せず null を返す。Window の「Could not parse
+            // CLI output」分岐(Exception を握る)を成立させるため、ここで throw に戻す。
+            if (Json.Deserialize(json) is not Dictionary<string, object> o)
+                throw new FormatException("diff json root is not an object");
             var m = new DiffModel();
-            foreach (var g in Items(o["unresolvedGuids"]))
-                m.UnresolvedGuids.Add((string)g);
-            if (o["resolved"] is JObject resolved)
-                foreach (var p in resolved.Properties())
-                    m.Resolved[p.Name] = (string)p.Value;
-            foreach (var r in Items(o["roots"]))
-                if (ParseNode(r as JObject) is NodeDiff n)
+            foreach (var g in Items(o, "unresolvedGuids"))
+                if (g is string s)
+                    m.UnresolvedGuids.Add(s);
+            if (Val(o, "resolved") is Dictionary<string, object> resolved)
+                foreach (var p in resolved)
+                    if (p.Value is string path)
+                        m.Resolved[p.Key] = path;
+            foreach (var r in Items(o, "roots"))
+                if (ParseNode(r as Dictionary<string, object>) is NodeDiff n)
                     m.Roots.Add(n);
-            foreach (var c in Items(o["loose"]))
-                if (c is JObject co)
+            foreach (var c in Items(o, "loose"))
+                if (c is Dictionary<string, object> co)
                     m.Loose.Add(ParseComponent(co));
             return m;
         }
@@ -103,77 +109,94 @@ namespace PrefabLens
             }
         }
 
-        static NodeDiff ParseNode(JObject o)
+        static NodeDiff ParseNode(Dictionary<string, object> o)
         {
             if (o == null) return null;
-            NodeDiff n = (string)o["kind"] switch
+            NodeDiff n = Str(o, "kind") switch
             {
                 "gameObject" => new GameObjectDiff(),
                 "prefabInstance" => ParsePrefabInstance(o),
                 _ => null, // 未知の kind は読み飛ばす
             };
             if (n == null) return null;
-            n.FileId = (string)o["fileId"] ?? "";
-            n.Name = (string)o["name"] ?? "";
-            n.Status = ParseStatus((string)o["status"]);
-            foreach (var c in Items(o["components"]))
-                if (c is JObject co)
+            n.FileId = Str(o, "fileId") ?? "";
+            n.Name = Str(o, "name") ?? "";
+            n.Status = ParseStatus(Str(o, "status"));
+            foreach (var c in Items(o, "components"))
+                if (c is Dictionary<string, object> co)
                     n.Components.Add(ParseComponent(co));
-            foreach (var ch in Items(o["children"]))
-                if (ParseNode(ch as JObject) is NodeDiff child)
+            foreach (var ch in Items(o, "children"))
+                if (ParseNode(ch as Dictionary<string, object>) is NodeDiff child)
                     n.Children.Add(child);
             return n;
         }
 
-        static PrefabInstanceDiff ParsePrefabInstance(JObject o)
+        static PrefabInstanceDiff ParsePrefabInstance(Dictionary<string, object> o)
         {
-            var pi = new PrefabInstanceDiff { SourceGuid = (string)o["sourceGuid"] };
-            foreach (var ov in Items(o["overrides"]))
-                if (ov is JObject ovo)
+            var pi = new PrefabInstanceDiff { SourceGuid = Str(o, "sourceGuid") };
+            foreach (var ov in Items(o, "overrides"))
+                if (ov is Dictionary<string, object> ovo)
                     pi.Overrides.Add(new OverrideDiff
                     {
-                        Group = (string)ovo["group"] ?? "",
-                        Label = (string)ovo["label"] ?? "",
-                        Status = ParseStatus((string)ovo["status"]),
-                        Before = ParseValue(ovo["before"]),
-                        After = ParseValue(ovo["after"]),
+                        Group = Str(ovo, "group") ?? "",
+                        Label = Str(ovo, "label") ?? "",
+                        Status = ParseStatus(Str(ovo, "status")),
+                        Before = ParseValue(Val(ovo, "before")),
+                        After = ParseValue(Val(ovo, "after")),
                     });
             return pi;
         }
 
-        static ComponentDiff ParseComponent(JObject o)
+        static ComponentDiff ParseComponent(Dictionary<string, object> o)
         {
             var c = new ComponentDiff
             {
-                FileId = (string)o["fileId"] ?? "",
-                ClassId = (int?)o["classId"] ?? 0,
-                TypeName = (string)o["typeName"] ?? "",
-                ScriptGuid = (string)o["scriptGuid"],
-                ClassName = (string)o["className"],
-                Status = ParseStatus((string)o["status"]),
+                FileId = Str(o, "fileId") ?? "",
+                ClassId = Val(o, "classId") is long id ? (int)id : 0,
+                TypeName = Str(o, "typeName") ?? "",
+                ScriptGuid = Str(o, "scriptGuid"),
+                ClassName = Str(o, "className"),
+                Status = ParseStatus(Str(o, "status")),
             };
-            foreach (var f in Items(o["fields"]))
-                if (f is JObject fo)
+            foreach (var f in Items(o, "fields"))
+                if (f is Dictionary<string, object> fo)
                     c.Fields.Add(new FieldDiff
                     {
-                        Path = (string)fo["path"] ?? "",
-                        Status = ParseStatus((string)fo["status"]),
-                        Before = ParseValue(fo["before"]),
-                        After = ParseValue(fo["after"]),
+                        Path = Str(fo, "path") ?? "",
+                        Status = ParseStatus(Str(fo, "status")),
+                        Before = ParseValue(Val(fo, "before")),
+                        After = ParseValue(Val(fo, "after")),
                     });
             return c;
         }
 
-        static Value ParseValue(JToken t)
+        static Value ParseValue(object t)
         {
-            if (t == null || t.Type == JTokenType.Null) return Value.Null;
-            if (t is JObject o && o["ref"] is JObject r)
-                return new Value { IsRef = true, RefFileId = (string)r["fileId"] ?? "0", RefGuid = (string)r["guid"] };
-            return new Value { Scalar = (string)t };
+            if (t == null) return Value.Null;
+            if (t is Dictionary<string, object> o && Val(o, "ref") is Dictionary<string, object> r)
+                return new Value { IsRef = true, RefFileId = Str(r, "fileId") ?? "0", RefGuid = Str(r, "guid") };
+            return new Value { Scalar = ScalarString(t) };
         }
 
-        static IEnumerable<JToken> Items(JToken t) =>
-            t is JArray a ? a : (IEnumerable<JToken>)Array.Empty<JToken>();
+        /// scalar は CLI が文字列で出すが、数値 / bool が来ても JSON 表記のまま文字列化する。
+        static string ScalarString(object t) => t switch
+        {
+            string s => s,
+            bool b => b ? "true" : "false",
+            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+            _ => t.ToString(),
+        };
+
+        static readonly List<object> EmptyList = new();
+
+        static string Str(Dictionary<string, object> o, string key) =>
+            o.TryGetValue(key, out var v) ? v as string : null;
+
+        static object Val(Dictionary<string, object> o, string key) =>
+            o.TryGetValue(key, out var v) ? v : null;
+
+        static List<object> Items(Dictionary<string, object> o, string key) =>
+            Val(o, key) as List<object> ?? EmptyList;
 
         static DiffStatus ParseStatus(string s) => s switch
         {

--- a/editor/Editor/MiniJson.cs
+++ b/editor/Editor/MiniJson.cs
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) 2013 Calvin Rien
+ *
+ * Based on the JSON parser by Patrick van Bergen
+ * http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
+ *
+ * Simplified it so that it doesn't throw exceptions
+ * and can be used in Unity iPhone with maximum code stripping.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+// PrefabLens への同梱元: https://gist.github.com/darktable/1411710(rev 513f1c0、MIT)
+// 変更点: namespace MiniJSON -> PrefabLens.MiniJson のみ。
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace PrefabLens.MiniJson {
+    // Example usage:
+    //
+    //  using UnityEngine;
+    //  using System.Collections;
+    //  using System.Collections.Generic;
+    //  using MiniJSON;
+    //
+    //  public class MiniJSONTest : MonoBehaviour {
+    //      void Start () {
+    //          var jsonString = "{ \"array\": [1.44,2,3], " +
+    //                          "\"object\": {\"key1\":\"value1\", \"key2\":256}, " +
+    //                          "\"string\": \"The quick brown fox \\\"jumps\\\" over the lazy dog \", " +
+    //                          "\"unicode\": \"\\u3041 Men\u00fa sesi\u00f3n\", " +
+    //                          "\"int\": 65536, " +
+    //                          "\"float\": 3.1415926, " +
+    //                          "\"bool\": true, " +
+    //                          "\"null\": null }";
+    //
+    //          var dict = Json.Deserialize(jsonString) as Dictionary<string,object>;
+    //
+    //          Debug.Log("deserialized: " + dict.GetType());
+    //          Debug.Log("dict['array'][0]: " + ((List<object>) dict["array"])[0]);
+    //          Debug.Log("dict['string']: " + (string) dict["string"]);
+    //          Debug.Log("dict['float']: " + (double) dict["float"]); // floats come out as doubles
+    //          Debug.Log("dict['int']: " + (long) dict["int"]); // ints come out as longs
+    //          Debug.Log("dict['unicode']: " + (string) dict["unicode"]);
+    //
+    //          var str = Json.Serialize(dict);
+    //
+    //          Debug.Log("serialized: " + str);
+    //      }
+    //  }
+
+    /// <summary>
+    /// This class encodes and decodes JSON strings.
+    /// Spec. details, see http://www.json.org/
+    ///
+    /// JSON uses Arrays and Objects. These correspond here to the datatypes IList and IDictionary.
+    /// All numbers are parsed to doubles.
+    /// </summary>
+    public static class Json {
+        /// <summary>
+        /// Parses the string json into a value
+        /// </summary>
+        /// <param name="json">A JSON string.</param>
+        /// <returns>An List&lt;object&gt;, a Dictionary&lt;string, object&gt;, a double, an integer,a string, null, true, or false</returns>
+        public static object Deserialize(string json) {
+            // save the string for debug information
+            if (json == null) {
+                return null;
+            }
+
+            return Parser.Parse(json);
+        }
+
+        sealed class Parser : IDisposable {
+            const string WORD_BREAK = "{}[],:\"";
+
+            public static bool IsWordBreak(char c) {
+                return Char.IsWhiteSpace(c) || WORD_BREAK.IndexOf(c) != -1;
+            }
+
+            enum TOKEN {
+                NONE,
+                CURLY_OPEN,
+                CURLY_CLOSE,
+                SQUARED_OPEN,
+                SQUARED_CLOSE,
+                COLON,
+                COMMA,
+                STRING,
+                NUMBER,
+                TRUE,
+                FALSE,
+                NULL
+            };
+
+            StringReader json;
+
+            Parser(string jsonString) {
+                json = new StringReader(jsonString);
+            }
+
+            public static object Parse(string jsonString) {
+                using (var instance = new Parser(jsonString)) {
+                    return instance.ParseValue();
+                }
+            }
+
+            public void Dispose() {
+                json.Dispose();
+                json = null;
+            }
+
+            Dictionary<string, object> ParseObject() {
+                Dictionary<string, object> table = new Dictionary<string, object>();
+
+                // ditch opening brace
+                json.Read();
+
+                // {
+                while (true) {
+                    switch (NextToken) {
+                    case TOKEN.NONE:
+                        return null;
+                    case TOKEN.COMMA:
+                        continue;
+                    case TOKEN.CURLY_CLOSE:
+                        return table;
+                    default:
+                        // name
+                        string name = ParseString();
+                        if (name == null) {
+                            return null;
+                        }
+
+                        // :
+                        if (NextToken != TOKEN.COLON) {
+                            return null;
+                        }
+                        // ditch the colon
+                        json.Read();
+
+                        // value
+                        table[name] = ParseValue();
+                        break;
+                    }
+                }
+            }
+
+            List<object> ParseArray() {
+                List<object> array = new List<object>();
+
+                // ditch opening bracket
+                json.Read();
+
+                // [
+                var parsing = true;
+                while (parsing) {
+                    TOKEN nextToken = NextToken;
+
+                    switch (nextToken) {
+                    case TOKEN.NONE:
+                        return null;
+                    case TOKEN.COMMA:
+                        continue;
+                    case TOKEN.SQUARED_CLOSE:
+                        parsing = false;
+                        break;
+                    default:
+                        object value = ParseByToken(nextToken);
+
+                        array.Add(value);
+                        break;
+                    }
+                }
+
+                return array;
+            }
+
+            object ParseValue() {
+                TOKEN nextToken = NextToken;
+                return ParseByToken(nextToken);
+            }
+
+            object ParseByToken(TOKEN token) {
+                switch (token) {
+                case TOKEN.STRING:
+                    return ParseString();
+                case TOKEN.NUMBER:
+                    return ParseNumber();
+                case TOKEN.CURLY_OPEN:
+                    return ParseObject();
+                case TOKEN.SQUARED_OPEN:
+                    return ParseArray();
+                case TOKEN.TRUE:
+                    return true;
+                case TOKEN.FALSE:
+                    return false;
+                case TOKEN.NULL:
+                    return null;
+                default:
+                    return null;
+                }
+            }
+
+            string ParseString() {
+                StringBuilder s = new StringBuilder();
+                char c;
+
+                // ditch opening quote
+                json.Read();
+
+                bool parsing = true;
+                while (parsing) {
+
+                    if (json.Peek() == -1) {
+                        parsing = false;
+                        break;
+                    }
+
+                    c = NextChar;
+                    switch (c) {
+                    case '"':
+                        parsing = false;
+                        break;
+                    case '\\':
+                        if (json.Peek() == -1) {
+                            parsing = false;
+                            break;
+                        }
+
+                        c = NextChar;
+                        switch (c) {
+                        case '"':
+                        case '\\':
+                        case '/':
+                            s.Append(c);
+                            break;
+                        case 'b':
+                            s.Append('\b');
+                            break;
+                        case 'f':
+                            s.Append('\f');
+                            break;
+                        case 'n':
+                            s.Append('\n');
+                            break;
+                        case 'r':
+                            s.Append('\r');
+                            break;
+                        case 't':
+                            s.Append('\t');
+                            break;
+                        case 'u':
+                            var hex = new char[4];
+
+                            for (int i=0; i< 4; i++) {
+                                hex[i] = NextChar;
+                            }
+
+                            s.Append((char) Convert.ToInt32(new string(hex), 16));
+                            break;
+                        }
+                        break;
+                    default:
+                        s.Append(c);
+                        break;
+                    }
+                }
+
+                return s.ToString();
+            }
+
+            object ParseNumber() {
+                string number = NextWord;
+
+                if (number.IndexOf('.') == -1) {
+                    long parsedInt;
+                    Int64.TryParse(number, out parsedInt);
+                    return parsedInt;
+                }
+
+                double parsedDouble;
+                Double.TryParse(number, out parsedDouble);
+                return parsedDouble;
+            }
+
+            void EatWhitespace() {
+                while (Char.IsWhiteSpace(PeekChar)) {
+                    json.Read();
+
+                    if (json.Peek() == -1) {
+                        break;
+                    }
+                }
+            }
+
+            char PeekChar {
+                get {
+                    return Convert.ToChar(json.Peek());
+                }
+            }
+
+            char NextChar {
+                get {
+                    return Convert.ToChar(json.Read());
+                }
+            }
+
+            string NextWord {
+                get {
+                    StringBuilder word = new StringBuilder();
+
+                    while (!IsWordBreak(PeekChar)) {
+                        word.Append(NextChar);
+
+                        if (json.Peek() == -1) {
+                            break;
+                        }
+                    }
+
+                    return word.ToString();
+                }
+            }
+
+            TOKEN NextToken {
+                get {
+                    EatWhitespace();
+
+                    if (json.Peek() == -1) {
+                        return TOKEN.NONE;
+                    }
+
+                    switch (PeekChar) {
+                    case '{':
+                        return TOKEN.CURLY_OPEN;
+                    case '}':
+                        json.Read();
+                        return TOKEN.CURLY_CLOSE;
+                    case '[':
+                        return TOKEN.SQUARED_OPEN;
+                    case ']':
+                        json.Read();
+                        return TOKEN.SQUARED_CLOSE;
+                    case ',':
+                        json.Read();
+                        return TOKEN.COMMA;
+                    case '"':
+                        return TOKEN.STRING;
+                    case ':':
+                        return TOKEN.COLON;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                    case '-':
+                        return TOKEN.NUMBER;
+                    }
+
+                    switch (NextWord) {
+                    case "false":
+                        return TOKEN.FALSE;
+                    case "true":
+                        return TOKEN.TRUE;
+                    case "null":
+                        return TOKEN.NULL;
+                    }
+
+                    return TOKEN.NONE;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts a IDictionary / IList object or a simple type (string, int, etc.) into a JSON string
+        /// </summary>
+        /// <param name="json">A Dictionary&lt;string, object&gt; / List&lt;object&gt;</param>
+        /// <returns>A JSON encoded string, or null if object 'json' is not serializable</returns>
+        public static string Serialize(object obj) {
+            return Serializer.Serialize(obj);
+        }
+
+        sealed class Serializer {
+            StringBuilder builder;
+
+            Serializer() {
+                builder = new StringBuilder();
+            }
+
+            public static string Serialize(object obj) {
+                var instance = new Serializer();
+
+                instance.SerializeValue(obj);
+
+                return instance.builder.ToString();
+            }
+
+            void SerializeValue(object value) {
+                IList asList;
+                IDictionary asDict;
+                string asStr;
+
+                if (value == null) {
+                    builder.Append("null");
+                } else if ((asStr = value as string) != null) {
+                    SerializeString(asStr);
+                } else if (value is bool) {
+                    builder.Append((bool) value ? "true" : "false");
+                } else if ((asList = value as IList) != null) {
+                    SerializeArray(asList);
+                } else if ((asDict = value as IDictionary) != null) {
+                    SerializeObject(asDict);
+                } else if (value is char) {
+                    SerializeString(new string((char) value, 1));
+                } else {
+                    SerializeOther(value);
+                }
+            }
+
+            void SerializeObject(IDictionary obj) {
+                bool first = true;
+
+                builder.Append('{');
+
+                foreach (object e in obj.Keys) {
+                    if (!first) {
+                        builder.Append(',');
+                    }
+
+                    SerializeString(e.ToString());
+                    builder.Append(':');
+
+                    SerializeValue(obj[e]);
+
+                    first = false;
+                }
+
+                builder.Append('}');
+            }
+
+            void SerializeArray(IList anArray) {
+                builder.Append('[');
+
+                bool first = true;
+
+                foreach (object obj in anArray) {
+                    if (!first) {
+                        builder.Append(',');
+                    }
+
+                    SerializeValue(obj);
+
+                    first = false;
+                }
+
+                builder.Append(']');
+            }
+
+            void SerializeString(string str) {
+                builder.Append('\"');
+
+                char[] charArray = str.ToCharArray();
+                foreach (var c in charArray) {
+                    switch (c) {
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        int codepoint = Convert.ToInt32(c);
+                        if ((codepoint >= 32) && (codepoint <= 126)) {
+                            builder.Append(c);
+                        } else {
+                            builder.Append("\\u");
+                            builder.Append(codepoint.ToString("x4"));
+                        }
+                        break;
+                    }
+                }
+
+                builder.Append('\"');
+            }
+
+            void SerializeOther(object value) {
+                // NOTE: decimals lose precision during serialization.
+                // They always have, I'm just letting you know.
+                // Previously floats and doubles lost precision too.
+                if (value is float) {
+                    builder.Append(((float) value).ToString("R"));
+                } else if (value is int
+                    || value is uint
+                    || value is long
+                    || value is sbyte
+                    || value is byte
+                    || value is short
+                    || value is ushort
+                    || value is ulong) {
+                    builder.Append(value);
+                } else if (value is double
+                    || value is decimal) {
+                    builder.Append(Convert.ToDouble(value).ToString("R"));
+                } else {
+                    SerializeString(value.ToString());
+                }
+            }
+        }
+    }
+}

--- a/editor/Editor/MiniJson.cs.meta
+++ b/editor/Editor/MiniJson.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 756f4dccc85744648a864f932dfcedf3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/PrefabLens.Editor.asmdef
+++ b/editor/Editor/PrefabLens.Editor.asmdef
@@ -6,7 +6,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": ["Newtonsoft.Json.dll"],
+    "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -107,6 +107,16 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void ThrowsOnMalformedOrNonObjectJson()
+        {
+            // 同梱の MiniJSON は不正入力で throw せず null を返す流儀だが、DiffModel.Parse は
+            // throw する契約(Window が「Could not parse CLI output」表示に変換する)を保つ。
+            Assert.That(() => DiffModel.Parse("not json at all"), Throws.Exception);
+            Assert.That(() => DiffModel.Parse(""), Throws.Exception);
+            Assert.That(() => DiffModel.Parse("[]"), Throws.Exception); // ルートが object でない
+        }
+
+        [Test]
         public void ResolveWithFillsOnlyUnresolvedGuids()
         {
             var m = DiffModel.Parse(Golden);

--- a/editor/Tests/Editor/PrefabLens.Editor.Tests.asmdef
+++ b/editor/Tests/Editor/PrefabLens.Editor.Tests.asmdef
@@ -10,7 +10,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": ["nunit.framework.dll", "Newtonsoft.Json.dll"],
+    "precompiledReferences": ["nunit.framework.dll"],
     "autoReferenced": false,
     "defineConstraints": ["UNITY_INCLUDE_TESTS"],
     "versionDefines": [],

--- a/editor/package.json
+++ b/editor/package.json
@@ -4,8 +4,5 @@
   "displayName": "PrefabLens",
   "description": "Semantic diffs for Unity YAML assets (prefab / scene / asset) against git, rendered inside the Editor.",
   "unity": "2022.3",
-  "license": "Apache-2.0",
-  "dependencies": {
-    "com.unity.nuget.newtonsoft-json": "3.2.1"
-  }
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## 概要

`com.unity.nuget.newtonsoft-json` への UPM 依存を削除し、PrefabLens を**依存ゼロのパッケージ**にする。JSON パースは MiniJSON(Calvin Rien、MIT、1 ファイル)を `PrefabLens.MiniJson` 名前空間で同梱して置き換える。

### 動機

- 利用者プロジェクトが既に Newtonsoft.Json.dll を持っている場合の duplicate assembly 衝突(Unity で頻出のトラブル)を根絶する
- 用途は「自前 CLI が出す既知スキーマ diff.v2 の読み取り専用」で、フル機能 JSON ライブラリは過剰

### 変更内容

- `editor/Editor/MiniJson.cs`(新規): gist darktable/1411710 rev 513f1c0 の原本を同梱。ライセンスヘッダ維持、変更は namespace(`MiniJSON` → `PrefabLens.MiniJson`)のみ。同梱元 URL をヘッダに明記
- `editor/Editor/DiffModel.cs`: JObject/JArray/JToken → Dictionary/List/object マッピングに置換。MiniJSON は不正入力で throw せず null を返すため、`Parse` 先頭でルート型を検査して throw し、Window の「Could not parse CLI output」表示契約を維持
- `editor/package.json`: `dependencies` 削除(空になったのでブロックごと)
- asmdef ×2: `Newtonsoft.Json.dll` の precompiledReferences を削除

### 代替案の検討(不採用理由)

- **JsonUtility**: Unity シリアライザの入れ子深さ制限で `children` 再帰が破綻。union 型(`before`/`after`)と動的キー辞書(`resolved`)も表現不可で、CLI/Chrome 拡張と共有する diff.v2 スキーマの fork が必要になる
- **自前パーサ**: 保守コストの懸念から実績ある同梱ファイルを選択

### 性能(実測、.NET 8 Release、中央値/15 回)

| ペイロード | Newtonsoft `JObject.Parse` | MiniJSON `Json.Deserialize` |
|---|---|---|
| 典型 95 KB | 2.88 ms / 2.7 MB alloc | **1.72 ms / 2.1 MB alloc(1.7 倍高速)** |
| シーン級 7.3 MB | 559 ms / 206 MB alloc | **156 ms / 161 MB alloc(3.6 倍高速)** |

`JProperty`/`JValue` の重い DOM を作らず素の `Dictionary`/`List` を返すため、置き換えでむしろ高速・省メモリになる。エンドツーエンド(`DiffModel.Parse` = パース + モデル構築)はシーン級 7.3 MB で 168 ms、典型 95 KB で 1.7 ms。

### 検証

- netstandard2.1 + C# 9(Unity 2022.3 相当)ハーネスで **PackageReference ゼロ**のままコンパイル成功 = 外部依存なしの証明
- 既存 DiffModelTests 6 件を**無変更**でパス(wasm golden 互換・forward compat・null セマンティクスの回帰ネット)。全体 18/18
- 追加テスト 1 件: 不正 JSON / 非 object ルートで `DiffModel.Parse` が throw する契約
- Unity EditMode(実機 Editor)は未実行