### PR TITLE
feat: merge source prefabs into instance diffs

### DIFF
--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -379,6 +379,64 @@ test "run: color=true colors tree output, --no-color forces it back off" {
     try testing.expect(std.mem.indexOf(u8, output2.items, "\x1b[") == null);
 }
 
+test "run: --project supplies source prefabs for merged instance diffs" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Cylinder.prefab", .data =
+        \\--- !u!1 &10
+        \\GameObject:
+        \\  m_Name: Cyl
+        \\  m_Component:
+        \\  - component: {fileID: 40}
+        \\--- !u!4 &40
+        \\Transform:
+        \\  m_GameObject: {fileID: 10}
+        \\  m_LocalScale: {x: 1, y: 1, z: 1}
+    });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Cylinder.prefab.meta", .data =
+        \\fileFormatVersion: 2
+        \\guid: 0123456789abcdef0123456789abcdef
+    });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Variant.prefab", .data =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 40, guid: 0123456789abcdef0123456789abcdef, type: 3}
+        \\      propertyPath: m_LocalScale.y
+        \\      value: 2
+        \\  m_SourcePrefab: {fileID: 100100000, guid: 0123456789abcdef0123456789abcdef, type: 3}
+    });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "empty.prefab", .data = "" });
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    const variant_path = try tmp.dir.realPathFileAlloc(testing.io, "Variant.prefab", arena);
+    const empty_path = try tmp.dir.realPathFileAlloc(testing.io, "empty.prefab", arena);
+
+    // --project あり: ソースを供給して合成表示(Scale (1, 2, 1))。
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var errbuf: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
+    const code = try run(testing.io, arena, &.{ "--no-color", "--project", dir, empty_path, variant_path }, &aw.writer, &aw_err.writer, false);
+    const output = aw.toArrayList();
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expect(std.mem.indexOf(u8, output.items, "Scale: (1, 2, 1)") != null);
+
+    // --project なし: 縮退表示(記録済み override の列挙)のまま。
+    var out2: std.ArrayList(u8) = .empty;
+    var aw2 = std.Io.Writer.Allocating.fromArrayList(arena, &out2);
+    var errbuf2: std.ArrayList(u8) = .empty;
+    var aw_err2 = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf2);
+    const code2 = try run(testing.io, arena, &.{ "--no-color", empty_path, variant_path }, &aw2.writer, &aw_err2.writer, false);
+    const output2 = aw2.toArrayList();
+    try testing.expectEqual(@as(u8, 0), code2);
+    try testing.expect(std.mem.indexOf(u8, output2.items, "Scale.y: 2") != null);
+}
+
 /// リリースタグ v<version> と lockstep(cut-release の 5 ソースの一員)。
 pub const version = "0.3.0";
 
@@ -569,7 +627,8 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             return 1;
         };
 
