### PR TITLE
fix: show full values for one-sided documents

### DIFF
--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -359,7 +359,8 @@ test "mcp: tools/call diffs a real git fixture with the ts host golden" {
         "  + Cylinder Variant  <Prefab>\n" ++
         "      components\n" ++
         "        + Transform\n" ++
-        "          + Position: (2.03, 3.63, 1.11797)\n", text);
+        "          + Position: (2.03, 3.63, 1.11797)\n" ++
+        "          + Rotation: (0, 0, 0, 1)\n", text);
 }
 
 test "mcp: tools/call format json returns diff v2 and bad refs surface as isError" {

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -443,7 +443,7 @@ test "diff: modified instance overrides are sorted group-contiguous, Transform f
     try testing.expectEqualStrings("Max Hp", d.overrides[2].label);
 }
 
-test "diff: added prefab instance collapses placement to summary" {
+test "diff: added prefab instance emits placement summary rows" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -484,11 +484,15 @@ test "diff: added prefab instance collapses placement to summary" {
     const fd = try compute(arena, "", after);
     const d = findDoc(fd, 1001).?;
     try testing.expectEqual(model.Status.added, d.status);
-    // Position のみ: 合成 1 行。identity Rotation・EulerAnglesHint・m_Name は省略。
-    try testing.expectEqual(@as(usize, 1), d.overrides.len);
+    // 記録済みの placement は default 値(identity Rotation)でも合成 1 行で出す。
+    // EulerAnglesHint(Inspector 非表示)と m_Name(ノード名に吸収)は出ない。
+    try testing.expectEqual(@as(usize, 2), d.overrides.len);
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Position", d.overrides[0].label);
     try testing.expectEqualStrings("(2.03, 3.63, 1.11797)", d.overrides[0].after.?.scalar);
+    try testing.expectEqualStrings("Transform", d.overrides[1].group);
+    try testing.expectEqualStrings("Rotation", d.overrides[1].label);
+    try testing.expectEqualStrings("(0, 0, 0, 1)", d.overrides[1].after.?.scalar);
 }
 
 test "diff: added prefab instance keeps partial scale override" {
@@ -984,13 +988,6 @@ fn scalarOf(n: ?*Node) ?[]const u8 {
     };
 }
 
-// 意図的な厳密一致: ほぼデフォルトに近い値も実在する override であり、
-// 表示され続けるべき(epsilon 比較は検討のうえ見送り済み)。
-fn numEql(s: []const u8, want: f64) bool {
-    const v = std.fmt.parseFloat(f64, std.mem.trim(u8, s, " ")) catch return false;
-    return v == want;
-}
-
 fn findMod(mods: []Mod, path: []const u8) ?Mod {
     for (mods) |m| if (std.mem.eql(u8, m.path, path)) return m;
     return null;
@@ -1000,12 +997,11 @@ fn addedInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document) 
     const mods = try collectMods(arena, doc);
     var out: std.ArrayList(model.OverrideDiff) = .empty;
 
-    // Placement サマリ: 全成分が揃っていれば合成 1 行(デフォルト値なら省略)。
+    // Placement サマリ: 全成分が揃っていれば合成 1 行。
     var consumed = [_]bool{false} ** placements.len;
     for (placements, 0..) |p, pi| {
         var vals: [4][]const u8 = undefined;
         var all = true;
-        var is_default = true;
         for (p.comps, 0..) |c, i| {
             const path = try std.fmt.allocPrint(arena, "{s}.{s}", .{ p.prefix, c });
             const m = findMod(mods, path) orelse {
@@ -1017,18 +1013,9 @@ fn addedInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document) 
                 break;
             };
             vals[i] = v;
-            // デフォルト: Position/Scale の各成分は 0/1、Rotation は (0,0,0,1)。
-            const want: f64 = if (std.mem.eql(u8, p.label, "Scale"))
-                1
-            else if (std.mem.eql(u8, p.label, "Rotation") and std.mem.eql(u8, c, "w"))
-                1
-            else
-                0;
-            if (!numEql(v, want)) is_default = false;
         }
         if (!all) continue;
         consumed[pi] = true;
-        if (is_default) continue;
         const n = try parenJoinNode(arena, vals[0..p.comps.len]);
         try out.append(arena, .{ .group = "Transform", .label = p.label, .status = .added, .before = null, .after = n });
     }

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -56,7 +56,12 @@ test "diff: added and removed documents" {
     try testing.expectEqual(model.Status.added, findDoc(fd, 2).?.status);
 
     const fd2 = try compute(arena, after, before);
-    try testing.expectEqual(model.Status.removed, findDoc(fd2, 2).?.status);
+    const removed = findDoc(fd2, 2).?;
+    try testing.expectEqual(model.Status.removed, removed.status);
+    // 削除側も全列挙: hierarchy で見えていた Name が before 値で残る。
+    try testing.expectEqual(@as(usize, 1), removed.fields.len);
+    try testing.expectEqualStrings("Name", removed.fields[0].path);
+    try testing.expectEqualStrings("B", removed.fields[0].before.?.scalar);
 }
 
 test "diff: nested field path and added field" {
@@ -340,6 +345,30 @@ test "diff: added document enumerates fields with vector collapse" {
     try testing.expectEqualStrings("Position", d.fields[0].path);
     try testing.expectEqualStrings("(4, 0, 0)", d.fields[0].after.?.scalar);
     try testing.expectEqualStrings("Max Hp", d.fields[1].path);
+}
+
+test "diff: removed document enumerates fields with vector collapse" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_LocalPosition: {x: 4, y: 0, z: 0}
+        \\  maxHp: 100
+    ;
+    const fd = try compute(arena, before, "");
+    const d = findDoc(fd, 4).?;
+    try testing.expectEqual(model.Status.removed, d.status);
+    // 追加側と対称: m_GameObject は非表示、Position はベクトル 1 行、値は before に載る。
+    try testing.expectEqual(@as(usize, 2), d.fields.len);
+    try testing.expectEqualStrings("Position", d.fields[0].path);
+    try testing.expectEqual(model.Status.removed, d.fields[0].status);
+    try testing.expectEqualStrings("(4, 0, 0)", d.fields[0].before.?.scalar);
+    try testing.expect(d.fields[0].after == null);
+    try testing.expectEqualStrings("Max Hp", d.fields[1].path);
+    try testing.expectEqualStrings("100", d.fields[1].before.?.scalar);
 }
 
 test "diff: prefab instance override keyed by target+propertyPath" {
@@ -697,15 +726,30 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
         if (bd.stripped) continue;
         if (after_idx.contains(bd.file_id)) continue;
         try collectGuids(arena, &guids, bd.body);
-        try docs.append(arena, .{
-            .file_id = bd.file_id,
-            .class_id = bd.class_id,
-            .type_name = resolvedTypeName(bd),
-            .script_guid = scriptGuid(bd),
-            .class_name = editorClassName(bd),
-            .status = .removed,
-            .fields = &.{},
-        });
+        if (bd.class_id == 1001) {
+            try docs.append(arena, .{
+                .file_id = bd.file_id,
+                .class_id = bd.class_id,
+                .type_name = resolvedTypeName(bd),
+                .script_guid = scriptGuid(bd),
+                .class_name = editorClassName(bd),
+                .status = .removed,
+                .fields = &.{},
+            });
+        } else {
+            // 追加側(flattenSubtree ~ presentFields)と対称の全列挙。
+            var raw: std.ArrayList(FieldDiff) = .empty;
+            for (bd.body.map) |e| try flattenSubtree(arena, &raw, e.key, e.value, .removed);
+            try docs.append(arena, .{
+                .file_id = bd.file_id,
+                .class_id = bd.class_id,
+                .type_name = resolvedTypeName(bd),
+                .script_guid = scriptGuid(bd),
+                .class_name = editorClassName(bd),
+                .status = .removed,
+                .fields = try presentFields(arena, raw.items),
+            });
+        }
     }
 
     return .{

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -545,6 +545,37 @@ test "diff: added prefab instance keeps partial scale override" {
     try testing.expectEqualStrings("2", d.overrides[0].after.?.scalar);
 }
 
+test "diff: removed prefab instance mirrors overrides to before" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 7, guid: aaa, type: 3}
+        \\      propertyPath: m_LocalScale.y
+        \\      value: 2
+        \\    m_AddedComponents:
+        \\    - targetCorrespondingSourceObject: {fileID: 7, guid: aaa, type: 3}
+        \\      insertIndex: -1
+        \\      addedObject: {fileID: 55}
+        \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
+    ;
+    const fd = try compute(arena, before, "");
+    const d = findDoc(fd, 1001).?;
+    try testing.expectEqual(model.Status.removed, d.status);
+    // added の鏡像: 値は before 側、構造サマリは before 側の件数で removed。
+    try testing.expectEqual(@as(usize, 2), d.overrides.len);
+    try testing.expectEqualStrings("Scale.y", d.overrides[0].label);
+    try testing.expectEqual(model.Status.removed, d.overrides[0].status);
+    try testing.expectEqualStrings("2", d.overrides[0].before.?.scalar);
+    try testing.expect(d.overrides[0].after == null);
+    try testing.expectEqualStrings("Added Components (1)", d.overrides[1].label);
+    try testing.expectEqual(model.Status.removed, d.overrides[1].status);
+}
+
 test "diff: non-empty added components produce a summary row" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -705,7 +736,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
                     .script_guid = scriptGuid(ad),
                     .status = .added,
                     .fields = &.{},
