### PR TITLE
feat: background prefetch on pr arrival

### DIFF
--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -78,6 +78,26 @@ test('detects a Unity file, toggles to Semantic, renders the tree', async ({ pag
   await expect(view).toBeHidden();
 });
 
+test('sends a prefetch message on pr page arrival', async ({ page }) => {
+  await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
+  await stubChrome(page, cannedResponse);
+  // stubChrome の sendMessage を包んで記録する
+  await page.addInitScript(() => {
+    const w = window as unknown as { chrome: { runtime: { sendMessage: (m: unknown) => Promise<unknown> } }; __sent: unknown[] };
+    w.__sent = [];
+    const orig = w.chrome.runtime.sendMessage;
+    w.chrome.runtime.sendMessage = (m: unknown) => {
+      w.__sent.push(m);
+      return orig(m);
+    };
+  });
+  await page.goto('https://prefablens.test/owner/repo/pull/1/files');
+  await page.addScriptTag({ path: 'dist/content.js' });
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __sent: Array<{ type?: string }> }).__sent.filter((m) => m?.type === 'prefetch').length))
+    .toBe(1); // 同一 PR では 1 回だけ
+});
+
 test('attaches toggles to files added after the initial scan (SPA lazy loading)', async ({ page }) => {
   await page.route('**/pull/1/files', (route) => route.fulfill({ body: fixture, contentType: 'text/html' }));
   await stubChrome(page, cannedResponse);
@@ -105,7 +125,10 @@ test('recovers after an error response', async ({ page }) => {
     (window as unknown as Record<string, unknown>)['__prefablensCalls'] = 0;
     (window as unknown as Record<string, unknown>)['chrome'] = {
       runtime: {
-        sendMessage: () => {
+        // prefetch はカウント対象外にする: attach() が pull ページ到達時に必ず 1 通送るため、
+        // 素朴な全件カウントだと 1 回目の semanticDiff がずれてエラー→成功の検証が壊れる
+        sendMessage: (msg: { type?: string }) => {
+          if (msg?.type !== 'semanticDiff') return Promise.resolve();
           const w = window as unknown as Record<string, number>;
           const call = w['__prefablensCalls']!;
           w['__prefablensCalls'] = call + 1;

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -42,19 +42,28 @@ function makeDeps(overrides?: {
       cacheData[repo] = { ...cacheData[repo], ...entries };
     }),
   };
+  const diffStoreData: Record<string, DiffV2> = {};
+  const diffStore = {
+    data: diffStoreData,
+    load: vi.fn(async (key: string) => diffStoreData[key]),
+    save: vi.fn(async (key: string, json: DiffV2) => {
+      diffStoreData[key] = json;
+    }),
+  };
   const deps: Deps = {
     getSettings: async () => ({ pat: Object.hasOwn(overrides ?? {}, 'pat') ? overrides!.pat : 'tok', baseUrl: undefined }),
-    makeClient: () => client,
+    makeClient: (_base: string, _token: string, _lane: 'user' | 'prefetch') => client,
     getDiffer: async () => differ,
     guidCache,
+    diffStore,
   };
-  return { deps, client, differ, guidCache };
+  return { deps, client, differ, guidCache, diffStore };
 }
 
 describe('createHandler', () => {
   it('returns pat-missing without touching the network', async () => {
     const { deps, client } = makeDeps({ pat: undefined });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res).toEqual({ ok: false, error: 'pat-missing' });
     expect(client.getPrRefs).not.toHaveBeenCalled();
   });
@@ -71,14 +80,14 @@ describe('createHandler', () => {
         'Assets/S.cs.meta@head-sha': 'guid: g1\n',
       },
     });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/S.cs' } } });
   });
 
   it('uses an empty before for added files without fetching the base side', async () => {
     const diff = vi.fn<Differ['diff']>(() => DIFF);
     const { deps, client } = makeDeps({ files: [{ path: 'Assets/Foo.prefab', status: 'added' }], diff });
-    await createHandler(deps)(REQ);
+    await createHandler(deps).semanticDiff(REQ);
     const baseFetches = client.getFileAtRef.mock.calls.filter(
       (c) => c[2] === 'Assets/Foo.prefab' && c[3] === 'base-sha',
     );
@@ -89,7 +98,7 @@ describe('createHandler', () => {
   it('uses an empty after for removed files without fetching the head side', async () => {
     const diff = vi.fn<Differ['diff']>(() => DIFF);
     const { deps, client } = makeDeps({ files: [{ path: 'Assets/Foo.prefab', status: 'removed' }], diff });
-    await createHandler(deps)(REQ);
+    await createHandler(deps).semanticDiff(REQ);
     const headFetches = client.getFileAtRef.mock.calls.filter(
       (c) => c[2] === 'Assets/Foo.prefab' && c[3] === 'head-sha',
     );
@@ -100,7 +109,7 @@ describe('createHandler', () => {
   it('diffs a file missing from the PR list as modified (files API caps at 3000)', async () => {
     // 3000 ファイル超の PR では一覧 API が打ち切られ、UI にあるファイルが一覧に無いことがある
     const { deps, client } = makeDeps({ files: [{ path: 'Assets/Other.prefab', status: 'modified' }] });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Foo.prefab', 'base-sha');
     expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Foo.prefab', 'head-sha');
@@ -118,7 +127,7 @@ describe('createHandler', () => {
       inFlight--;
       return new TextEncoder().encode('x');
     });
-    await createHandler(deps)(REQ);
+    await createHandler(deps).semanticDiff(REQ);
     expect(maxInFlight).toBe(2);
   });
 
@@ -127,7 +136,7 @@ describe('createHandler', () => {
       files: [{ path: 'Assets/Foo.prefab', status: 'renamed', previousPath: 'Assets/Old.prefab' }],
       contents: { 'Assets/Old.prefab@base-sha': 'b', 'Assets/Foo.prefab@head-sha': 'a' },
     });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Old.prefab', 'base-sha');
   });
@@ -135,8 +144,8 @@ describe('createHandler', () => {
   it('caches PR context across calls (refs/files/guid index fetched once)', async () => {
     const { deps, client } = makeDeps();
     const handle = createHandler(deps);
-    await handle(REQ);
-    await handle({ ...REQ, path: 'Assets/Foo.prefab' });
+    await handle.semanticDiff(REQ);
+    await handle.semanticDiff({ ...REQ, path: 'Assets/Foo.prefab' });
     expect(client.getPrRefs).toHaveBeenCalledTimes(1);
     expect(client.listPrFiles).toHaveBeenCalledTimes(1);
   });
@@ -146,12 +155,12 @@ describe('createHandler', () => {
     try {
       const { deps, client } = makeDeps();
       const handle = createHandler(deps);
-      await handle(REQ);
+      await handle.semanticDiff(REQ);
       vi.setSystemTime(Date.now() + 59_000);
-      await handle(REQ);
+      await handle.semanticDiff(REQ);
       expect(client.getPrRefs).toHaveBeenCalledTimes(1);
       vi.setSystemTime(Date.now() + 2_000); // 計 61 秒
-      await handle(REQ);
+      await handle.semanticDiff(REQ);
       expect(client.getPrRefs).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
@@ -163,22 +172,22 @@ describe('createHandler', () => {
     const { deps, client } = makeDeps();
     client.listPrFiles.mockRejectedValueOnce(new Error('socket'));
     const handle = createHandler(deps);
-    expect(await handle(REQ)).toEqual({ ok: false, error: 'fetch-failed' });
-    expect((await handle(REQ)).ok).toBe(true);
+    expect(await handle.semanticDiff(REQ)).toEqual({ ok: false, error: 'fetch-failed' });
+    expect((await handle.semanticDiff(REQ)).ok).toBe(true);
   });
 
   it('fetches each sha+path blob only once (immutable content)', async () => {
     const { deps, client } = makeDeps();
     const handle = createHandler(deps);
-    await handle(REQ);
-    await handle(REQ);
+    await handle.semanticDiff(REQ);
+    await handle.semanticDiff(REQ);
     const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === 'Assets/Foo.prefab');
     expect(fooFetches).toHaveLength(2); // base + head の 2 回だけ(2 回目の handle では再フェッチしない)
   });
 
   it('resolves remaining guids via code search and persists them', async () => {
     const { deps, guidCache } = makeDeps({ search: { g1: 'Assets/Scripts/S.cs' } });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/Scripts/S.cs' } } });
     expect(guidCache.save).toHaveBeenCalledWith('https://api.github.com/o/r', { g1: 'Assets/Scripts/S.cs' });
   });
@@ -196,14 +205,14 @@ describe('createHandler', () => {
       },
       search: { g1: 'Assets/Elsewhere.cs' },
     });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/S.cs' } } });
     expect(client.searchMetaByGuid).not.toHaveBeenCalled();
   });
 
   it('serves cached guids without searching', async () => {
     const { deps, client } = makeDeps({ cached: { g1: 'Assets/Cached.cs' } });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/Cached.cs' } } });
     expect(client.searchMetaByGuid).not.toHaveBeenCalled();
   });
@@ -211,8 +220,8 @@ describe('createHandler', () => {
   it('does not re-search a missed guid within the worker lifetime', async () => {
     const { deps, client } = makeDeps(); // search 未ヒット
     const handle = createHandler(deps);
-    await handle(REQ);
-    await handle(REQ);
+    await handle.semanticDiff(REQ);
+    await handle.semanticDiff(REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
   });
 
@@ -222,14 +231,14 @@ describe('createHandler', () => {
     client.searchMetaByGuid
       .mockResolvedValueOnce('Assets/First.cs')
       .mockRejectedValueOnce(new RateLimitError('x'));
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(res).toEqual({ ok: true, json: { ...twoGuids, resolved: { g1: 'Assets/First.cs' } } });
   });
 
   it('does not treat Object.prototype members as cache hits (hostile guid)', async () => {
     const proto: DiffV2 = { ...DIFF, unresolvedGuids: ['constructor'] };
     const { deps, client } = makeDeps({ diff: () => proto, cached: { g9: 'Assets/X.cs' } });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     // 'constructor' はキャッシュヒットではなく検索に回り、未ヒットで未解決のまま
     expect(client.searchMetaByGuid).toHaveBeenCalledWith('o', 'r', 'constructor');
     expect(res).toEqual({ ok: true, json: { ...proto, resolved: {} } });
@@ -238,7 +247,7 @@ describe('createHandler', () => {
   it('caps code searches at 10 per request', async () => {
     const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
     const { deps, client } = makeDeps({ diff: () => many });
-    await createHandler(deps)(REQ);
+    await createHandler(deps).semanticDiff(REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
   });
 
@@ -246,7 +255,7 @@ describe('createHandler', () => {
     // 12 guid 中 2 つがキャッシュ済みなら、検索枠 10 は未知の 10 guid にまるごと使える
     const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
     const { deps, client } = makeDeps({ diff: () => many, cached: { g0: 'Assets/A.cs', g1: 'Assets/B.cs' } });
-    const res = await createHandler(deps)(REQ);
+    const res = await createHandler(deps).semanticDiff(REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
     expect(res).toEqual({ ok: true, json: { ...many, resolved: { g0: 'Assets/A.cs', g1: 'Assets/B.cs' } } });
   });
@@ -254,18 +263,18 @@ describe('createHandler', () => {
   it('maps AuthError / DiffError / other failures to stable error codes', async () => {
     const auth = makeDeps();
     auth.client.getPrRefs.mockRejectedValue(new AuthError('x'));
-    expect(await createHandler(auth.deps)(REQ)).toEqual({ ok: false, error: 'auth-failed' });
+    expect(await createHandler(auth.deps).semanticDiff(REQ)).toEqual({ ok: false, error: 'auth-failed' });
 
     const bad = makeDeps({
       diff: () => {
         throw new DiffError('NestingTooDeep');
       },
     });
-    expect(await createHandler(bad.deps)(REQ)).toEqual({ ok: false, error: 'diff-failed' });
+    expect(await createHandler(bad.deps).semanticDiff(REQ)).toEqual({ ok: false, error: 'diff-failed' });
 
     const net = makeDeps();
     net.client.listPrFiles.mockRejectedValue(new Error('socket'));
-    expect(await createHandler(net.deps)(REQ)).toEqual({ ok: false, error: 'fetch-failed' });
+    expect(await createHandler(net.deps).semanticDiff(REQ)).toEqual({ ok: false, error: 'fetch-failed' });
   });
 
   it('returns too-large above 25MB unless forced', async () => {
@@ -274,11 +283,11 @@ describe('createHandler', () => {
     const { deps, client } = makeDeps({ diff });
     client.getFileAtRef.mockResolvedValue(big);
     const handle = createHandler(deps);
-    expect(await handle(REQ)).toEqual({ ok: false, error: 'too-large', bytes: big.length * 2 });
+    expect(await handle.semanticDiff(REQ)).toEqual({ ok: false, error: 'too-large', bytes: big.length * 2 });
     expect(diff).not.toHaveBeenCalled();
     // force で描画に進む。blob は sha キャッシュに乗っており再フェッチもない
     const fetches = client.getFileAtRef.mock.calls.length;
-    expect((await handle({ ...REQ, force: true })).ok).toBe(true);
+    expect((await handle.semanticDiff({ ...REQ, force: true })).ok).toBe(true);
     expect(diff).toHaveBeenCalledTimes(1);
     expect(client.getFileAtRef.mock.calls.length).toBe(fetches);
   });
@@ -287,13 +296,13 @@ describe('createHandler', () => {
     const half = new Uint8Array((25 * 1024 * 1024) / 2);
     const { deps, client } = makeDeps();
     client.getFileAtRef.mockResolvedValue(half);
-    expect((await createHandler(deps)(REQ)).ok).toBe(true);
+    expect((await createHandler(deps).semanticDiff(REQ)).ok).toBe(true);
   });
 
   it('maps RateLimitError to rate-limited', async () => {
     const limited = makeDeps();
     limited.client.getPrRefs.mockRejectedValue(new RateLimitError('x'));
-    expect(await createHandler(limited.deps)(REQ)).toEqual({ ok: false, error: 'rate-limited' });
+    expect(await createHandler(limited.deps).semanticDiff(REQ)).toEqual({ ok: false, error: 'rate-limited' });
   });
 
   describe('source prefab merging', () => {
@@ -317,7 +326,7 @@ describe('createHandler', () => {
           'Assets/Cyl.prefab@head-sha': 'SRC',
         },
       });
-      const res = await createHandler(deps)(REQ);
+      const res = await createHandler(deps).semanticDiff(REQ);
       // side=after なので head からソースを取り、その bytes が assets に載る。
       expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Cyl.prefab', 'head-sha');
       const assets = diffWithAssets.mock.calls[0]![2];
@@ -338,14 +347,14 @@ describe('createHandler', () => {
           'Assets/Cyl.prefab@base-sha': 'OLD',
         },
       });
-      await createHandler(deps)(REQ);
+      await createHandler(deps).semanticDiff(REQ);
       expect(client.getFileAtRef).toHaveBeenCalledWith('o', 'r', 'Assets/Cyl.prefab', 'base-sha');
     });
 
     it('keeps the phase-1 diff when the source path cannot be resolved', async () => {
       const diffWithAssets = vi.fn<Differ['diffWithAssets']>(() => MERGED);
       const { deps } = makeDeps({ diff: () => NEEDS, diffWithAssets }); // search 未ヒット
-      const res = await createHandler(deps)(REQ);
+      const res = await createHandler(deps).semanticDiff(REQ);
       // パス不明のソースは諦め、縮退表示(phase 1 の json)のまま返す。
       expect(diffWithAssets).not.toHaveBeenCalled();
       expect(res).toEqual({ ok: true, json: { ...NEEDS, resolved: {} } });
@@ -364,9 +373,109 @@ describe('createHandler', () => {
           'Assets/Cyl.prefab@head-sha': 'SRC',
         },
       });
-      const res = await createHandler(deps)(REQ);
+      const res = await createHandler(deps).semanticDiff(REQ);
       expect(diffWithAssets).toHaveBeenCalledTimes(1);
       expect(res.ok).toBe(true);
     });
+
+    it('still merges sources when serving a prefetched diff', async () => {
+      // raw diff だけをキャッシュする設計の要: 後段(resolve → mergeSources)はキャッシュヒットでも毎回走る
+      const withSource: DiffV2 = { ...DIFF, unresolvedGuids: ['src1'], neededSources: [{ guid: 'src1', side: 'after' }] };
+      const merged: DiffV2 = { ...DIFF, unresolvedGuids: ['src1'] };
+      const diffWithAssets = vi.fn(() => merged);
+      const { deps, client } = makeDeps({
+        files: [
+          { path: 'Assets/Foo.prefab', status: 'modified' },
+          { path: 'Assets/Src.prefab.meta', status: 'modified' },
+        ],
+        contents: {
+          'Assets/Foo.prefab@base-sha': 'b',
+          'Assets/Foo.prefab@head-sha': 'a',
+          'Assets/Src.prefab.meta@head-sha': 'guid: src1\n',
+          'Assets/Src.prefab@head-sha': 'source prefab',
+        },
+        diff: () => withSource,
+        diffWithAssets,
+      });
+      const handler = createHandler(deps);
+      await handler.prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+      expect(diffWithAssets).not.toHaveBeenCalled(); // プリフェッチは raw まで
+      const res = await handler.semanticDiff(REQ);
+      expect(res.ok).toBe(true);
+      expect(diffWithAssets).toHaveBeenCalledTimes(1); // serve 時に合成が走る
+    });
   });
+});
+
+describe('prefetch', () => {
+  it('precomputes diffs so a later toggle serves without new blob fetches', async () => {
+    const { deps, client } = makeDeps();
+    const handler = createHandler(deps);
+    await handler.prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    const fetchesAfterPrefetch = client.getFileAtRef.mock.calls.length;
+    const res = await handler.semanticDiff(REQ);
+    expect(res.ok).toBe(true);
+    expect(client.getFileAtRef.mock.calls.length).toBe(fetchesAfterPrefetch); // blob 再フェッチなし
+  });
+
+  it('persists prefetched diffs to the diff store (sw restart survival)', async () => {
+    const { deps } = makeDeps();
+    await createHandler(deps).prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    expect(deps.diffStore.save).toHaveBeenCalledWith('base-sha:head-sha:Assets/Foo.prefab', DIFF);
+  });
+
+  it('serves a diff persisted by a previous worker from the store', async () => {
+    // SW は 30 秒で死ぬ: 前世でプリフェッチした結果を storage.session 経由で拾えること
+    const { deps, client, diffStore } = makeDeps();
+    diffStore.data['base-sha:head-sha:Assets/Foo.prefab'] = DIFF; // 前世の SW が保存した体でシード
+    const res = await createHandler(deps).semanticDiff(REQ);
+    expect(res.ok).toBe(true);
+    expect(client.getFileAtRef).not.toHaveBeenCalledWith('o', 'r', 'Assets/Foo.prefab', 'base-sha');
+  });
+
+  it('prefetches only unity files and caps at 100', async () => {
+    const files: PrFile[] = Array.from({ length: 120 }, (_, i) => ({ path: `Assets/F${i}.prefab`, status: 'modified' }));
+    files.push({ path: 'README.md', status: 'modified' });
+    const { deps, client } = makeDeps({ files });
+    await createHandler(deps).prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    const paths = new Set(client.getFileAtRef.mock.calls.map((c) => c[2]));
+    expect(paths.has('README.md')).toBe(false);
+    expect(paths.size).toBe(100); // 上限で打ち切り
+  });
+
+  it('skips oversized files without caching them', async () => {
+    const big = new Uint8Array(13 * 1024 * 1024);
+    const { deps, client } = makeDeps();
+    client.getFileAtRef.mockResolvedValue(big);
+    const handler = createHandler(deps);
+    await handler.prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    expect(deps.diffStore.save).not.toHaveBeenCalled();
+    // 後からの手動トグルでは従来通り too-large ゲートが出る
+    expect(await handler.semanticDiff(REQ)).toEqual({ ok: false, error: 'too-large', bytes: big.length * 2 });
+  });
+
+  it('aborts silently on rate limit instead of surfacing an error', async () => {
+    const { deps, client } = makeDeps();
+    client.getFileAtRef.mockRejectedValue(new RateLimitError('x'));
+    await expect(createHandler(deps).prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 })).resolves.toBeUndefined();
+  });
+
+  it('returns without network when the pat is missing', async () => {
+    const { deps, client } = makeDeps({ pat: undefined });
+    await createHandler(deps).prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    expect(client.getPrRefs).not.toHaveBeenCalled();
+  });
+});
+
+it('dedupes a concurrent user toggle against an in-flight prefetch compute', async () => {
+  // プリフェッチ中にユーザーがクリックしても diff 計算・blob フェッチが二重にならない
+  const { deps, client } = makeDeps();
+  const handler = createHandler(deps);
+  const [, res] = await Promise.all([
+    handler.prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 }),
+    handler.semanticDiff(REQ),
+  ]);
+  expect(res.ok).toBe(true);
+  const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === 'Assets/Foo.prefab');
+  expect(fooFetches).toHaveLength(2); // base + head の 2 回だけ
 });

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -412,6 +412,7 @@ describe('prefetch', () => {
     const { deps, client } = makeDeps();
     const handler = createHandler(deps);
     await handler.prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    expect(client.searchMetaByGuid).not.toHaveBeenCalled(); // prefetch は 10 req/min の Code Search に触れない
     const fetchesAfterPrefetch = client.getFileAtRef.mock.calls.length;
     const res = await handler.semanticDiff(REQ);
     expect(res.ok).toBe(true);

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -1,15 +1,22 @@
 import { AuthError, RateLimitError, apiBase, type GithubClient, type PrFile, type PrRefs } from '../github/client';
 import { applyResolved, buildGuidIndex, type GuidCache } from '../github/guids';
 import { DiffError, type Differ } from '../wasm/differ';
-import type { DiffV2, SemanticDiffRequest, SemanticDiffResponse } from '../types';
+import { isUnityPath } from '../unity';
+import type { DiffV2, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
 type ClientLike = Pick<GithubClient, 'getPrRefs' | 'listPrFiles' | 'getFileAtRef' | 'searchMetaByGuid'>;
 
 export type Deps = {
   getSettings(): Promise<{ pat?: string; baseUrl?: string }>;
-  makeClient(base: string, token: string): ClientLike;
+  makeClient(base: string, token: string, lane: 'user' | 'prefetch'): ClientLike;
   getDiffer(): Promise<Differ>;
   guidCache: GuidCache;
+  diffStore: { load(key: string): Promise<DiffV2 | undefined>; save(key: string, json: DiffV2): Promise<void> };
+};
+
+export type Handler = {
+  semanticDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse>;
+  prefetch(req: PrefetchRequest): Promise<void>;
 };
 
 type PrContext = { refs: PrRefs; files: PrFile[]; guidIndex: Map<string, string> };
@@ -20,14 +27,20 @@ const MAX_SOURCE_ROUNDS = 3; // 入れ子ソースの再 diff 上限(core 側の
 const CONTEXT_TTL_MS = 60_000; // push で headSha が変わるため PR コンテキストは短命
 const BLOB_CACHE_MAX = 32;
 const TOO_LARGE_BYTES = 25 * 1024 * 1024; // 親仕様 §5.7: 25MB 超はクリックで描画
+const PREFETCH_MAX = 100; // spec B2: 1 PR あたりの先読み上限
+const PREFETCH_CONCURRENCY = 4;
 
-export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise<SemanticDiffResponse> {
+type DiffOutcome = { ok: true; json: DiffV2 } | { ok: false; error: 'too-large'; bytes: number };
+
+export function createHandler(deps: Deps): Handler {
   // PR 単位のコンテキストキャッシュ。SW はいつ殺されてもよく、その場合は再取得するだけ。
   const contexts = new Map<string, { at: number; ctx: Promise<PrContext> }>();
-  // sha+path → bytes。内容は不変なので TTL 不要。25MB ガードの force 再要求もここに当たる
-  const blobs = new Map<string, Uint8Array | null>();
+  // sha+path → bytes の Promise。格納が Promise なので prefetch と手動トグルの同時要求が 1 フェッチに畳まれる。
+  const blobs = new Map<string, Promise<Uint8Array | null>>();
   // Code Search の未ヒット guid。索引遅延があるため永続化せず SW 生存期間のみ
   const misses = new Set<string>();
+  // baseSha:headSha:path → raw diff 計算の Promise。成功のみ保持(too-large/失敗は再計算を許す)
+  const diffs = new Map<string, Promise<DiffOutcome>>();
 
   /** PR 内 .meta で解決できなかった guid を キャッシュ → Code Search の順で解決する。
    *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ載せる。 */
@@ -59,12 +72,13 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
 
   async function fetchBlob(client: ClientLike, owner: string, repo: string, path: string, sha: string): Promise<Uint8Array | null> {
     const key = `${sha}:${path}`;
-    const hit = blobs.get(key); // 格納値は Uint8Array | null なので undefined = 未キャッシュ
+    const hit = blobs.get(key); // 格納値は Promise<Uint8Array | null> なので undefined = 未キャッシュ
     if (hit !== undefined) return hit;
-    const bytes = await client.getFileAtRef(owner, repo, path, sha);
-    blobs.set(key, bytes);
+    const p = client.getFileAtRef(owner, repo, path, sha);
+    p.catch(() => blobs.delete(key)); // 失敗は残さない: 次回呼び出しで再フェッチできる
+    blobs.set(key, p);
     if (blobs.size > BLOB_CACHE_MAX) blobs.delete(blobs.keys().next().value!);
-    return bytes;
+    return p;
   }
 
   /** neededSources(added/removed instance のソース prefab)を resolved パス経由で
@@ -135,36 +149,72 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
     return ctx;
   }
 
-  return async function handle(req) {
+  /** blob 取得 → 25MB ガード → 素の diff まで。解決や mergeSources はここに入れない
+   *  (resolved は Code Search で後から良くなるため、sha だけで決まる raw diff がキャッシュ単位)。 */
+  async function computeDiff(client: ClientLike, ctx: PrContext, owner: string, repo: string, path: string, force: boolean): Promise<DiffOutcome> {
+    const file = ctx.files.find((f) => f.path === path);
+    // 一覧に無い場合(files API は 3000 件で打ち切り)は modified 扱い: 無い側は 404 → EMPTY に落ちるだけ
+    const status = file?.status ?? 'modified';
+    const beforePath = file?.previousPath ?? path;
+    const fetchSide = (p: string, sha: string): Promise<Uint8Array> =>
+      fetchBlob(client, owner, repo, p, sha).then((bytes) => bytes ?? EMPTY);
+    const [before, after] = await Promise.all([
+      status === 'added' ? EMPTY : fetchSide(beforePath, ctx.refs.baseSha),
+      status === 'removed' ? EMPTY : fetchSide(path, ctx.refs.headSha),
+    ]);
+    if (!force && before.length + after.length > TOO_LARGE_BYTES) {
+      return { ok: false, error: 'too-large', bytes: before.length + after.length };
+    }
+    const differ = await deps.getDiffer();
+    return { ok: true, json: differ.diff(before, after) };
+  }
+
+  /** sha キーなので push されたら自然に別キーになる(無効化不要)。 */
+  function getDiff(client: ClientLike, ctx: PrContext, owner: string, repo: string, path: string, force: boolean): Promise<DiffOutcome> {
+    const key = `${ctx.refs.baseSha}:${ctx.refs.headSha}:${path}`;
+    const hit = diffs.get(key);
+    if (hit) return hit;
+    const p = (async (): Promise<DiffOutcome> => {
+      const stored = await deps.diffStore.load(key); // 前世の SW が残した結果
+      if (stored) return { ok: true, json: stored };
+      const outcome = await computeDiff(client, ctx, owner, repo, path, force);
+      if (outcome.ok) void deps.diffStore.save(key, outcome.json);
+      return outcome;
+    })();
+    diffs.set(key, p);
+    p.then((o) => {
+      if (!o.ok) diffs.delete(key); // too-large は force 再計算を許す
+    }, () => diffs.delete(key));
+    return p;
+  }
+
+  async function semanticDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
     try {
       const settings = await deps.getSettings();
       if (!settings.pat) return { ok: false, error: 'pat-missing' };
       const base = apiBase(settings.baseUrl);
-      const client = deps.makeClient(base, settings.pat);
-      const { refs, files, guidIndex } = await loadContext(client, req.owner, req.repo, req.prNumber);
-
-      const file = files.find((f) => f.path === req.path);
-      // 一覧に無い場合(files API は 3000 件で打ち切り)は modified 扱い: 無い側は 404 → EMPTY に落ちるだけ
-      const status = file?.status ?? 'modified';
-      const beforePath = file?.previousPath ?? req.path;
-
-      const fetchSide = (path: string, sha: string) =>
-        fetchBlob(client, req.owner, req.repo, path, sha).then((bytes) => bytes ?? EMPTY);
-      const [before, after] = await Promise.all([
-        status === 'added' ? EMPTY : fetchSide(beforePath, refs.baseSha),
-        status === 'removed' ? EMPTY : fetchSide(req.path, refs.headSha),
-      ]);
-
-      if (!req.force && before.length + after.length > TOO_LARGE_BYTES) {
-        return { ok: false, error: 'too-large', bytes: before.length + after.length };
-      }
+      const client = deps.makeClient(base, settings.pat, 'user');
+      const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
+      const outcome = await getDiff(client, ctx, req.owner, req.repo, req.path, req.force === true);
+      if (!outcome.ok) return outcome;
 
       const differ = await deps.getDiffer();
       const repoKey = `${base}/${req.owner}/${req.repo}`;
-      const json = differ.diff(before, after);
-      const withPr = applyResolved(json, guidIndex);
+      const withPr = applyResolved(outcome.json, ctx.guidIndex);
       const first = await searchUnresolved(withPr, client, req.owner, req.repo, repoKey);
-      const ctx = { refs, files, guidIndex };
+      if (!first.neededSources?.length) return { ok: true, json: first };
+
+      // mergeSources は元の before/after を要する。computeDiff と同じ手順で取り直す
+      // (メモリの blob Promise キャッシュに当たるので、通常ここで実フェッチは起きない)
+      const file = ctx.files.find((f) => f.path === req.path);
+      const status = file?.status ?? 'modified';
+      const beforePath = file?.previousPath ?? req.path;
+      const fetchSide = (p: string, sha: string): Promise<Uint8Array> =>
+        fetchBlob(client, req.owner, req.repo, p, sha).then((bytes) => bytes ?? EMPTY);
+      const [before, after] = await Promise.all([
+        status === 'added' ? EMPTY : fetchSide(beforePath, ctx.refs.baseSha),
+        status === 'removed' ? EMPTY : fetchSide(req.path, ctx.refs.headSha),
+      ]);
       return { ok: true, json: await mergeSources(first, differ, before, after, ctx, client, req.owner, req.repo, repoKey) };
     } catch (err) {
       if (err instanceof RateLimitError) return { ok: false, error: 'rate-limited' };
@@ -172,5 +222,34 @@ export function createHandler(deps: Deps): (req: SemanticDiffRequest) => Promise
       if (err instanceof DiffError) return { ok: false, error: 'diff-failed' };
       return { ok: false, error: 'fetch-failed' }; // raw エラーは応答に載せない
     }
-  };
+  }
+
+  /** raw diff のプリコンピュートのみ。resolve/search/mergeSources は行わない
+   *  — Code Search は 10 req/min の希少資源で、mergeSources は解決結果依存のため serve 時に任せる。 */
+  async function prefetch(req: PrefetchRequest): Promise<void> {
+    try {
+      const settings = await deps.getSettings();
+      if (!settings.pat) return;
+      const base = apiBase(settings.baseUrl);
+      const client = deps.makeClient(base, settings.pat, 'prefetch');
+      const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
+      const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
+      for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
+        const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);
+        await Promise.all(
+          chunk.map((f) =>
+            getDiff(client, ctx, req.owner, req.repo, f.path, false).catch((err) => {
+              if (err instanceof RateLimitError) throw err; // レート制限だけは全体を止める
+              // ファイル単位の失敗は握りつぶす: 手動トグル時に改めてエラー表示される
+            }),
+          ),
+        );
+      }
+    } catch (err) {
+      // プリフェッチは静かに諦める。エラー UI はユーザー操作経路だけが出す
+      console.debug('prefablens: prefetch aborted', err);
+    }
+  }
+
+  return { semanticDiff, prefetch };
 }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,18 +1,24 @@
 import { createHandler } from './handler';
+import { createQueue } from './queue';
 import { GithubClient } from '../github/client';
 import { createDiffer, type Differ } from '../wasm/differ';
-import type { SemanticDiffRequest } from '../types';
+import type { BackgroundRequest, DiffV2 } from '../types';
 
 let differ: Promise<Differ> | undefined;
 
-const { semanticDiff } = createHandler({
+// REST 全体で同時 6 本(spec B2)。ユーザー操作由来は front で行列を追い越す
+const queue = createQueue(6);
+const queuedFetch = (front: boolean): typeof fetch => (input, init) => queue(() => fetch(input, init), { front });
+
+const SESSION_MAX_BYTES = 512 * 1024; // storage.session は 10MB: 大物はメモリのみ(SW が死んだら再計算)
+
+const handler = createHandler({
   async getSettings() {
     const stored = await chrome.storage.local.get(['pat', 'baseUrl']);
     return { pat: stored['pat'] as string | undefined, baseUrl: stored['baseUrl'] as string | undefined };
   },
-  makeClient: (base, token, _lane) => new GithubClient(base, token),
+  makeClient: (base, token, lane) => new GithubClient(base, token, queuedFetch(lane === 'user')),
   getDiffer() {
-    // 遅延シングルトン。SW が再起動したらフェッチし直すだけ。
     differ ??= fetch(chrome.runtime.getURL('prefablens.wasm'))
       .then((r) => r.arrayBuffer())
       .then(createDiffer);
@@ -30,12 +36,25 @@ const { semanticDiff } = createHandler({
       await chrome.storage.local.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
     },
   },
-  // Task 8 で storage.session 実装に差し替える
-  diffStore: { load: async () => undefined, save: async () => {} },
+  diffStore: {
+    async load(key) {
+      const stored = await chrome.storage.session.get([`diff:${key}`]);
+      return stored[`diff:${key}`] as DiffV2 | undefined;
+    },
+    async save(key, json) {
+      if (JSON.stringify(json).length > SESSION_MAX_BYTES) return;
+      await chrome.storage.session.set({ [`diff:${key}`]: json }).catch(() => {
+        // quota 超過等は無視: メモリキャッシュだけで続行する
+      });
+    },
+  },
 });
 
-chrome.runtime.onMessage.addListener((msg: SemanticDiffRequest, _sender, sendResponse) => {
-  if (msg?.type !== 'semanticDiff') return;
-  void semanticDiff(msg).then(sendResponse);
-  return true; // 非同期応答
+chrome.runtime.onMessage.addListener((msg: BackgroundRequest, _sender, sendResponse) => {
+  if (msg?.type === 'semanticDiff') {
+    void handler.semanticDiff(msg).then(sendResponse);
+    return true; // 非同期応答
+  }
+  if (msg?.type === 'prefetch') void handler.prefetch(msg);
+  return undefined; // prefetch は応答しない(fire-and-forget)
 });

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -19,6 +19,7 @@ const handler = createHandler({
   },
   makeClient: (base, token, lane) => new GithubClient(base, token, queuedFetch(lane === 'user')),
   getDiffer() {
+    // 遅延シングルトン。SW が再起動したらフェッチし直すだけ。
     differ ??= fetch(chrome.runtime.getURL('prefablens.wasm'))
       .then((r) => r.arrayBuffer())
       .then(createDiffer);

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -5,12 +5,12 @@ import type { SemanticDiffRequest } from '../types';
 
 let differ: Promise<Differ> | undefined;
 
-const handle = createHandler({
+const { semanticDiff } = createHandler({
   async getSettings() {
     const stored = await chrome.storage.local.get(['pat', 'baseUrl']);
     return { pat: stored['pat'] as string | undefined, baseUrl: stored['baseUrl'] as string | undefined };
   },
-  makeClient: (base, token) => new GithubClient(base, token),
+  makeClient: (base, token, _lane) => new GithubClient(base, token),
   getDiffer() {
     // 遅延シングルトン。SW が再起動したらフェッチし直すだけ。
     differ ??= fetch(chrome.runtime.getURL('prefablens.wasm'))
@@ -30,10 +30,12 @@ const handle = createHandler({
       await chrome.storage.local.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
     },
   },
+  // Task 8 で storage.session 実装に差し替える
+  diffStore: { load: async () => undefined, save: async () => {} },
 });
 
 chrome.runtime.onMessage.addListener((msg: SemanticDiffRequest, _sender, sendResponse) => {
   if (msg?.type !== 'semanticDiff') return;
-  void handle(msg).then(sendResponse);
+  void semanticDiff(msg).then(sendResponse);
   return true; // 非同期応答
 });

--- a/extension/src/background/queue.test.ts
+++ b/extension/src/background/queue.test.ts
@@ -48,4 +48,26 @@ describe('createQueue', () => {
     await expect(queue(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
     await expect(queue(async () => 'next')).resolves.toBe('next');
   });
+
+  it('normalizes a synchronous throw into a rejection without losing a slot', async () => {
+    // task() が Promise を返す前に throw しても active が漏れない: limit 1 で後続が動けば漏れていない
+    const queue = createQueue(1);
+    const syncThrow = (() => { throw new Error('sync boom'); }) as () => Promise<never>;
+    await expect(queue(syncThrow)).rejects.toThrow('sync boom');
+    await expect(queue(async () => 'next')).resolves.toBe('next');
+  });
+
+  it('keeps pumping when a queued task throws synchronously on dispatch', async () => {
+    // pump() の .finally 内から起動されるタスクの同期 throw が未処理拒否にならず、呼び出し元の Promise が確定する
+    const queue = createQueue(1);
+    const gate = deferred();
+    const first = queue(async () => { await gate.promise; });
+    const syncThrow = (() => { throw new Error('boom'); }) as () => Promise<never>;
+    const bad = queue(syncThrow);
+    const good = queue(async () => 'ok');
+    gate.resolve();
+    await first;
+    await expect(bad).rejects.toThrow('boom');
+    await expect(good).resolves.toBe('ok');
+  });
 });

--- a/extension/src/background/queue.test.ts
+++ b/extension/src/background/queue.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { createQueue } from './queue';
+
+// 手動で解決できる deferred を並べ、実行順と同時実行数を観測する
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+describe('createQueue', () => {
+  it('caps concurrent tasks at the limit', async () => {
+    const queue = createQueue(2);
+    let active = 0;
+    let maxActive = 0;
+    const gate = deferred();
+    const tasks = Array.from({ length: 5 }, () =>
+      queue(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await gate.promise;
+        active--;
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(maxActive).toBe(2); // secondary rate limit 回避: 同時 2 本を超えない
+    gate.resolve();
+    await Promise.all(tasks);
+    expect(maxActive).toBe(2);
+  });
+
+  it('runs front tasks before queued ones', async () => {
+    // ユーザークリックがプリフェッチの行列に並ばされない
+    const queue = createQueue(1);
+    const order: string[] = [];
+    const gate = deferred();
+    const first = queue(async () => { await gate.promise; order.push('running'); });
+    const prefetchTask = queue(async () => { order.push('prefetch'); });
+    const user = queue(async () => { order.push('user'); }, { front: true });
+    gate.resolve();
+    await Promise.all([first, prefetchTask, user]);
+    expect(order).toEqual(['running', 'user', 'prefetch']);
+  });
+
+  it('keeps pumping after a task rejects', async () => {
+    // 1 つの失敗でキューが詰まると、以降の全フェッチが永久に待つ
+    const queue = createQueue(1);
+    await expect(queue(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    await expect(queue(async () => 'next')).resolves.toBe('next');
+  });
+});

--- a/extension/src/background/queue.ts
+++ b/extension/src/background/queue.ts
@@ -1,0 +1,27 @@
+type Job = { run: () => Promise<unknown>; resolve: (v: unknown) => void; reject: (e: unknown) => void };
+
+export type Queue = <T>(task: () => Promise<T>, opts?: { front?: boolean }) => Promise<T>;
+
+/** REST の同時実行数を絞る(GitHub secondary rate limit はバーストで発動する)。
+ *  front はユーザー操作由来の割り込み用: プリフェッチの行列を追い越す。 */
+export function createQueue(limit: number): Queue {
+  const pending: Job[] = [];
+  let active = 0;
+  const pump = (): void => {
+    while (active < limit && pending.length) {
+      const job = pending.shift()!;
+      active++;
+      job.run().then(job.resolve, job.reject).finally(() => {
+        active--;
+        pump();
+      });
+    }
+  };
+  return <T>(task: () => Promise<T>, opts?: { front?: boolean }) =>
+    new Promise<T>((resolve, reject) => {
+      const job: Job = { run: task, resolve: resolve as (v: unknown) => void, reject };
+      if (opts?.front) pending.unshift(job);
+      else pending.push(job);
+      pump();
+    });
+}

--- a/extension/src/background/queue.ts
+++ b/extension/src/background/queue.ts
@@ -11,10 +11,14 @@ export function createQueue(limit: number): Queue {
     while (active < limit && pending.length) {
       const job = pending.shift()!;
       active++;
-      job.run().then(job.resolve, job.reject).finally(() => {
-        active--;
-        pump();
-      });
+      // 同期 throw も reject に正規化する: ここで漏れると active が戻らず、キューが永久に詰まる
+      Promise.resolve()
+        .then(job.run)
+        .then(job.resolve, job.reject)
+        .finally(() => {
+          active--;
+          pump();
+        });
     }
   };
   return <T>(task: () => Promise<T>, opts?: { front?: boolean }) =>

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
-import { parsePrUrl, scanUnityFiles } from './detect';
+import { parsePrPage, parsePrUrl, scanUnityFiles } from './detect';
 
 const FIXTURE = `
   <div class="file">
@@ -30,6 +30,21 @@ describe('parsePrUrl', () => {
   it('rejects other pages', () => {
     expect(parsePrUrl('/owner/repo/pull/42')).toBeNull();
     expect(parsePrUrl('/owner/repo/blob/main/a.prefab')).toBeNull();
+  });
+});
+
+describe('parsePrPage', () => {
+  it('matches every pr tab, not just files', () => {
+    // プリフェッチは conversation タブ到達時から始める(spec B2)
+    expect(parsePrPage('/o/r/pull/12')).toEqual({ owner: 'o', repo: 'r', prNumber: 12 });
+    expect(parsePrPage('/o/r/pull/12/commits')).toEqual({ owner: 'o', repo: 'r', prNumber: 12 });
+    expect(parsePrPage('/o/r/pull/12/files')).toEqual({ owner: 'o', repo: 'r', prNumber: 12 });
+  });
+
+  it('rejects non-pr pages', () => {
+    expect(parsePrPage('/o/r/pulls')).toBeNull();
+    expect(parsePrPage('/o/r/issues/12')).toBeNull();
+    expect(parsePrPage('/o/r/pull/notanumber')).toBeNull();
   });
 });
 

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -1,7 +1,4 @@
-// Unity がテキストシリアライズ(UnityYAML)する拡張子。unityyamlmerge の対象と同じ集合。
-// .meta(!u! ドキュメント形式でない)と .asmdef 等の JSON は対象外。
-const UNITY_PATH =
-  /\.(prefab|unity|asset|mat|anim|controller|overrideController|physicMaterial|physicsMaterial2D|playable|mask|brush|flare|fontsettings|guiskin|giparams|renderTexture|spriteatlas|spriteatlasv2|terrainlayer|mixer|shadervariants|preset|signal|lighting|scenetemplate)$/i;
+import { isUnityPath } from '../unity';
 
 export type FileEntry = { path: string; header: HTMLElement; content: HTMLElement };
 
@@ -15,7 +12,7 @@ export function scanUnityFiles(root: ParentNode): FileEntry[] {
   const out: FileEntry[] = [];
   for (const header of root.querySelectorAll<HTMLElement>('.file-header[data-path]')) {
     const path = header.dataset['path'];
-    if (!path || !UNITY_PATH.test(path)) continue;
+    if (!path || !isUnityPath(path)) continue;
     const container = header.closest('.file');
     const content = container?.querySelector<HTMLElement>('.js-file-content') ?? null;
     if (!content) continue;

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -7,6 +7,12 @@ export function parsePrUrl(pathname: string): { owner: string; repo: string; prN
   return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
 }
 
+/** PR のどのタブでもマッチする(プリフェッチ起点)。files 限定の parsePrUrl とは役割が違う。 */
+export function parsePrPage(pathname: string): { owner: string; repo: string; prNumber: number } | null {
+  const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(\/|$)/.exec(pathname);
+  return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
+}
+
 // GitHub の Files changed(クラシック DOM)を防御的に探す。合わなければ空配列で無害に終わる。
 export function scanUnityFiles(root: ParentNode): FileEntry[] {
   const out: FileEntry[] = [];

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,8 +1,8 @@
-import { parsePrUrl, scanUnityFiles, type FileEntry } from './detect';
+import { parsePrPage, parsePrUrl, scanUnityFiles, type FileEntry } from './detect';
 import { createToggle, type Toggle, type View } from './toggle';
 import { createViewState, type ViewState } from './viewstate';
 import { render, renderError, renderLoading, renderTooLarge } from '../renderer/render';
-import type { BackgroundError, SemanticDiffRequest, SemanticDiffResponse } from '../types';
+import type { BackgroundError, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
   'pat-missing': 'Set a GitHub token in the PrefabLens options page.',
@@ -17,8 +17,17 @@ type Applier = { header: HTMLElement; apply(view: View): void };
 const appliers = new Set<Applier>();
 let globalToggle: Toggle | undefined;
 let currentPr = ''; // 上書きは PR 滞在中のみ有効: PR が変わったら捨てる
+let prefetchedPr = ''; // conversation タブ含む全 PR タブで 1 回だけプリフェッチを送る
 
 function attach(state: ViewState): void {
+  const page = parsePrPage(location.pathname);
+  if (!page) return;
+  const pageKey = `${page.owner}/${page.repo}#${page.prNumber}`;
+  if (pageKey !== prefetchedPr) {
+    prefetchedPr = pageKey;
+    // fire-and-forget: 応答は待たず、失敗も無視(手動トグル経路が別に生きている)
+    void (chrome.runtime.sendMessage({ type: 'prefetch', ...page } satisfies PrefetchRequest) as Promise<unknown>).catch(() => {});
+  }
   const pr = parsePrUrl(location.pathname);
   if (!pr) return;
   const key = `${pr.owner}/${pr.repo}#${pr.prNumber}`;

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -72,6 +72,9 @@ export type SemanticDiffRequest = {
   force?: boolean; // 25MB ガードを越えて描画する(「Render anyway」クリック)
 };
 
+export type PrefetchRequest = { type: 'prefetch'; owner: string; repo: string; prNumber: number };
+export type BackgroundRequest = SemanticDiffRequest | PrefetchRequest;
+
 export type BackgroundError = 'pat-missing' | 'auth-failed' | 'rate-limited' | 'fetch-failed' | 'diff-failed';
 
 export type SemanticDiffResponse =

--- a/extension/src/unity.ts
+++ b/extension/src/unity.ts
@@ -1,0 +1,9 @@
+// Unity がテキストシリアライズ(UnityYAML)する拡張子。unityyamlmerge の対象と同じ集合。
+// .meta(!u! ドキュメント形式でない)と .asmdef 等の JSON は対象外。
+const UNITY_PATH =
+  /\.(prefab|unity|asset|mat|anim|controller|overrideController|physicMaterial|physicsMaterial2D|playable|mask|brush|flare|fontsettings|guiskin|giparams|renderTexture|spriteatlas|spriteatlasv2|terrainlayer|mixer|shadervariants|preset|signal|lighting|scenetemplate)$/i;
+
+/** content の検出と background のプリフェッチが同じ判定を共有する。 */
+export function isUnityPath(path: string): boolean {
+  return UNITY_PATH.test(path);
+}


### PR DESCRIPTION
## 概要

Semantic 表示のたびに待つのをやめるため、PR ページ到達時(conversation タブ含む)からバックグラウンドで blob 取得 + WASM diff を先行実行する。拡張 UX 改善 3 PR の 2 本目(B2)。#43 の続き、次は B3/B4(repo guid 索引 + プログレッシブ描画)。

## 変更点

- `background/queue.ts`: REST 同時 6 本の優先度付きキュー。ユーザー操作由来の fetch は行列の先頭に割り込み(プリフェッチ待ちでクリックが遅くならない)。同期 throw も reject に正規化しキューが詰まらない
- `handler.ts`: raw diff(`differ.diff` 出力)を `baseSha:headSha:path` キーの Promise キャッシュ + `chrome.storage.session`(512KB 以下のみ)に格納。**sha キーなので push で自然に無効化され TTL 不要**。resolve → Code Search → mergeSources(#42)の後段は解決状態に依存するため毎 serve 実行し、キャッシュしない。mergeSources / searchUnresolved / loadContext の本文は不変
- `prefetch()`: Unity ファイルのみ・1 PR 上限 100・並列 4。**Code Search(10 req/min)には一切触れない**(テストで固定)。RateLimitError は静かに全体中断、ファイル単位の失敗は握りつぶし(エラー UI はユーザー操作経路だけ)
- `content`: `parsePrPage` で全 PR タブを検知し、同一 PR につき 1 回だけ prefetch メッセージを送信(fire-and-forget)

## レート制限への配慮

Unity 50 ファイルの PR でも約 110 REST call(5,000/h の 2%)。secondary limit はキューの同時 6 本で回避。プリフェッチとユーザークリックの同一 blob/diff 同時要求は Promise キャッシュで 1 回に畳まれる。

## テスト

- unit 114/114(queue 5、prefetch/キャッシュ系 9 新規、mergeSources 既存テストは無改変で green = 機能保持の回帰確認)
- e2e 8/8(prefetch 送信の検証 1 本新規)

## Follow-up(マージ後に別 PR)

- `chrome.storage.session` の `diff:` キーに削除経路がなく、長寿命ブラウザセッションで 10MB quota に達すると永続層が無言で恒久停止する(機能は劣化のみ、メモリキャッシュで動作継続)。掃除ロジック 5-10 行を follow-up で入れる