-    const res = core.diffBytes(arena, before, after) catch |err| {
+    var assets: core.Assets = .empty;
+    var res = core.diffBytesWithAssets(arena, before, after, &assets) catch |err| {
         if (err == error.NestingTooDeep) {
             try stderr.writeAll("error: input nested too deeply\n");
             return 1;
@@ -584,6 +643,22 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             return 1;
         };
         resolver_ptr = &idx;
+        // needed_sources をローカル資産で満たして再 diff(入れ子ソースで新たな
+        // 要求が出るため最大 3 周、進捗が無ければ打ち切り)。読めない資産は
+        // スキップして diff は落とさない。
+        var rounds: usize = 0;
+        while (res.needed_sources.len != 0 and rounds < 3) : (rounds += 1) {
+            var progressed = false;
+            for (res.needed_sources) |ns| {
+                if (assets.contains(ns.guid)) continue;
+                const path = idx.get(ns.guid) orelse continue;
+                const bytes = readFile(io, arena, path) catch continue;
+                try assets.put(arena, ns.guid, bytes);
+                progressed = true;
+            }
+            if (!progressed) break;
+            res = try core.diffBytesWithAssets(arena, before, after, &assets);
+        }
     }
     switch (opt.format) {
         .json => {

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -705,7 +705,11 @@ fn resolvedTypeName(doc: *const model.Document) []const u8 {
 pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8) !FlatDiff {
     const before = try parser.parse(arena, before_src);
     const after = try parser.parse(arena, after_src);
+    return computeParsed(arena, before, after);
+}
 
+// 既にパース済みのドキュメント列を diff する(instantiate が変異済み docs を食わせる)。
+pub fn computeParsed(arena: std.mem.Allocator, before: []model.Document, after: []model.Document) !FlatDiff {
     var docs: std.ArrayList(DocDiff) = .empty;
     // array hash map は初回挿入順を保持するので、unresolvedGuids が
     // 参照順で決定的にシリアライズされる。

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -121,6 +121,51 @@ test "fixture: deleted Cylinder Variant.prefab mirrors the added enumeration" {
     try testing.expectEqualStrings("2", inst.overrides[2].before.?.scalar);
 }
 
+test "fixture: variant merged with source shows Scale (1, 2, 1) and all components" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // ソース(Cylinder.prefab 相当)を supply すると Inspector と同じ合成状態になる。
+    var assets: root.Assets = .empty;
+    try assets.put(arena, "05ba59bdbdf954600a21005e3b7bf963", cylinder_after);
+    const res = try root.diffBytesWithAssets(arena, "", cylinder_variant_after, &assets);
+    try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    const inst = res.roots[0];
+    try testing.expectEqualStrings("Cylinder Variant", inst.name);
+    try testing.expectEqual(model.Status.added, inst.status);
+    // 展開成功: overrides は消え、ソースの全コンポーネントが added で並ぶ。
+    try testing.expectEqual(@as(usize, 0), inst.overrides.len);
+    var saw = [_]bool{false} ** 4; // Transform / MeshFilter / MeshRenderer / CapsuleCollider
+    for (inst.components) |c| {
+        try testing.expectEqual(model.Status.added, c.status);
+        switch (c.class_id) {
+            4 => {
+                saw[0] = true;
+                // override 適用済み: Scale.y=2 が (1, 2, 1) に、Position は (0, 0, 0)。
+                var saw_scale = false;
+                var saw_pos = false;
+                for (c.fields) |f| {
+                    if (std.mem.eql(u8, f.path, "Scale")) {
+                        saw_scale = true;
+                        try testing.expectEqualStrings("(1, 2, 1)", f.after.?.scalar);
+                    }
+                    if (std.mem.eql(u8, f.path, "Position")) {
+                        saw_pos = true;
+                        try testing.expectEqualStrings("(0, 0, 0)", f.after.?.scalar);
+                    }
+                }
+                try testing.expect(saw_scale and saw_pos);
+            },
+            33 => saw[1] = true,
+            23 => saw[2] = true,
+            136 => saw[3] = true,
+            else => {},
+        }
+    }
+    for (saw) |s| try testing.expect(s);
+}
+
 // ---- prefab/scene 以外の UnityYAML アセット(.mat / .controller)----
 // core は拡張子を見ないので既に diff できる。ここはその保証を固定する回帰点。
 

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -1,0 +1,370 @@
+// PrefabInstance のソースプレハブ合成(親 spec: docs/superpowers/specs/2026-07-06-prefab-source-resolution-design.md)。
+// 合成 = ソースを parse -> m_Modifications を Document に適用 -> 既存の片側
+// compute + tree.build を再利用 -> instance ノードへ接ぎ木。core は I/O を持たず、
+// ホストが guid -> bytes(Assets)を供給する。供給が無い guid は needed_sources に載る。
+const std = @import("std");
+const model = @import("model.zig");
+const parser = @import("parser.zig");
+const diffmod = @import("diff.zig");
+const tree = @import("tree.zig");
+
+pub const Assets = std.StringHashMapUnmanaged([]const u8);
+
+// 入れ子展開の深さ上限(tree.zig の max_instance_hops と同じ思想)。
+const max_depth = 8;
+
+const Ctx = struct {
+    arena: std.mem.Allocator,
+    assets: *const Assets,
+    // 供給が必要な guid -> side(初出順を保ち decisions を決定的にする)。
+    needed: std.StringArrayHashMapUnmanaged(model.SourceSide) = .empty,
+    // 参照済み guid の全体集合(unresolvedGuids へのマージ用、初出順)。
+    guids: std.StringArrayHashMapUnmanaged(void) = .empty,
+    // 祖先チェーンの guid(循環ガード)。兄弟同士での同一ソース再利用は許す。
+    chain: std.ArrayList([]const u8) = .empty,
+};
+
+pub fn expand(arena: std.mem.Allocator, res: *model.DiffResult, fd: diffmod.FlatDiff, assets: *const Assets) !void {
+    var ctx = Ctx{ .arena = arena, .assets = assets };
+    // ソース由来の外部参照(script/material 等)もホスト解決の対象に
+    // 含めるため、トップレベルの unresolvedGuids へマージしていく。
+    for (res.unresolved_guids) |g| try ctx.guids.put(arena, g, {});
+
+    var docs = std.AutoHashMap(i64, *model.Document).init(arena);
+    // sole-status instance の生 doc(m_Modifications 読取り用)。added は after、
+    // removed は before 側にしか存在しないので、両方入れれば片側が引ける。
+    for (fd.before) |*d| try docs.put(d.file_id, d);
+    for (fd.after) |*d| try docs.put(d.file_id, d);
+
+    for (res.roots) |*node| try expandNode(&ctx, node, &docs, 0);
+
+    res.unresolved_guids = ctx.guids.keys();
+    res.needed_sources = try neededSlice(&ctx);
+}
+
+fn neededSlice(ctx: *Ctx) ![]model.NeededSource {
+    var out: std.ArrayList(model.NeededSource) = .empty;
+    var it = ctx.needed.iterator();
+    while (it.next()) |e| try out.append(ctx.arena, .{ .guid = e.key_ptr.*, .side = e.value_ptr.* });
+    return out.toOwnedSlice(ctx.arena);
+}
+
+fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *model.Document), depth: usize) !void {
+    for (node.children) |*child| try expandNode(ctx, child, docs, depth);
+    if (node.kind != .prefab_instance) return;
+    if (node.status != .added and node.status != .removed) return;
+    const guid = node.source_guid orelse return;
+    if (depth >= max_depth or inChain(ctx, guid)) return;
+    const side: model.SourceSide = if (node.status == .added) .after else .before;
+    const bytes = ctx.assets.get(guid) orelse {
+        try ctx.needed.put(ctx.arena, guid, side);
+        return;
+    };
+    const inst_doc = docs.get(node.file_id) orelse return;
+
+    // ソースを parse し、この instance の m_RemovedComponents / m_Modifications を適用。
+    const src_docs = try parser.parse(ctx.arena, bytes);
+    applyRemovedComponents(inst_doc, src_docs);
+    applyModifications(inst_doc, src_docs, guid);
+
+    // 片側 diff として全列挙し、既存パイプラインで ObjectDiff 化する。
+    const none = try parser.parse(ctx.arena, "");
+    const sub_fd = if (node.status == .added)
+        try diffmod.computeParsed(ctx.arena, none, src_docs)
+    else
+        try diffmod.computeParsed(ctx.arena, src_docs, none);
+    const sub = try tree.build(ctx.arena, sub_fd);
+    for (sub_fd.unresolved_guids) |g| try ctx.guids.put(ctx.arena, g, {});
+
+    // 入れ子 instance を再帰展開(祖先チェーンに自分の guid を積む)。
+    try ctx.chain.append(ctx.arena, guid);
+    defer _ = ctx.chain.pop();
+    var sub_docs = std.AutoHashMap(i64, *model.Document).init(ctx.arena);
+    for (sub_fd.before) |*d| try sub_docs.put(d.file_id, d);
+    for (sub_fd.after) |*d| try sub_docs.put(d.file_id, d);
+    for (sub.roots) |*r| try expandNode(ctx, r, &sub_docs, depth + 1);
+
+    // 接ぎ木: 単一 GameObject root ならその中身を instance ノードへ持ち上げる
+    // (Unity の hierarchy 表示と同じ: instance = ソース root の合成)。
+    if (sub.roots.len == 1 and sub.roots[0].kind == .game_object) {
+        node.components = try concatComponents(ctx.arena, node.components, sub.roots[0].components, sub.loose);
+        node.children = try concatObjects(ctx.arena, node.children, sub.roots[0].children);
+    } else {
+        node.components = try concatComponents(ctx.arena, node.components, &.{}, sub.loose);
+        node.children = try concatObjects(ctx.arena, node.children, sub.roots);
+    }
+    node.overrides = &.{}; // 合成値に反映済み
+}
+
+fn inChain(ctx: *Ctx, guid: []const u8) bool {
+    for (ctx.chain.items) |g| if (std.mem.eql(u8, g, guid)) return true;
+    return false;
+}
+
+fn concatComponents(arena: std.mem.Allocator, a: []model.ComponentDiff, b: []model.ComponentDiff, c: []model.ComponentDiff) ![]model.ComponentDiff {
+    var out: std.ArrayList(model.ComponentDiff) = .empty;
+    try out.appendSlice(arena, a);
+    try out.appendSlice(arena, b);
+    try out.appendSlice(arena, c);
+    return out.toOwnedSlice(arena);
+}
+
+fn concatObjects(arena: std.mem.Allocator, a: []model.ObjectDiff, b: []model.ObjectDiff) ![]model.ObjectDiff {
+    var out: std.ArrayList(model.ObjectDiff) = .empty;
+    try out.appendSlice(arena, a);
+    try out.appendSlice(arena, b);
+    return out.toOwnedSlice(arena);
+}
+
+// m_RemovedComponents の参照先(ソース内 fileID)を stripped 扱いで落とす
+// (computeParsed が stripped doc を除外する)。
+fn applyRemovedComponents(inst_doc: *const model.Document, src_docs: []model.Document) void {
+    const m = model.findValue(inst_doc.body.map, "m_Modification") orelse return;
+    if (m.* != .map) return;
+    const list = model.findValue(m.map, "m_RemovedComponents") orelse return;
+    if (list.* != .seq) return;
+    for (list.seq) |item| {
+        if (item.* != .ref) continue;
+        for (src_docs) |*d| {
+            if (d.file_id == item.ref.file_id) d.stripped = true;
+        }
+    }
+}
+
+// m_Modifications をソース Document へ適用する。target.guid が source guid の
+// もののみ(入れ子ソースのオブジェクトを狙う override はスコープ外)。
+fn applyModifications(inst_doc: *const model.Document, src_docs: []model.Document, source_guid: []const u8) void {
+    const m = model.findValue(inst_doc.body.map, "m_Modification") orelse return;
+    if (m.* != .map) return;
+    const list = model.findValue(m.map, "m_Modifications") orelse return;
+    if (list.* != .seq) return;
+    for (list.seq) |item| {
+        if (item.* != .map) continue;
+        const pp = model.findValue(item.map, "propertyPath") orelse continue;
+        if (pp.* != .scalar) continue;
+        const target = model.findValue(item.map, "target") orelse continue;
+        if (target.* != .ref) continue;
+        const tguid = target.ref.guid orelse continue;
+        if (!std.mem.eql(u8, tguid, source_guid)) continue;
+        // objectReference が設定されていればそれ、なければ value(diff.zig の modValue と同じ規則)。
+        const value = objRefIfSet(model.findValue(item.map, "objectReference")) orelse
+            (model.findValue(item.map, "value") orelse continue);
+        for (src_docs) |*d| {
+            if (d.file_id != target.ref.file_id) continue;
+            setByPropertyPath(d.body, pp.scalar, value);
+            break;
+        }
+    }
+}
+
+fn objRefIfSet(n: ?*model.Node) ?*model.Node {
+    const node = n orelse return null;
+    return switch (node.*) {
+        .ref => |r| if (r.file_id != 0 or r.guid != null) node else null,
+        else => null,
+    };
+}
+
+// "m_LocalScale.y" / "m_Materials.Array.data[0]" 形式のパスで leaf を差し替える。
+// 途中が見つからない・型が合わないパスは黙って捨てる(表示合成なので安全側)。
+fn setByPropertyPath(body: *model.Node, path: []const u8, value: *model.Node) void {
+    var cur: *model.Node = body;
+    var it = std.mem.splitScalar(u8, path, '.');
+    var pending: ?[]const u8 = it.next();
+    while (pending) |seg| {
+        const next = it.next();
+        if (std.mem.eql(u8, seg, "Array")) {
+            pending = next;
+            continue; // Unity の仮想セグメント
+        }
+        if (std.mem.startsWith(u8, seg, "data[")) {
+            const close = std.mem.indexOfScalar(u8, seg, ']') orelse return;
+            const idx = std.fmt.parseInt(usize, seg["data[".len..close], 10) catch return;
+            if (cur.* != .seq or idx >= cur.seq.len) return;
+            if (next == null) {
+                cur.seq[idx] = value;
+                return;
+            }
+            cur = cur.seq[idx];
+            pending = next;
+            continue;
+        }
+        if (cur.* != .map) return;
+        var advanced = false;
+        for (cur.map) |*e| {
+            if (!std.mem.eql(u8, e.key, seg)) continue;
+            if (next == null) {
+                e.value = value;
+                return;
+            }
+            cur = e.value;
+            advanced = true;
+            break;
+        }
+        if (!advanced) return;
+        pending = next;
+    }
+}
+
+const testing = std.testing;
+const root = @import("root.zig");
+
+const test_source =
+    \\--- !u!1 &10
+    \\GameObject:
+    \\  m_Name: Cyl
+    \\  m_Component:
+    \\  - component: {fileID: 40}
+    \\--- !u!4 &40
+    \\Transform:
+    \\  m_GameObject: {fileID: 10}
+    \\  m_LocalScale: {x: 1, y: 1, z: 1}
+;
+
+const test_variant =
+    \\--- !u!1001 &1001
+    \\PrefabInstance:
+    \\  m_Modification:
+    \\    m_Modifications:
+    \\    - target: {fileID: 40, guid: srcguid, type: 3}
+    \\      propertyPath: m_LocalScale.y
+    \\      value: 2
+    \\    - target: {fileID: 10, guid: srcguid, type: 3}
+    \\      propertyPath: m_Name
+    \\      value: Cyl Variant
+    \\  m_SourcePrefab: {fileID: 100100000, guid: srcguid, type: 3}
+;
+
+test "instantiate: merged variant shows full source values with overrides applied" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var assets: Assets = .empty;
+    try assets.put(arena, "srcguid", test_source);
+    const res = try root.diffBytesWithAssets(arena, "", test_variant, &assets);
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    const inst = res.roots[0];
+    try testing.expectEqualStrings("Cyl Variant", inst.name);
+    // 展開成功: overrides は空、ソースの Transform が component として現れ、
+    // override 適用済みの Scale (1, 2, 1) を全列挙で持つ。
+    try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
+    try testing.expectEqual(@as(usize, 0), inst.overrides.len);
+    try testing.expectEqual(@as(usize, 1), inst.components.len);
+    const tr = inst.components[0];
+    try testing.expectEqual(@as(u32, 4), tr.class_id);
+    try testing.expectEqual(model.Status.added, tr.status);
+    try testing.expectEqual(@as(usize, 1), tr.fields.len);
+    try testing.expectEqualStrings("Scale", tr.fields[0].path);
+    try testing.expectEqualStrings("(1, 2, 1)", tr.fields[0].after.?.scalar);
+}
+
+test "instantiate: missing asset degrades and reports neededSources with side" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const empty: Assets = .empty;
+
+    // added 方向: 縮退表示(override 全列挙)のまま、side は after。
+    const added = try root.diffBytesWithAssets(arena, "", test_variant, &empty);
+    try testing.expectEqual(@as(usize, 1), added.needed_sources.len);
+    try testing.expectEqualStrings("srcguid", added.needed_sources[0].guid);
+    try testing.expectEqual(model.SourceSide.after, added.needed_sources[0].side);
+    try testing.expect(added.roots[0].overrides.len != 0);
+
+    // removed 方向: side は before。
+    const removed = try root.diffBytesWithAssets(arena, test_variant, "", &empty);
+    try testing.expectEqual(@as(usize, 1), removed.needed_sources.len);
+    try testing.expectEqual(model.SourceSide.before, removed.needed_sources[0].side);
+}
+
+test "instantiate: cyclic source reference terminates" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // ソース自身が同じ guid の PrefabInstance を含む(壊れたデータ)。
+    // 祖先チェーンの循環ガードで停止し、needed にも載らないことだけを確認する。
+    const cyclic_source =
+        \\--- !u!1001 &7
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications: []
+        \\  m_SourcePrefab: {fileID: 100100000, guid: loopguid, type: 3}
+    ;
+    const variant =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications: []
+        \\  m_SourcePrefab: {fileID: 100100000, guid: loopguid, type: 3}
+    ;
+    var assets: Assets = .empty;
+    try assets.put(arena, "loopguid", cyclic_source);
+    const res = try root.diffBytesWithAssets(arena, "", variant, &assets);
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
+}
+
+test "instantiate: removed components are dropped from the merged tree" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const source =
+        \\--- !u!1 &10
+        \\GameObject:
+        \\  m_Name: Cyl
+        \\  m_Component:
+        \\  - component: {fileID: 40}
+        \\  - component: {fileID: 50}
+        \\--- !u!4 &40
+        \\Transform:
+        \\  m_GameObject: {fileID: 10}
+        \\--- !u!65 &50
+        \\BoxCollider:
+        \\  m_GameObject: {fileID: 10}
+        \\  m_IsTrigger: 0
+    ;
+    const variant =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications: []
+        \\    m_RemovedComponents:
+        \\    - {fileID: 50, guid: srcguid, type: 3}
+        \\  m_SourcePrefab: {fileID: 100100000, guid: srcguid, type: 3}
+    ;
+    var assets: Assets = .empty;
+    try assets.put(arena, "srcguid", source);
+    const res = try root.diffBytesWithAssets(arena, "", variant, &assets);
+    const inst = res.roots[0];
+    // BoxCollider (fileID 50) は除去済み: Transform だけが残る。
+    for (inst.components) |c| try testing.expect(c.class_id != 65);
+}
+
+test "instantiate: setByPropertyPath handles nested and array paths" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const docs = try parser.parse(arena,
+        \\--- !u!23 &5
+        \\MeshRenderer:
+        \\  m_Materials:
+        \\  - {fileID: 2100000, guid: mat0, type: 2}
+        \\  - {fileID: 2100000, guid: mat1, type: 2}
+        \\  m_LocalScale: {x: 1, y: 1, z: 1}
+    );
+    var value = model.Node{ .scalar = "9" };
+
+    // ネストしたパス。
+    setByPropertyPath(docs[0].body, "m_LocalScale.y", &value);
+    const scale = model.findValue(docs[0].body.map, "m_LocalScale").?;
+    try testing.expectEqualStrings("9", model.findValue(scale.map, "y").?.scalar);
+
+    // Array.data[i] パス(leaf 差し替え)。
+    setByPropertyPath(docs[0].body, "m_Materials.Array.data[1]", &value);
+    const mats = model.findValue(docs[0].body.map, "m_Materials").?;
+    try testing.expectEqualStrings("9", mats.seq[1].scalar);
+
+    // 不在パスと範囲外 index は no-op(panic しない)。
+    setByPropertyPath(docs[0].body, "m_Missing.x", &value);
+    setByPropertyPath(docs[0].body, "m_Materials.Array.data[99]", &value);
+}

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -63,7 +63,9 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     const inst_doc = docs.get(node.file_id) orelse return;
 
     // ソースを parse し、この instance の m_RemovedComponents / m_Modifications を適用。
