### PR TITLE
fix: keep added component cards expanded

### DIFF
--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -220,7 +220,7 @@ describe('render', () => {
     expect(row?.textContent).not.toContain('—');
   });
 
-  it('collapses added component cards but keeps modified ones open', () => {
+  it('keeps added and modified component cards open', () => {
     const root = freshRoot();
     const diff: DiffV2 = {
       schema: 'prefablens.diff.v2',
@@ -251,7 +251,8 @@ describe('render', () => {
     render(root, diff);
     const cards = [...root.querySelectorAll('.pl-components > details')] as HTMLDetailsElement[];
     expect(cards).toHaveLength(2);
-    expect(cards[0]!.open).toBe(false); // added Cylinder1 は閉
+    // added を閉じると「Cylinder1 だけ折り畳まれる」非対称な見え方になるため、状態によらず常に開く
+    expect(cards[0]!.open).toBe(true); // added Cylinder1 も開
     expect(cards[0]!.textContent).toContain('Cylinder1'); // className フォールバック
     expect(cards[1]!.open).toBe(true); // modified Transform は開
   });

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -150,7 +150,6 @@ function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElem
 
 function renderComponent(c: ComponentDiff, diff: DiffV2): HTMLElement {
   const details = openDetails('pl-comp', c.status);
-  details.open = c.status !== 'added'; // added(初期値の全列挙)は閉、それ以外は開
   const resolved = c.scriptGuid ? diff.resolved?.[c.scriptGuid] : undefined;
   const display = resolved ? stem(resolved) : (c.className ?? c.typeName);
   const summary = summaryLine(c.status, display);


### PR DESCRIPTION
## 背景

PR で semantic view を表示した際、追加されたコンポーネントのカードだけが折りたたまれて表示される。

例: https://github.com/hashiiiii/unity-yaml-playground/pull/1/files の `Assets/Cylinder.prefab` では、modified な Transform は展開されるのに、新規追加された Cylinder1 (MonoBehaviour) だけが閉じた状態で描画される。

## 原因

`render.ts` の `renderComponent` が `details.open = c.status !== 'added'` により added コンポーネントを意図的に閉じていた (#5 で導入)。「added は初期値の全列挙でノイズが多い」という判断だったが、実際には modified と added が混在するファイルで片方だけ折りたたまれる非対称な見え方になり、diff の見落としにつながる。

## 修正

状態によらずコンポーネントカードを常に開く。`openDetails` が既定で `open = true` を設定しているため、上書き行の削除のみ。

## 検証

- vitest: 83 passed (該当テストは「added も開」に更新)
- tsc: OK
- Playwright e2e: 5 passed