### PR TITLE
fix: flush session diff cache on quota overflow

### DIFF
--- a/extension/src/background/diffStore.test.ts
+++ b/extension/src/background/diffStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSessionDiffStore } from './diffStore';
+import type { DiffV2 } from '../types';
+
+const DIFF: DiffV2 = { schema: 'prefablens.diff.v2', unresolvedGuids: [], roots: [], loose: [] };
+
+// chrome.storage.session の必要部分だけを Map で模した fake。set は failWhen で溢れを再現する。
+function fakeArea(failWhen?: () => boolean) {
+  const data = new Map<string, unknown>();
+  const area = {
+    data,
+    get: vi.fn(async (keys: string | string[] | null) => {
+      if (keys === null) return Object.fromEntries(data);
+      const list = Array.isArray(keys) ? keys : [keys];
+      const out: Record<string, unknown> = {};
+      for (const k of list) if (data.has(k)) out[k] = data.get(k);
+      return out;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      if (failWhen?.()) throw new Error('QUOTA_BYTES quota exceeded');
+      for (const [k, v] of Object.entries(items)) data.set(k, v);
+    }),
+    remove: vi.fn(async (keys: string | string[]) => {
+      for (const k of Array.isArray(keys) ? keys : [keys]) data.delete(k);
+    }),
+  };
+  return area;
+}
+
+describe('createSessionDiffStore', () => {
+  it('round-trips a diff under the diff: prefix', async () => {
+    const area = fakeArea();
+    const store = createSessionDiffStore(area);
+    await store.save('base:head:Assets/Foo.prefab', DIFF);
+    expect(area.data.get('diff:base:head:Assets/Foo.prefab')).toEqual(DIFF);
+    expect(await store.load('base:head:Assets/Foo.prefab')).toEqual(DIFF);
+  });
+
+  it('returns undefined for a missing key', async () => {
+    const store = createSessionDiffStore(fakeArea());
+    expect(await store.load('nope')).toBeUndefined();
+  });
+
+  it('skips diffs larger than the session budget without touching storage', async () => {
+    // 大物はメモリキャッシュだけに任せる(session は 10MB しかない)
+    const area = fakeArea();
+    const store = createSessionDiffStore(area);
+    const big: DiffV2 = { ...DIFF, unresolvedGuids: [' '.repeat(600 * 1024)] };
+    await store.save('k', big);
+    expect(area.set).not.toHaveBeenCalled();
+  });
+
+  it('flushes stale diff entries and retries once when the quota overflows', async () => {
+    // 一度埋まると以後 SW 再起動のたびに全再計算になる恒久劣化を防ぐ:
+    // 溢れたら溜まった diff を一掃して 1 回だけ書き直す
+    const area = fakeArea(); // 既定 set は成功。1 回目だけ下で溢れさせる
+    // 既存の diff エントリと、無関係なキーを 1 つ仕込む
+    area.data.set('diff:old1', DIFF);
+    area.data.set('diff:old2', DIFF);
+    area.data.set('viewMode', 'semantic'); // diff: 以外は消さない
+    const store = createSessionDiffStore(area);
+
+    // 1 回目の set は溢れる → flush → retry(既定 set)は通す
+    area.set.mockImplementationOnce(async () => {
+      throw new Error('quota exceeded');
+    });
+    await store.save('new', DIFF);
+
+    expect(area.remove).toHaveBeenCalledWith(['diff:old1', 'diff:old2']); // diff: だけ一掃
+    expect(area.data.has('viewMode')).toBe(true); // 無関係キーは残す
+    expect(area.data.get('diff:new')).toEqual(DIFF); // 再試行で書けている
+  });
+
+  it('gives up quietly if the retry also fails', async () => {
+    // flush しても書けない(単一 diff が quota 超): メモリキャッシュで続行、例外は投げない
+    const area = fakeArea(() => true); // 常に溢れる
+    const store = createSessionDiffStore(area);
+    await expect(store.save('k', DIFF)).resolves.toBeUndefined();
+  });
+});

