### PR TITLE
feat: fetch source prefabs in the extension

### DIFF
--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -12,6 +12,7 @@ function makeDeps(overrides?: {
   files?: PrFile[];
   contents?: Record<string, string>; // `${path}@${ref}` → text
   diff?: Differ['diff'];
+  diffWithAssets?: Differ['diffWithAssets'];
   pat?: string | undefined;
   search?: Record<string, string | null>; // guid → asset path(null = 未ヒット)
   cached?: Record<string, string>; // guidCache の初期内容
@@ -28,7 +29,10 @@ function makeDeps(overrides?: {
     getFileAtRef,
     searchMetaByGuid: vi.fn(async (_o: string, _r: string, guid: string) => overrides?.search?.[guid] ?? null),
   };
-  const differ: Differ = { diff: overrides?.diff ?? vi.fn(() => DIFF) };
+  const differ: Differ = {
+    diff: overrides?.diff ?? vi.fn(() => DIFF),
+    diffWithAssets: overrides?.diffWithAssets ?? vi.fn(() => DIFF),
+  };
   const cacheData: Record<string, Record<string, string>> = {};
   if (overrides?.cached) cacheData['https://api.github.com/o/r'] = { ...overrides.cached };
   const guidCache = {
@@ -290,5 +294,79 @@ describe('createHandler', () => {
     const limited = makeDeps();
     limited.client.getPrRefs.mockRejectedValue(new RateLimitError('x'));
     expect(await createHandler(limited.deps)(REQ)).toEqual({ ok: false, error: 'rate-limited' });
+  });
+
+  describe('source prefab merging', () => {
+    // phase 1 がソース供給を要求する diff。src1 のパスは Code Search で解決される。
+    const NEEDS: DiffV2 = {
+      ...DIFF,
+      unresolvedGuids: ['src1'],
+      neededSources: [{ guid: 'src1', side: 'after' }],
+    };
+    const MERGED: DiffV2 = { schema: 'prefablens.diff.v2', unresolvedGuids: ['src1'], roots: [], loose: [] };
+
+    it('fetches the resolved source at head and re-diffs with assets', async () => {
+      const diffWithAssets = vi.fn<Differ['diffWithAssets']>(() => MERGED);
+      const { deps, client } = makeDeps({
+        diff: () => NEEDS,
+        diffWithAssets,
+        search: { src1: 'Assets/Cyl.prefab' },
+        contents: {
+          'Assets/Foo.prefab@base-sha': 'b',
+          'Assets/Foo.prefab@head-sha': 'a',
+          'Assets/Cyl.prefab@head-sha': 'SRC',
+        },
+      });
+      const res = await createHandler(deps)(REQ);
+      // side=after なので head からソースを取り、その bytes が assets に載る。
+      expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Cyl.prefab', 'head-sha');
+      const assets = diffWithAssets.mock.calls[0]![2];
+      expect(new TextDecoder().decode(assets.get('src1')!)).toBe('SRC');
+      // 再 diff 後も resolved は guidCache から復元されて残る。
+      expect(res).toEqual({ ok: true, json: { ...MERGED, resolved: { src1: 'Assets/Cyl.prefab' } } });
+    });
+
+    it('fetches removed-instance sources from the base side', async () => {
+      const diffWithAssets = vi.fn<Differ['diffWithAssets']>(() => MERGED);
+      const { deps, client } = makeDeps({
+        diff: () => ({ ...NEEDS, neededSources: [{ guid: 'src1', side: 'before' }] }),
+        diffWithAssets,
+        search: { src1: 'Assets/Cyl.prefab' },
+        contents: {
+          'Assets/Foo.prefab@base-sha': 'b',
+          'Assets/Foo.prefab@head-sha': 'a',
+          'Assets/Cyl.prefab@base-sha': 'OLD',
+        },
+      });
+      await createHandler(deps)(REQ);
+      expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Cyl.prefab', 'base-sha');
+    });
+
+    it('keeps the phase-1 diff when the source path cannot be resolved', async () => {
+      const diffWithAssets = vi.fn<Differ['diffWithAssets']>(() => MERGED);
+      const { deps } = makeDeps({ diff: () => NEEDS, diffWithAssets }); // search 未ヒット
+      const res = await createHandler(deps)(REQ);
+      // パス不明のソースは諦め、縮退表示(phase 1 の json)のまま返す。
+      expect(diffWithAssets).not.toHaveBeenCalled();
+      expect(res).toEqual({ ok: true, json: { ...NEEDS, resolved: {} } });
+    });
+
+    it('does not loop when the merged output still needs the same source', async () => {
+      // 供給しても縮退したまま(壊れたソース等)の場合、同じ guid で無限に回らない。
+      const diffWithAssets = vi.fn<Differ['diffWithAssets']>(() => NEEDS);
+      const { deps } = makeDeps({
+        diff: () => NEEDS,
+        diffWithAssets,
+        search: { src1: 'Assets/Cyl.prefab' },
+        contents: {
+          'Assets/Foo.prefab@base-sha': 'b',
+          'Assets/Foo.prefab@head-sha': 'a',
+          'Assets/Cyl.prefab@head-sha': 'SRC',
+        },
+      });
+      const res = await createHandler(deps)(REQ);
+      expect(diffWithAssets).toHaveBeenCalledTimes(1);
+      expect(res.ok).toBe(true);
+    });
   });
 });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -16,6 +16,7 @@ type PrContext = { refs: PrRefs; files: PrFile[]; guidIndex: Map<string, string>
 
 const EMPTY = new Uint8Array(0);
 const MAX_SEARCHES = 10; // Code Search は認証済み 10 req/min — 1 応答で使い切らない
+const MAX_SOURCE_ROUNDS = 3; // 入れ子ソースの再 diff 上限(core 側の深さ上限 8 とは独立)
 const CONTEXT_TTL_MS = 60_000; // push で headSha が変わるため PR コンテキストは短命
 const BLOB_CACHE_MAX = 32;
 const TOO_LARGE_BYTES = 25 * 1024 * 1024; // 親仕様 §5.7: 25MB 超はクリックで描画
@@ -66,6 +67,54 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
     return bytes;
   }
 
+  /** neededSources(added/removed instance のソース prefab)を resolved パス経由で
+   *  取得し、assets を添えて再 diff する。ソース guid は m_SourcePrefab 参照として
+   *  unresolvedGuids に載るため、パス解決は searchUnresolved が済ませている。
+   *  解決・取得・合成の失敗はその時点の diff で縮退する(全体は落とさない)。 */
+  async function mergeSources(
+    first: DiffV2,
+    differ: Differ,
+    before: Uint8Array,
+    after: Uint8Array,
+    ctx: PrContext,
+    client: ClientLike,
+    owner: string,
+    repo: string,
+    repoKey: string,
+  ): Promise<DiffV2> {
+    const assets = new Map<string, Uint8Array>();
+    let current = first;
+    for (let round = 0; round < MAX_SOURCE_ROUNDS; round++) {
+      const needed = (current.neededSources ?? []).filter((s) => !assets.has(s.guid));
+      if (!needed.length) break;
+      let progressed = false;
+      for (const s of needed) {
+        const path = current.resolved?.[s.guid];
+        if (path === undefined) continue;
+        const sha = s.side === 'before' ? ctx.refs.baseSha : ctx.refs.headSha;
+        let bytes: Uint8Array | null = null;
+        try {
+          bytes = await fetchBlob(client, owner, repo, path, sha);
+        } catch {
+          return current; // rate limit 等: phase 1 の結果で縮退表示
+        }
+        if (!bytes) continue;
+        assets.set(s.guid, bytes);
+        progressed = true;
+      }
+      if (!progressed) break;
+      let merged: DiffV2;
+      try {
+        merged = differ.diffWithAssets(before, after, assets);
+      } catch {
+        return current; // 合成失敗はその時点の結果で縮退
+      }
+      // 合成でソース内の外部参照(script/material)が新たに現れるので解決し直す。
+      current = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
+    }
+    return current;
+  }
+
   function loadContext(client: ClientLike, owner: string, repo: string, prNumber: number): Promise<PrContext> {
     const key = `${owner}/${repo}#${prNumber}`;
     const entry = contexts.get(key);
@@ -111,9 +160,12 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
       }
 
       const differ = await deps.getDiffer();
+      const repoKey = `${base}/${req.owner}/${req.repo}`;
       const json = differ.diff(before, after);
       const withPr = applyResolved(json, guidIndex);
-      return { ok: true, json: await searchUnresolved(withPr, client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`) };
+      const first = await searchUnresolved(withPr, client, req.owner, req.repo, repoKey);
+      const ctx = { refs, files, guidIndex };
+      return { ok: true, json: await mergeSources(first, differ, before, after, ctx, client, req.owner, req.repo, repoKey) };
     } catch (err) {
       if (err instanceof RateLimitError) return { ok: false, error: 'rate-limited' };
       if (err instanceof AuthError) return { ok: false, error: 'auth-failed' };

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -47,9 +47,14 @@ export type PrefabInstanceDiff = {
 
 export type NodeDiff = GameObjectDiff | PrefabInstanceDiff;
 
+// core が内容の供給を求めるソースプレハブ。side は取得すべき ref
+// (added instance -> after/head、removed instance -> before/base)。
+export type NeededSource = { guid: string; side: 'before' | 'after' };
+
 export type DiffV2 = {
   schema: 'prefablens.diff.v2';
   unresolvedGuids: string[];
+  neededSources?: NeededSource[]; // 空なら省略される(additive)
   resolved?: Record<string, string>; // ホスト側(applyResolved)が付与
   roots: NodeDiff[];
   loose: ComponentDiff[];

--- a/extension/src/wasm/differ.test.ts
+++ b/extension/src/wasm/differ.test.ts
@@ -42,4 +42,38 @@ describe('createDiffer', () => {
   it('is re-entrant across many calls', () => {
     for (let i = 0; i < 50; i++) expect(differ.diff(BEFORE, AFTER).schema).toBe('prefablens.diff.v2');
   });
+
+  it('diffWithAssets merges a source prefab into the instance node', () => {
+    const variant = enc.encode(`--- !u!1001 &1001
+PrefabInstance:
+  m_Modification:
+    m_Modifications:
+    - target: {fileID: 40, guid: srcguid, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2
+  m_SourcePrefab: {fileID: 100100000, guid: srcguid, type: 3}`);
+    const source = enc.encode(`--- !u!1 &10
+GameObject:
+  m_Name: Cyl
+  m_Component:
+  - component: {fileID: 40}
+--- !u!4 &40
+Transform:
+  m_GameObject: {fileID: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}`);
+
+    // assets なし: core が供給を要求する。
+    const first = differ.diff(new Uint8Array(0), variant);
+    expect(first.neededSources).toEqual([{ guid: 'srcguid', side: 'after' }]);
+
+    // assets あり: 合成されて neededSources は消え、override 適用済みの全列挙になる。
+    const merged = differ.diffWithAssets(new Uint8Array(0), variant, new Map([['srcguid', source]]));
+    expect(merged.neededSources).toBeUndefined();
+    const inst = merged.roots[0]!;
+    expect(inst.kind).toBe('prefabInstance');
+    if (inst.kind !== 'prefabInstance') return;
+    expect(inst.overrides).toEqual([]);
+    const scale = inst.components[0]!.fields.find((f) => f.path === 'Scale');
+    expect(scale?.after).toBe('(1, 2, 1)');
+  });
 });

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -2,39 +2,75 @@ import type { DiffErrorV1, DiffV2 } from '../types';
 
 export class DiffError extends Error {}
 
-export type Differ = { diff(before: Uint8Array, after: Uint8Array): DiffV2 };
+export type Differ = {
+  diff(before: Uint8Array, after: Uint8Array): DiffV2;
+  diffWithAssets(before: Uint8Array, after: Uint8Array, assets: Map<string, Uint8Array>): DiffV2;
+};
 
 type Exports = {
   memory: WebAssembly.Memory;
   alloc(len: number): number;
   free(ptr: number, len: number): void;
   diff(bp: number, bl: number, ap: number, al: number): number;
+  diff_with_assets(bp: number, bl: number, ap: number, al: number, tp: number, tl: number): number;
 };
+
+/** assets TLV(LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }。
+ *  core/src/wasm.zig の parseAssets と 1:1。 */
+export function encodeAssets(assets: Map<string, Uint8Array>): Uint8Array {
+  const enc = new TextEncoder();
+  const guids = [...assets.keys()].map((g) => enc.encode(g));
+  let total = 4;
+  let i = 0;
+  for (const data of assets.values()) total += 8 + guids[i++]!.length + data.length;
+  const out = new Uint8Array(total);
+  const view = new DataView(out.buffer);
+  let off = 0;
+  view.setUint32(off, assets.size, true);
+  off += 4;
+  i = 0;
+  for (const data of assets.values()) {
+    const guid = guids[i++]!;
+    view.setUint32(off, guid.length, true);
+    out.set(guid, off + 4);
+    off += 4 + guid.length;
+    view.setUint32(off, data.length, true);
+    out.set(data, off + 4);
+    off += 4 + data.length;
+  }
+  return out;
+}
 
 export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
   const { instance } = await WebAssembly.instantiate(wasmBytes);
   const exp = instance.exports as unknown as Exports;
 
+  function call(before: Uint8Array, after: Uint8Array, assets?: Uint8Array): DiffV2 {
+    const bufs = assets === undefined ? [before, after] : [before, after, assets];
+    const ptrs = bufs.map((b) => (b.length ? exp.alloc(b.length) : 0));
+    // コピーは最後の alloc の後: memory.grow で古いビューは detach される
+    bufs.forEach((b, i) => new Uint8Array(exp.memory.buffer, ptrs[i]!, b.length).set(b));
+    const rp =
+      assets === undefined
+        ? exp.diff(ptrs[0]!, before.length, ptrs[1]!, after.length)
+        : exp.diff_with_assets(ptrs[0]!, before.length, ptrs[1]!, after.length, ptrs[2]!, assets.length);
+    try {
+      if (rp === 0) throw new DiffError('OutOfMemory');
+      const len = new DataView(exp.memory.buffer).getUint32(rp, true);
+      const text = new TextDecoder().decode(new Uint8Array(exp.memory.buffer, rp + 4, len));
+      exp.free(rp, 4 + len);
+      const parsed = JSON.parse(text) as DiffV2 | DiffErrorV1;
+      if (parsed.schema !== 'prefablens.diff.v2') throw new DiffError((parsed as DiffErrorV1).error);
+      return parsed;
+    } finally {
+      bufs.forEach((b, i) => {
+        if (b.length) exp.free(ptrs[i]!, b.length);
+      });
+    }
+  }
+
   return {
-    diff(before, after) {
-      const bp = before.length ? exp.alloc(before.length) : 0;
-      const ap = after.length ? exp.alloc(after.length) : 0;
-      // コピーは最後の alloc の後: memory.grow で古いビューは detach される
-      new Uint8Array(exp.memory.buffer, bp, before.length).set(before);
-      new Uint8Array(exp.memory.buffer, ap, after.length).set(after);
-      const rp = exp.diff(bp, before.length, ap, after.length);
-      try {
-        if (rp === 0) throw new DiffError('OutOfMemory');
-        const len = new DataView(exp.memory.buffer).getUint32(rp, true);
-        const text = new TextDecoder().decode(new Uint8Array(exp.memory.buffer, rp + 4, len));
-        exp.free(rp, 4 + len);
-        const parsed = JSON.parse(text) as DiffV2 | DiffErrorV1;
-        if (parsed.schema !== 'prefablens.diff.v2') throw new DiffError((parsed as DiffErrorV1).error);
-        return parsed;
-      } finally {
-        if (before.length) exp.free(bp, before.length);
-        if (after.length) exp.free(ap, after.length);
-      }
-    },
+    diff: (before, after) => call(before, after),
+    diffWithAssets: (before, after, assets) => call(before, after, encodeAssets(assets)),
   };
 }


### PR DESCRIPTION
## 概要

親スペック(prefab source resolution)の PR 3 / 3(最終)。#41 の core 合成を extension から使う。PR ページ上の追加/削除された PrefabInstance が、ソースプレハブ取得後に Inspector と同じ合成状態(`Scale (1, 2, 1)` + ソースの全コンポーネント)で描画される。

## 変更点

- **`differ.ts`**: `diffWithAssets(before, after, assets)` を追加(TLV encode → `diff_with_assets` export 呼び出し)。`diff` と共通の呼び出し・デコード経路に整理。
- **`handler.ts`**: 二段 diff ループ `mergeSources`(最大 3 周)。ソース guid は `m_SourcePrefab` 参照として unresolvedGuids に載るため、パス解決は既存の PR 内 .meta 索引 → GuidCache → Code Search がそのまま担う。内容取得は既存 `fetchBlob`(side: added → headSha / removed → baseSha)。解決・取得・合成の失敗はその時点の diff で縮退し、全体は落とさない。
- **`types.ts`**: `DiffV2.neededSources?` を追加。
- レンダラ変更なし(合成ツリーは通常の components / children として描画される)。

## テスト

- extension: 90/90(differ の実 WASM 合成テスト 1 本 + handler の二段 diff テスト 4 本を追加)、typecheck / build 成功
- core: 145/145、wasm golden 7/7(変更なし、リグレッション確認のみ)

## 動作確認手順(マージ後)

unity-yaml-playground#1 の `Cylinder Variant.prefab` で、Transform が `Scale (1, 2, 1)` を含む全列挙になり、MeshRenderer 等ソース由来のコンポーネントが表示される(ソース .meta が Code Search で解決できることが前提。未解決時は #40 の縮退表示)。