-    const src_docs = try parser.parse(ctx.arena, bytes);
+    // 壊れたソース資産で diff 全体を落とさない: parse 失敗はその instance だけ
+    // 縮退表示(override 列挙)のままにする。
+    const src_docs = parser.parse(ctx.arena, bytes) catch return;
     applyRemovedComponents(inst_doc, src_docs);
     applyModifications(inst_doc, src_docs, guid);
 
@@ -301,6 +303,26 @@ test "instantiate: cyclic source reference terminates" {
     try assets.put(arena, "loopguid", cyclic_source);
     const res = try root.diffBytesWithAssets(arena, "", variant, &assets);
     try testing.expectEqual(@as(usize, 1), res.roots.len);
+    try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
+}
+
+test "instantiate: unparseable source degrades to the override view" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // parser の max_nesting_depth(128)を確実に超える壊れたソース。
+    var hostile: std.ArrayList(u8) = .empty;
+    try hostile.appendSlice(arena, "--- !u!1 &1\nGameObject:\n");
+    for (1..200) |depth| {
+        try hostile.appendNTimes(arena, ' ', depth * 2);
+        try hostile.appendSlice(arena, "a:\n");
+    }
+    var assets: Assets = .empty;
+    try assets.put(arena, "srcguid", hostile.items);
+    // diff 全体は成功し、instance は縮退表示(override が残る)のまま。
+    const res = try root.diffBytesWithAssets(arena, "", test_variant, &assets);
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    try testing.expect(res.roots[0].overrides.len != 0);
     try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
 }
 

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -21,6 +21,18 @@ pub fn serialize(arena: std.mem.Allocator, res: model.DiffResult, resolved: ?*co
     }
     try w.writeByte(']');
 