-                    .overrides = try addedInstanceOverrides(arena, ad),
+                    .overrides = try soleInstanceOverrides(arena, ad, .added),
                 });
             } else {
                 var raw: std.ArrayList(FieldDiff) = .empty;
@@ -735,6 +766,7 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
                 .class_name = editorClassName(bd),
                 .status = .removed,
                 .fields = &.{},
+                .overrides = try soleInstanceOverrides(arena, bd, .removed),
             });
         } else {
             // 追加側(flattenSubtree ~ presentFields)と対称の全列挙。
@@ -1037,7 +1069,9 @@ fn findMod(mods: []Mod, path: []const u8) ?Mod {
     return null;
 }
 
-fn addedInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document) ![]model.OverrideDiff {
+// 片側にしか存在しない instance(added/removed)の override 全列挙。
+// 値は added なら after、removed なら before に載る。
+fn soleInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document, status: Status) ![]model.OverrideDiff {
     const mods = try collectMods(arena, doc);
     var out: std.ArrayList(model.OverrideDiff) = .empty;
 
@@ -1061,7 +1095,13 @@ fn addedInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document) 
         if (!all) continue;
         consumed[pi] = true;
         const n = try parenJoinNode(arena, vals[0..p.comps.len]);
-        try out.append(arena, .{ .group = "Transform", .label = p.label, .status = .added, .before = null, .after = n });
+        try out.append(arena, .{
+            .group = "Transform",
+            .label = p.label,
+            .status = status,
+            .before = if (status == .removed) n else null,
+            .after = if (status == .added) n else null,
+        });
     }
 
     for (mods) |m| {
@@ -1075,9 +1115,20 @@ fn addedInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document) 
             break :blk false;
         };
         if (in_consumed) continue;
