### PR TITLE
ci: automate version bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,72 @@
 name: Release
 on:
-  push:
-    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (X.Y.Z, no v prefix)'
+        required: true
 
 permissions:
   contents: write
 
+# 二重起動で bump commit とタグが交錯しないよう、リリースは常に直列。
+concurrency:
+  group: release
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+      - name: Validate input
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_NAME" = "main" ] || { echo "::error::run this workflow from main (got $GITHUB_REF_NAME)"; exit 1; }
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::version must be X.Y.Z (got $VERSION)"; exit 1; }
+          if git ls-remote --exit-code origin "refs/tags/v$VERSION" >/dev/null 2>&1; then
+            echo "::error::tag v$VERSION already exists; delete it first to re-release: git push origin :refs/tags/v$VERSION"
+            exit 1
+          fi
+      # bump は冪等(既に一致していれば no-op)。commit 済み・タグ未 push で落ちた回の再 Run に耐える。
+      - name: Bump versions
+        run: |
+          set -euo pipefail
+          sed -i "s/\.version = \"[^\"]*\"/.version = \"$VERSION\"/" build.zig.zon
+          (cd extension && npm version "$VERSION" --no-git-tag-version --allow-same-version)
+          # JSON を再シリアライズすると 1 行配列などが再フォーマットされるため、version 行だけを置換する。
+          # "manifest_version": 3 はキー名も値の形も異なるためマッチしない。
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" extension/manifest.json editor/package.json
+          sed -i "s/public const string Version = \"[^\"]*\"/public const string Version = \"$VERSION\"/" editor/Editor/Cli.cs
+      # 書き換え漏れの即 fail。バージョン記載箇所を増やしたらここにも追加する。
+      - name: Verify versions
+        run: |
+          set -euo pipefail
+          check() { grep -qF "$2" "$1" || { echo "::error::$1 does not contain: $2"; exit 1; }; }
+          check build.zig.zon ".version = \"$VERSION\""
+          check extension/package.json "\"version\": \"$VERSION\""
+          check extension/package-lock.json "\"version\": \"$VERSION\""
+          check extension/manifest.json "\"version\": \"$VERSION\""
+          check editor/package.json "\"version\": \"$VERSION\""
+          check editor/Editor/Cli.cs "public const string Version = \"$VERSION\""
+      # GITHUB_TOKEN での push は他ワークフローを起動しない(再帰防止)ため、CI 相当の検証をここで行う。
+      - name: Test
+        run: |
+          zig build test
+          zig build wasm
+      - name: Commit and tag
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add build.zig.zon extension/package.json extension/package-lock.json extension/manifest.json editor/package.json editor/Editor/Cli.cs
+          git diff --cached --quiet || git commit -m "chore: release v$VERSION"
+          git push origin HEAD:main
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
       # zig は素でクロスコンパイルできるため 1 ランナーで全ターゲットを吐く。
       # zig-out/bin はターゲットごとに上書きされるので都度 zip に退避する。
       # アセットは zip 統一(Unity 側の System.IO.Compression.ZipFile が全 OS で扱える)。
@@ -33,4 +87,4 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" dist/*.zip dist/SHA256SUMS --generate-notes
+        run: gh release create "v$VERSION" dist/*.zip dist/SHA256SUMS --generate-notes

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,14 @@
 const std = @import("std");
+const zon = @import("build.zig.zon");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    // バージョンの単一ソースは build.zig.zon。CLI バイナリへは build options で注入する。
+    const opts = b.addOptions();
+    opts.addOption([]const u8, "version", zon.version);
+    const build_options_mod = opts.createModule();
 
     const core_mod = b.addModule("core", .{
         .root_source_file = b.path("core/src/root.zig"),
@@ -23,6 +29,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "core", .module = core_mod },
                 .{ .name = "testdata_plane_before", .module = plane_before },
                 .{ .name = "testdata_plane_after", .module = plane_after },
+                .{ .name = "build_options", .module = build_options_mod },
             },
         }),
     });
@@ -46,6 +53,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "core", .module = core_mod },
                 .{ .name = "testdata_plane_before", .module = plane_before },
                 .{ .name = "testdata_plane_after", .module = plane_after },
+                .{ .name = "build_options", .module = build_options_mod },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .prefablens,
-    .version = "0.1.0",
+    .version = "0.3.0",
     .fingerprint = 0x963f0eb06ee0745d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -437,8 +437,8 @@ test "run: --project supplies source prefabs for merged instance diffs" {
     try testing.expect(std.mem.indexOf(u8, output2.items, "Scale.y: 2") != null);
 }
 
-/// リリースタグ v<version> と lockstep(cut-release の 5 ソースの一員)。
-pub const version = "0.3.0";
+/// リリースタグ v<version> と lockstep。単一ソースは build.zig.zon(release.yml が bump する)。
+pub const version = @import("build_options").version;
 
 test "run: --project points git mode at a repo outside the cwd" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
@@ -483,10 +483,6 @@ test "run: --project points git mode at a repo outside the cwd" {
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"after\":\"2\"") != null);
-}
-
-test "version constant exists for serverInfo and release lockstep" {
-    try testing.expectEqualStrings("0.3.0", version);
 }
 
 pub const Format = enum { tree, json, html };


### PR DESCRIPTION
## Summary
- release.yml を workflow_dispatch 化し、version 入力から bump → verify → test → commit/tag → build → Release 作成まで一気通貫にした
- Zig 側の版数は build.zig.zon を単一ソースにし、CLI バイナリへは build options で注入(main.zig のハードコード定数と lockstep テストを廃止)
- build.zig.zon の取り残し(0.1.0)を 0.3.0 に追いつかせた

## Release procedure
Actions タブ → Release → Run workflow → version(例 `0.4.0`)を入力するだけ。bump は冪等で、タグ未 push で落ちた回はそのまま再 Run できる。

## Verification
- `zig build test` 全パス、実バイナリの MCP serverInfo が build.zig.zon 由来の 0.3.0 を返すことを確認
- bump/verify コマンド一式をローカルで dry-run し、diff が各ファイルの version 行のみであること(JSON 再フォーマットなし)と、同一版数での再実行が no-op であることを確認

## Spec
ローカル docs(gitignore 済み): docs/superpowers/specs/2026-07-07-release-version-automation-design.md