### PR TITLE
feat: semantic default view with global toggle

### DIFF
--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -1,8 +1,32 @@
 /// <reference types="node" />
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 
 const fixture = readFileSync(new URL('./fixtures/pr-files.html', import.meta.url), 'utf8');
+
+// content script は起動時に chrome.storage.local から viewMode を読む。
+// スタブに storage が無いと init が落ちて全テストが壊れるため、必ず与える。
+function stubChrome(page: Page, res: unknown, viewMode?: string) {
+  return page.addInitScript(
+    ({ res, viewMode }) => {
+      (window as unknown as Record<string, unknown>)['chrome'] = {
+        runtime: {
+          sendMessage: (msg: { type?: string }) =>
+            msg?.type === 'semanticDiff' ? Promise.resolve(res) : Promise.resolve(),
+          onMessage: { addListener: () => {} },
+        },
+        storage: {
+          local: {
+            get: () => Promise.resolve(viewMode ? { viewMode } : {}),
+            set: () => Promise.resolve(),
+          },
+          onChanged: { addListener: () => {} },
+        },
+      };
+    },
+    { res, viewMode },
+  );
+}
 
 const cannedResponse = {
   ok: true,
@@ -30,11 +54,7 @@ test('detects a Unity file, toggles to Semantic, renders the tree', async ({ pag
   // content script は URL(/pull/N/files)を見る: フィクスチャを PR の URL で返す
   await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
   // background を固定応答でスタブ(この面の本物は handler.test.ts が担保)
-  await page.addInitScript((res) => {
-    (window as unknown as Record<string, unknown>)['chrome'] = {
-      runtime: { sendMessage: () => Promise.resolve(res) },
-    };
-  }, cannedResponse);
+  await stubChrome(page, cannedResponse);
 
   await page.goto('https://prefablens.test/owner/repo/pull/1/files');
   await page.addScriptTag({ path: 'dist/content.js' });
@@ -60,11 +80,7 @@ test('detects a Unity file, toggles to Semantic, renders the tree', async ({ pag
 
 test('attaches toggles to files added after the initial scan (SPA lazy loading)', async ({ page }) => {
   await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
-  await page.addInitScript((res) => {
-    (window as unknown as Record<string, unknown>)['chrome'] = {
-      runtime: { sendMessage: () => Promise.resolve(res) },
-    };
-  }, cannedResponse);
+  await stubChrome(page, cannedResponse);
 
   await page.goto('https://prefablens.test/owner/repo/pull/1/files');
   await page.addScriptTag({ path: 'dist/content.js' });
@@ -84,6 +100,7 @@ test('attaches toggles to files added after the initial scan (SPA lazy loading)'
 test('recovers after an error response', async ({ page }) => {
   await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
   // 1回目は pat-missing エラー、2回目以降は正常応答を返す(エラーはキャッシュされず再フェッチされることを確認)
+  // カウンタ用に専用スタブを使うが、init が落ちないよう storage/onMessage は stubChrome と同じ形にする
   await page.addInitScript((res) => {
     (window as unknown as Record<string, unknown>)['__prefablensCalls'] = 0;
     (window as unknown as Record<string, unknown>)['chrome'] = {
@@ -94,6 +111,14 @@ test('recovers after an error response', async ({ page }) => {
           w['__prefablensCalls'] = call + 1;
           return Promise.resolve(call === 0 ? { ok: false, error: 'pat-missing' } : res);
         },
+        onMessage: { addListener: () => {} },
+      },
+      storage: {
+        local: {
+          get: () => Promise.resolve({}),
+          set: () => Promise.resolve(),
+        },
+        onChanged: { addListener: () => {} },
       },
     };
   }, cannedResponse);
@@ -112,4 +137,54 @@ test('recovers after an error response', async ({ page }) => {
   await unityHeader.getByRole('button', { name: 'Raw' }).click();
   await unityHeader.getByRole('button', { name: 'Semantic' }).click();
   await expect(view).toContainText('MonoBehaviour');
+});
+
+test('applies the persisted semantic default to every unity file and late additions', async ({ page }) => {
+  await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
+  await stubChrome(page, cannedResponse, 'semantic'); // 前回の選択が semantic で保存済み
+
+  await page.goto('https://prefablens.test/owner/repo/pull/1/files');
+  await page.addScriptTag({ path: 'dist/content.js' });
+
+  // クリックなしで両方の Unity ファイルが semantic 描画になっている
+  await expect(page.locator('[data-prefablens-view]')).toHaveCount(2);
+  await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();
+
+  // 遅延ロードで現れたファイルも既定を継承する(「押したのに raw」が起きない核心)
+  await page.evaluate(() => {
+    const file = document.createElement('div');
+    file.className = 'file';
+    file.innerHTML =
+      '<div class="file-header" data-path="Assets/Late.prefab"></div><div class="js-file-content">raw diff</div>';
+    document.body.append(file);
+  });
+  await expect(page.locator('[data-prefablens-view]')).toHaveCount(3);
+  await expect(page.locator('.file:has(.file-header[data-path="Assets/Late.prefab"]) .js-file-content')).toBeHidden();
+});
+
+test('global toggle switches all files and resets per-file overrides', async ({ page }) => {
+  await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
+  await stubChrome(page, cannedResponse);
+
+  await page.goto('https://prefablens.test/owner/repo/pull/1/files');
+  await page.addScriptTag({ path: 'dist/content.js' });
+
+  // 全体トグルは最初の Unity ファイルの直前に 1 つだけ注入される
+  const global = page.locator('[data-prefablens-global]');
+  await expect(global).toHaveCount(1);
+
+  // 全体 Semantic → 全 Unity ファイルが切り替わる(README は対象外)
+  await global.getByRole('button', { name: 'Semantic' }).click();
+  await expect(page.locator('[data-prefablens-view]')).toHaveCount(2);
+
+  // 個別に Raw へ上書き → そのファイルだけ raw に戻る
+  const fooHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await fooHeader.getByRole('button', { name: 'Raw' }).click();
+  await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeVisible();
+  await expect(page.locator('.file:has(.file-header[data-path="Assets/Big.unity"]) .js-file-content')).toBeHidden();
+
+  // 全体 Raw → Semantic と操作すると上書きがリセットされ、必ず全ファイルが揃う
+  await global.getByRole('button', { name: 'Raw' }).click();
+  await global.getByRole('button', { name: 'Semantic' }).click();
+  await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();
 });

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -150,6 +150,10 @@ test('applies the persisted semantic default to every unity file and late additi
   await expect(page.locator('[data-prefablens-view]')).toHaveCount(2);
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();
 
+  // 全体トグルも既定を反映して Semantic 押下状態で現れる
+  const global = page.locator('[data-prefablens-global]');
+  await expect(global.locator('button[data-view="semantic"]')).toHaveAttribute('aria-pressed', 'true');
+
   // 遅延ロードで現れたファイルも既定を継承する(「押したのに raw」が起きない核心)
   await page.evaluate(() => {
     const file = document.createElement('div');
@@ -172,6 +176,9 @@ test('global toggle switches all files and resets per-file overrides', async ({ 
   // 全体トグルは最初の Unity ファイルの直前に 1 つだけ注入される
   const global = page.locator('[data-prefablens-global]');
   await expect(global).toHaveCount(1);
+
+  // 位置契約: バーは最初の Unity ファイルの .file コンテナ直前に入る
+  await expect(page.locator('[data-prefablens-global] + .file .file-header[data-path="Assets/Foo.prefab"]')).toHaveCount(1);
 
   // 全体 Semantic → 全 Unity ファイルが切り替わる(README は対象外)
   await global.getByRole('button', { name: 'Semantic' }).click();

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -52,7 +52,7 @@ function attachToggle(pr: { owner: string; repo: string; prNumber: number }, ent
     };
     request();
   });
-  entry.header.append(toggle);
+  entry.header.append(toggle.element);
 }
 
 function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -104,9 +104,12 @@ function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
 }
 
 async function init(): Promise<void> {
-  const stored = await chrome.storage.local.get(['viewMode']);
+  const stored = await chrome.storage.local.get(['viewMode']).catch(() => ({}) as Record<string, unknown>);
   const initial: View = stored['viewMode'] === 'semantic' ? 'semantic' : 'raw';
-  const state = createViewState(initial, (view) => void chrome.storage.local.set({ viewMode: view }));
+  const state = createViewState(
+    initial,
+    (view) => void chrome.storage.local.set({ viewMode: view }).catch(() => {}),
+  );
   state.onDefaultChange((view) => {
     globalToggle?.set(view);
     for (const a of [...appliers]) {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,5 +1,6 @@
 import { parsePrUrl, scanUnityFiles, type FileEntry } from './detect';
-import { createToggle } from './toggle';
+import { createToggle, type Toggle, type View } from './toggle';
+import { createViewState, type ViewState } from './viewstate';
 import { render, renderError, renderLoading, renderTooLarge } from '../renderer/render';
 import type { BackgroundError, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
@@ -11,20 +12,50 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
   'diff-failed': 'Could not compute a semantic diff for this file.',
 };
 
-function attach(): void {
+// 全体切り替えの適用先: attach 済みファイルのトグル + 表示を外から駆動する
+type Applier = { header: HTMLElement; apply(view: View): void };
+const appliers = new Set<Applier>();
+let globalToggle: Toggle | undefined;
+let currentPr = ''; // 上書きは PR 滞在中のみ有効: PR が変わったら捨てる
+
+function attach(state: ViewState): void {
   const pr = parsePrUrl(location.pathname);
   if (!pr) return;
-  for (const entry of scanUnityFiles(document)) attachToggle(pr, entry);
+  const key = `${pr.owner}/${pr.repo}#${pr.prNumber}`;
+  if (key !== currentPr) {
+    currentPr = key;
+    state.clearOverrides();
+  }
+  const entries = scanUnityFiles(document);
+  if (entries.length) ensureGlobalToggle(state, entries[0]!);
+  for (const entry of entries) attachToggle(state, pr, entry);
 }
 
-function attachToggle(pr: { owner: string; repo: string; prNumber: number }, entry: FileEntry): void {
+/** 最初の Unity ファイルの .file コンテナ直前に全体トグルを 1 つだけ注入する。
+ *  ツールバー DOM は GitHub 側の変更が激しいため、確実に存在する .file を錨にする。 */
+function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
+  if (globalToggle?.element.closest('[data-prefablens-global]')?.isConnected) return;
+  const container = first.header.closest('.file');
+  if (!container?.parentElement) return;
+  const bar = document.createElement('div');
+  bar.setAttribute('data-prefablens-global', '');
+  bar.style.cssText = 'display:flex;align-items:center;gap:8px;margin:0 0 8px;font:12px system-ui;';
+  const label = document.createElement('span');
+  label.textContent = 'PrefabLens';
+  const toggle = createToggle((view) => state.setDefault(view), state.defaultView());
+  bar.append(label, toggle.element);
+  container.before(bar);
+  globalToggle = toggle;
+}
+
+function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNumber: number }, entry: FileEntry): void {
   if (entry.header.hasAttribute('data-prefablens')) return;
   entry.header.setAttribute('data-prefablens', '');
 
   let host: HTMLElement | undefined;
   let requested = false;
 
-  const toggle = createToggle((view) => {
+  const show = (view: View): void => {
     if (view === 'raw') {
       entry.content.style.display = '';
       if (host) host.style.display = 'none';
@@ -40,7 +71,7 @@ function attachToggle(pr: { owner: string; repo: string; prNumber: number }, ent
     host.style.display = '';
     if (requested) return; // 成功結果のみファイル単位でキャッシュ(再トグルで再フェッチしない)
     const root = host.shadowRoot!;
-    const request = (force?: boolean) => {
+    const request = (force?: boolean): void => {
       requested = true;
       renderLoading(root);
       void requestDiff({ type: 'semanticDiff', ...pr, path: entry.path, force }).then((res) => {
@@ -51,8 +82,18 @@ function attachToggle(pr: { owner: string; repo: string; prNumber: number }, ent
       });
     };
     request();
-  });
+  };
+
+  const toggle = createToggle((view) => {
+    state.setOverride(entry.path, view); // クリックはこのファイルだけの上書き
+    show(view);
+  }, state.effective(entry.path));
   entry.header.append(toggle.element);
+  appliers.add({ header: entry.header, apply: (view) => { toggle.set(view); show(view); } });
+
+  // 既定が semantic なら attach 時点で描画開始: 遅延ロードされたファイルもここを通るので
+  // 「全体は semantic なのに後から来たファイルだけ raw」は起きない
+  if (state.effective(entry.path) === 'semantic') show('semantic');
 }
 
 function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
@@ -62,14 +103,38 @@ function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
   }));
 }
 
-// GitHub は SPA: 初回スキャン + MutationObserver で遅延ロード・タブ遷移に追従(200ms デバウンス)。
-attach();
-let scheduled = false;
-new MutationObserver(() => {
-  if (scheduled) return;
-  scheduled = true;
-  setTimeout(() => {
-    scheduled = false;
-    attach();
-  }, 200);
-}).observe(document.body, { childList: true, subtree: true });
+async function init(): Promise<void> {
+  const stored = await chrome.storage.local.get(['viewMode']);
+  const initial: View = stored['viewMode'] === 'semantic' ? 'semantic' : 'raw';
+  const state = createViewState(initial, (view) => void chrome.storage.local.set({ viewMode: view }));
+  state.onDefaultChange((view) => {
+    globalToggle?.set(view);
+    for (const a of [...appliers]) {
+      if (!a.header.isConnected) {
+        appliers.delete(a); // SPA 遷移で死んだ DOM の掃除
+        continue;
+      }
+      a.apply(view);
+    }
+  });
+  // 他タブでの既定変更に追随(set 元タブのエコーは applyExternal 側で無視される)
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local') return;
+    const next = changes['viewMode']?.newValue;
+    if (next === 'raw' || next === 'semantic') state.applyExternal(next);
+  });
+
+  // GitHub は SPA: 初回スキャン + MutationObserver で遅延ロード・タブ遷移に追従(200ms デバウンス)。
+  attach(state);
+  let scheduled = false;
+  new MutationObserver(() => {
+    if (scheduled) return;
+    scheduled = true;
+    setTimeout(() => {
+      scheduled = false;
+      attach(state);
+    }, 200);
+  }).observe(document.body, { childList: true, subtree: true });
+}
+
+void init();

--- a/extension/src/content/toggle.test.ts
+++ b/extension/src/content/toggle.test.ts
@@ -6,8 +6,8 @@ describe('createToggle', () => {
   it('starts on Raw and reports selection changes', () => {
     const onSelect = vi.fn();
     const toggle = createToggle(onSelect);
-    document.body.append(toggle);
-    const [raw, semantic] = [...toggle.querySelectorAll('button')];
+    document.body.append(toggle.element);
+    const [raw, semantic] = [...toggle.element.querySelectorAll('button')];
     expect(raw!.getAttribute('aria-pressed')).toBe('true');
     semantic!.click();
     expect(onSelect).toHaveBeenCalledWith('semantic');
@@ -15,5 +15,25 @@ describe('createToggle', () => {
     expect(raw!.getAttribute('aria-pressed')).toBe('false');
     raw!.click();
     expect(onSelect).toHaveBeenLastCalledWith('raw');
+  });
+
+  it('starts on the given initial view', () => {
+    // 永続既定が semantic のとき、遅延ロードで現れたファイルのトグルも semantic 押下状態で生まれる
+    const toggle = createToggle(vi.fn(), 'semantic');
+    document.body.append(toggle.element);
+    const [raw, semantic] = [...toggle.element.querySelectorAll('button')];
+    expect(semantic!.getAttribute('aria-pressed')).toBe('true');
+    expect(raw!.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('updates visuals via set() without firing onSelect', () => {
+    // 全体トグルからの一括適用: 個別トグルの見た目だけ追随させ、onSelect の副作用(再フェッチ)は起こさない
+    const onSelect = vi.fn();
+    const toggle = createToggle(onSelect);
+    document.body.append(toggle.element);
+    toggle.set('semantic');
+    const [, semantic] = [...toggle.element.querySelectorAll('button')];
+    expect(semantic!.getAttribute('aria-pressed')).toBe('true');
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/extension/src/content/toggle.ts
+++ b/extension/src/content/toggle.ts
@@ -1,19 +1,22 @@
 export type View = 'raw' | 'semantic';
 
-export function createToggle(onSelect: (view: View) => void): HTMLElement {
+export type Toggle = { element: HTMLElement; set(view: View): void };
+
+export function createToggle(onSelect: (view: View) => void, initial: View = 'raw'): Toggle {
   const wrap = document.createElement('span');
   wrap.setAttribute('data-prefablens-toggle', '');
   wrap.style.cssText = 'display:inline-flex;gap:0;margin-left:8px;vertical-align:middle;';
 
   const buttons: HTMLButtonElement[] = [];
-  const select = (view: View) => {
+  // set は表示のみ更新する: 全体適用時に onSelect(再フェッチ側)を巻き込まないため
+  const select = (view: View): void => {
     for (const b of buttons) {
       const active = b.dataset['view'] === view;
       b.setAttribute('aria-pressed', String(active));
       b.style.fontWeight = active ? '600' : '400';
     }
   };
-  const make = (view: View, label: string) => {
+  const make = (view: View, label: string): HTMLButtonElement => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.textContent = label;
@@ -29,6 +32,6 @@ export function createToggle(onSelect: (view: View) => void): HTMLElement {
   };
 
   wrap.append(make('raw', 'Raw'), make('semantic', 'Semantic'));
-  select('raw'); // 既定は Raw(GitHub 既定表示のまま)
-  return wrap;
+  select(initial);
+  return { element: wrap, set: select };
 }

--- a/extension/src/content/viewstate.test.ts
+++ b/extension/src/content/viewstate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createViewState } from './viewstate';
+
+describe('createViewState', () => {
+  it('resolves effective view as override-or-default', () => {
+    const state = createViewState('raw', vi.fn());
+    expect(state.effective('a.prefab')).toBe('raw');
+    state.setOverride('a.prefab', 'semantic');
+    expect(state.effective('a.prefab')).toBe('semantic');
+    expect(state.effective('b.prefab')).toBe('raw'); // 上書きは対象ファイルだけ
+  });
+
+  it('setDefault persists, clears overrides, and notifies listeners', () => {
+    // 「全体を押したら必ず全ファイルが揃う」の核: 個別上書きは全体トグルでリセットされる
+    const persist = vi.fn();
+    const state = createViewState('raw', persist);
+    const listener = vi.fn();
+    state.onDefaultChange(listener);
+    state.setOverride('a.prefab', 'raw');
+    state.setDefault('semantic');
+    expect(persist).toHaveBeenCalledWith('semantic');
+    expect(listener).toHaveBeenCalledWith('semantic');
+    expect(state.effective('a.prefab')).toBe('semantic'); // 上書きは消えている
+  });
+
+  it('setDefault is a no-op when the view is unchanged', () => {
+    // 冪等性: 同値の再設定で上書きが消えたり storage 書き込みが走ったりしない
+    const persist = vi.fn();
+    const state = createViewState('semantic', persist);
+    state.setOverride('a.prefab', 'raw');
+    state.setDefault('semantic');
+    expect(persist).not.toHaveBeenCalled();
+    expect(state.effective('a.prefab')).toBe('raw');
+  });
+
+  it('applyExternal updates without persisting (storage.onChanged echo)', () => {
+    // storage.onChanged は set した本人のタブでも発火する: 再永続化すると無限ループになる
+    const persist = vi.fn();
+    const state = createViewState('raw', persist);
+    const listener = vi.fn();
+    state.onDefaultChange(listener);
+    state.applyExternal('semantic');
+    expect(state.defaultView()).toBe('semantic');
+    expect(persist).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith('semantic');
+    listener.mockClear();
+    state.applyExternal('semantic'); // 同値エコーは無視
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('clearOverrides drops per-file overrides only', () => {
+    const state = createViewState('semantic', vi.fn());
+    state.setOverride('a.prefab', 'raw');
+    state.clearOverrides();
+    expect(state.effective('a.prefab')).toBe('semantic');
+    expect(state.defaultView()).toBe('semantic');
+  });
+});

--- a/extension/src/content/viewstate.test.ts
+++ b/extension/src/content/viewstate.test.ts
@@ -23,14 +23,29 @@ describe('createViewState', () => {
     expect(state.effective('a.prefab')).toBe('semantic'); // 上書きは消えている
   });
 
-  it('setDefault is a no-op when the view is unchanged', () => {
-    // 冪等性: 同値の再設定で上書きが消えたり storage 書き込みが走ったりしない
+  it('same-value setDefault still clears overrides without persisting', () => {
+    // 「全体を押したら必ず全部揃う」: 既に押されている側をもう一度押しても上書きは消える。
+    // storage への再書き込みだけはしない(onChanged エコーの無駄打ち防止)
     const persist = vi.fn();
     const state = createViewState('semantic', persist);
+    const listener = vi.fn();
+    state.onDefaultChange(listener);
     state.setOverride('a.prefab', 'raw');
     state.setDefault('semantic');
     expect(persist).not.toHaveBeenCalled();
-    expect(state.effective('a.prefab')).toBe('raw');
+    expect(listener).toHaveBeenCalledWith('semantic');
+    expect(state.effective('a.prefab')).toBe('semantic');
+  });
+
+  it('same-value setDefault with no overrides is a pure no-op', () => {
+    // 上書きが無ければ通知も不要: appliers の全再適用を無駄に走らせない
+    const persist = vi.fn();
+    const state = createViewState('semantic', persist);
+    const listener = vi.fn();
+    state.onDefaultChange(listener);
+    state.setDefault('semantic');
+    expect(persist).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
   });
 
   it('applyExternal updates without persisting (storage.onChanged echo)', () => {
@@ -39,7 +54,9 @@ describe('createViewState', () => {
     const state = createViewState('raw', persist);
     const listener = vi.fn();
     state.onDefaultChange(listener);
+    state.setOverride('a.prefab', 'raw');
     state.applyExternal('semantic');
+    expect(state.effective('a.prefab')).toBe('semantic'); // 他タブ由来の切り替えでも全ファイルが揃う
     expect(state.defaultView()).toBe('semantic');
     expect(persist).not.toHaveBeenCalled();
     expect(listener).toHaveBeenCalledWith('semantic');

--- a/extension/src/content/viewstate.ts
+++ b/extension/src/content/viewstate.ts
@@ -26,7 +26,11 @@ export function createViewState(initial: View, persist: (view: View) => void): V
     setOverride: (path, view) => void overrides.set(path, view),
     clearOverrides: () => overrides.clear(),
     setDefault: (view) => {
-      if (view === def) return;
+      if (view === def) {
+        // 同値クリックでも「全体を押したら必ず全部揃う」: 上書きを消して再適用し、storage には書かない
+        if (overrides.size) change(view);
+        return;
+      }
       change(view);
       persist(view);
     },

--- a/extension/src/content/viewstate.ts
+++ b/extension/src/content/viewstate.ts
@@ -1,0 +1,39 @@
+import type { View } from './toggle';
+
+export type ViewState = {
+  defaultView(): View;
+  effective(path: string): View;
+  setOverride(path: string, view: View): void;
+  clearOverrides(): void;
+  setDefault(view: View): void;
+  applyExternal(view: View): void;
+  onDefaultChange(fn: (view: View) => void): void;
+};
+
+/** 既定モード(永続)+ ページ滞在中のファイル単位上書き。全体切り替えは上書きを必ずリセットする。 */
+export function createViewState(initial: View, persist: (view: View) => void): ViewState {
+  let def = initial;
+  const overrides = new Map<string, View>();
+  const listeners: Array<(view: View) => void> = [];
+  const change = (view: View): void => {
+    def = view;
+    overrides.clear();
+    for (const fn of listeners) fn(view);
+  };
+  return {
+    defaultView: () => def,
+    effective: (path) => overrides.get(path) ?? def,
+    setOverride: (path, view) => void overrides.set(path, view),
+    clearOverrides: () => overrides.clear(),
+    setDefault: (view) => {
+      if (view === def) return;
+      change(view);
+      persist(view);
+    },
+    // storage.onChanged は set 元のタブでも発火するため、同値は無視して永続化もしない
+    applyExternal: (view) => {
+      if (view !== def) change(view);
+    },
+    onDefaultChange: (fn) => void listeners.push(fn),
+  };
+}


### PR DESCRIPTION
## 概要

Raw/Semantic をファイル単位でしか切り替えられなかったのを、Semantic を永続既定モードにできる全体トグル + ファイル単位の一時上書きに拡張する。拡張 UX 改善 3 PR の 1 本目(B1)。後続: B2 プリフェッチ、B3/B4 repo guid 索引 + プログレッシブ描画。

## 変更点

- `createToggle` が `{ element, set }` を返し初期ビューを受け取る(`set` は表示のみ更新、全体適用時に再フェッチを巻き込まない)
- 新モジュール `viewstate.ts`: 永続既定(`chrome.storage.local` の `viewMode`、初期値 raw)+ ページ滞在中のみのファイル単位上書き。全体トグル操作は同値クリックでも上書きをリセット(「全体を押したら必ず全部揃う」)
- `content/index.ts`: 全体トグルバー `[data-prefablens-global]` を最初の Unity ファイル直前に注入(アンカー不在時は注入しない)。遅延ロードで現れたファイルも attach 時に既定を継承するため「semantic なのに raw で現れる」が構造的に起きない。`storage.onChanged` で他タブにも追随
- storage 失敗時は raw フォールバック / メモリのみで続行(既存挙動を壊さない)

## テスト

- unit 93/93(viewstate 7 本新規、同値クリックの上書きリセットを含む)
- e2e 7/7(新規 2 本: 永続 semantic 既定のクリックなし適用 + 遅延追加ファイルへの継承 / 全体トグル一括切り替えと上書きリセット。既存 smoke は storage 対応スタブへ移行)

## 既知の制約(後続 PR で解決)

- 既定 semantic で大きな PR を開くと diff 要求の並列数が絞られない → B2 の優先度付きキューで解決
- `appliers` の dead 要素掃除が全体トグル操作時のみ(soft leak)→ B2 で PR 遷移時掃除を追加