+    // ホストに内容取得を求めるソースプレハブ。空なら省略(additive な拡張)。
+    if (res.needed_sources.len != 0) {
+        try w.writeAll(",\"neededSources\":[");
+        for (res.needed_sources, 0..) |ns, i| {
+            if (i != 0) try w.writeByte(',');
+            try w.writeAll("{\"guid\":");
+            try writeJsonString(w, ns.guid);
+            try w.print(",\"side\":\"{s}\"}}", .{@tagName(ns.side)});
+        }
+        try w.writeByte(']');
+    }
+
     if (resolved) |r| {
         // diff が実際に参照した guid だけに絞る(プロジェクト index 全体を
         // 出さない)。順序は unresolvedGuids と同じで決定的。
@@ -222,6 +234,31 @@ test "json: v2 prefab instance node with overrides" {
     try testing.expect(std.mem.indexOf(u8, out, "\"overrides\":[{\"group\":\"Transform\",\"label\":\"Scale.y\",\"status\":\"added\",\"before\":null,\"after\":\"2\"}]") != null);
 }
 
+test "json: needed sources are emitted only when unresolved" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const after =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 7, guid: aaa, type: 3}
+        \\      propertyPath: m_LocalScale.y
+        \\      value: 2
+        \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
+    ;
+    // assets 未供給: ホストへの取得要求として neededSources が載る。
+    const out = try root.diffToJson(arena, "", after);
+    try testing.expect(std.mem.indexOf(u8, out, "\"neededSources\":[{\"guid\":\"aaa\",\"side\":\"after\"}]") != null);
+
+    // 供給済み: 展開されて neededSources は emit されない(空なら省略)。
+    var assets: root.Assets = .empty;
+    try assets.put(arena, "aaa", "--- !u!1 &10\nGameObject:\n  m_Name: Src\n");
+    const merged = try root.diffToJsonWithAssets(arena, "", after, &assets);
+    try testing.expect(std.mem.indexOf(u8, merged, "neededSources") == null);
+}
+
 test "json: v2 root node shape matches golden" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -277,7 +314,7 @@ test "json: v2 root node shape matches golden" {
     // roots 側のノード全形状 (gameObject + components + 子 prefabInstance +
     // overrides + 構造サマリ) を byte-for-byte で固定する回帰ピン。
     const golden =
-        \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
+        \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"neededSources":[{"guid":"aaa","side":"after"}],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
     ;
     try testing.expectEqualStrings(golden, out);
 }

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -113,10 +113,16 @@ pub const ObjectDiff = struct {
     children: []ObjectDiff,
 };
 
