### PR TITLE
ci: add pr labeler and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashiiiii

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,34 @@
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "core/**"
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "cli/**"
+
+editor:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "editor/**"
+
+extension:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extension/**"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "build.zig"
+          - "build.zig.zon"
+          - "mise.toml"
+          - "renovate.json"
+          - ".bumpversion.toml"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: true


### PR DESCRIPTION
## 概要

PR のパスベース自動ラベリングと CODEOWNERS を追加する。reknotes の `.github` 構成に倣った。

## 変更内容

- `.github/labeler.yml` — 変更ファイルのパスから領域ラベルを付与
  - `core` (`core/**`) / `cli` (`cli/**`) / `editor` (`editor/**`) / `extension` (`extension/**`)
  - `ci` (`.github/**`, `build.zig*`, `mise.toml`, `renovate.json`, `.bumpversion.toml`) / `documentation` (`**/*.md`)
- `.github/workflows/labeler.yml` — `actions/labeler@v6` を `pull_request_target` で実行、`sync-labels: true`。action は `renovate.json` の github-actions 方針(`pinDigests: false` = タグ運用)と既存 `ci.yml` に合わせてタグ指定。
- `.github/CODEOWNERS` — `* @hashiiiii`(宣言的・将来のコラボ加入への布石)

## 補足

- リポジトリ側の不足ラベル(`core` / `cli` / `editor` / `extension` / `ci`)は作成済み。
- `pull_request_target` は base ブランチ側の定義で走るため、labeler はこの PR マージ後の次 PR から効き始める(この PR 自身には付かない)。
- CODEOWNERS は「Require review from Code Owners」ブランチ保護を ON にすると自分の PR マージがブロックされるため、当面その保護は有効化しない前提。