--- a/extension/src/background/diffStore.test.ts
+++ b/extension/src/background/diffStore.test.ts
@@ -69,6 +69,7 @@ describe('createSessionDiffStore', () => {
     expect(area.remove).toHaveBeenCalledWith(['diff:old1', 'diff:old2']); // diff: だけ一掃
     expect(area.data.has('viewMode')).toBe(true); // 無関係キーは残す
     expect(area.data.get('diff:new')).toEqual(DIFF); // 再試行で書けている
+    expect(area.set).toHaveBeenCalledTimes(2); // 溢れ 1 回 + retry 1 回だけ(ループ化への退行を固定)
   });
 
   it('gives up quietly if the retry also fails', async () => {

--- a/extension/src/background/diffStore.ts
+++ b/extension/src/background/diffStore.ts
@@ -1,0 +1,46 @@
+import type { DiffV2 } from '../types';
+
+const PREFIX = 'diff:';
+const MAX_BYTES = 512 * 1024; // storage.session は 10MB: 大物はメモリキャッシュだけに任せる(SW が死んだら再計算)
+
+// chrome.storage.session の必要部分だけを受ける(テストで fake に差し替え可能にするため)
+type Area = {
+  get(keys: string | string[] | null): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+  remove(keys: string | string[]): Promise<void>;
+};
+
+export type DiffStore = {
+  load(key: string): Promise<DiffV2 | undefined>;
+  save(key: string, json: DiffV2): Promise<void>;
+};
+
+/** raw diff を sha キーで storage.session に載せ、SW 再起動をまたいで再利用する。
+ *  quota が溢れたら溜まった diff を一掃して 1 回だけ書き直す: これをしないと一度埋まると
+ *  以後 SW 再起動のたびに全再計算になり、無言で恒久劣化する(内容は sha キーで再計算可能)。 */
+export function createSessionDiffStore(area: Area): DiffStore {
+  return {
+    async load(key) {
+      const stored = await area.get(PREFIX + key);
+      return stored[PREFIX + key] as DiffV2 | undefined;
+    },
+    async save(key, json) {
+      if (JSON.stringify(json).length > MAX_BYTES) return;
+      try {
+        await area.set({ [PREFIX + key]: json });
+      } catch {
+        await flushDiffs(area);
+        await area.set({ [PREFIX + key]: json }).catch(() => {
+          // flush しても書けない(単一 diff が quota 超など): メモリキャッシュで続行する
+        });
+      }
+    },
+  };
+}
+
+/** diff: 付きのキーだけを一掃する(viewMode など無関係な session キーは残す)。 */
+async function flushDiffs(area: Area): Promise<void> {
+  const all = await area.get(null).catch(() => ({}));
+  const keys = Object.keys(all).filter((k) => k.startsWith(PREFIX));
+  if (keys.length) await area.remove(keys).catch(() => {});
+}

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,16 +1,16 @@
 import { createHandler } from './handler';
 import { createQueue } from './queue';
+import { createSessionDiffStore } from './diffStore';
 import { GithubClient } from '../github/client';
 import { createDiffer, type Differ } from '../wasm/differ';
-import type { BackgroundRequest, DiffV2, GuidResolvedPush } from '../types';
+import type { BackgroundRequest, GuidResolvedPush } from '../types';
 
 let differ: Promise<Differ> | undefined;
 
-// REST 全体で同時 6 本(spec B2)。ユーザー操作由来は front で行列を追い越す
+// REST/GraphQL 全体で同時 6 本(spec B2)。GraphQL も fetchFn 経由なので同じ枠を共有する。
+// ユーザー操作由来は front で行列を追い越す
 const queue = createQueue(6);
 const queuedFetch = (front: boolean): typeof fetch => (input, init) => queue(() => fetch(input, init), { front });
-
-const SESSION_MAX_BYTES = 512 * 1024; // storage.session は 10MB: 大物はメモリのみ(SW が死んだら再計算)
 
 const handler = createHandler({
   async getSettings() {
@@ -37,18 +37,7 @@ const handler = createHandler({
       await chrome.storage.local.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
     },
   },
-  diffStore: {
-    async load(key) {
-      const stored = await chrome.storage.session.get([`diff:${key}`]);
-      return stored[`diff:${key}`] as DiffV2 | undefined;
-    },
-    async save(key, json) {
-      if (JSON.stringify(json).length > SESSION_MAX_BYTES) return;
-      await chrome.storage.session.set({ [`diff:${key}`]: json }).catch(() => {
-        // quota 超過等は無視: メモリキャッシュだけで続行する
-      });
-    },
-  },
+  diffStore: createSessionDiffStore(chrome.storage.session),
   repoIndexStore: {
     async loadGuids(repo) {
       const key = `metaGuids:${repo}`;

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -22,9 +22,10 @@ export function apiBase(baseUrl: string | undefined): string {
   return origin === 'https://github.com' ? 'https://api.github.com' : `${origin}/api/v3`;
 }
 
-/** REST の apiBase から GraphQL エンドポイントを導く。GHES は /api/v3 → /api/graphql。 */
-export function graphqlUrl(apiBase: string): string {
-  return apiBase.endsWith('/api/v3') ? `${apiBase.slice(0, -'/api/v3'.length)}/api/graphql` : `${apiBase}/graphql`;
+/** REST の base から GraphQL エンドポイントを導く。GHES は /api/v3 → /api/graphql。
+ *  引数名は apiBase 関数と紛れないよう restBase とする。 */
+export function graphqlUrl(restBase: string): string {
+  return restBase.endsWith('/api/v3') ? `${restBase.slice(0, -'/api/v3'.length)}/api/graphql` : `${restBase}/graphql`;
 }
 
 export class GithubClient {


### PR DESCRIPTION
## 概要

拡張 UX 改善 3 PR(#43/#46/#48)の最終レビューで挙がった小粒な指摘のうち、価値の高いものをまとめた follow-up。

## 変更点

### fix: session diff キャッシュの quota 溢れ回復(本体)
- `background/index.ts` のインライン `chrome.storage.session` diff キャッシュをテスタブルな factory `src/background/diffStore.ts`(`createSessionDiffStore(area)`)に抽出
- **quota 溢れ回復を追加**: `set` が reject(session 10MB 満杯)したら `diff:` 付きキーを一掃して 1 回だけ書き直す。これが無いと一度埋まると以後 SW 再起動のたびに全 diff を再計算する無言の恒久劣化になる(内容は sha キーで再計算可能なので一掃は安全)
- flush は `diff:` 接頭辞のキーだけを消し、`viewMode` など無関係な session キーは残す
- unit test 5 本(round-trip / 欠損キー / 512KB 超スキップ / flush+retry で無関係キー温存 + retry は 1 回だけ / 二度目失敗は静かに諦める)

### refactor: cosmetic
- `graphqlUrl` の引数名が `apiBase` 関数を shadow していたのを `restBase` に改名
- キュー並列数コメントに GraphQL も同枠を共有する旨を追記

## テスト

- unit 142/142(diffStore 5 本新規)、e2e 8/8、typecheck clean

## 見送った指摘(理由付き)

- **metaGuids の剪定**: 5 万 meta 級の高チャーンリポジトリでのみ意味があり、guidCache 劣化は graceful(再フェッチで済む)。費用対効果が低く見送り
- **SW 死時の「Resolving…」固着タイムアウト**: 表示のみの稀な papercut(diff 本体は正しく描画済み)。entry-point でのタイマー管理はテストが困難で、複雑さに見合わない
- **push と views.set の理論レース**: push が storage 往復の後ろに必ず入るため実質発生しない