+// ホストに内容の供給を求めるソースプレハブ。side は取得すべき ref
+// (added instance -> after/head、removed instance -> before/base)。
+pub const SourceSide = enum { before, after };
+pub const NeededSource = struct { guid: []const u8, side: SourceSide };
+
 pub const DiffResult = struct {
     roots: []ObjectDiff,
     loose: []ComponentDiff,
     unresolved_guids: [][]const u8,
+    needed_sources: []NeededSource = &.{},
 };
 
 test "Node.eql: scalars, refs, seqs, maps" {

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -7,14 +7,30 @@ pub const tree = @import("tree.zig");
 pub const json = @import("json.zig");
 pub const inspector = @import("inspector.zig");
 pub const perf = @import("perf.zig");
+pub const instantiate = @import("instantiate.zig");
+
+pub const Assets = instantiate.Assets;
+const no_assets: Assets = .empty;
 
 pub fn diffBytes(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8) !model.DiffResult {
+    return diffBytesWithAssets(arena, before_src, after_src, &no_assets);
+}
+
+// assets(guid -> ソース prefab bytes)を供給された sole-status instance は
+// 合成ツリーへ展開される。供給が無い guid は needed_sources に載る。
+pub fn diffBytesWithAssets(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8, assets: *const Assets) !model.DiffResult {
     const fd = try diff.compute(arena, before_src, after_src);
-    return tree.build(arena, fd);
+    var res = try tree.build(arena, fd);
+    try instantiate.expand(arena, &res, fd, assets);
+    return res;
 }
 
 pub fn diffToJson(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8) ![]u8 {
-    const res = try diffBytes(arena, before_src, after_src);
+    return diffToJsonWithAssets(arena, before_src, after_src, &no_assets);
+}
+
+pub fn diffToJsonWithAssets(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8, assets: *const Assets) ![]u8 {
+    const res = try diffBytesWithAssets(arena, before_src, after_src, assets);
     return json.serialize(arena, res, null);
 }
 

--- a/core/src/wasm.zig
+++ b/core/src/wasm.zig
@@ -23,14 +23,32 @@ export fn diff(
     after_ptr: ?[*]const u8,
     after_len: usize,
 ) ?[*]u8 {
-    const before: []const u8 = if (before_ptr) |p| p[0..before_len] else "";
-    const after: []const u8 = if (after_ptr) |p| p[0..after_len] else "";
+    return run(slice(before_ptr, before_len), slice(after_ptr, after_len), null);
+}
 
+// assets はバイナリ TLV(LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }。
+// JSON 文字列エスケープを避けるため、ソース prefab bytes はそのまま渡す。
+export fn diff_with_assets(
+    before_ptr: ?[*]const u8,
+    before_len: usize,
+    after_ptr: ?[*]const u8,
+    after_len: usize,
+    assets_ptr: ?[*]const u8,
+    assets_len: usize,
+) ?[*]u8 {
+    return run(slice(before_ptr, before_len), slice(after_ptr, after_len), slice(assets_ptr, assets_len));
+}
+
+fn slice(ptr: ?[*]const u8, len: usize) []const u8 {
+    return if (ptr) |p| p[0..len] else "";
+}
+
+fn run(before: []const u8, after: []const u8, assets_bytes: ?[]const u8) ?[*]u8 {
     var arena_state = std.heap.ArenaAllocator.init(gpa);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    const json = core.diffToJson(arena, before, after) catch |err| {
+    const json = computeJson(arena, before, after, assets_bytes) catch |err| {
         const msg = std.fmt.allocPrint(
             arena,
             "{{\"schema\":\"prefablens.error.v1\",\"error\":\"{s}\"}}",
@@ -39,6 +57,42 @@ export fn diff(
         return packResult(msg);
     };
     return packResult(json);
+}
+
+fn computeJson(arena: std.mem.Allocator, before: []const u8, after: []const u8, assets_bytes: ?[]const u8) ![]u8 {
+    const ab = assets_bytes orelse return core.diffToJson(arena, before, after);
+    var assets = try parseAssets(arena, ab);
+    return core.diffToJsonWithAssets(arena, before, after, &assets);
+}
+
+// 壊れた TLV は error を返し、error.v1 ペイロードに落ちる(trap しない)。
+fn parseAssets(arena: std.mem.Allocator, bytes: []const u8) !core.Assets {
+    var assets: core.Assets = .empty;
+    if (bytes.len == 0) return assets;
+    var off: usize = 0;
+    const count = try readU32(bytes, &off);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const guid = try readChunk(bytes, &off);
+        const data = try readChunk(bytes, &off);
+        try assets.put(arena, guid, data);
+    }
+    return assets;
+}
+
+fn readU32(bytes: []const u8, off: *usize) !u32 {
+    if (bytes.len - off.* < 4) return error.TruncatedAssets;
+    const v = std.mem.readInt(u32, bytes[off.*..][0..4], .little);
+    off.* += 4;
+    return v;
+}
+
+fn readChunk(bytes: []const u8, off: *usize) ![]const u8 {
+    const len = try readU32(bytes, off);
+    if (bytes.len - off.* < len) return error.TruncatedAssets;
+    const s = bytes[off.*..][0..len];
+    off.* += len;
+    return s;
 }
 
 // arena の外(呼び出し側所有)へコピーして長さ前置する。

--- a/core/tests/wasm_golden.test.mjs
+++ b/core/tests/wasm_golden.test.mjs
@@ -58,3 +58,95 @@ test('hostile nesting returns a clean error.v1 payload, not a trap', () => {
 test('repeated calls do not leak or corrupt state (pure, re-entrant)', () => {
   for (let i = 0; i < 50; i++) assert.equal(callDiff(BEFORE, AFTER), GOLDEN);
 });
+
+// ---- diff_with_assets(ソース prefab の合成)----
+
+// assets TLV(LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }
+function buildAssetsTlv(entries) {
+  const enc = new TextEncoder();
+  const parts = [];
+  const push32 = (n) => {
+    const b = new Uint8Array(4);
+    new DataView(b.buffer).setUint32(0, n, true);
+    parts.push(b);
+  };
+  const list = Object.entries(entries);
+  push32(list.length);
+  for (const [guid, data] of list) {
+    for (const chunk of [enc.encode(guid), enc.encode(data)]) {
+      push32(chunk.length);
+      parts.push(chunk);
+    }
+  }
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+function callDiffWithAssets(before, after, assetsTlv) {
+  const enc = new TextEncoder();
+  const b = enc.encode(before);
+  const a = enc.encode(after);
+  const t = assetsTlv;
+  const bp = b.length ? exports.alloc(b.length) : 0;
+  const ap = a.length ? exports.alloc(a.length) : 0;
+  const tp = t.length ? exports.alloc(t.length) : 0;
+  // ビューは最後の alloc の後に作る: memory.grow で古い ArrayBuffer は detach される
+  new Uint8Array(exports.memory.buffer, bp, b.length).set(b);
+  new Uint8Array(exports.memory.buffer, ap, a.length).set(a);
+  new Uint8Array(exports.memory.buffer, tp, t.length).set(t);
+  const rp = exports.diff_with_assets(bp, b.length, ap, a.length, tp, t.length);
+  assert.notEqual(rp, 0, 'diff_with_assets returned null (OOM)');
+  const len = new DataView(exports.memory.buffer).getUint32(rp, true);
+  const json = new TextDecoder().decode(new Uint8Array(exports.memory.buffer, rp + 4, len));
+  exports.free(rp, 4 + len);
+  if (b.length) exports.free(bp, b.length);
+  if (a.length) exports.free(ap, a.length);
+  if (t.length) exports.free(tp, t.length);
+  return json;
+}
+
+const VARIANT = `--- !u!1001 &1001
+PrefabInstance:
+  m_Modification:
+    m_Modifications:
+    - target: {fileID: 40, guid: srcguid, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
+  m_SourcePrefab: {fileID: 100100000, guid: srcguid, type: 3}`;
+
+const SOURCE = `--- !u!1 &10
+GameObject:
+  m_Name: Cyl
+  m_Component:
+  - component: {fileID: 40}
+--- !u!4 &40
+Transform:
+  m_GameObject: {fileID: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}`;
+
+test('added instance without assets reports neededSources', () => {
+  const json = JSON.parse(callDiff('', VARIANT));
+  assert.deepEqual(json.neededSources, [{ guid: 'srcguid', side: 'after' }]);
+});
+
+test('diff_with_assets merges the source prefab', () => {
+  const json = JSON.parse(callDiffWithAssets('', VARIANT, buildAssetsTlv({ srcguid: SOURCE })));
+  assert.equal(json.neededSources, undefined);
+  const inst = json.roots[0];
+  assert.equal(inst.kind, 'prefabInstance');
+  assert.deepEqual(inst.overrides, []);
+  const tr = inst.components.find((c) => c.classId === 4);
+  const scale = tr.fields.find((f) => f.path === 'Scale');
+  assert.equal(scale.after, '(1, 2, 1)');
+});
+
+test('broken assets TLV yields a clean error.v1 payload', () => {
+  const json = JSON.parse(callDiffWithAssets('', VARIANT, new Uint8Array([1, 0, 0, 0, 9])));
+  assert.equal(json.schema, 'prefablens.error.v1');
+  assert.equal(json.error, 'TruncatedAssets');
+});


### PR DESCRIPTION
## 概要

親スペック(prefab source resolution)の PR 2 / 3。#40 の縮退パスの上に、ソースプレハブ合成を core に実装する。追加/削除された PrefabInstance は、ホストが供給したソースプレハブ bytes に `m_Modifications` を適用した合成状態(= Inspector と同じ)で全列挙表示される。

## 変更点

- **`core/src/instantiate.zig`(新規)**: ソースを parse → `m_Modifications` / `m_RemovedComponents` を Document に適用 → 既存の片側 `computeParsed` + `tree.build` を再利用して instance ノードへ接ぎ木。新規レンダリングロジックなし。深さ上限 8・祖先チェーンの循環ガード・壊れたソースは縮退表示に隔離。
- **`diffBytesWithAssets` / `diffToJsonWithAssets`**: assets(guid → bytes)を受ける API。`diffBytes` は空 assets への委譲。
- **`neededSources`**: 未供給の sole-status instance のソース guid を `{guid, side}` で JSON 出力(空なら省略 = additive、schema は diff.v2 のまま)。side は added → after / removed → before。
- **WASM**: `diff_with_assets` export(assets はバイナリ TLV `[u32 count]{[u32 glen][guid][u32 dlen][data]}`)。壊れた TLV は error.v1。
- **CLI**: `--project` 指定時、needed_sources をローカル .meta 索引で解決して最大 3 周の再 diff。読めない資産はスキップ。

## 表示例(E2E 実行結果、要望の Scale.x=1 が出る)

```
+ Cylinder Variant  <Prefab>
    components
      + Transform
        + Rotation: (0, 0, 0, 1)
        + Position: (0, 0, 0)
        + Scale: (1, 2, 1)
      + MeshFilter
      + MeshRenderer (全プロパティ)
      + CapsuleCollider (全プロパティ)
      + Cylinder1 (script)
```

## テスト

- zig build test: 145/145(instantiate 6 + json 1 + cli 1 を新規追加)
- zig build perf: 156 ms / 上限 600 ms
- wasm golden: 7/7(TLV 合成・neededSources・壊れ TLV の 3 本追加)
- extension: typecheck / 85 tests / build すべて成功(既存 JSON への影響なし)

## 備考 / スコープ外

- extension の二段 diff(GitHub からのソース取得)は PR 3
- editor(Cli.cs)は `--project` を渡していないため自動追随しない(別途判断)
- 入れ子ソースのオブジェクトを直接狙う override の適用はスコープ外(コメントに明記)