### PR TITLE
feat: repo guid index with progressive rendering

### DIFF
--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -39,6 +39,8 @@ function startServer(): Promise<{ server: Server; port: number }> {
         return json({ base: { sha: 'B' }, head: { sha: 'H' } });
       case '/api/v3/repos/o/r/compare/B...H':
         return json({ merge_base_commit: { sha: 'MB' } });
+      case '/api/v3/repos/o/r/git/trees/H':
+        return json({ truncated: false, tree: [] });
       case '/api/v3/repos/o/r/contents/Assets/Foo.prefab':
         return send(url.searchParams.get('ref') === 'MB' ? BEFORE : AFTER, 'application/vnd.github.raw+json');
       case '/api/v3/repos/o/r/contents/Assets/Big.unity':

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -255,6 +255,34 @@ describe('createHandler', () => {
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
   });
 
+  it('serves cached names even for guids that once missed in code search', async () => {
+    // 索引解決が guidCache に入る設計になったため、miss 記録済み guid がキャッシュに現れるケースが実在する。
+    // misses は「再検索しない」の門番であって「名前を出さない」の門番ではない
+    const { deps, client, guidCache } = makeDeps(); // search 未ヒット → g1 が misses に入る
+    const handler = createHandler(deps);
+    await handler.semanticDiff(REQ);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+    guidCache.data['https://api.github.com/o/r'] = { g1: 'Assets/Later.cs' }; // 索引解決が後から書いた体
+    const res = await handler.semanticDiff(REQ);
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/Later.cs' } } });
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1); // 再検索はしない
+  });
+
+  it('dedupes concurrent code searches for the same guid', async () => {
+    // semantic 既定では複数ファイルが同時に解決を走らせる: 同一 guid の検索は 1 回に畳む
+    const { deps, client } = makeDeps({ search: { g1: 'Assets/S.cs' } });
+    let release!: (v: string) => void;
+    client.searchMetaByGuid.mockImplementation(() => new Promise((r) => { release = r; }));
+    const handler = createHandler(deps);
+    const [a, b] = [handler.semanticDiff(REQ), handler.semanticDiff(REQ)];
+    await vi.waitFor(() => expect(client.searchMetaByGuid).toHaveBeenCalled());
+    release('Assets/S.cs');
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+    expect(ra).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/S.cs' } } });
+    expect(rb).toEqual(ra);
+  });
+
   it('keeps the diff usable when code search hits the rate limit', async () => {
     const twoGuids: DiffV2 = { ...DIFF, unresolvedGuids: ['g1', 'g2'] };
     const { deps, client } = makeDeps({ diff: () => twoGuids });

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createHandler, type Deps } from './handler';
+import { createHandler, type Deps, type Handler } from './handler';
 import { AuthError, RateLimitError, type PrFile } from '../github/client';
 import { DiffError, type Differ } from '../wasm/differ';
-import type { DiffV2, SemanticDiffRequest } from '../types';
+import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from '../types';
 
 const REQ: SemanticDiffRequest = { type: 'semanticDiff', owner: 'o', repo: 'r', prNumber: 1, path: 'Assets/Foo.prefab' };
 
@@ -28,6 +28,11 @@ function makeDeps(overrides?: {
     listPrFiles: vi.fn(async () => files),
     getFileAtRef,
     searchMetaByGuid: vi.fn(async (_o: string, _r: string, guid: string) => overrides?.search?.[guid] ?? null),
+    listMetaTree: vi.fn(async (): Promise<{ truncated: boolean; metas: Array<{ path: string; sha: string }> }> => ({
+      truncated: false,
+      metas: [],
+    })),
+    batchBlobTexts: vi.fn(async (): Promise<Record<string, string | null>> => ({})),
   };
   const differ: Differ = {
     diff: overrides?.diff ?? vi.fn(() => DIFF),
@@ -50,14 +55,39 @@ function makeDeps(overrides?: {
       diffStoreData[key] = json;
     }),
   };
+  // Task 11 の makeFakes と同型(loadGuids/saveGuids/loadIndex/saveIndex)。テストごとに空で始まる。
+  const guidsData: Record<string, Record<string, string>> = {};
+  const indexData: Record<string, { treeSha: string; guids: Record<string, string> }> = {};
+  const repoIndexStore = {
+    loadGuids: vi.fn(async (repo: string) => guidsData[repo] ?? {}),
+    saveGuids: vi.fn(async (repo: string, entries: Record<string, string>) => {
+      guidsData[repo] = { ...guidsData[repo], ...entries };
+    }),
+    loadIndex: vi.fn(async (repo: string) => indexData[repo]),
+    saveIndex: vi.fn(async (repo: string, index: { treeSha: string; guids: Record<string, string> }) => {
+      indexData[repo] = index;
+    }),
+  };
   const deps: Deps = {
     getSettings: async () => ({ pat: Object.hasOwn(overrides ?? {}, 'pat') ? overrides!.pat : 'tok', baseUrl: undefined }),
     makeClient: (_base: string, _token: string, _lane: 'user' | 'prefetch') => client,
     getDiffer: async () => differ,
     guidCache,
     diffStore,
+    repoIndexStore,
   };
-  return { deps, client, differ, guidCache, diffStore };
+  return { deps, client, differ, guidCache, diffStore, repoIndexStore };
+}
+
+/** pending 応答の後始末: done push が来るまで待ってから検証する。 */
+async function serveAndResolve(
+  handler: Handler,
+  req: SemanticDiffRequest,
+): Promise<{ res: Awaited<ReturnType<Handler['semanticDiff']>>; pushes: GuidResolvedPush[] }> {
+  const pushes: GuidResolvedPush[] = [];
+  const res = await handler.semanticDiff(req, (m) => pushes.push(m));
+  if (res.ok && res.pending) await vi.waitFor(() => expect(pushes.at(-1)?.done).toBe(true));
+  return { res, pushes };
 }
 
 describe('createHandler', () => {
@@ -479,4 +509,97 @@ it('dedupes a concurrent user toggle against an in-flight prefetch compute', asy
   expect(res.ok).toBe(true);
   const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === 'Assets/Foo.prefab');
   expect(fooFetches).toHaveLength(2); // base + head の 2 回だけ
+});
+
+describe('semanticDiff with push (two-stage)', () => {
+  it('responds immediately with pending and pushes code-search results in the final json', async () => {
+    const { deps, guidCache } = makeDeps({ search: { g1: 'Assets/Scripts/S.cs' } });
+    const { res, pushes } = await serveAndResolve(createHandler(deps), REQ);
+    // 応答は即返り、resolved は空 + pending。名前は push で届く(B4 の核心)
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: {} }, pending: true });
+    const last = pushes.at(-1)!;
+    expect(last.done).toBe(true);
+    expect(last.json?.resolved).toEqual({ g1: 'Assets/Scripts/S.cs' });
+    expect(guidCache.save).toHaveBeenCalledWith('https://api.github.com/o/r', { g1: 'Assets/Scripts/S.cs' });
+  });
+
+  it('does not set pending when the pr meta index resolves everything', async () => {
+    const { deps } = makeDeps({
+      files: [
+        { path: 'Assets/Foo.prefab', status: 'modified' },
+        { path: 'Assets/S.cs.meta', status: 'modified' },
+      ],
+      contents: {
+        'Assets/Foo.prefab@base-sha': 'b',
+        'Assets/Foo.prefab@head-sha': 'a',
+        'Assets/S.cs.meta@head-sha': 'guid: g1\n',
+      },
+    });
+    const { res, pushes } = await serveAndResolve(createHandler(deps), REQ);
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: 'Assets/S.cs' } } });
+    expect(pushes).toEqual([]); // 全部解決済み・ソース合成も不要なら push は無い
+  });
+
+  it('resolves via the repo index and only searches the leftover', async () => {
+    const { deps, client } = makeDeps({ diff: () => ({ ...DIFF, unresolvedGuids: ['g1', 'g2'] }), search: { g2: 'Assets/Other.cs' } });
+    client.listMetaTree.mockResolvedValue({ truncated: false, metas: [{ path: 'Assets/S.cs.meta', sha: 'sha1' }] });
+    client.batchBlobTexts.mockResolvedValue({ sha1: 'guid: g1\n' });
+    const { pushes } = await serveAndResolve(createHandler(deps), REQ);
+    // 索引で g1 が先に届き(中間 push)、索引に無い g2 だけが Code Search に回る(3 段解決)
+    expect(pushes[0]).toMatchObject({ resolved: { g1: 'Assets/S.cs' }, done: false });
+    expect(pushes.at(-1)!.json?.resolved).toEqual({ g1: 'Assets/S.cs', g2: 'Assets/Other.cs' });
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+    expect(client.searchMetaByGuid).toHaveBeenCalledWith('o', 'r', 'g2');
+  });
+
+  it('falls back to code search when the tree is truncated', async () => {
+    const { deps, client } = makeDeps({ search: { g1: 'Assets/S.cs' } });
+    client.listMetaTree.mockResolvedValue({ truncated: true, metas: [] });
+    const { pushes } = await serveAndResolve(createHandler(deps), REQ);
+    expect(pushes.at(-1)!.json?.resolved).toEqual({ g1: 'Assets/S.cs' });
+  });
+
+  it('stops retrying the index for the session after an index rate limit', async () => {
+    const { deps, client } = makeDeps();
+    client.listMetaTree.mockRejectedValue(new RateLimitError('x'));
+    const handler = createHandler(deps);
+    await serveAndResolve(handler, REQ);
+    await serveAndResolve(handler, REQ);
+    expect(client.listMetaTree).toHaveBeenCalledTimes(1); // SW 生存期間はフォールバック固定
+  });
+
+  it('re-merges sources in the async stage once the source guid resolves', async () => {
+    // mergeSources 整合の核心: stage 1 は未合成のまま即応答し、
+    // repo index でソース guid が解けたら合成し直した json が最終 push で届く
+    const withSource: DiffV2 = { ...DIFF, unresolvedGuids: ['src1'], neededSources: [{ guid: 'src1', side: 'after' }] };
+    const merged: DiffV2 = { ...DIFF, unresolvedGuids: ['src1'], resolved: { src1: 'Assets/Src.prefab' } };
+    const diffWithAssets = vi.fn(() => merged);
+    const { deps, client } = makeDeps({
+      contents: {
+        'Assets/Foo.prefab@base-sha': 'b',
+        'Assets/Foo.prefab@head-sha': 'a',
+        'Assets/Src.prefab@head-sha': 'source prefab',
+      },
+      diff: () => withSource,
+      diffWithAssets,
+    });
+    client.listMetaTree.mockResolvedValue({ truncated: false, metas: [{ path: 'Assets/Src.prefab.meta', sha: 'sha1' }] });
+    client.batchBlobTexts.mockResolvedValue({ sha1: 'guid: src1\n' });
+    // 注: serveAndResolve は done push を待つため、その後段では diffWithAssets が必ず既に呼ばれている
+    // (done:true は mergeSources 完了後にしか出ない)。「まだ呼ばれていない」の検証は
+    // 即応答の直後(push 完了を待つ前)に行う必要があるため、ここだけ手動で組み立てる。
+    const pushes: GuidResolvedPush[] = [];
+    const res = await createHandler(deps).semanticDiff(REQ, (m) => pushes.push(m));
+    expect(res.ok && res.pending).toBe(true);
+    expect(diffWithAssets).not.toHaveBeenCalled(); // stage 1 では合成しない(即応答優先)
+    await vi.waitFor(() => expect(diffWithAssets).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(pushes.at(-1)?.done).toBe(true));
+    expect(pushes.at(-1)!.json).toMatchObject({ resolved: { src1: 'Assets/Src.prefab' } });
+  });
+
+  it('kicks the repo index sync from prefetch', async () => {
+    const { deps, client } = makeDeps();
+    await createHandler(deps).prefetch({ type: 'prefetch', owner: 'o', repo: 'r', prNumber: 1 });
+    await vi.waitFor(() => expect(client.listMetaTree).toHaveBeenCalledWith('o', 'r', 'head-sha'));
+  });
 });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -1,10 +1,14 @@
 import { AuthError, RateLimitError, apiBase, type GithubClient, type PrFile, type PrRefs } from '../github/client';
 import { applyResolved, buildGuidIndex, type GuidCache } from '../github/guids';