-        try out.append(arena, try makeOverride(arena, m.path, .added, null, modValue(m)));
+        const v = modValue(m);
+        try out.append(arena, try makeOverride(
+            arena,
+            m.path,
+            status,
+            if (status == .removed) v else null,
+            if (status == .added) v else null,
+        ));
     }
-    try appendStructuralSummaries(arena, &out, null, doc);
+    if (status == .added) {
+        try appendStructuralSummaries(arena, &out, null, doc);
+    } else {
+        try appendStructuralSummaries(arena, &out, doc, null);
+    }
     sortByGroup(out.items);
     return out.toOwnedSlice(arena);
 }
@@ -1093,7 +1144,7 @@ fn modificationSeqLen(doc: *const model.Document, key: []const u8) usize {
 }
 
 // m_Added*/m_Removed* の完全展開はスコープ外。件数の要約 1 行で情報が黙って消えるのを防ぐ。
-fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model.OverrideDiff), before_doc: ?*const model.Document, after_doc: *const model.Document) !void {
+fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model.OverrideDiff), before_doc: ?*const model.Document, after_doc: ?*const model.Document) !void {
     const keys = [_]struct { key: []const u8, label: []const u8 }{
         .{ .key = "m_AddedGameObjects", .label = "Added GameObjects" },
         .{ .key = "m_AddedComponents", .label = "Added Components" },
@@ -1101,12 +1152,14 @@ fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model
         .{ .key = "m_RemovedGameObjects", .label = "Removed GameObjects" },
     };
     for (keys) |e| {
-        const alen = modificationSeqLen(after_doc, e.key);
+        const alen = if (after_doc) |ad| modificationSeqLen(ad, e.key) else 0;
         const blen = if (before_doc) |bd| modificationSeqLen(bd, e.key) else 0;
         if (alen == blen) continue;
+        // 件数は生き残っている側: instance ごと削除なら before の件数を出す。
+        const count = if (after_doc != null) alen else blen;
         try out.append(arena, .{
             .group = "Overrides",
-            .label = try std.fmt.allocPrint(arena, "{s} ({d})", .{ e.label, alen }),
+            .label = try std.fmt.allocPrint(arena, "{s} ({d})", .{ e.label, count }),
             .status = if (alen > blen) .added else .removed,
             .before = null,
             .after = null,

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -28,14 +28,16 @@ test "fixture: Plane.prefab shows both cylinder instances under Plane" {
     const plane = res.roots[0];
     try testing.expectEqualStrings("Plane", plane.name);
 
-    // 追加された Cylinder Variant: 配置サマリのみ(Position 合成 1 行)。
+    // 追加された Cylinder Variant: 記録済み placement を default 含め全表示。
     const variant = childByName(plane, "Cylinder Variant").?;
     try testing.expectEqual(model.ObjectKind.prefab_instance, variant.kind);
     try testing.expectEqual(model.Status.added, variant.status);
-    try testing.expectEqual(@as(usize, 1), variant.overrides.len);
+    try testing.expectEqual(@as(usize, 2), variant.overrides.len);
     try testing.expectEqualStrings("Transform", variant.overrides[0].group);
     try testing.expectEqualStrings("Position", variant.overrides[0].label);
     try testing.expectEqualStrings("(2.03, 3.63, 1.11797)", variant.overrides[0].after.?.scalar);
+    try testing.expectEqualStrings("Rotation", variant.overrides[1].label);
+    try testing.expectEqualStrings("(0, 0, 0, 1)", variant.overrides[1].after.?.scalar);
 
     // 変更された Cylinder: Position.x の 1 override のみ。
     const cylinder = childByName(plane, "Cylinder").?;
@@ -78,7 +80,7 @@ test "fixture: Cylinder.prefab shows added script and transform change" {
     try testing.expect(saw_script and saw_transform);
 }
 
-test "fixture: new Cylinder Variant.prefab is a single added instance with Scale.y" {
+test "fixture: new Cylinder Variant.prefab shows all recorded placement values" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -88,10 +90,15 @@ test "fixture: new Cylinder Variant.prefab is a single added instance with Scale
     try testing.expectEqual(model.ObjectKind.prefab_instance, inst.kind);
     try testing.expectEqualStrings("Cylinder Variant", inst.name);
     try testing.expectEqual(model.Status.added, inst.status);
-    // Position (0,0,0)・identity Rotation・EulerAnglesHint・m_Name は省略され Scale.y だけ残る。
-    try testing.expectEqual(@as(usize, 1), inst.overrides.len);
-    try testing.expectEqualStrings("Scale.y", inst.overrides[0].label);
-    try testing.expectEqualStrings("2", inst.overrides[0].after.?.scalar);
+    // ファイルに記録された placement は default でも全部出す。
+    // 出ないのは EulerAnglesHint(非表示)と m_Name(ノード名に吸収)のみ。
+    try testing.expectEqual(@as(usize, 3), inst.overrides.len);
+    try testing.expectEqualStrings("Position", inst.overrides[0].label);
+    try testing.expectEqualStrings("(0, 0, 0)", inst.overrides[0].after.?.scalar);
+    try testing.expectEqualStrings("Rotation", inst.overrides[1].label);
+    try testing.expectEqualStrings("(0, 0, 0, 1)", inst.overrides[1].after.?.scalar);
+    try testing.expectEqualStrings("Scale.y", inst.overrides[2].label);
+    try testing.expectEqualStrings("2", inst.overrides[2].after.?.scalar);
 }
 
 // ---- prefab/scene 以外の UnityYAML アセット(.mat / .controller)----

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -101,6 +101,26 @@ test "fixture: new Cylinder Variant.prefab shows all recorded placement values" 
     try testing.expectEqualStrings("2", inst.overrides[2].after.?.scalar);
 }
 
+test "fixture: deleted Cylinder Variant.prefab mirrors the added enumeration" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // added(直前のテスト)の鏡像: 同じ 3 行が before 値・removed で出る。
+    const res = try root.diffBytes(arena, cylinder_variant_after, "");
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    const inst = res.roots[0];
+    try testing.expectEqual(model.ObjectKind.prefab_instance, inst.kind);
+    try testing.expectEqualStrings("Cylinder Variant", inst.name);
+    try testing.expectEqual(model.Status.removed, inst.status);
+    try testing.expectEqual(@as(usize, 3), inst.overrides.len);
+    try testing.expectEqualStrings("Position", inst.overrides[0].label);
+    try testing.expectEqualStrings("(0, 0, 0)", inst.overrides[0].before.?.scalar);
+    try testing.expectEqualStrings("Rotation", inst.overrides[1].label);
+    try testing.expectEqualStrings("(0, 0, 0, 1)", inst.overrides[1].before.?.scalar);
+    try testing.expectEqualStrings("Scale.y", inst.overrides[2].label);
+    try testing.expectEqualStrings("2", inst.overrides[2].before.?.scalar);
+}
+
 // ---- prefab/scene 以外の UnityYAML アセット(.mat / .controller)----
 // core は拡張子を見ないので既に diff できる。ここはその保証を固定する回帰点。
 


### PR DESCRIPTION
## 概要

Inspector / Hierarchy で確認できる値を diff にすべて表示するための第 1 弾(縮退パスの完成)。unity-yaml-playground#1 で新規追加プレハブが `Scale.y: 2` しか表示しなかった問題のうち、「ファイルに記録済みなのに抑制されていた値」を解消する。

## 変更点

- **追加された PrefabInstance のデフォルト値抑制を撤廃**: `m_Modifications` に記録された Position (0,0,0) や identity Rotation も合成 1 行で表示する(`numEql` とデフォルト判定を削除)
- **削除された通常ドキュメントの全列挙**: 追加側と対称に、全 inspector 可視フィールドを before 値で列挙する
- **削除された PrefabInstance の overrides**: `addedInstanceOverrides` を `soleInstanceOverrides(doc, status)` に一般化し、削除側でも override と構造サマリを表示する

## 表示例(Cylinder Variant.prefab 追加)

```
+ Cylinder Variant  <Prefab>
    components
      + Transform
        + Position: (0, 0, 0)
        + Rotation: (0, 0, 0, 1)
        + Scale.y: 2
```

## テスト

- zig build test: 134/134 pass(新規 4 テスト、既存 4 テストの期待値更新)
- zig build perf: 150 ms / 上限 600 ms
- wasm golden + extension(typecheck / 85 tests / build): すべて成功

## 備考

`Scale.x` などソースプレハブ由来の値は本 PR では出ない(ファイルに存在しないため)。ソースプレハブ解決による合成表示は follow-up(PR 2: core、PR 3: extension)で対応する。