### PR TITLE
ci: add least-privilege permissions to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   core:
     strategy:


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` の 3 ジョブ(`core` / `extension` / `editor`)がいずれも `permissions` ブロックを持たず、CodeQL の code scanning で `actions/missing-workflow-permissions`(medium)が 3 件 open になっていた。トップレベルに最小権限の `permissions` を 1 つ追加して一括で解消する。

## Changes

- ci.yml の `on:` 直後・`jobs:` の前にトップレベル `permissions: { contents: read }` を追加

## Why

- 3 ジョブは checkout + build/test/lint のみで、`GITHUB_TOKEN` に書き込み権限は不要。`contents: read` が最小権限。
- トップレベル 1 箇所で全ジョブに適用されるため、ジョブ単位で 3 回書くより DRY。既存の labeler.yml / release.yml もトップレベル `permissions` を採用しており、記法・配置を揃えた。
- CodeQL の `actions/missing-workflow-permissions` はトップレベルまたはジョブ単位いずれかの `permissions` で解消されるため、この 1 変更で 3 アラートすべてが closed になる。

## Alerts addressed

- Code scanning alert #1 (ci.yml `core`)
- Code scanning alert #2 (ci.yml `extension`)
- Code scanning alert #3 (ci.yml `editor`)