+import { syncRepoIndex, type RepoIndexStore } from '../github/repoIndex';
 import { DiffError, type Differ } from '../wasm/differ';
 import { isUnityPath } from '../unity';
-import type { DiffV2, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from '../types';
+import type { DiffV2, GuidResolvedPush, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
-type ClientLike = Pick<GithubClient, 'getPrRefs' | 'listPrFiles' | 'getFileAtRef' | 'searchMetaByGuid'>;
+type ClientLike = Pick<
+  GithubClient,
+  'getPrRefs' | 'listPrFiles' | 'getFileAtRef' | 'searchMetaByGuid' | 'listMetaTree' | 'batchBlobTexts'
+>;
 
 export type Deps = {
   getSettings(): Promise<{ pat?: string; baseUrl?: string }>;
@@ -12,10 +16,11 @@ export type Deps = {
   getDiffer(): Promise<Differ>;
   guidCache: GuidCache;
   diffStore: { load(key: string): Promise<DiffV2 | undefined>; save(key: string, json: DiffV2): Promise<void> };
+  repoIndexStore: RepoIndexStore;
 };
 
 export type Handler = {
-  semanticDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse>;
+  semanticDiff(req: SemanticDiffRequest, push?: (msg: GuidResolvedPush) => void): Promise<SemanticDiffResponse>;
   prefetch(req: PrefetchRequest): Promise<void>;
 };
 
@@ -41,15 +46,19 @@ export function createHandler(deps: Deps): Handler {
   const misses = new Set<string>();
   // baseSha:headSha:path → raw diff 計算の Promise。成功のみ保持(too-large/失敗は再計算を許す)
   const diffs = new Map<string, Promise<DiffOutcome>>();
+  // repoKey@ref → repo 全体索引の Promise(Task 11)。null は索引不可(truncated/上限超/失敗)
+  const indexes = new Map<string, Promise<Record<string, string> | null>>();
+  // レート制限を踏んだ repo は SW 生存期間フォールバック(索引を諦めて Code Search のみに委ねる)
+  const indexFallback = new Set<string>();
 
-  /** PR 内 .meta で解決できなかった guid を キャッシュ → Code Search の順で解決する。
-   *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ載せる。 */
-  async function searchUnresolved(json: DiffV2, client: ClientLike, owner: string, repo: string, repoKey: string): Promise<DiffV2> {
-    const resolved = { ...json.resolved };
+  /** guid[] をキャッシュ → Code Search の順で解決する(searchUnresolved の中身そのもの)。
+   *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ返す。 */
+  async function searchGuids(guids: string[], client: ClientLike, owner: string, repo: string, repoKey: string): Promise<Record<string, string>> {
     // hasOwn: guid は任意文字列なので 'constructor' 等が Object.prototype に誤ヒットしない(cached も同様)
-    const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g) && !misses.has(`${repoKey}:${g}`));
-    if (!pending.length) return { ...json, resolved };
+    const pending = guids.filter((g) => !misses.has(`${repoKey}:${g}`));
+    if (!pending.length) return {};
     const cached = await deps.guidCache.load(repoKey);
+    const resolved: Record<string, string> = {};
     const unknown: string[] = [];
     for (const g of pending) {
       if (Object.hasOwn(cached, g)) resolved[g] = cached[g]!;
@@ -67,7 +76,31 @@ export function createHandler(deps: Deps): Handler {
       }
     }
     if (Object.keys(found).length) await deps.guidCache.save(repoKey, found);
-    return { ...json, resolved };
+    return resolved;
+  }
+
+  /** PR 内 .meta で解決できなかった guid を キャッシュ → Code Search の順で解決する薄いラッパ。
+   *  mergeSources が内部で呼ぶため、シグネチャと挙動を変えない。 */
+  async function searchUnresolved(json: DiffV2, client: ClientLike, owner: string, repo: string, repoKey: string): Promise<DiffV2> {
+    const resolved = { ...json.resolved };
+    const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g));
+    const found = await searchGuids(pending, client, owner, repo, repoKey);
+    return { ...json, resolved: { ...resolved, ...found } };
+  }
+
+  /** repo 全体の guid 索引を取得・メモ化する。レート制限を踏んだ repo は SW 生存期間フォールバック固定。 */
+  function getRepoIndex(client: ClientLike, owner: string, repo: string, repoKey: string, ref: string): Promise<Record<string, string> | null> {
+    if (indexFallback.has(repoKey)) return Promise.resolve(null);
+    const key = `${repoKey}@${ref}`;
+    const hit = indexes.get(key);
+    if (hit) return hit;
+    const p = syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref).catch((err: unknown) => {
+      indexes.delete(key); // 失敗はキャッシュしない: 次回訪問で再試行
+      if (err instanceof RateLimitError) indexFallback.add(repoKey);
+      return null;
+    });
+    indexes.set(key, p);
+    return p;
   }
 
   async function fetchBlob(client: ClientLike, owner: string, repo: string, path: string, sha: string): Promise<Uint8Array | null> {
@@ -79,6 +112,19 @@ export function createHandler(deps: Deps): Handler {
     blobs.set(key, p);
     if (blobs.size > BLOB_CACHE_MAX) blobs.delete(blobs.keys().next().value!);
     return p;
+  }
+
+  /** before/after の blob を取り出す(status/previousPath の規則は files API 準拠)。 */
+  async function fetchPair(client: ClientLike, ctx: PrContext, owner: string, repo: string, path: string): Promise<[Uint8Array, Uint8Array]> {
+    const file = ctx.files.find((f) => f.path === path);
+    const status = file?.status ?? 'modified';
+    const beforePath = file?.previousPath ?? path;
+    const fetchSide = (p: string, sha: string): Promise<Uint8Array> =>
+      fetchBlob(client, owner, repo, p, sha).then((bytes) => bytes ?? EMPTY);
+    return Promise.all([
+      status === 'added' ? Promise.resolve(EMPTY) : fetchSide(beforePath, ctx.refs.baseSha),
+      status === 'removed' ? Promise.resolve(EMPTY) : fetchSide(path, ctx.refs.headSha),
+    ]);
   }
 
   /** neededSources(added/removed instance のソース prefab)を resolved パス経由で
@@ -152,16 +198,8 @@ export function createHandler(deps: Deps): Handler {
   /** blob 取得 → 25MB ガード → 素の diff まで。解決や mergeSources はここに入れない
    *  (resolved は Code Search で後から良くなるため、sha だけで決まる raw diff がキャッシュ単位)。 */
   async function computeDiff(client: ClientLike, ctx: PrContext, owner: string, repo: string, path: string, force: boolean): Promise<DiffOutcome> {
-    const file = ctx.files.find((f) => f.path === path);
-    // 一覧に無い場合(files API は 3000 件で打ち切り)は modified 扱い: 無い側は 404 → EMPTY に落ちるだけ
-    const status = file?.status ?? 'modified';
-    const beforePath = file?.previousPath ?? path;
-    const fetchSide = (p: string, sha: string): Promise<Uint8Array> =>
-      fetchBlob(client, owner, repo, p, sha).then((bytes) => bytes ?? EMPTY);
-    const [before, after] = await Promise.all([
-      status === 'added' ? EMPTY : fetchSide(beforePath, ctx.refs.baseSha),
-      status === 'removed' ? EMPTY : fetchSide(path, ctx.refs.headSha),
-    ]);
+    // 一覧に無い場合(files API は 3000 件で打ち切り)は modified 扱い: 無い側は 404 → EMPTY に落ちるだけ(fetchPair 側の規則)
+    const [before, after] = await fetchPair(client, ctx, owner, repo, path);
     if (!force && before.length + after.length > TOO_LARGE_BYTES) {
       return { ok: false, error: 'too-large', bytes: before.length + after.length };
     }
@@ -188,7 +226,52 @@ export function createHandler(deps: Deps): Handler {
     return p;
   }
 
-  async function semanticDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
+  /** 3 段解決の続き(索引 → Code Search)とソース再合成を裏で走らせ、push で結果を届ける。
+   *  push 無しの互換経路とは異なり、失敗しても catch で done push を出して待ち手を解放する。 */
+  async function resolveRemaining(
+    first: DiffV2,
+    remaining: string[],
+    client: ClientLike,
+    req: SemanticDiffRequest,
+    base: string,
+    ctx: PrContext,
+    push: (msg: GuidResolvedPush) => void,
+  ): Promise<void> {
+    const repoKey = `${base}/${req.owner}/${req.repo}`;
+    const at = { owner: req.owner, repo: req.repo, prNumber: req.prNumber, path: req.path };
+    try {
+      const index = await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha);
+      const fromIndex: Record<string, string> = {};
+      let leftover = remaining;
+      if (index) {
+        for (const g of remaining) if (Object.hasOwn(index, g)) fromIndex[g] = index[g]!;
+        leftover = remaining.filter((g) => !Object.hasOwn(fromIndex, g));
+        if (Object.keys(fromIndex).length) {
+          // guidCache にも載せる: mergeSources 内部の searchUnresolved は applyResolved で
+          // resolved を ctx.guidIndex ベースに作り直すため、guidCache 経由でないと索引由来の
+          // 解決がソース再合成後に消える(Code Search 由来が既にこの経路で復元されるのと同じ理屈)。
+          await deps.guidCache.save(repoKey, fromIndex);
+          // 名前が既に出せる分は先に届ける(構造は後続の最終 push で確定)
+          push({ type: 'guidResolved', ...at, resolved: fromIndex, done: false });
+        }
+      }
+      // 索引不可、または索引に無い guid だけが Code Search に回る(spec B3 の 3 段目)
+      const fromSearch = leftover.length ? await searchGuids(leftover, client, req.owner, req.repo, repoKey) : {};
+      let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...fromSearch } };
+      if (json.neededSources?.length) {
+        // 解決が進んだのでソース合成をやり直す(ソース guid が今回解けたケースを拾う)
+        const differ = await deps.getDiffer();
+        const [before, after] = await fetchPair(client, ctx, req.owner, req.repo, req.path);
+        json = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
+      }
+      push({ type: 'guidResolved', ...at, resolved: {}, json, done: true }); // 最終 push は json 置換
+    } catch (err) {
+      console.debug('prefablens: guid resolution aborted', err);
+      push({ type: 'guidResolved', ...at, resolved: {}, done: true });
+    }
+  }
+
+  async function semanticDiff(req: SemanticDiffRequest, push?: (msg: GuidResolvedPush) => void): Promise<SemanticDiffResponse> {
     try {
       const settings = await deps.getSettings();
       if (!settings.pat) return { ok: false, error: 'pat-missing' };
@@ -197,25 +280,23 @@ export function createHandler(deps: Deps): Handler {
       const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
       const outcome = await getDiff(client, ctx, req.owner, req.repo, req.path, req.force === true);
       if (!outcome.ok) return outcome;
-
-      const differ = await deps.getDiffer();
       const repoKey = `${base}/${req.owner}/${req.repo}`;
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
-      const first = await searchUnresolved(withPr, client, req.owner, req.repo, repoKey);
-      if (!first.neededSources?.length) return { ok: true, json: first };
 
-      // mergeSources は元の before/after を要する。computeDiff と同じ手順で取り直す
-      // (メモリの blob Promise キャッシュに当たるので、通常ここで実フェッチは起きない)
-      const file = ctx.files.find((f) => f.path === req.path);
-      const status = file?.status ?? 'modified';
-      const beforePath = file?.previousPath ?? req.path;
-      const fetchSide = (p: string, sha: string): Promise<Uint8Array> =>
-        fetchBlob(client, req.owner, req.repo, p, sha).then((bytes) => bytes ?? EMPTY);
-      const [before, after] = await Promise.all([
-        status === 'added' ? EMPTY : fetchSide(beforePath, ctx.refs.baseSha),
-        status === 'removed' ? EMPTY : fetchSide(req.path, ctx.refs.headSha),
-      ]);
-      return { ok: true, json: await mergeSources(first, differ, before, after, ctx, client, req.owner, req.repo, repoKey) };
+      if (!push) {
+        // 互換経路: 従来の同期フルパイプライン(既存テスト・呼び出しの挙動を変えない)
+        const first = await searchUnresolved(withPr, client, req.owner, req.repo, repoKey);
+        if (!first.neededSources?.length) return { ok: true, json: first };
+        const differ = await deps.getDiffer();
+        const [before, after] = await fetchPair(client, ctx, req.owner, req.repo, req.path);
+        return { ok: true, json: await mergeSources(first, differ, before, after, ctx, client, req.owner, req.repo, repoKey) };
+      }
+
+      // 2 段階経路: diff は即返し、解決とソース合成は裏で続けて push で届ける(B4)
+      const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));
+      if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
+      void resolveRemaining(withPr, remaining, client, req, base, ctx, push);
+      return { ok: true, json: withPr, pending: true };
     } catch (err) {
       if (err instanceof RateLimitError) return { ok: false, error: 'rate-limited' };
       if (err instanceof AuthError) return { ok: false, error: 'auth-failed' };
@@ -233,6 +314,8 @@ export function createHandler(deps: Deps): Handler {
       const base = apiBase(settings.baseUrl);
       const client = deps.makeClient(base, settings.pat, 'prefetch');
       const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
+      // raw diff の先読みとは独立に走らせる(索引 sync は serve 時の 3 段解決を高速化する)
+      void getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
       const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
       for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
         const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -44,6 +44,8 @@ export function createHandler(deps: Deps): Handler {
   const blobs = new Map<string, Promise<Uint8Array | null>>();
   // Code Search の未ヒット guid。索引遅延があるため永続化せず SW 生存期間のみ
   const misses = new Set<string>();
+  // repoKey:guid → 実行中の検索。同時多発の同一 guid 検索を 1 回に畳む(10 req/min 保護)
+  const searches = new Map<string, Promise<string | null>>();
   // baseSha:headSha:path → raw diff 計算の Promise。成功のみ保持(too-large/失敗は再計算を許す)
   const diffs = new Map<string, Promise<DiffOutcome>>();
   // repoKey@ref → repo 全体索引の Promise(Task 11)。null は索引不可(truncated/上限超/失敗)
@@ -54,25 +56,34 @@ export function createHandler(deps: Deps): Handler {
   /** guid[] をキャッシュ → Code Search の順で解決する(searchUnresolved の中身そのもの)。
    *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ返す。 */
   async function searchGuids(guids: string[], client: ClientLike, owner: string, repo: string, repoKey: string): Promise<Record<string, string>> {
-    // hasOwn: guid は任意文字列なので 'constructor' 等が Object.prototype に誤ヒットしない(cached も同様)
-    const pending = guids.filter((g) => !misses.has(`${repoKey}:${g}`));
-    if (!pending.length) return {};
+    if (!guids.length) return {};
+    // hasOwn: guid は任意文字列なので 'constructor' 等が Object.prototype に誤ヒットしない
+    // cached lookup は misses を経由しない全 guid が対象: 索引解決も guidCache に載るため、
+    // misses(検索の門番)に入っていてもキャッシュ済みの名前は必ず出す
     const cached = await deps.guidCache.load(repoKey);
     const resolved: Record<string, string> = {};
     const unknown: string[] = [];
-    for (const g of pending) {
+    for (const g of guids) {
       if (Object.hasOwn(cached, g)) resolved[g] = cached[g]!;
       else unknown.push(g);
     }
+    const searchable = unknown.filter((g) => !misses.has(`${repoKey}:${g}`));
     const found: Record<string, string> = {};
-    for (const g of unknown.slice(0, MAX_SEARCHES)) {
+    for (const g of searchable.slice(0, MAX_SEARCHES)) {
+      const key = `${repoKey}:${g}`;
       try {
-        const path = await client.searchMetaByGuid(owner, repo, g);
+        let p = searches.get(key);
+        if (!p) {
+          p = client.searchMetaByGuid(owner, repo, g);
+          searches.set(key, p);
+          void p.catch(() => {}).then(() => searches.delete(key)); // 完了後は guidCache/misses が引き継ぐ
+        }
+        const path = await p;
         if (path) resolved[g] = found[g] = path;
-        else misses.add(`${repoKey}:${g}`);
+        else misses.add(key);
       } catch (err) {
         if (err instanceof RateLimitError) break;
-        misses.add(`${repoKey}:${g}`);
+        misses.add(key);
       }
     }
     if (Object.keys(found).length) await deps.guidCache.save(repoKey, found);
@@ -240,7 +251,8 @@ export function createHandler(deps: Deps): Handler {
     const repoKey = `${base}/${req.owner}/${req.repo}`;
     const at = { owner: req.owner, repo: req.repo, prNumber: req.prNumber, path: req.path };
     try {
-      const index = await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha);
+      // remaining が空(ソース再合成のみ)なら索引を待たない: 初回索引構築は数十秒かかり得て解決に寄与しない
+      const index = remaining.length ? await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha) : null;
       const fromIndex: Record<string, string> = {};
       let leftover = remaining;
       if (index) {

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -2,7 +2,7 @@ import { createHandler } from './handler';
 import { createQueue } from './queue';
 import { GithubClient } from '../github/client';
 import { createDiffer, type Differ } from '../wasm/differ';
-import type { BackgroundRequest, DiffV2 } from '../types';
+import type { BackgroundRequest, DiffV2, GuidResolvedPush } from '../types';
 
 let differ: Promise<Differ> | undefined;
 
@@ -49,11 +49,36 @@ const handler = createHandler({
       });
     },
   },
+  repoIndexStore: {
+    async loadGuids(repo) {
+      const key = `metaGuids:${repo}`;
+      const stored = await chrome.storage.local.get([key]);
+      return (stored[key] as Record<string, string> | undefined) ?? {};
+    },
+    async saveGuids(repo, entries) {
+      const key = `metaGuids:${repo}`;
+      const stored = await chrome.storage.local.get([key]);
+      await chrome.storage.local
+        .set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } })
+        .catch(() => {}); // quota 超過はメモリのみで続行
+    },
+    async loadIndex(repo) {
+      const key = `guidIndex:${repo}`;
+      const stored = await chrome.storage.local.get([key]);
+      return stored[key] as { treeSha: string; guids: Record<string, string> } | undefined;
+    },
+    async saveIndex(repo, index) {
+      await chrome.storage.local.set({ [`guidIndex:${repo}`]: index }).catch(() => {});
+    },
+  },
 });
 
-chrome.runtime.onMessage.addListener((msg: BackgroundRequest, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendResponse) => {
   if (msg?.type === 'semanticDiff') {
-    void handler.semanticDiff(msg).then(sendResponse);
+    const tabId = sender.tab?.id;
+    const push =
+      tabId === undefined ? undefined : (m: GuidResolvedPush) => void chrome.tabs.sendMessage(tabId, m).catch(() => {});
+    void handler.semanticDiff(msg, push).then(sendResponse);
     return true; // 非同期応答
   }
   if (msg?.type === 'prefetch') void handler.prefetch(msg);

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -43,6 +43,7 @@ function attach(state: ViewState): void {
     state.clearOverrides();
     // PR をまたいだら死んだ DOM への参照も捨てる(soft leak 防止)
     for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
+    for (const [k, v] of views) if (!v.root.host.isConnected) views.delete(k); // 遷移で死んだ view への late push を無視するだけでなく参照も切る
   }
   const entries = scanUnityFiles(document);
   if (entries.length) ensureGlobalToggle(state, entries[0]!);
@@ -96,7 +97,8 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
       void requestDiff({ type: 'semanticDiff', ...pr, path: entry.path, force }).then((res) => {
         if (res.ok) {
           views.set(viewKey, { root, json: res.json });
-          return render(root, res.json, { resolving: res.pending ? countUnresolved(res.json) : 0 });
+          // pending の間は必ず表示する: 名前が全解決でもソース合成が残っていることがある
+          return render(root, res.json, { resolving: res.pending ? Math.max(countUnresolved(res.json), 1) : 0 });
         }
         requested = false; // エラーはキャッシュしない: 次回トグルで再フェッチさせる
         if (res.error === 'too-large') renderTooLarge(root, res.bytes, () => request(true));
@@ -156,7 +158,7 @@ async function init(): Promise<void> {
     if (!view) return; // 既に別 PR へ遷移した等: 黙って捨てる
     // 最終 push は json 置換(mergeSources で構造が変わり得る)、中間 push は resolved のマージ
     view.json = msg.json ?? { ...view.json, resolved: { ...view.json.resolved, ...msg.resolved } };
-    render(view.root, view.json, { resolving: msg.done ? 0 : countUnresolved(view.json) });
+    render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(countUnresolved(view.json), 1) });
   });
 
   // GitHub は SPA: 初回スキャン + MutationObserver で遅延ロード・タブ遷移に追従(200ms デバウンス)。

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -2,7 +2,7 @@ import { parsePrPage, parsePrUrl, scanUnityFiles, type FileEntry } from './detec
 import { createToggle, type Toggle, type View } from './toggle';
 import { createViewState, type ViewState } from './viewstate';
 import { render, renderError, renderLoading, renderTooLarge } from '../renderer/render';
-import type { BackgroundError, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from '../types';
+import type { BackgroundError, DiffV2, GuidResolvedPush, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from '../types';
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
   'pat-missing': 'Set a GitHub token in the PrefabLens options page.',
@@ -11,6 +11,13 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
   'fetch-failed': 'Could not fetch file contents from GitHub.',
   'diff-failed': 'Could not compute a semantic diff for this file.',
 };
+
+// path → 描画先。push(guidResolved)が届いたら resolved をマージして再描画する
+const views = new Map<string, { root: ShadowRoot; json: DiffV2 }>();
+
+function countUnresolved(json: DiffV2): number {
+  return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g)).length;
+}
 
 // 全体切り替えの適用先: attach 済みファイルのトグル + 表示を外から駆動する
 type Applier = { header: HTMLElement; apply(view: View): void };
@@ -34,6 +41,8 @@ function attach(state: ViewState): void {
   if (key !== currentPr) {
     currentPr = key;
     state.clearOverrides();
+    // PR をまたいだら死んだ DOM への参照も捨てる(soft leak 防止)
+    for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
   }
   const entries = scanUnityFiles(document);
   if (entries.length) ensureGlobalToggle(state, entries[0]!);
@@ -60,6 +69,7 @@ function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
 function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNumber: number }, entry: FileEntry): void {
   if (entry.header.hasAttribute('data-prefablens')) return;
   entry.header.setAttribute('data-prefablens', '');
+  const viewKey = `${pr.owner}/${pr.repo}#${pr.prNumber}:${entry.path}`;
 
   let host: HTMLElement | undefined;
   let requested = false;
@@ -84,7 +94,10 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
       requested = true;
       renderLoading(root);
       void requestDiff({ type: 'semanticDiff', ...pr, path: entry.path, force }).then((res) => {
-        if (res.ok) return render(root, res.json);
+        if (res.ok) {
+          views.set(viewKey, { root, json: res.json });
+          return render(root, res.json, { resolving: res.pending ? countUnresolved(res.json) : 0 });
+        }
         requested = false; // エラーはキャッシュしない: 次回トグルで再フェッチさせる
         if (res.error === 'too-large') renderTooLarge(root, res.bytes, () => request(true));
         else renderError(root, ERROR_TEXT[res.error]);
@@ -134,6 +147,16 @@ async function init(): Promise<void> {
     if (area !== 'local') return;
     const next = changes['viewMode']?.newValue;
     if (next === 'raw' || next === 'semantic') state.applyExternal(next);
+  });
+
+  // background からの guid 解決 push(2 段階応答の後段): 該当 view があれば再描画する
+  chrome.runtime.onMessage.addListener((msg: GuidResolvedPush) => {
+    if (msg?.type !== 'guidResolved') return;
+    const view = views.get(`${msg.owner}/${msg.repo}#${msg.prNumber}:${msg.path}`);
+    if (!view) return; // 既に別 PR へ遷移した等: 黙って捨てる
+    // 最終 push は json 置換(mergeSources で構造が変わり得る)、中間 push は resolved のマージ
+    view.json = msg.json ?? { ...view.json, resolved: { ...view.json.resolved, ...msg.resolved } };
+    render(view.root, view.json, { resolving: msg.done ? 0 : countUnresolved(view.json) });
   });
 
   // GitHub は SPA: 初回スキャン + MutationObserver で遅延ロード・タブ遷移に追従(200ms デバウンス)。

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { ApiError, AuthError, GithubClient, RateLimitError, apiBase } from './client';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiError, AuthError, GithubClient, RateLimitError, apiBase, graphqlUrl } from './client';
 
 // パス→レスポンスの固定表を返す fetch フェイク。呼び出しも記録する。
 // 照合は url.includes(key) なのでキーは一意な部分文字列にすること
@@ -147,5 +147,78 @@ describe('GithubClient', () => {
     await expect(
       at(403, { 'x-ratelimit-remaining': '4999' }, '{"message":"Resource not accessible by personal access token"}').getPrRefs('o', 'r', 1),
     ).rejects.toBeInstanceOf(AuthError);
+  });
+});
+
+describe('graphqlUrl', () => {
+  it('maps github.com and GHES api bases to their graphql endpoints', () => {
+    expect(graphqlUrl('https://api.github.com')).toBe('https://api.github.com/graphql');
+    expect(graphqlUrl('https://ghes.example.com/api/v3')).toBe('https://ghes.example.com/api/graphql');
+  });
+});
+
+describe('listMetaTree', () => {
+  it('returns only .meta blobs with the truncated flag', async () => {
+    const fetchFn = vi.fn(async (..._args: Parameters<typeof fetch>) =>
+      new Response(
+        JSON.stringify({
+          truncated: false,
+          tree: [
+            { path: 'Assets/S.cs.meta', type: 'blob', sha: 'sha1' },
+            { path: 'Assets/S.cs', type: 'blob', sha: 'sha2' },      // .meta 以外は除外
+            { path: 'Assets/Dir.meta', type: 'blob', sha: 'sha3' },
+            { path: 'Assets', type: 'tree', sha: 'sha4' },            // tree ノードは除外
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    const client = new GithubClient('https://api.github.com', 'tok', fetchFn);
+    const res = await client.listMetaTree('o', 'r', 'H');
+    expect(fetchFn.mock.calls[0]?.[0]).toBe('https://api.github.com/repos/o/r/git/trees/H?recursive=1');
+    expect(res).toEqual({
+      truncated: false,
+      metas: [
+        { path: 'Assets/S.cs.meta', sha: 'sha1' },
+        { path: 'Assets/Dir.meta', sha: 'sha3' },
+      ],
+    });
+  });
+});
+
+describe('batchBlobTexts', () => {
+  it('posts an aliased graphql query and maps oids to texts', async () => {
+    const fetchFn = vi.fn(async (..._args: Parameters<typeof fetch>) =>
+      new Response(
+        JSON.stringify({ data: { repository: { b0: { text: 'guid: g1\n' }, b1: null } } }),
+        { status: 200 },
+      ),
+    );
+    const client = new GithubClient('https://ghes.example.com/api/v3', 'tok', fetchFn);
+    const res = await client.batchBlobTexts('o', 'r', ['sha1', 'sha2']);
+    expect(fetchFn.mock.calls[0]?.[0]).toBe('https://ghes.example.com/api/graphql'); // GHES は /api/graphql
+    const init = fetchFn.mock.calls[0]?.[1] as RequestInit;
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string) as { query: string };
+    expect(body.query).toContain('b0: object(oid: "sha1")');
+    expect(body.query).toContain('b1: object(oid: "sha2")');
+    expect(res).toEqual({ sha1: 'guid: g1\n', sha2: null }); // 取得不可の blob は null
+  });
+
+  it('maps graphql RATE_LIMITED errors to RateLimitError', async () => {
+    // GraphQL は HTTP 200 で errors 配列を返すことがある: ここを見逃すと索引が黙って空になる
+    const fetchFn = vi.fn(async () =>
+      new Response(JSON.stringify({ errors: [{ type: 'RATE_LIMITED' }] }), { status: 200 }),
+    );
+    const client = new GithubClient('https://api.github.com', 'tok', fetchFn);
+    await expect(client.batchBlobTexts('o', 'r', ['sha1'])).rejects.toBeInstanceOf(RateLimitError);
+  });
+
+  it('maps http 403 with retry-after to RateLimitError (shared classification)', async () => {
+    const fetchFn = vi.fn(async () =>
+      new Response('slow down', { status: 403, headers: { 'retry-after': '60' } }),
+    );
+    const client = new GithubClient('https://api.github.com', 'tok', fetchFn);
+    await expect(client.batchBlobTexts('o', 'r', ['sha1'])).rejects.toBeInstanceOf(RateLimitError);
   });
 });

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -22,6 +22,11 @@ export function apiBase(baseUrl: string | undefined): string {
   return origin === 'https://github.com' ? 'https://api.github.com' : `${origin}/api/v3`;
 }
 
+/** REST の apiBase から GraphQL エンドポイントを導く。GHES は /api/v3 → /api/graphql。 */
+export function graphqlUrl(apiBase: string): string {
+  return apiBase.endsWith('/api/v3') ? `${apiBase.slice(0, -'/api/v3'.length)}/api/graphql` : `${apiBase}/graphql`;
+}
+
 export class GithubClient {
   constructor(
     private readonly base: string,
@@ -31,14 +36,8 @@ export class GithubClient {
     private readonly fetchFn: typeof fetch = (input, init) => fetch(input, init),
   ) {}
 
-  private async request(path: string, accept: string): Promise<Response> {
-    const res = await this.fetchFn(`${this.base}${path}`, {
-      headers: {
-        accept,
-        authorization: `Bearer ${this.token}`,
-        'x-github-api-version': '2022-11-28',
-      },
-    });
+  private async rawRequest(url: string, init: RequestInit): Promise<Response> {
+    const res = await this.fetchFn(url, init);
     if (res.status === 403 || res.status === 429) {
       // primary は 403 + x-ratelimit-remaining: 0、secondary は 403 + retry-after または
       // ヘッダなし(ボディの message のみ)、新 API は 429。ボディは分類にだけ使い、保持しない。
@@ -53,6 +52,16 @@ export class GithubClient {
     }
     if (res.status === 401) throw new AuthError('GitHub authentication failed');
     return res;
+  }
+
+  private async request(path: string, accept: string): Promise<Response> {
+    return this.rawRequest(`${this.base}${path}`, {
+      headers: {
+        accept,
+        authorization: `Bearer ${this.token}`,
+        'x-github-api-version': '2022-11-28',
+      },
+    });
   }
 
   private async json<T>(path: string): Promise<T> {
@@ -104,5 +113,41 @@ export class GithubClient {
     if (res.status === 404) return null;
     if (!res.ok) throw new ApiError(res.status);
     return new Uint8Array(await res.arrayBuffer());
+  }
+
+  /** ref(commit SHA 可)時点の全 .meta の path + blob SHA。truncated は 10 万エントリ超の打ち切り。 */
+  async listMetaTree(owner: string, repo: string, ref: string): Promise<{ truncated: boolean; metas: Array<{ path: string; sha: string }> }> {
+    const body = await this.json<{ truncated: boolean; tree: Array<{ path: string; type: string; sha: string }> }>(
+      `/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`,
+    );
+    const metas = body.tree
+      .filter((e) => e.type === 'blob' && e.path.endsWith('.meta'))
+      .map((e) => ({ path: e.path, sha: e.sha }));
+    return { truncated: body.truncated, metas };
+  }
+
+  /** GraphQL で blob text を一括取得(分割は呼び出し側)。GraphQL は 5,000 pt/h の独立枠。 */
+  async batchBlobTexts(owner: string, repo: string, oids: string[]): Promise<Record<string, string | null>> {
+    const aliases = oids.map((oid, i) => `b${i}: object(oid: ${JSON.stringify(oid)}) { ... on Blob { text } }`).join('\n');
+    const query = `query { repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(repo)}) {\n${aliases}\n} }`;
+    const res = await this.rawRequest(graphqlUrl(this.base), {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        authorization: `Bearer ${this.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ query }),
+    });
+    if (!res.ok) throw new ApiError(res.status);
+    const body = (await res.json()) as {
+      data?: { repository?: Record<string, { text?: string | null } | null> } | null;
+      errors?: Array<{ type?: string }>;
+    };
+    // GraphQL は HTTP 200 のまま errors を返す: RATE_LIMITED はここで拾う
+    if (body.errors?.some((e) => e.type === 'RATE_LIMITED')) throw new RateLimitError('GitHub rate limit exceeded');
+    const blobs = body.data?.repository;
+    if (!blobs) throw new ApiError(res.status);
+    return Object.fromEntries(oids.map((oid, i) => [oid, blobs[`b${i}`]?.text ?? null]));
   }
 }

--- a/extension/src/github/repoIndex.test.ts
+++ b/extension/src/github/repoIndex.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { syncRepoIndex, type RepoIndexStore } from './repoIndex';
+
+function makeFakes(overrides?: {
+  metas?: Array<{ path: string; sha: string }>;
+  truncated?: boolean;
+  texts?: Record<string, string | null>;
+  knownGuids?: Record<string, string>;
+  storedIndex?: { treeSha: string; guids: Record<string, string> };
+}) {
+  const client = {
+    listMetaTree: vi.fn(async () => ({
+      truncated: overrides?.truncated ?? false,
+      metas: overrides?.metas ?? [{ path: 'Assets/S.cs.meta', sha: 'sha1' }],
+    })),
+    batchBlobTexts: vi.fn(async (_o: string, _r: string, oids: string[]) =>
+      Object.fromEntries(oids.map((oid) => [oid, overrides?.texts?.[oid] ?? null])),
+    ),
+  };
+  const guids: Record<string, Record<string, string>> = { repoKey: { ...overrides?.knownGuids } };
+  const indexes: Record<string, { treeSha: string; guids: Record<string, string> }> = {};
+  if (overrides?.storedIndex) indexes['repoKey'] = overrides.storedIndex;
+  const store: RepoIndexStore = {
+    loadGuids: vi.fn(async (repo) => guids[repo] ?? {}),
+    saveGuids: vi.fn(async (repo, entries) => {
+      guids[repo] = { ...guids[repo], ...entries };
+    }),
+    loadIndex: vi.fn(async (repo) => indexes[repo]),
+    saveIndex: vi.fn(async (repo, index) => {
+      indexes[repo] = index;
+    }),
+  };
+  return { client, store };
+}
+
+describe('syncRepoIndex', () => {
+  it('builds guid → asset path from meta blobs and persists both layers', async () => {
+    const { client, store } = makeFakes({ texts: { sha1: 'fileFormatVersion: 2\nguid: g1\n' } });
+    const res = await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H');
+    expect(res).toEqual({ g1: 'Assets/S.cs' }); // .meta を剥いだパス
+    expect(store.saveGuids).toHaveBeenCalledWith('repoKey', { sha1: 'g1' });
+    expect(store.saveIndex).toHaveBeenCalledWith('repoKey', { treeSha: 'H', guids: { g1: 'Assets/S.cs' } });
+  });
+
+  it('returns the stored index without any api call when the tree sha is unchanged', async () => {
+    // push が無ければ tree も blob も取り直さない(2 回目以降の訪問はゼロコスト)
+    const stored = { treeSha: 'H', guids: { g1: 'Assets/S.cs' } };
+    const { client, store } = makeFakes({ storedIndex: stored });
+    const res = await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H');
+    expect(res).toEqual(stored.guids);
+    expect(client.listMetaTree).not.toHaveBeenCalled();
+  });
+
+  it('fetches only meta blobs missing from the persistent sha cache', async () => {
+    // blobSha → guid は内容由来の永久キャッシュ: 変わった .meta だけ GraphQL に回る
+    const { client, store } = makeFakes({
+      metas: [
+        { path: 'Assets/A.cs.meta', sha: 'known-sha' },
+        { path: 'Assets/B.cs.meta', sha: 'new-sha' },
+      ],
+      knownGuids: { 'known-sha': 'gA' },
+      texts: { 'new-sha': 'guid: gB\n' },
+    });
+    const res = await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H');
+    expect(client.batchBlobTexts).toHaveBeenCalledTimes(1);
+    expect(client.batchBlobTexts.mock.calls[0]?.[2]).toEqual(['new-sha']);
+    expect(res).toEqual({ gA: 'Assets/A.cs', gB: 'Assets/B.cs' });
+  });
+
+  it('chunks graphql fetches at 100 blobs per query', async () => {
+    const metas = Array.from({ length: 250 }, (_, i) => ({ path: `Assets/F${i}.cs.meta`, sha: `s${i}` }));
+    const { client, store } = makeFakes({ metas });
+    await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H');
+    expect(client.batchBlobTexts).toHaveBeenCalledTimes(3); // 100 + 100 + 50
+    expect(client.batchBlobTexts.mock.calls[0]?.[2]).toHaveLength(100);
+    expect(client.batchBlobTexts.mock.calls[2]?.[2]).toHaveLength(50);
+  });
+
+  it('gives up on truncated trees', async () => {
+    const { client, store } = makeFakes({ truncated: true });
+    expect(await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H')).toBeNull();
+    expect(client.batchBlobTexts).not.toHaveBeenCalled();
+  });
+
+  it('gives up above 50,000 metas (storage quota guard)', async () => {
+    const metas = Array.from({ length: 50_001 }, (_, i) => ({ path: `m${i}.meta`, sha: `s${i}` }));
+    const { client, store } = makeFakes({ metas });
+    expect(await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H')).toBeNull();
+    expect(store.saveIndex).not.toHaveBeenCalled();
+  });
+
+  it('skips blobs without a parsable guid', async () => {
+    const { client, store } = makeFakes({
+      metas: [
+        { path: 'Assets/A.cs.meta', sha: 'sha1' },
+        { path: 'Assets/B.cs.meta', sha: 'sha2' },
+      ],
+      texts: { sha1: 'guid: g1\n', sha2: 'not yaml at all' },
+    });
+    expect(await syncRepoIndex(client, store, 'o', 'r', 'repoKey', 'H')).toEqual({ g1: 'Assets/A.cs' });
+  });
+});

--- a/extension/src/github/repoIndex.ts
+++ b/extension/src/github/repoIndex.ts
@@ -1,0 +1,53 @@
+import { parseGuidFromMeta } from './guids';
+import type { GithubClient } from './client';
+
+type ClientLike = Pick<GithubClient, 'listMetaTree' | 'batchBlobTexts'>;
+
+export type RepoIndexStore = {
+  loadGuids(repo: string): Promise<Record<string, string>>;
+  saveGuids(repo: string, entries: Record<string, string>): Promise<void>;
+  loadIndex(repo: string): Promise<{ treeSha: string; guids: Record<string, string> } | undefined>;
+  saveIndex(repo: string, index: { treeSha: string; guids: Record<string, string> }): Promise<void>;
+};
+
+const INDEX_MAX_METAS = 50_000; // spec B3: これ超は storage quota 保護で索引を諦める
+const GRAPHQL_BATCH = 100;
+
+/** repo 全体の guid → asset path 索引。索引不可(truncated / 上限超)は null で Code Search に委ねる。
+ *  blobSha → guid は内容由来なので永久キャッシュでき、push 後は変わった .meta だけ取得する。 */
+export async function syncRepoIndex(
+  client: ClientLike,
+  store: RepoIndexStore,
+  owner: string,
+  repo: string,
+  repoKey: string,
+  ref: string,
+): Promise<Record<string, string> | null> {
+  const existing = await store.loadIndex(repoKey);
+  if (existing?.treeSha === ref) return existing.guids;
+  const tree = await client.listMetaTree(owner, repo, ref);
+  if (tree.truncated || tree.metas.length > INDEX_MAX_METAS) return null;
+  const known = await store.loadGuids(repoKey);
+  // hasOwn: guid キャッシュ同様、プロトタイプ誤ヒットを避ける
+  const missing = tree.metas.filter((m) => !Object.hasOwn(known, m.sha));
+  const fetched: Record<string, string> = {};
+  for (let i = 0; i < missing.length; i += GRAPHQL_BATCH) {
+    const chunk = missing.slice(i, i + GRAPHQL_BATCH);
+    const texts = await client.batchBlobTexts(owner, repo, chunk.map((m) => m.sha));
+    for (const m of chunk) {
+      const text = texts[m.sha];
+      if (!text) continue; // バイナリ・取得不可はスキップ
+      const guid = parseGuidFromMeta(text);
+      if (guid) fetched[m.sha] = guid;
+    }
+  }
+  if (Object.keys(fetched).length) await store.saveGuids(repoKey, fetched);
+  const merged = { ...known, ...fetched };
+  const guids: Record<string, string> = {};
+  for (const m of tree.metas) {
+    const guid = merged[m.sha];
+    if (guid) guids[guid] = m.path.slice(0, -'.meta'.length);
+  }
+  await store.saveIndex(repoKey, { treeSha: ref, guids });
+  return guids;
+}

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -293,6 +293,21 @@ describe('render', () => {
     expect(root.textContent).toContain('‹Prefab›');
   });
 
+  it('shows a resolving indicator while guid resolution is pending', () => {
+    const root = freshRoot();
+    render(root, { schema: 'prefablens.diff.v2', unresolvedGuids: ['g1', 'g2'], roots: [], loose: [] }, { resolving: 2 });
+    expect(root.textContent).toContain('Resolving 2 reference(s)…');
+  });
+
+  it('drops the indicator on re-render after resolution completes', () => {
+    // push の done で再描画されたときに消えること(mount が全置換するので自然に消える)
+    const root = freshRoot();
+    const diff = { schema: 'prefablens.diff.v2' as const, unresolvedGuids: ['g1'], roots: [], loose: [] };
+    render(root, diff, { resolving: 1 });
+    render(root, diff);
+    expect(root.textContent).not.toContain('Resolving');
+  });
+
   it('falls back component display to className when the script guid is unresolved', () => {
     const root = freshRoot();
     const diff: DiffV2 = {

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -25,6 +25,7 @@ const STYLES = `
   .pl-after { color: var(--pl-added); }
   .pl-arrow { color: var(--pl-muted); margin: 0 4px; }
   .pl-empty, .pl-error, .pl-loading { color: var(--pl-muted); margin: 0; }
+  .pl-resolving { color: var(--pl-muted); margin: 0 0 4px; }
   .pl-error { color: var(--pl-removed); }
   .pl-render { font: inherit; margin-top: 4px; padding: 1px 8px; border: 1px solid var(--pl-border); background: transparent; color: inherit; cursor: pointer; }
   .pl-components { border-left: 1px solid var(--pl-border); margin: 2px 0 2px 4px; padding-left: 8px; }
@@ -40,8 +41,10 @@ export function detectTheme(doc: Document): 'light' | 'dark' {
   return doc.defaultView?.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
-export function render(root: ShadowRoot, diff: DiffV2): void {
+export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: number }): void {
   const container = mount(root);
+  // 解決中の合図(spec B4): diff 本体は最初から正しく、参照名だけが後から埋まる
+  if (opts?.resolving) container.append(note('pl-resolving', `Resolving ${opts.resolving} reference(s)…`));
   for (const node of diff.roots) container.append(renderNode(node, diff));
   for (const c of diff.loose) container.append(renderComponent(c, diff));
   if (!diff.roots.length && !diff.loose.length) {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -78,6 +78,18 @@ export type BackgroundRequest = SemanticDiffRequest | PrefetchRequest;
 export type BackgroundError = 'pat-missing' | 'auth-failed' | 'rate-limited' | 'fetch-failed' | 'diff-failed';
 
 export type SemanticDiffResponse =
-  | { ok: true; json: DiffV2 }
+  | { ok: true; json: DiffV2; pending?: boolean }
   | { ok: false; error: BackgroundError }
   | { ok: false; error: 'too-large'; bytes: number };
+
+// background → content の非同期 push(2 段階応答の後段)。
+export type GuidResolvedPush = {
+  type: 'guidResolved';
+  owner: string;
+  repo: string;
+  prNumber: number;
+  path: string;
+  resolved: Record<string, string>;
+  json?: DiffV2; // mergeSources で構造が更新されたとき最終 push に載る(content は view を置換)
+  done: boolean; // true が来たら解決作業は終わり(空 resolved でも送る = インジケータ消灯の合図)
+};


### PR DESCRIPTION
## 概要

guid → アセット名の解決を Code Search(10 req/min)依存から解放し、diff は即描画・参照名は後埋めのプログレッシブ UX にする。拡張 UX 改善 3 PR の最終(B3/B4)。**#46 の上に積んだ stacked PR**(base = feat/pr-prefetch。#46 マージ後に base を main に付け替えてください)。

## 変更点

### B3: repo guid 索引
- `GithubClient.listMetaTree`(git trees 1 call、.meta blob のみ + truncated 透過)/ `batchBlobTexts`(GraphQL エイリアスで 100 blob/クエリ、**5,000 pt/h の独立枠**)。403/429 分類は `rawRequest` に抽出し REST/GraphQL で共有
- `repoIndex.ts`: blobSha → guid は内容由来の**永久キャッシュ**、同一 treeSha は API ゼロ、push 後は変わった .meta だけ差分取得。truncated / .meta 5 万超は索引を諦めて Code Search フォールバック
- 解決は 3 段: PR 内 .meta → repo 索引(ローカル参照)→ Code Search は「索引不可 or 索引に無い guid」だけに縮退。同時多発の同一 guid 検索は in-flight map で 1 回に畳む

### B4: プログレッシブ描画
- `semanticDiff(req, push?)`: **push なしは従来の同期パイプラインそのまま**(既存テスト無改変 green = mergeSources 機能保持の回帰証明)。push ありは diff 即応答 → 中間 push(索引解決名)→ 最終 push(Code Search + ソース再合成後の json 置換)
- mergeSources(#42)との整合: 非同期解決でソース guid が解けたら合成をやり直し、最終 push が構造ごと更新。索引解決名は guidCache 永続化で mergeSources 内部の再解決を生き残る(misses は検索のみの門番に変更)
- 解決中は「Resolving n reference(s)…」を表示(ソース合成のみ残るケースも含む)、done で消灯

## テスト

- unit 137/137(repoIndex 7、client 5、handler 2 段階 9 本新規。既存 126 本は無改変で green)
- e2e 8/8(空 tree → Code Search フォールバックの実機経路)

## Follow-up(マージ後に別 PR でまとめて)

- storage.session の `diff:` キー掃除(#46 の申し送り)/ metaGuids の剪定(50k リポジトリで local quota 8-9MB)/ SW 死でのインジケータ固着タイムアウト / push と views.set の理論レース / cosmetic 群(graphqlUrl 引数名、ApiError(200) 等)