### PR TITLE
docs: translate Japanese comments to English

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 *.cs text diff=csharp eol=lf
 *.zig text eol=lf
 
-# testdata の UnityYAML fixture をテキストとして扱わないことで、改行コードの自動変換を防止する。
-# こうすることで Windows で checkout した際に CSRF になってしまうことを防ぐ。
+# Treat the testdata UnityYAML fixtures as binary (not text) to prevent automatic line-ending conversion.
+# This keeps them from being converted to CRLF when checked out on Windows.
 core/src/testdata/** -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Test
         run: zig build test
       - name: Performance budget
-        # Windows ランナーはノイズが大きいので計測結果がブレ過ぎるため対象外とする
+        # Windows runners are too noisy; the measurements swing too much, so skip them here
         if: matrix.os == 'ubuntu-latest'
         run: zig build perf
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: write
 
-# release.yml の重複実行を防止する
+# Prevent overlapping runs of release.yml
 concurrency:
   group: release
 

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // バージョンの単一ソースは build.zig.zon。CLI バイナリへは build options で注入する。
+    // Single source of the version is build.zig.zon; inject it into the CLI binary via build options.
     const opts = b.addOptions();
     opts.addOption([]const u8, "version", zon.version);
     const build_options_mod = opts.createModule();
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
     });
 
-    // mcp のパリティテストが server.test.ts と同じ plane fixture を @embedFile するための配線。
+    // Wiring so the mcp parity test can @embedFile the same plane fixture as server.test.ts.
     const plane_before = b.createModule(.{ .root_source_file = b.path("core/src/testdata/plane_before.prefab") });
     const plane_after = b.createModule(.{ .root_source_file = b.path("core/src/testdata/plane_after.prefab") });
 
@@ -62,8 +62,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&b.addRunArtifact(core_tests).step);
     test_step.dependOn(&b.addRunArtifact(cli_tests).step);
 
-    // 実バイナリでの MCP プロトコル smoke。git 不要な静的応答のみを exact match する。
-    // tools/list の期待値は cli/src/mcp.zig と同じ tools_list.json を埋め込む。
+    // MCP protocol smoke against the real binary; exact-match only the static, git-free responses.
+    // The tools/list expectation embeds the same tools_list.json as cli/src/mcp.zig.
     const tools_list_json = comptime std.mem.trimEnd(u8, @embedFile("cli/src/tools_list.json"), "\r\n");
     const mcp_smoke = b.addRunArtifact(exe);
     mcp_smoke.addArg("mcp");

--- a/cli/src/display.zig
+++ b/cli/src/display.zig
@@ -1,4 +1,4 @@
-//! render_tree / render_html 共通の表示名解決。
+//! Shared display-name resolution for render_tree / render_html.
 const std = @import("std");
 const core = @import("core");
 const model = core.model;
@@ -14,7 +14,7 @@ pub fn objectName(o: model.ObjectDiff, resolved: ?*const core.json.Resolver) []c
     return "(GameObject)";
 }
 
-/// 優先度: guid 解決したスクリプト名 > m_EditorClassIdentifier のクラス名 > 型名。
+/// Priority: guid-resolved script name > m_EditorClassIdentifier class name > type name.
 pub fn componentName(c: model.ComponentDiff, resolved: ?*const core.json.Resolver) []const u8 {
     if (c.script_guid) |g| if (resolved) |r| if (r.get(g)) |p| {
         return std.fs.path.stem(p);

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -6,8 +6,9 @@ const testing = std.testing;
 /// same way instead of diverging on an arbitrary limit.
 pub const max_input_bytes: usize = 64 * 1024 * 1024; // 64 MiB guard
 
-/// git 実行の既定タイムアウト。CLI 直叩きだけでなく、常駐 MCP サーバーと Unity Editor
-/// (WaitForExit で待つ)がハングした git に道連れにされないための上限。
+/// Default timeout for running git. An upper bound so that not just the direct CLI
+/// invocation but also the resident MCP server and Unity Editor (which waits with
+/// WaitForExit) aren't dragged down by a hung git.
 pub const default_git_timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(60) } };
 
 pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref: []const u8, path: []const u8, timeout: std.Io.Timeout) ![]u8 {
@@ -24,7 +25,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
         .environ_map = &env,
         .timeout = timeout,
     }) catch |err| switch (err) {
-        // std.process.run は deadline 超過で子プロセスを kill して error.Timeout を返す。
+        // std.process.run kills the child on deadline overrun and returns error.Timeout.
         error.Timeout => return error.GitTimeout,
         else => return err,
     };
@@ -42,7 +43,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     }
 }
 
-/// 作業ツリー側(--git REF PATH の after)。ファイル不在は「削除済み」= 空側として扱う。
+/// Working-tree side (the after of --git REF PATH). A missing file is treated as "deleted" = empty side.
 pub fn readWorktree(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, path: []const u8) ![]u8 {
     const full = try std.fs.path.join(arena, &.{ repo_dir, path });
     return std.Io.Dir.cwd().readFileAlloc(io, full, arena, .limited(max_input_bytes)) catch |err| switch (err) {
@@ -70,7 +71,7 @@ test "readWorktree reads the file and treats absence as an empty side" {
     try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v2\n" });
 
     try testing.expectEqualStrings("v2\n", try readWorktree(testing.io, arena, dir, "Foo.prefab"));
-    // 作業ツリーで削除済み = 空側(エラーにしない)
+    // Deleted in the working tree = empty side (not an error)
     try testing.expectEqual(@as(usize, 0), (try readWorktree(testing.io, arena, dir, "Gone.prefab")).len);
 }
 
@@ -117,8 +118,8 @@ test "showAtRef kills git and errors when the timeout passes" {
     try git(testing.io, arena, dir, &.{ "add", "Foo.prefab" });
     try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
 
-    // 実 git でも 1µs では完了できない(spawn だけで ms かかる)。常駐 MCP セッションを
-    // ハングした git から守る打ち切りが、明確なエラーとして返ることを確認する。
+    // Even real git can't finish in 1µs (spawn alone takes ms). Confirm that the cutoff
+    // protecting a resident MCP session from a hung git returns as a clear error.
     const tiny: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromMicroseconds(1) } };
     try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", tiny));
 }

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -72,7 +72,7 @@ test "parseArgs: --git with two operands means ref vs working tree" {
     const opt = try parseArgs(&args);
     try testing.expect(opt.git_mode);
     try testing.expectEqualStrings("HEAD", opt.git_ref_before);
-    try testing.expectEqualStrings("", opt.git_ref_after); // 空 = 作業ツリー側
+    try testing.expectEqualStrings("", opt.git_ref_after); // empty = working-tree side
     try testing.expectEqualStrings("Foo.prefab", opt.git_path);
     try testing.expectEqual(Format.json, opt.format);
 }
@@ -416,7 +416,7 @@ test "run: --project supplies source prefabs for merged instance diffs" {
     const variant_path = try tmp.dir.realPathFileAlloc(testing.io, "Variant.prefab", arena);
     const empty_path = try tmp.dir.realPathFileAlloc(testing.io, "empty.prefab", arena);
 
-    // --project あり: ソースを供給して合成表示(Scale (1, 2, 1))。
+    // With --project: supply the source for a merged display (Scale (1, 2, 1)).
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
@@ -426,7 +426,7 @@ test "run: --project supplies source prefabs for merged instance diffs" {
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "Scale: (1, 2, 1)") != null);
 
-    // --project なし: 縮退表示(記録済み override の列挙)のまま。
+    // Without --project: stays a degraded display (enumeration of recorded overrides).
     var out2: std.ArrayList(u8) = .empty;
     var aw2 = std.Io.Writer.Allocating.fromArrayList(arena, &out2);
     var errbuf2: std.ArrayList(u8) = .empty;
@@ -437,7 +437,7 @@ test "run: --project supplies source prefabs for merged instance diffs" {
     try testing.expect(std.mem.indexOf(u8, output2.items, "Scale.y: 2") != null);
 }
 
-/// リリースタグ v<version> と lockstep。単一ソースは build.zig.zon(release.yml が bump する)。
+/// Lockstep with the release tag v<version>. The single source is build.zig.zon (release.yml bumps it).
 pub const version = @import("build_options").version;
 
 test "run: --project points git mode at a repo outside the cwd" {
@@ -445,8 +445,8 @@ test "run: --project points git mode at a repo outside the cwd" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // cwd の外に実 git リポジトリを作る。--project がその repo を指せば
-    // git show は成功する(cwd 固定 "." のままだと失敗する)。
+    // Create a real git repository outside the cwd. If --project points at that repo,
+    // git show succeeds (with the cwd fixed at "." it would fail).
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
@@ -526,8 +526,8 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             if (i >= args.len) return ArgError.MissingOperands;
             project_root = args[i];
         } else if (std.mem.eql(u8, a, "--git")) {
-            // --git <beforeRef> [<afterRef>] <path>: 非フラグ operand を 2〜3 個消費し、
-            // 2 個なら after 側は作業ツリー(git_ref_after = "")。後続フラグは引き続き解釈する。
+            // --git <beforeRef> [<afterRef>] <path>: consumes 2-3 non-flag operands;
+            // with 2, the after side is the working tree (git_ref_after = ""). Trailing flags are still parsed.
             var ops: [3][]const u8 = undefined;
             var n: usize = 0;
             while (n < 3 and i + 1 < args.len and !std.mem.startsWith(u8, args[i + 1], "--")) : (n += 1) {
@@ -588,7 +588,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         return 2;
     };
 
-    // --project は guid 解決の基点と git repo dir を兼ねる(未指定は従来どおり cwd)。
+    // --project doubles as the guid-resolution base and the git repo dir (unset falls back to cwd as before).
     const repo_dir = opt.project_root orelse ".";
     const before = if (opt.git_mode)
         input.showAtRef(io, arena, repo_dir, opt.git_ref_before, opt.git_path, input.default_git_timeout) catch |err| {
@@ -604,7 +604,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             return 1;
         };
     const after = if (opt.git_mode and opt.git_ref_after.len == 0)
-        // ref 1 個 = 作業ツリーとの比較(ファイル不在は削除 = 空側)
+        // one ref = comparison against the working tree (a missing file is deletion = empty side)
         input.readWorktree(io, arena, repo_dir, opt.git_path) catch {
             try stderr.print("error: cannot read file '{s}'\n", .{opt.git_path});
             return 1;
@@ -639,9 +639,9 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             return 1;
         };
         resolver_ptr = &idx;
-        // needed_sources をローカル資産で満たして再 diff(入れ子ソースで新たな
-        // 要求が出るため最大 3 周、進捗が無ければ打ち切り)。読めない資産は
-        // スキップして diff は落とさない。
+        // Satisfy needed_sources with local assets and re-diff (nested sources raise new
+        // requests, so up to 3 rounds; stop if there's no progress). Unreadable assets are
+        // skipped without failing the diff.
         var rounds: usize = 0;
         while (res.needed_sources.len != 0 and rounds < 3) : (rounds += 1) {
             var progressed = false;
@@ -684,7 +684,7 @@ pub fn main(init: std.process.Init) !u8 {
     if (user_args.len >= 1 and std.mem.eql(u8, user_args[0], "mcp")) {
         var stdin_buffer: [64 * 1024]u8 = undefined;
         var stdin_reader: std.Io.File.Reader = .init(.stdin(), init.io, &stdin_buffer);
-        // クライアント切断(broken pipe 等)は常態。スタックトレースを吐かず静かに終了する。
+        // Client disconnect (broken pipe, etc.) is normal. Exit quietly without emitting a stack trace.
         mcp.serve(init.io, std.heap.page_allocator, &stdin_reader.interface, stdout) catch {
             stdout.flush() catch {};
             return 1;

--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -4,25 +4,25 @@ const core = @import("core");
 const main = @import("main.zig");
 
 pub const default_protocol_version = "2025-06-18";
-// 2025-03-26 はバッチ要求を MUST とするが、主要クライアントは送らないため非対応のまま受理する。
-// 2024-10-07 はプレリリース版だが旧 TS SDK が受理していたためパリティで残す。
+// 2025-03-26 makes batch requests a MUST, but major clients don't send them, so we accept it while leaving batching unsupported.
+// 2024-10-07 is a prerelease, but the old TS SDK accepted it, so keep it for parity.
 const supported_versions = [_][]const u8{ "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07" };
 
-/// tools/list の result ペイロード。description と inputSchema は旧 TS ホスト
-/// (mcp/src/index.ts の zod 定義)の忠実な変換。build.zig の smoke golden も同じ
-/// tools_list.json を @embedFile するので、編集はそのファイル 1 箇所で済む。
+/// result payload for tools/list. description and inputSchema are a faithful port of the old TS host
+/// (the zod definitions in mcp/src/index.ts). build.zig's smoke golden @embedFiles the same
+/// tools_list.json, so edits are confined to that one file.
 pub const tools_list_result: []const u8 = std.mem.trimEnd(u8, @embedFile("tools_list.json"), "\r\n");
 
-/// MCP stdio transport: 改行区切り JSON-RPC 2.0。stdin EOF で正常終了。
-/// stdout はプロトコル専用(診断は stderr へ)。リクエストごとに arena を張る。
+/// MCP stdio transport: newline-delimited JSON-RPC 2.0. Exits cleanly on stdin EOF.
+/// stdout is protocol-only (diagnostics go to stderr). A fresh arena per request.
 pub fn serve(io: std.Io, gpa: std.mem.Allocator, reader: *std.Io.Reader, writer: *std.Io.Writer) !void {
     while (true) {
-        // takeDelimiterInclusive は改行を消費して返す(Exclusive はデリミタを消費せず
-        // 空スライスを返し続けるため、ここでは使えない)。
+        // takeDelimiterInclusive consumes the newline and returns it (Exclusive leaves the delimiter
+        // unconsumed and keeps returning an empty slice, so it can't be used here).
         const raw = reader.takeDelimiterInclusive('\n') catch |err| switch (err) {
             error.EndOfStream => return,
-            // 1 行が読み取りバッファを超えた。行の残りを読み捨てて再同期はできない
-            // (バッファが行の途中で詰まっている)ため、エラー応答を書いてから閉じる。
+            // One line exceeded the read buffer. We can't discard the rest of the line and resync
+            // (the buffer is stuck mid-line), so write an error response and then close.
             error.StreamTooLong => {
                 try writer.writeAll("{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Request too large\"}}\n");
                 try writer.flush();
@@ -61,7 +61,7 @@ fn handleLine(io: std.Io, arena: std.mem.Allocator, line: []const u8, w: *std.Io
     }
     const method = method_v.string;
 
-    // 通知(id なし)には未知のものも含め一切応答しない(JSON-RPC 2.0)。
+    // Notifications (no id) get no response at all, unknown ones included (JSON-RPC 2.0).
     if (!has_id) return;
 
     if (std.mem.eql(u8, method, "initialize")) {
@@ -81,9 +81,9 @@ fn handleLine(io: std.Io, arena: std.mem.Allocator, line: []const u8, w: *std.Io
 
 pub const tree_char_limit: usize = 50_000;
 
-/// LLM コンテキスト保護(旧 diff.ts の truncateTree 相当、単位はバイト)。
-/// マルチバイト文字の途中で切ると応答が不正な UTF-8 になり strict なクライアントが
-/// セッションごと落ちるため、コードポイント境界まで戻してから切る。
+/// LLM context protection (equivalent to the old diff.ts truncateTree; units are bytes).
+/// Cutting mid-multibyte-character would make the response invalid UTF-8 and crash strict clients
+/// for the whole session, so back up to a code-point boundary before cutting.
 pub fn truncateTree(arena: std.mem.Allocator, text: []const u8) ![]const u8 {
     if (text.len <= tree_char_limit) return text;
     var end = tree_char_limit;
@@ -94,11 +94,11 @@ pub fn truncateTree(arena: std.mem.Allocator, text: []const u8) ![]const u8 {
 fn validationError(w: *std.Io.Writer, id: std.json.Value, msg: []const u8) !void {
     try writeEnvelopePrefix(w, id);
     try w.writeAll("\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"Input validation error: ");
-    try w.writeAll(msg); // msg は静的文字列のみ(必要なエスケープは呼び出し側リテラルで済ませる)
+    try w.writeAll(msg); // msg is static strings only (any needed escaping is handled in the caller's literal)
     try w.writeAll("\"}],\"isError\":true}}\n");
 }
 
-/// arguments から文字列を取り出す。キー欠落は null、型違いは error.Invalid。
+/// Extract a string from arguments. A missing key is null; a type mismatch is error.Invalid.
 fn getString(args: ?std.json.Value, key: []const u8) error{Invalid}!?[]const u8 {
     const a = args orelse return null;
     if (a != .object) return error.Invalid;
@@ -137,7 +137,7 @@ fn handleToolsCall(io: std.Io, arena: std.mem.Allocator, w: *std.Io.Writer, id: 
     if (!is_json and !std.mem.eql(u8, format, "tree"))
         return validationError(w, id, "format must be \\\"tree\\\" or \\\"json\\\"");
 
-    // 旧 TS ホストの buildArgs + cwd=projectRoot と同じ argv(--project が git repo dir を兼ねる)。
+    // Same argv as the old TS host's buildArgs + cwd=projectRoot (--project doubles as the git repo dir).
     var argv: std.ArrayList([]const u8) = .empty;
     try argv.append(arena, if (is_json) "--json" else "--no-color");
     try argv.appendSlice(arena, &.{ "--project", project_root orelse "." });
@@ -176,12 +176,12 @@ fn writeInitialize(w: *std.Io.Writer, id: std.json.Value, params: ?std.json.Valu
     try w.print("\"result\":{{\"protocolVersion\":\"{s}\",\"capabilities\":{{\"tools\":{{}}}},\"serverInfo\":{{\"name\":\"prefablens\",\"version\":\"{s}\"}}}}}}\n", .{ negotiated, main.version });
 }
 
-/// `{"jsonrpc":"2.0","id":<id>,` まで書く。呼び出し側が result/error 以降を続ける。
+/// Writes up to `{"jsonrpc":"2.0","id":<id>,`. The caller continues with result/error onward.
 fn writeEnvelopePrefix(w: *std.Io.Writer, id: std.json.Value) !void {
     try w.writeAll("{\"jsonrpc\":\"2.0\",\"id\":");
     switch (id) {
         .integer => |n| try w.print("{d}", .{n}),
-        // 小数・i64 超の整数も JSON-RPC では合法な id。素通しで相関を保つ。
+        // Floats and integers past i64 are also valid JSON-RPC ids. Pass through verbatim to preserve correlation.
         .float => |f| try w.print("{d}", .{f}),
         .number_string => |s| try w.writeAll(s),
         .string => |s| try core.json.writeJsonString(w, s),
@@ -195,7 +195,7 @@ fn writeError(w: *std.Io.Writer, id: std.json.Value, code: i32, msg: []const u8)
     try w.print("\"error\":{{\"code\":{d},\"message\":\"{s}\"}}}}\n", .{ code, msg });
 }
 
-/// テストヘルパー: 実 git を叩く(モックなし方針)。
+/// Test helper: invokes real git (no-mocks policy).
 fn gitc(io: std.Io, a: std.mem.Allocator, d: []const u8, argv: []const []const u8) !void {
     var full: std.ArrayList([]const u8) = .empty;
     try full.append(a, "git");
@@ -204,8 +204,8 @@ fn gitc(io: std.Io, a: std.mem.Allocator, d: []const u8, argv: []const []const u
     if (r.term != .exited or r.term.exited != 0) return error.GitFailed;
 }
 
-/// テストヘルパー: plane fixture の git リポジトリを組み、その絶対パスを返す。
-/// server.test.ts の beforeAll と同じ形(before をコミット、after を作業ツリーに)。
+/// Test helper: builds the git repository for the plane fixture and returns its absolute path.
+/// Same shape as server.test.ts's beforeAll (commit before, put after in the working tree).
 fn setupPlaneRepo(io: std.Io, arena: std.mem.Allocator, tmp: *std.testing.TmpDir) ![]const u8 {
     const dir = try tmp.dir.realPathFileAlloc(io, ".", arena);
     try tmp.dir.writeFile(io, .{ .sub_path = "Plane.prefab", .data = @embedFile("testdata_plane_before") });
@@ -218,7 +218,7 @@ fn setupPlaneRepo(io: std.Io, arena: std.mem.Allocator, tmp: *std.testing.TmpDir
     return dir;
 }
 
-/// テストヘルパー: 入力行をまとめて食わせ、応答全文を返す。
+/// Test helper: feeds the input lines all at once and returns the full response.
 fn roundtrip(arena: std.mem.Allocator, input_lines: []const u8) ![]const u8 {
     var reader = std.Io.Reader.fixed(input_lines);
     var out: std.ArrayList(u8) = .empty;
@@ -290,9 +290,9 @@ test "mcp: tools/list returns the single prefab_diff tool" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     const res = try roundtrip(arena, "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n");
-    // golden: 実装の tools_list_result と envelope の結合そのもの
+    // golden: exactly the implementation's tools_list_result joined with the envelope
     try testing.expectEqualStrings("{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":" ++ tools_list_result ++ "}\n", res);
-    // スキーマの要点が入っていること(golden の自己一致だけにしない)
+    // The schema's key points must be present (not just self-consistency with the golden)
     try testing.expect(std.mem.indexOf(u8, res, "\"name\":\"prefab_diff\"") != null);
     try testing.expect(std.mem.indexOf(u8, res, "\"required\":[\"path\"]") != null);
     try testing.expect(std.mem.indexOf(u8, res, "\"enum\":[\"tree\",\"json\"]") != null);
@@ -302,7 +302,7 @@ test "mcp: tools/call validation errors match the ts host contract" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 空 path / 空 projectRoot / 不正 format / arguments 欠落 / 未知ツール
+    // empty path / empty projectRoot / invalid format / missing arguments / unknown tool
     const res = try roundtrip(arena, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"\"}}}\n" ++
         "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"a.prefab\",\"projectRoot\":\"\"}}}\n" ++
         "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"a.prefab\",\"format\":\"xml\"}}}\n" ++
@@ -326,7 +326,7 @@ test "mcp: tools/call diffs a real git fixture with the ts host golden" {
     defer tmp.cleanup();
     const dir = try setupPlaneRepo(testing.io, arena, &tmp);
 
-    // projectRoot は Windows パスを含み得るので JSON エスケープして埋め込む。
+    // projectRoot may contain a Windows path, so embed it JSON-escaped.
     var req: std.ArrayList(u8) = .empty;
     var req_w = std.Io.Writer.Allocating.fromArrayList(arena, &req);
     try req_w.writer.writeAll("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"Plane.prefab\",\"projectRoot\":");
@@ -334,7 +334,7 @@ test "mcp: tools/call diffs a real git fixture with the ts host golden" {
     try req_w.writer.writeAll("}}}\n");
     const res = try roundtrip(arena, req_w.toArrayList().items);
 
-    // 応答をパースして text を server.test.ts の golden と一致比較する。
+    // Parse the response and compare text against server.test.ts's golden.
     const parsed = try std.json.parseFromSliceLeaky(std.json.Value, arena, std.mem.trimEnd(u8, res, "\n"), .{});
     const result = parsed.object.get("result").?.object;
     try testing.expect(result.get("isError") == null);
@@ -401,7 +401,7 @@ test "mcp: float and oversized integer ids are echoed verbatim" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // JSON-RPC 2.0 は応答 id が要求 id と等しいことを要求する(小数も i64 超の整数も合法)。
+    // JSON-RPC 2.0 requires the response id to equal the request id (floats and integers past i64 are both valid).
     const res = try roundtrip(arena, "{\"jsonrpc\":\"2.0\",\"id\":1.5,\"method\":\"ping\"}\n" ++
         "{\"jsonrpc\":\"2.0\",\"id\":92233720368547758080,\"method\":\"ping\"}\n");
     try testing.expectEqualStrings("{\"jsonrpc\":\"2.0\",\"id\":1.5,\"result\":{}}\n" ++
@@ -412,15 +412,15 @@ test "mcp: truncateTree never splits a multibyte utf-8 character" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 50,000 バイト目が「あ」(3 バイト) の途中に落ちる入力を作る。
+    // Build input where byte 50,000 lands in the middle of a 3-byte '€'.
     var big: std.ArrayList(u8) = .empty;
     try big.appendNTimes(arena, 'x', tree_char_limit - 1);
-    try big.appendSlice(arena, "あああ");
+    try big.appendSlice(arena, "€€€");
     const cut = try truncateTree(arena, big.items);
-    // 分断された lead バイトが混じらず、全体が有効な UTF-8 であること。
+    // No split lead byte creeps in; the whole thing is valid UTF-8.
     try testing.expect(std.unicode.utf8ValidateSlice(cut));
     try testing.expect(std.mem.endsWith(u8, cut, "\n[truncated: 50008 chars total]\n"));
-    // カットは「あ」の手前(49,999 バイト)で止まる。
+    // The cut stops just before the '€' (byte 49,999).
     try testing.expectEqual(@as(usize, tree_char_limit - 1), std.mem.indexOf(u8, cut, "\n[truncated").?);
 }
 
@@ -428,8 +428,8 @@ test "mcp: oversized request line responds with an error before closing" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 読み取りバッファ(テストでは 32 バイト)を超える 1 行 → プロセスを殺さず
-    // エラー応答を書いてから閉じる。
+    // One line exceeding the read buffer (32 bytes in the test) -> without killing the process,
+    // write an error response and then close.
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     const big_line = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\",\"padding\":\"" ++ ("x" ** 100) ++ "\"}\n";

--- a/cli/src/render_html.zig
+++ b/cli/src/render_html.zig
@@ -269,9 +269,9 @@ fn renderObject(w: *std.Io.Writer, o: model.ObjectDiff, resolved: ?*const core.j
     try writeEscaped(w, display.objectName(o, resolved));
     if (o.kind == .prefab_instance) try w.writeAll(" &lt;Prefab&gt;");
     try w.writeAll("</span>\n");
-    // 表示次元の規則: コンポーネント/override は必ず components セクション配下。
-    // ラベル行には sign+space の前置がないため、render_tree.zig と同様に
-    // depth+2 を使って子オブジェクトの名前列に視覚的に揃える。
+    // Display-dimension rule: components/overrides always sit under the components section.
+    // The label line has no sign+space prefix, so, as in render_tree.zig,
+    // use depth+2 to visually align with the child objects' name column.
     if (o.overrides.len != 0 or o.components.len != 0) {
         try pad(w, depth + 2);
         try w.writeAll("<span class=\"unchanged\">components</span>\n");

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -92,7 +92,7 @@ test "render: components label separates object and component dimensions" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     try render(&aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    // "  Player" → "    components" → "      ~ MonoBehaviour" の深度になる。
+    // The depths become "  Player" -> "    components" -> "      ~ MonoBehaviour".
     try testing.expect(std.mem.indexOf(u8, text, "\n    components\n") != null);
     try testing.expect(std.mem.indexOf(u8, text, "\n      ~ MonoBehaviour\n") != null);
 }
@@ -118,7 +118,7 @@ test "render: component shows editor class name when script is unresolved" {
     const res = try core.diffBytes(arena, before, after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    // resolver なし → guid は解決できないが、クラス名で MonoBehaviour より具体的に。
+    // No resolver -> the guid can't be resolved, but the class name is more specific than MonoBehaviour.
     try render(&aw.writer, res, null, false);
     const text = aw.toArrayList().items;
     try testing.expect(std.mem.indexOf(u8, text, "~ Cylinder1\n") != null);
@@ -139,8 +139,8 @@ test "render: mixed-status override group gets a modified heading" {
         \\      value: 0
         \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
     ;
-    // 追加された mod が先頭に来る順にして、見出しが先頭行の status に
-    // 引きずられないことを見る。
+    // Order it so the added mod comes first, to check the heading isn't
+    // dragged by the first line's status.
     const after =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -197,7 +197,7 @@ test "render: structural summary row shows label only, no dangling value" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     try render(&aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    // 件数はラベルに含まれるので、値なし行はラベルだけで終わる。
+    // The count is included in the label, so a value-less row ends with just the label.
     try testing.expect(std.mem.indexOf(u8, text, "+ Added Components (1)\n") != null);
     try testing.expect(std.mem.indexOf(u8, text, "∅") == null);
 }
@@ -267,9 +267,9 @@ fn renderObject(
     try w.print(" {s}", .{display.objectName(o, resolved)});
     if (o.kind == .prefab_instance) try w.writeAll("  <Prefab>");
     try w.writeByte('\n');
-    // 表示次元の規則: コンポーネント/override は必ず components セクション配下。
-    // ラベル行には sign+space の 2 文字分の前置がないため、子オブジェクトの
-    // 名前列(depth+1 の indent + sign+space)に視覚的に揃うよう depth+2 を使う。
+    // Display-dimension rule: components/overrides always sit under the components section.
+    // The label line has no 2-char sign+space prefix, so use depth+2 to visually align with
+    // the child objects' name column (depth+1 indent + sign+space).
     if (o.overrides.len != 0 or o.components.len != 0) {
         try indent(w, depth + 2);
         try paint(w, color, Color.dim, "components");
@@ -280,7 +280,7 @@ fn renderObject(
     for (o.children) |child| try renderObject(w, child, resolved, color, depth + 1);
 }
 
-/// 見出しの status: グループ内で一様ならその status、混在なら modified。
+/// Heading status: that status if uniform within the group, modified if mixed.
 fn groupHeadingStatus(overrides: []const model.OverrideDiff, start: usize) model.Status {
     const first = overrides[start];
     for (overrides[start + 1 ..]) |ov| {
@@ -302,7 +302,7 @@ fn renderOverrides(w: *std.Io.Writer, overrides: []const model.OverrideDiff, col
         }
         try indent(w, depth + 1);
         try paint(w, color, statusColor(ov.status), statusSign(ov.status));
-        // 構造サマリ行 (before=after=null) は件数がラベルに含まれ、値を持たない。
+        // A structural summary row (before=after=null) has the count in the label and no value.
         if (ov.before == null and ov.after == null) {
             try w.print(" {s}\n", .{ov.label});
             continue;

--- a/cli/src/resolve.zig
+++ b/cli/src/resolve.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const core = @import("core");
 const testing = std.testing;
 
-/// guid -> asset path。core.json.Resolver と同一型なのでそのまま渡せる。
+/// guid -> asset path. Same type as core.json.Resolver, so it can be passed through directly.
 pub const Index = core.json.Resolver;
 
 pub fn buildIndex(io: std.Io, arena: std.mem.Allocator, project_root: []const u8) !Index {
@@ -58,7 +58,7 @@ test "buildIndex maps guid to asset path from .meta files" {
     const root = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
     var index = try buildIndex(testing.io, arena, root);
     const path = index.get("1234567890abcdef1234567890abcdef").?;
-    // Windows の walker/join は `\` 区切りを返すため、期待値もネイティブ区切りで組む。
+    // Windows's walker/join returns `\`-separated paths, so build the expected value with native separators too.
     const want = try std.fs.path.join(arena, &.{ "Assets", "Scripts", "Player.cs" });
     try testing.expect(std.mem.endsWith(u8, path, want));
 }

--- a/core/src/classid.zig
+++ b/core/src/classid.zig
@@ -2,8 +2,8 @@ const std = @import("std");
 
 const Pair = struct { id: u32, name: []const u8 };
 
-// Unity classID の全マッピング(id 昇順)。
-// 出典: Unity 6000.5 Manual "ClassID Reference"(343 エントリ)。
+// Full Unity classID mapping (ascending by id).
+// Source: Unity 6000.5 Manual "ClassID Reference" (343 entries).
 const table = [_]Pair{
     .{ .id = 0, .name = "Object" },
     .{ .id = 1, .name = "GameObject" },
@@ -351,7 +351,7 @@ const table = [_]Pair{
 };
 
 comptime {
-    // 二分探索の前提: id 昇順・重複なし。崩れたらビルドで落とす。
+    // Binary search invariant: id ascending, no duplicates. Fail the build if violated.
     for (table[1..], 0..) |p, i| {
         if (p.id <= table[i].id) @compileError("classid table must be sorted by id and unique");
     }
@@ -380,8 +380,8 @@ test "classID lookup covers common types and returns null for unknown" {
 }
 
 test "classID lookup covers the full ClassIDReference table" {
-    // Unity 6000.5 の ClassIDReference は 343 エントリ。境界(最小/最大 ID)と
-    // 旧サブセットに無かった代表例で全域をおさえる。
+    // Unity 6000.5 ClassIDReference has 343 entries. Cover the whole range with the
+    // boundaries (min/max ID) and representative entries absent from the old subset.
     try std.testing.expectEqual(@as(usize, 343), table.len);
     try std.testing.expectEqualStrings("Object", typeName(0).?);
     try std.testing.expectEqualStrings("Rigidbody", typeName(54).?);

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -38,8 +38,8 @@ test "diff: unknown classID falls back to the document top-level key" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 999999 は ClassIDReference に存在しない ID。テーブルで解決できない
-    // ドキュメントはトップレベルキーで命名される。
+    // 999999 is an ID absent from ClassIDReference. A document that cannot be
+    // resolved via the table is named by its top-level key.
     const before =
         \\--- !u!999999 &7
         \\MyCustomThing:
@@ -80,7 +80,7 @@ test "diff: added and removed documents" {
     const fd2 = try compute(arena, after, before);
     const removed = findDoc(fd2, 2).?;
     try testing.expectEqual(model.Status.removed, removed.status);
-    // 削除側も全列挙: hierarchy で見えていた Name が before 値で残る。
+    // Removed side enumerates fully too: the Name visible in the hierarchy remains with its before value.
     try testing.expectEqual(@as(usize, 1), removed.fields.len);
     try testing.expectEqualStrings("Name", removed.fields[0].path);
     try testing.expectEqualStrings("B", removed.fields[0].before.?.scalar);
@@ -104,8 +104,8 @@ test "diff: nested field path and added field" {
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
     try testing.expectEqual(model.Status.modified, d.status);
-    // 期待: modified な leaf(m_LocalPosition.y)と、added な m_LocalScale が
-    // ベクトル縮約されて "Scale" 1 行になること。
+    // Expect: the modified leaf (m_LocalPosition.y) plus the added m_LocalScale
+    // collapsed as a vector into a single "Scale" row.
     var saw_y = false;
     var saw_added_scale = false;
     for (d.fields) |f| {
@@ -128,9 +128,9 @@ test "diff: duplicate before fileIDs match the first occurrence" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 不正な anchor は parser が file_id を 0 に落とすため、重複は実際に
-    // 起こる。index 導入前の線形探索は「最初の」ドキュメントに一致して
-    // いたので、そのセマンティクスを維持しなければならない。
+    // A malformed anchor makes the parser drop file_id to 0, so duplicates do
+    // actually occur. The linear scan before the index was introduced matched the
+    // "first" document, so that semantics must be preserved.
     const before =
         \\--- !u!114 &5
         \\MonoBehaviour:
@@ -148,7 +148,7 @@ test "diff: duplicate before fileIDs match the first occurrence" {
     const d = findDoc(fd, 5).?;
     try testing.expectEqual(model.Status.modified, d.status);
     try testing.expectEqual(@as(usize, 1), d.fields.len);
-    // 最初の出現が勝つ: before は重複側の 999 ではなく 100。
+    // First occurrence wins: before is 100, not the duplicate's 999.
     try testing.expectEqualStrings("100", d.fields[0].before.?.scalar);
     try testing.expectEqualStrings("150", d.fields[0].after.?.scalar);
 }
@@ -168,7 +168,7 @@ test "diff: unresolved guids collected from external refs" {
         \\  m_Script: {fileID: 1, guid: bbbb, type: 3}
     ;
     const fd = try compute(arena, before, after);
-    // aaaa と bbbb はどちらも参照された外部 guid なので両方現れる。
+    // Both aaaa and bbbb are referenced external guids, so both appear.
     var saw_a = false;
     var saw_b = false;
     for (fd.unresolved_guids) |g| {
@@ -197,7 +197,7 @@ test "diff: stripped documents are excluded from docs but kept in before/after" 
     ;
     const fd = try compute(arena, before, after);
     try testing.expect(findDoc(fd, 42) == null);
-    // 構造解決用に after 配列には残る。
+    // Retained in the after array for structural resolution.
     var found = false;
     for (fd.after) |d| if (d.file_id == 42) {
         found = true;
@@ -224,7 +224,7 @@ test "diff: removed stripped documents are skipped" {
         \\  m_Name: A
     ;
     const fd = try compute(arena, before, after);
-    // stripped はインスタンス側の実体の影なので、消えても removed 行にしない。
+    // A stripped doc is a shadow of the instance's real object, so its removal is not a removed row.
     try testing.expect(findDoc(fd, 42) == null);
 }
 
@@ -246,7 +246,7 @@ test "diff: hidden fields are dropped and paths humanized" {
     ;
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
-    // m_GameObject の変更は非表示。m_LocalPosition.x は "Position.x" に。
+    // The m_GameObject change is hidden. m_LocalPosition.x becomes "Position.x".
     try testing.expectEqual(@as(usize, 1), d.fields.len);
     try testing.expectEqualStrings("Position.x", d.fields[0].path);
 }
@@ -302,7 +302,7 @@ test "diff: editor class identifier without separator or with empty tail" {
         \\  m_EditorClassIdentifier: Assembly-CSharp::
     ;
     const fd = try compute(arena, src, src);
-    // 区切りなしは全体をクラス名として使い、末尾が空なら class_name なし。
+    // No separator uses the whole string as the class name; an empty tail means no class_name.
     try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.class_name.?);
     try testing.expect(findDoc(fd, 6).?.class_name == null);
 }
@@ -323,16 +323,16 @@ test "diff: unresolved guids are deduplicated in first-reference order" {
         \\  m_Script: {fileID: 1, guid: bbb, type: 3}
     ;
     const fd = try compute(arena, "", after);
-    // 重複する bbb は 1 回だけ、初回参照順(bbb, aaa)で並ぶ。
-    // JSON の unresolvedGuids/resolved の決定的な順序はこれに依存する。
+    // Duplicate bbb appears once, in first-reference order (bbb, aaa).
+    // The deterministic order of JSON unresolvedGuids/resolved depends on this.
     try testing.expectEqual(@as(usize, 2), fd.unresolved_guids.len);
     try testing.expectEqualStrings("bbb", fd.unresolved_guids[0]);
     try testing.expectEqualStrings("aaa", fd.unresolved_guids[1]);
 }
 
 test "diff: sortByGroup keeps same-group rows contiguous beyond known ranks" {
-    // レンダラは「同一グループの行は連続」を core の不変条件として前提にする。
-    // groupOf が将来 4 つ目のグループ名を返しても壊れないことを直接固定する。
+    // The renderer relies on "rows of the same group are contiguous" as a core invariant.
+    // Pin directly that this holds even if groupOf returns a fourth group name in the future.
     var rows = [_]model.OverrideDiff{
         .{ .group = "Overrides", .label = "a", .status = .added, .before = null, .after = null },
         .{ .group = "Custom", .label = "b", .status = .added, .before = null, .after = null },
@@ -342,7 +342,7 @@ test "diff: sortByGroup keeps same-group rows contiguous beyond known ranks" {
     try testing.expectEqualStrings("Custom", rows[0].group);
     try testing.expectEqualStrings("Overrides", rows[1].group);
     try testing.expectEqualStrings("Overrides", rows[2].group);
-    // 同一グループ内の相対順は安定 (a が c より先)。
+    // Relative order within a group is stable (a before c).
     try testing.expectEqualStrings("a", rows[1].label);
     try testing.expectEqualStrings("c", rows[2].label);
 }
@@ -362,7 +362,7 @@ test "diff: added document enumerates fields with vector collapse" {
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
     try testing.expectEqual(model.Status.added, d.status);
-    // m_GameObject は非表示。Position はベクトル 1 行、maxHp は Max Hp。
+    // m_GameObject is hidden. Position is a single vector row, maxHp is Max Hp.
     try testing.expectEqual(@as(usize, 2), d.fields.len);
     try testing.expectEqualStrings("Position", d.fields[0].path);
     try testing.expectEqualStrings("(4, 0, 0)", d.fields[0].after.?.scalar);
@@ -383,7 +383,7 @@ test "diff: removed document enumerates fields with vector collapse" {
     const fd = try compute(arena, before, "");
     const d = findDoc(fd, 4).?;
     try testing.expectEqual(model.Status.removed, d.status);
-    // 追加側と対称: m_GameObject は非表示、Position はベクトル 1 行、値は before に載る。
+    // Symmetric with the added side: m_GameObject hidden, Position a single vector row, values on before.
     try testing.expectEqual(@as(usize, 2), d.fields.len);
     try testing.expectEqualStrings("Position", d.fields[0].path);
     try testing.expectEqual(model.Status.removed, d.fields[0].status);
@@ -412,7 +412,7 @@ test "diff: prefab instance override keyed by target+propertyPath" {
         \\      objectReference: {fileID: 0}
         \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
     ;
-    // 順序を入れ替えつつ x のみ変更: 順序入れ替えは diff にならない。
+    // Reorder while changing only x: reordering is not a diff.
     const after =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -462,7 +462,7 @@ test "diff: modified instance overrides are sorted group-contiguous, Transform f
         \\      objectReference: {fileID: 0}
         \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
     ;
-    // 生の YAML 順は Overrides, Transform, Overrides: グループ非連続になる入力。
+    // Raw YAML order is Overrides, Transform, Overrides: input with non-contiguous groups.
     const after =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -489,7 +489,7 @@ test "diff: modified instance overrides are sorted group-contiguous, Transform f
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Overrides", d.overrides[1].group);
     try testing.expectEqualStrings("Overrides", d.overrides[2].group);
-    // Overrides 内では元の相対順序(rangeMin が maxHp より先)を維持する。
+    // Within Overrides, keep the original relative order (rangeMin before maxHp).
     try testing.expectEqualStrings("Range Min", d.overrides[1].label);
     try testing.expectEqualStrings("Max Hp", d.overrides[2].label);
 }
@@ -535,8 +535,8 @@ test "diff: added prefab instance emits placement summary rows" {
     const fd = try compute(arena, "", after);
     const d = findDoc(fd, 1001).?;
     try testing.expectEqual(model.Status.added, d.status);
-    // 記録済みの placement は default 値(identity Rotation)でも合成 1 行で出す。
-    // EulerAnglesHint(Inspector 非表示)と m_Name(ノード名に吸収)は出ない。
+    // Recorded placement is emitted as a single synthesized row even at default values (identity Rotation).
+    // EulerAnglesHint (hidden in Inspector) and m_Name (absorbed into the node name) are not emitted.
     try testing.expectEqual(@as(usize, 2), d.overrides.len);
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Position", d.overrides[0].label);
@@ -588,7 +588,7 @@ test "diff: removed prefab instance mirrors overrides to before" {
     const fd = try compute(arena, before, "");
     const d = findDoc(fd, 1001).?;
     try testing.expectEqual(model.Status.removed, d.status);
-    // added の鏡像: 値は before 側、構造サマリは before 側の件数で removed。
+    // Mirror of added: values on the before side, structural summary removed with the before-side count.
     try testing.expectEqual(@as(usize, 2), d.overrides.len);
     try testing.expectEqualStrings("Scale.y", d.overrides[0].label);
     try testing.expectEqual(model.Status.removed, d.overrides[0].status);
@@ -657,8 +657,8 @@ fn buildIndex(arena: std.mem.Allocator, docs: []model.Document) !std.AutoHashMap
     var idx = std.AutoHashMap(i64, *model.Document).init(arena);
     try idx.ensureTotalCapacity(@intCast(docs.len));
     for (docs) |*d| {
-        // fileID 重複は最初の出現が勝つ(不正な anchor で発生する)。
-        // index 導入前の線形探索と同じセマンティクス。
+        // Duplicate fileIDs: first occurrence wins (happens with malformed anchors).
+        // Same semantics as the linear scan before the index was introduced.
         const gop = idx.getOrPutAssumeCapacity(d.file_id);
         if (!gop.found_existing) gop.value_ptr.* = d;
     }
@@ -673,7 +673,7 @@ fn scriptGuid(doc: *const model.Document) ?[]const u8 {
     };
 }
 
-// "Assembly-CSharp::Cylinder1" -> "Cylinder1"(最後の ':' より後)。
+// "Assembly-CSharp::Cylinder1" -> "Cylinder1" (after the last ':').
 fn editorClassName(doc: *const model.Document) ?[]const u8 {
     const v = model.findValue(doc.body.map, "m_EditorClassIdentifier") orelse return null;
     const s = switch (v.*) {
@@ -684,7 +684,7 @@ fn editorClassName(doc: *const model.Document) ?[]const u8 {
     return if (tail.len != 0) tail else null;
 }
 
-// 生の field diff から Inspector 非表示を落とし、path を表示名に置換する。
+// Drop Inspector-hidden entries from the raw field diff and replace path with the display name.
 fn presentFields(arena: std.mem.Allocator, raw: []FieldDiff) ![]FieldDiff {
     var kept: std.ArrayList(FieldDiff) = .empty;
     for (raw) |f| {
@@ -698,7 +698,7 @@ fn presentFields(arena: std.mem.Allocator, raw: []FieldDiff) ![]FieldDiff {
 
 fn resolvedTypeName(doc: *const model.Document) []const u8 {
     if (classid.typeName(doc.class_id)) |n| return n;
-    // 未知の classID はドキュメント自身のトップレベルキーに fallback。
+    // Unknown classID falls back to the document's own top-level key.
     return doc.type_name;
 }
 
@@ -708,20 +708,20 @@ pub fn compute(arena: std.mem.Allocator, before_src: []const u8, after_src: []co
     return computeParsed(arena, before, after);
 }
 
-// 既にパース済みのドキュメント列を diff する(instantiate が変異済み docs を食わせる)。
+// Diff an already-parsed document list (instantiate feeds in mutated docs).
 pub fn computeParsed(arena: std.mem.Allocator, before: []model.Document, after: []model.Document) !FlatDiff {
     var docs: std.ArrayList(DocDiff) = .empty;
-    // array hash map は初回挿入順を保持するので、unresolvedGuids が
-    // 参照順で決定的にシリアライズされる。
+    // The array hash map preserves first-insertion order, so unresolvedGuids
+    // serializes deterministically in reference order.
     var guids: std.StringArrayHashMapUnmanaged(void) = .empty;
 
-    // fileID -> *Document の索引。以降の和集合の走査を O(n^2) の線形探索
-    // ではなく O(n) にする(数万 doc のシーン規模で効く)。
+    // fileID -> *Document index. Makes the subsequent union walk O(n) instead of
+    // an O(n^2) linear scan (matters at scene scale of tens of thousands of docs).
     var before_idx = try buildIndex(arena, before);
     var after_idx = try buildIndex(arena, after);
 
-    // file_id の和集合を歩く: まず `after` を順に(after の順序を保つ)、
-    // 次に `before` にしかないドキュメントを処理する。
+    // Walk the union of file_ids: first `after` in order (preserving after's order),
+    // then process documents that exist only in `before`.
     for (after) |*ad| {
         if (ad.stripped) continue;
         try collectGuids(arena, &guids, ad.body);
@@ -795,7 +795,7 @@ pub fn computeParsed(arena: std.mem.Allocator, before: []model.Document, after: 
                 .overrides = try soleInstanceOverrides(arena, bd, .removed),
             });
         } else {
-            // 追加側(flattenSubtree ~ presentFields)と対称の全列挙。
+            // Full enumeration symmetric with the added side (flattenSubtree ~ presentFields).
             var raw: std.ArrayList(FieldDiff) = .empty;
             for (bd.body.map) |e| try flattenSubtree(arena, &raw, e.key, e.value, .removed);
             try docs.append(arena, .{
@@ -818,7 +818,7 @@ pub fn computeParsed(arena: std.mem.Allocator, before: []model.Document, after: 
     };
 }
 
-// 再帰的な field diff。`prefix` は `a`/`b` へのドット/添字区切りパス。
+// Recursive field diff. `prefix` is the dot/index-separated path into `a`/`b`.
 fn diffNode(
     arena: std.mem.Allocator,
     out: *std.ArrayList(FieldDiff),
@@ -826,7 +826,7 @@ fn diffNode(
     a: *const Node,
     b: *const Node,
 ) anyerror!void {
-    // 同じ種別なら再帰。
+    // Recurse if the same kind.
     if (a.* == .map and b.* == .map) {
         try diffMap(arena, out, prefix, a.map, b.map);
         return;
@@ -835,7 +835,7 @@ fn diffNode(
         try diffSeq(arena, out, prefix, a.seq, b.seq);
         return;
     }
-    // leaf(scalar/ref)または種別の変化。
+    // Leaf (scalar/ref) or a change of kind.
     if (!Node.eql(a, b)) {
         try out.append(arena, .{ .path = prefix, .status = .modified, .before = a, .after = b });
     }
@@ -848,7 +848,7 @@ fn diffMap(
     a: []model.Entry,
     b: []model.Entry,
 ) anyerror!void {
-    // a にあるキー: modified/removed または再帰
+    // Keys in a: modified/removed or recurse
     for (a) |ea| {
         const path = try joinKey(arena, prefix, ea.key);
         if (model.findValue(b, ea.key)) |bv| {
@@ -857,7 +857,7 @@ fn diffMap(
             try flattenSubtree(arena, out, path, ea.value, .removed);
         }
     }
-    // b にしかないキー: added
+    // Keys only in b: added
     for (b) |eb| {
         if (model.findValue(a, eb.key) == null) {
             const path = try joinKey(arena, prefix, eb.key);
@@ -903,7 +903,7 @@ fn isVectorMap(entries: []model.Entry) bool {
     return true;
 }
 
-// "(a, b, c)" 形の合成スカラー Node("Position: (2, 3, 1)" 等の 1 行表示用)。
+// Synthesized scalar Node of the form "(a, b, c)" (for single-row display like "Position: (2, 3, 1)").
 fn parenJoinNode(arena: std.mem.Allocator, vals: []const []const u8) !*Node {
     var out: std.ArrayList(u8) = .empty;
     try out.append(arena, '(');
@@ -931,7 +931,7 @@ fn appendLeaf(arena: std.mem.Allocator, out: *std.ArrayList(FieldDiff), path: []
     });
 }
 
-// added/removed サブツリーを leaf 単位に展開する。ベクトル風 map は 1 行に縮約。
+// Expand an added/removed subtree into leaves. A vector-like map collapses to one row.
 fn flattenSubtree(
     arena: std.mem.Allocator,
     out: *std.ArrayList(FieldDiff),
@@ -994,12 +994,12 @@ fn objRefIfSet(n: ?*Node) ?*Node {
     };
 }
 
-// objectReference が設定されていればそれ、なければ value。
+// objectReference if set, otherwise value.
 fn modValue(m: Mod) ?*Node {
     return m.obj_ref orelse m.value;
 }
 
-// instantiate と共有する mod の同一性キー(target fileID + propertyPath)。
+// Mod identity key shared with instantiate (target fileID + propertyPath).
 pub fn modKeyOf(arena: std.mem.Allocator, target: i64, path: []const u8) ![]const u8 {
     return std.fmt.allocPrint(arena, "{d}:{s}", .{ target, path });
 }
@@ -1046,7 +1046,7 @@ fn diffOverrides(arena: std.mem.Allocator, before_doc: ?*const model.Document, a
             try out.append(arena, try makeOverride(arena, am.path, .added, null, av));
         }
     }
-    // removed: before 側の順序で決定的に。
+    // removed: deterministic in before-side order.
     for (before_mods) |bm| {
         if (seen.contains(try modKey(arena, bm))) continue;
         if (inspector.isHidden(bm.path)) continue;
@@ -1057,9 +1057,9 @@ fn diffOverrides(arena: std.mem.Allocator, before_doc: ?*const model.Document, a
     return out.toOwnedSlice(arena);
 }
 
-// group 単位で安定ソート(Transform → GameObject → Overrides)。
-// レンダラは同一グループの行が連続することを前提に見出しを出すため、
-// 生の m_Modifications 順を group ごとに束ね直す。
+// Stable sort by group (Transform → GameObject → Overrides).
+// The renderer emits headings assuming rows of the same group are contiguous, so
+// rebundle the raw m_Modifications order by group.
 fn groupRank(group: []const u8) u2 {
     if (std.mem.eql(u8, group, "Transform")) return 0;
     if (std.mem.eql(u8, group, "GameObject")) return 1;
@@ -1072,8 +1072,8 @@ fn sortByGroup(overrides: []model.OverrideDiff) void {
             const ra = groupRank(a.group);
             const rb = groupRank(b.group);
             if (ra != rb) return ra < rb;
-            // rank 同値 (catch-all) はグループ名で tie-break し、groupOf に
-            // 未知のグループ名が増えても同一グループの連続性を保つ。
+            // Equal rank (catch-all) tie-breaks by group name, keeping same-group
+            // contiguity even as groupOf gains unknown group names.
             return std.mem.order(u8, a.group, b.group) == .lt;
         }
     };
@@ -1100,15 +1100,15 @@ fn findMod(mods: []Mod, path: []const u8) ?Mod {
     return null;
 }
 
-// 片側にしか存在しない instance(added/removed)の override 全列挙。
-// 値は added なら after、removed なら before に載る。
+// Full override enumeration for an instance present on only one side (added/removed).
+// Values go on after if added, on before if removed.
 fn soleInstanceOverrides(arena: std.mem.Allocator, doc: *const model.Document, status: Status) ![]model.OverrideDiff {
     return soleOverridesFromMods(arena, doc, try dedupModsLastWins(arena, try collectMods(arena, doc)), status);
 }
 
-// 同一 (target, propertyPath) は後勝ちで 1 件に畳む(表示位置は初出)。実ファイルに
-// 重複は無いが、instantiate の push-down は外側の mod を末尾に追記するため、
-// 縮退表示でも適用と同じ「外側が勝つ」セマンティクスになるよう揃える。
+// Collapse duplicate (target, propertyPath) to one, last-wins (display position is the first occurrence). Real files
+// have no duplicates, but instantiate's push-down appends the outer mod at the tail, so
+// align the degraded view with the same "outer wins" semantics as application.
 fn dedupModsLastWins(arena: std.mem.Allocator, mods: []Mod) ![]Mod {
     var map: std.StringArrayHashMapUnmanaged(Mod) = .empty;
     for (mods) |m| try map.put(arena, try modKey(arena, m), m);
@@ -1117,8 +1117,8 @@ fn dedupModsLastWins(arena: std.mem.Allocator, mods: []Mod) ![]Mod {
     return out.toOwnedSlice(arena);
 }
 
-// 展開済み instance の残余行(instantiate 用): 合成へ適用できた mod を除き、
-// 適用できなかったものだけを従来の縮退表示で残す(黙って消さない)。
+// Leftover rows of an expanded instance (for instantiate): drop mods applied to the
+// synthesis, keep only the unapplied ones in the usual degraded view (don't drop silently).
 pub fn soleInstanceOverridesSkipping(arena: std.mem.Allocator, doc: *const model.Document, status: Status, applied: *const std.StringHashMapUnmanaged(void)) ![]model.OverrideDiff {
     const all = try dedupModsLastWins(arena, try collectMods(arena, doc));
     var kept: std.ArrayList(Mod) = .empty;
@@ -1132,7 +1132,7 @@ pub fn soleInstanceOverridesSkipping(arena: std.mem.Allocator, doc: *const model
 fn soleOverridesFromMods(arena: std.mem.Allocator, doc: *const model.Document, mods: []Mod, status: Status) ![]model.OverrideDiff {
     var out: std.ArrayList(model.OverrideDiff) = .empty;
 
-    // Placement サマリ: 全成分が揃っていれば合成 1 行。
+    // Placement summary: a single synthesized row if all components are present.
     var consumed = [_]bool{false} ** placements.len;
     for (placements, 0..) |p, pi| {
         var vals: [4][]const u8 = undefined;
@@ -1163,7 +1163,7 @@ fn soleOverridesFromMods(arena: std.mem.Allocator, doc: *const model.Document, m
 
     for (mods) |m| {
         if (inspector.isHidden(m.path)) continue;
-        if (std.mem.eql(u8, m.path, "m_Name")) continue; // ノード名に吸収
+        if (std.mem.eql(u8, m.path, "m_Name")) continue; // absorbed into the node name
         const in_consumed = blk: {
             for (placements, 0..) |p, pi| {
                 if (consumed[pi] and std.mem.startsWith(u8, m.path, p.prefix) and
@@ -1200,7 +1200,7 @@ fn modificationSeqLen(doc: *const model.Document, key: []const u8) usize {
     };
 }
 
-// m_Added*/m_Removed* の完全展開はスコープ外。件数の要約 1 行で情報が黙って消えるのを防ぐ。
+// Full expansion of m_Added*/m_Removed* is out of scope. A single count-summary row prevents information from silently vanishing.
 fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model.OverrideDiff), before_doc: ?*const model.Document, after_doc: ?*const model.Document) !void {
     const keys = [_]struct { key: []const u8, label: []const u8 }{
         .{ .key = "m_AddedGameObjects", .label = "Added GameObjects" },
@@ -1212,7 +1212,7 @@ fn appendStructuralSummaries(arena: std.mem.Allocator, out: *std.ArrayList(model
         const alen = if (after_doc) |ad| modificationSeqLen(ad, e.key) else 0;
         const blen = if (before_doc) |bd| modificationSeqLen(bd, e.key) else 0;
         if (alen == blen) continue;
-        // 件数は生き残っている側: instance ごと削除なら before の件数を出す。
+        // Count from the surviving side: if the whole instance is removed, emit the before count.
         const count = if (after_doc != null) alen else blen;
         try out.append(arena, .{
             .group = "Overrides",

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -1,5 +1,5 @@
-// 検証 PR (hashiiiii/unity-yaml-playground#1) の実データに対する統合テスト。
-// 期待値は spec の承認済みモック(docs/superpowers/specs/2026-07-03-semantic-diff-inspector-model-design.md)。
+// Integration tests against real data from the verification PR (hashiiiii/unity-yaml-playground#1).
+// Expected values are the spec's approved mocks (docs/superpowers/specs/2026-07-03-semantic-diff-inspector-model-design.md).
 const std = @import("std");
 const root = @import("root.zig");
 const model = @import("model.zig");
@@ -22,13 +22,13 @@ test "fixture: Plane.prefab shows both cylinder instances under Plane" {
     const arena = arena_state.allocator();
     const res = try root.diffBytes(arena, plane_before, plane_after);
 
-    // stripped Transform や PrefabInstance が loose に漏れない。
+    // stripped Transform and PrefabInstance do not leak into loose.
     try testing.expectEqual(@as(usize, 0), res.loose.len);
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     const plane = res.roots[0];
     try testing.expectEqualStrings("Plane", plane.name);
 
-    // 追加された Cylinder Variant: 記録済み placement を default 含め全表示。
+    // Added Cylinder Variant: all recorded placement shown, including defaults.
     const variant = childByName(plane, "Cylinder Variant").?;
     try testing.expectEqual(model.ObjectKind.prefab_instance, variant.kind);
     try testing.expectEqual(model.Status.added, variant.status);
@@ -39,7 +39,7 @@ test "fixture: Plane.prefab shows both cylinder instances under Plane" {
     try testing.expectEqualStrings("Rotation", variant.overrides[1].label);
     try testing.expectEqualStrings("(0, 0, 0, 1)", variant.overrides[1].after.?.scalar);
 
-    // 変更された Cylinder: Position.x の 1 override のみ。
+    // Modified Cylinder: only the single Position.x override.
     const cylinder = childByName(plane, "Cylinder").?;
     try testing.expectEqual(model.ObjectKind.prefab_instance, cylinder.kind);
     try testing.expectEqual(model.Status.modified, cylinder.status);
@@ -66,7 +66,7 @@ test "fixture: Cylinder.prefab shows added script and transform change" {
             saw_script = true;
             try testing.expectEqual(model.Status.added, c.status);
             try testing.expectEqualStrings("Cylinder1", c.class_name.?);
-            // 追加コンポーネントは初期値を全列挙している(空ではない)。
+            // The added component enumerates its initial values in full (not empty).
             try testing.expect(c.fields.len != 0);
         }
         if (c.class_id == 4) {
@@ -90,8 +90,8 @@ test "fixture: new Cylinder Variant.prefab shows all recorded placement values" 
     try testing.expectEqual(model.ObjectKind.prefab_instance, inst.kind);
     try testing.expectEqualStrings("Cylinder Variant", inst.name);
     try testing.expectEqual(model.Status.added, inst.status);
-    // ファイルに記録された placement は default でも全部出す。
-    // 出ないのは EulerAnglesHint(非表示)と m_Name(ノード名に吸収)のみ。
+    // Placement recorded in the file is all emitted, even at defaults.
+    // The only omissions are EulerAnglesHint (hidden) and m_Name (absorbed into the node name).
     try testing.expectEqual(@as(usize, 3), inst.overrides.len);
     try testing.expectEqualStrings("Position", inst.overrides[0].label);
     try testing.expectEqualStrings("(0, 0, 0)", inst.overrides[0].after.?.scalar);
@@ -105,7 +105,7 @@ test "fixture: deleted Cylinder Variant.prefab mirrors the added enumeration" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // added(直前のテスト)の鏡像: 同じ 3 行が before 値・removed で出る。
+    // Mirror of added (the previous test): the same 3 rows appear with before values and removed.
     const res = try root.diffBytes(arena, cylinder_variant_after, "");
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     const inst = res.roots[0];
@@ -125,7 +125,7 @@ test "fixture: variant merged with source shows Scale (1, 2, 1) and all componen
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // ソース(Cylinder.prefab 相当)を supply すると Inspector と同じ合成状態になる。
+    // Supplying the source (equivalent to Cylinder.prefab) yields the same merged state as the Inspector.
     var assets: root.Assets = .empty;
     try assets.put(arena, "05ba59bdbdf954600a21005e3b7bf963", cylinder_after);
     const res = try root.diffBytesWithAssets(arena, "", cylinder_variant_after, &assets);
@@ -134,7 +134,7 @@ test "fixture: variant merged with source shows Scale (1, 2, 1) and all componen
     const inst = res.roots[0];
     try testing.expectEqualStrings("Cylinder Variant", inst.name);
     try testing.expectEqual(model.Status.added, inst.status);
-    // 展開成功: overrides は消え、ソースの全コンポーネントが added で並ぶ。
+    // Expansion succeeds: overrides vanish, all source components appear as added.
     try testing.expectEqual(@as(usize, 0), inst.overrides.len);
     var saw = [_]bool{false} ** 4; // Transform / MeshFilter / MeshRenderer / CapsuleCollider
     for (inst.components) |c| {
@@ -142,7 +142,7 @@ test "fixture: variant merged with source shows Scale (1, 2, 1) and all componen
         switch (c.class_id) {
             4 => {
                 saw[0] = true;
-                // override 適用済み: Scale.y=2 が (1, 2, 1) に、Position は (0, 0, 0)。
+                // Overrides applied: Scale.y=2 becomes (1, 2, 1), Position is (0, 0, 0).
                 var saw_scale = false;
                 var saw_pos = false;
                 for (c.fields) |f| {
@@ -170,9 +170,9 @@ test "fixture: Plane variant instance merges nested sources with outer placement
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Plane -> Cylinder Variant.prefab -> Cylinder.prefab の 2 段解決。
-    // Plane 側の配置 (2.03, 3.63, 1.11797) が XOR push-down で Transform に届き、
-    // Scale は variant の override (1, 2, 1) が残る = Inspector と同じ合成。
+    // Two-level resolution: Plane -> Cylinder Variant.prefab -> Cylinder.prefab.
+    // Plane's placement (2.03, 3.63, 1.11797) reaches the Transform via XOR push-down,
+    // and Scale keeps the variant's override (1, 2, 1) = the same merge as the Inspector.
     var assets: root.Assets = .empty;
     try assets.put(arena, "b01772ea746dd4b869440c40c8b1f48e", cylinder_variant_after);
     try assets.put(arena, "05ba59bdbdf954600a21005e3b7bf963", cylinder_after);
@@ -181,7 +181,7 @@ test "fixture: Plane variant instance merges nested sources with outer placement
     const plane = res.roots[0];
     const variant = childByName(plane, "Cylinder Variant").?;
     try testing.expectEqual(model.Status.added, variant.status);
-    // 二重ノードにならず、override は全部適用済みで行としては残らない。
+    // No duplicate node; all overrides are applied and none remain as rows.
     try testing.expectEqual(@as(usize, 0), variant.children.len);
     try testing.expectEqual(@as(usize, 0), variant.overrides.len);
     var saw_transform = false;
@@ -205,8 +205,8 @@ test "fixture: Plane variant instance merges nested sources with outer placement
     try testing.expect(saw_transform);
 }
 
-// ---- prefab/scene 以外の UnityYAML アセット(.mat / .controller)----
-// core は拡張子を見ないので既に diff できる。ここはその保証を固定する回帰点。
+// ---- UnityYAML assets other than prefab/scene (.mat / .controller) ----
+// core does not look at extensions, so these already diff. This is the regression point that pins that guarantee.
 
 const material_before = @embedFile("testdata/material_before.mat");
 const material_after = @embedFile("testdata/material_after.mat");
@@ -219,7 +219,7 @@ test "fixture: .mat diffs as a loose Material with nested property paths" {
     const arena = arena_state.allocator();
     const res = try root.diffBytes(arena, material_before, material_after);
 
-    // GameObject 階層を持たないので roots は空、Material 本体は loose に 1 件。
+    // No GameObject hierarchy, so roots is empty and the Material itself is a single loose entry.
     try testing.expectEqual(@as(usize, 0), res.roots.len);
     try testing.expectEqual(@as(usize, 1), res.loose.len);
     const mat = res.loose[0];
@@ -227,7 +227,7 @@ test "fixture: .mat diffs as a loose Material with nested property paths" {
     try testing.expectEqualStrings("Material", mat.type_name);
     try testing.expectEqual(model.Status.modified, mat.status);
 
-    // m_SavedProperties 配下の変更 2 件が Inspector 風パスで出る。
+    // Two changes under m_SavedProperties appear with Inspector-style paths.
     try testing.expectEqual(@as(usize, 2), mat.fields.len);
     try testing.expectEqualStrings("Saved Properties.Floats[1]._Metallic", mat.fields[0].path);
     try testing.expectEqualStrings("0", mat.fields[0].before.?.scalar);
@@ -243,11 +243,11 @@ test "fixture: .controller shows only the changed AnimatorState" {
     const arena = arena_state.allocator();
     const res = try root.diffBytes(arena, animator_before, animator_after);
 
-    // 3 ドキュメント(State / StateMachine / Controller)のうち変更は State のみ。
+    // Of the 3 documents (State / StateMachine / Controller), only State changed.
     try testing.expectEqual(@as(usize, 0), res.roots.len);
     try testing.expectEqual(@as(usize, 1), res.loose.len);
     const state = res.loose[0];
-    // 1102 は classid.zig のテーブルで AnimatorState に解決される。
+    // 1102 resolves to AnimatorState via the classid.zig table.
     try testing.expectEqual(@as(u32, 1102), state.class_id);
     try testing.expectEqualStrings("AnimatorState", state.type_name);
     try testing.expectEqual(model.Status.modified, state.status);

--- a/core/src/inspector.zig
+++ b/core/src/inspector.zig
@@ -33,7 +33,7 @@ test "inspector: groupOf infers pseudo component from propertyPath" {
     try testing.expectEqualStrings("Overrides", groupOf("maxHp"));
 }
 
-// Inspector に表示されないフィールド(パス先頭セグメントで判定)。
+// Fields not shown in the Inspector (matched by the path's first segment).
 const hidden = [_][]const u8{
     "m_ObjectHideFlags",
     "m_CorrespondingSourceObject",
@@ -50,7 +50,7 @@ const hidden = [_][]const u8{
     "m_RootOrder",
 };
 
-// 主要ビルトインの Inspector 表示名(先頭セグメント単位)。
+// Inspector display names for the main built-ins (per first segment).
 const display = [_]struct { raw: []const u8, shown: []const u8 }{
     .{ .raw = "m_LocalPosition", .shown = "Position" },
     .{ .raw = "m_LocalRotation", .shown = "Rotation" },
@@ -88,15 +88,15 @@ pub fn displayPath(arena: std.mem.Allocator, path: []const u8) ![]const u8 {
     return out.toOwnedSlice(arena);
 }
 
-// "[N]" 添字は名前部の後ろにそのまま残す。
+// Keep the "[N]" index as-is after the name part.
 fn appendSegment(arena: std.mem.Allocator, out: *std.ArrayList(u8), seg: []const u8) !void {
     const br = std.mem.indexOfScalar(u8, seg, '[') orelse seg.len;
     try appendNicified(arena, out, seg[0..br]);
     try out.appendSlice(arena, seg[br..]);
 }
 
-// Unity の ObjectNames.NicifyVariableName 相当: 固定テーブル →
-// "m_" 除去 + 先頭大文字化 + 小文字/数字→大文字境界に空白挿入。
+// Equivalent to Unity's ObjectNames.NicifyVariableName: fixed table →
+// strip "m_" + capitalize first + insert a space at lowercase/digit→uppercase boundaries.
 fn appendNicified(arena: std.mem.Allocator, out: *std.ArrayList(u8), name: []const u8) !void {
     for (display) |d| if (std.mem.eql(u8, name, d.raw)) {
         try out.appendSlice(arena, d.shown);
@@ -108,7 +108,7 @@ fn appendNicified(arena: std.mem.Allocator, out: *std.ArrayList(u8), name: []con
         try out.appendSlice(arena, name);
         return;
     }
-    // 単一小文字セグメント (x/y/z/w) は Inspector 同様そのまま。
+    // A single lowercase segment (x/y/z/w) is left as-is, like the Inspector.
     if (s.len == 1 and std.ascii.isLower(s[0])) {
         try out.appendSlice(arena, s);
         return;

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -1,7 +1,7 @@
-// PrefabInstance のソースプレハブ合成(親 spec: docs/superpowers/specs/2026-07-06-prefab-source-resolution-design.md)。
-// 合成 = ソースを parse -> m_Modifications を Document に適用 -> 既存の片側
-// compute + tree.build を再利用 -> instance ノードへ接ぎ木。core は I/O を持たず、
-// ホストが guid -> bytes(Assets)を供給する。供給が無い guid は needed_sources に載る。
+// Source-prefab merging for PrefabInstance (parent spec: docs/superpowers/specs/2026-07-06-prefab-source-resolution-design.md).
+// Merge = parse the source -> apply m_Modifications to the Document -> reuse the existing
+// one-sided compute + tree.build -> graft onto the instance node. core owns no I/O;
+// the host supplies guid -> bytes (Assets). Guids with no supply go into needed_sources.
 const std = @import("std");
 const model = @import("model.zig");
 const parser = @import("parser.zig");
@@ -10,29 +10,29 @@ const tree = @import("tree.zig");
 
 pub const Assets = std.StringHashMapUnmanaged([]const u8);
 
-// 入れ子展開の深さ上限(tree.zig の max_instance_hops と同じ思想)。
+// Depth limit for nested expansion (same idea as tree.zig's max_instance_hops).
 const max_depth = 8;
 
 const Ctx = struct {
     arena: std.mem.Allocator,
     assets: *const Assets,
-    // 供給が必要な guid -> side(初出順を保ち decisions を決定的にする)。
+    // guids that need supplying -> side (first-seen order kept to make decisions deterministic).
     needed: std.StringArrayHashMapUnmanaged(model.SourceSide) = .empty,
-    // 参照済み guid の全体集合(unresolvedGuids へのマージ用、初出順)。
+    // Full set of referenced guids (for merging into unresolvedGuids, first-seen order).
     guids: std.StringArrayHashMapUnmanaged(void) = .empty,
-    // 祖先チェーンの guid(循環ガード)。兄弟同士での同一ソース再利用は許す。
+    // guids of the ancestor chain (cycle guard). Reusing the same source among siblings is allowed.
     chain: std.ArrayList([]const u8) = .empty,
 };
 
 pub fn expand(arena: std.mem.Allocator, res: *model.DiffResult, fd: diffmod.FlatDiff, assets: *const Assets) !void {
     var ctx = Ctx{ .arena = arena, .assets = assets };
-    // ソース由来の外部参照(script/material 等)もホスト解決の対象に
-    // 含めるため、トップレベルの unresolvedGuids へマージしていく。
+    // Merge source-derived external references (scripts/materials etc.) into the
+    // top-level unresolvedGuids so they too become subject to host resolution.
     for (res.unresolved_guids) |g| try ctx.guids.put(arena, g, {});
 
     var docs = std.AutoHashMap(i64, *model.Document).init(arena);
-    // sole-status instance の生 doc(m_Modifications 読取り用)。added は after、
-    // removed は before 側にしか存在しないので、両方入れれば片側が引ける。
+    // Raw docs of sole-status instances (for reading m_Modifications). added exists only
+    // on after, removed only on before, so inserting both lets either side be looked up.
     for (fd.before) |*d| try docs.put(d.file_id, d);
     for (fd.after) |*d| try docs.put(d.file_id, d);
 
@@ -62,14 +62,14 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     };
     const inst_doc = docs.get(node.file_id) orelse return;
 
-    // ソースを parse し、この instance の m_RemovedComponents / m_Modifications を適用。
-    // 壊れたソース資産で diff 全体を落とさない: parse 失敗はその instance だけ
-    // 縮退表示(override 列挙)のままにする。
+    // Parse the source and apply this instance's m_RemovedComponents / m_Modifications.
+    // Don't let a broken source asset sink the whole diff: on parse failure, leave just that
+    // instance in the degraded view (override enumeration).
     const src_docs = parser.parse(ctx.arena, bytes) catch return;
     applyRemovedComponents(inst_doc, src_docs);
     var applied = try applyModifications(ctx.arena, inst_doc, src_docs, guid);
 
-    // 片側 diff として全列挙し、既存パイプラインで ObjectDiff 化する。
+    // Enumerate fully as a one-sided diff and turn it into an ObjectDiff via the existing pipeline.
     const none = try parser.parse(ctx.arena, "");
     const sub_fd = if (node.status == .added)
         try diffmod.computeParsed(ctx.arena, none, src_docs)
@@ -78,7 +78,7 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     const sub = try tree.build(ctx.arena, sub_fd);
     for (sub_fd.unresolved_guids) |g| try ctx.guids.put(ctx.arena, g, {});
 
-    // 入れ子 instance を再帰展開(祖先チェーンに自分の guid を積む)。
+    // Recursively expand nested instances (push our own guid onto the ancestor chain).
     try ctx.chain.append(ctx.arena, guid);
     defer _ = ctx.chain.pop();
     var sub_docs = std.AutoHashMap(i64, *model.Document).init(ctx.arena);
@@ -86,9 +86,9 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     for (sub_fd.after) |*d| try sub_docs.put(d.file_id, d);
     for (sub.roots) |*r| try expandNode(ctx, r, &sub_docs, depth + 1);
 
-    // 接ぎ木: 単一 root ならその中身を instance ノードへ持ち上げる(Unity の
-    // hierarchy 表示と同じ: instance = ソース root の合成)。変種ファイルの root は
-    // PrefabInstance なので、その残余 override も引き継いで二重ノードを畳む。
+    // Graft: for a single root, lift its contents up into the instance node (same as Unity's
+    // hierarchy display: instance = merge of the source root). A variant file's root is a
+    // PrefabInstance, so carry over its leftover overrides too and collapse the duplicate node.
     var inner_overrides: []model.OverrideDiff = &.{};
     if (sub.roots.len == 1) {
         node.components = try concatComponents(ctx.arena, node.components, sub.roots[0].components, sub.loose);
@@ -98,7 +98,7 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
         node.components = try concatComponents(ctx.arena, node.components, &.{}, sub.loose);
         node.children = try concatObjects(ctx.arena, node.children, sub.roots);
     }
-    // 適用できなかった mod は行として残す(黙って消さない)。
+    // Keep unapplied mods as rows (don't drop them silently).
     const leftover = try diffmod.soleInstanceOverridesSkipping(ctx.arena, inst_doc, node.status, &applied);
     node.overrides = try concatOverrides(ctx.arena, leftover, inner_overrides);
 }
@@ -131,8 +131,8 @@ fn concatObjects(arena: std.mem.Allocator, a: []model.ObjectDiff, b: []model.Obj
     return out.toOwnedSlice(arena);
 }
 
-// m_RemovedComponents の参照先(ソース内 fileID)を stripped 扱いで落とす
-// (computeParsed が stripped doc を除外する)。
+// Mark the referents of m_RemovedComponents (source-internal fileIDs) as stripped
+// (computeParsed excludes stripped docs).
 fn applyRemovedComponents(inst_doc: *const model.Document, src_docs: []model.Document) void {
     const m = model.findValue(inst_doc.body.map, "m_Modification") orelse return;
     if (m.* != .map) return;
@@ -148,11 +148,11 @@ fn applyRemovedComponents(inst_doc: *const model.Document, src_docs: []model.Doc
 
 const AppliedSet = std.StringHashMapUnmanaged(void);
 
-// m_Modifications をソース Document へ適用する(target.guid が source guid のもの)。
-// 直接一致しない fileID は入れ子 instance の名前空間: Unity の入れ子 fileID は
-// 「instance fileID XOR ソース内 fileID」なので、XOR で変換した mod を instance の
-// m_Modifications 末尾へ追記して押し下げる(末尾 = 外側が後勝ち、Inspector と同じ)。
-// 戻り値は適用または押し下げできた mod のキー集合(残余の縮退表示用)。
+// Apply m_Modifications to the source Document (those whose target.guid is the source guid).
+// A fileID that doesn't match directly belongs to a nested instance's namespace: Unity's nested
+// fileID is "instance fileID XOR source-internal fileID", so append the XOR-transformed mod to the
+// instance's m_Modifications tail to push it down (tail = outer wins last, same as the Inspector).
+// Returns the key set of mods that were applied or pushed down (for the leftover degraded view).
 fn applyModifications(arena: std.mem.Allocator, inst_doc: *const model.Document, src_docs: []model.Document, source_guid: []const u8) !AppliedSet {
     var applied: AppliedSet = .empty;
     const m = model.findValue(inst_doc.body.map, "m_Modification") orelse return applied;
@@ -169,7 +169,7 @@ fn applyModifications(arena: std.mem.Allocator, inst_doc: *const model.Document,
         if (!std.mem.eql(u8, tguid, source_guid)) continue;
         const value = model.findValue(item.map, "value");
         const obj_ref = objRefIfSet(model.findValue(item.map, "objectReference"));
-        // objectReference が設定されていればそれ、なければ value(diff.zig の modValue と同じ規則)。
+        // objectReference if set, otherwise value (same rule as diff.zig's modValue).
         const eff = obj_ref orelse (value orelse continue);
         var handled = false;
         for (src_docs) |*d| {
@@ -184,9 +184,9 @@ fn applyModifications(arena: std.mem.Allocator, inst_doc: *const model.Document,
     return applied;
 }
 
-// XOR 変換した mod を全 instance doc に追記する。正しい instance でのみ内側の
-// fileID が一致して適用され、他は再帰的に押し下げられるか残余行として現れる
-// (複数 instance を持つソースでの余分な行は許容 — 情報を消すより安全側)。
+// Append the XOR-transformed mod to every instance doc. Only in the correct instance does the
+// inner fileID match and get applied; others are pushed down recursively or surface as leftover rows
+// (extra rows in a source with multiple instances are tolerated — safer than dropping information).
 fn pushDown(arena: std.mem.Allocator, src_docs: []model.Document, target_id: i64, pp: *model.Node, value: ?*model.Node, obj_ref: ?*model.Node) !bool {
     var pushed = false;
     for (src_docs) |*d| {
@@ -234,8 +234,8 @@ fn objRefIfSet(n: ?*model.Node) ?*model.Node {
     };
 }
 
-// "m_LocalScale.y" / "m_Materials.Array.data[0]" 形式のパスで leaf を差し替える。
-// 途中が見つからない・型が合わないパスは黙って捨てる(表示合成なので安全側)。
+// Replace a leaf via a path like "m_LocalScale.y" / "m_Materials.Array.data[0]".
+// Paths with a missing intermediate or a type mismatch are silently dropped (safe side, since this is display merging).
 fn setByPropertyPath(body: *model.Node, path: []const u8, value: *model.Node) void {
     var cur: *model.Node = body;
     var it = std.mem.splitScalar(u8, path, '.');
@@ -244,7 +244,7 @@ fn setByPropertyPath(body: *model.Node, path: []const u8, value: *model.Node) vo
         const next = it.next();
         if (std.mem.eql(u8, seg, "Array")) {
             pending = next;
-            continue; // Unity の仮想セグメント
+            continue; // Unity's virtual segment
         }
         if (std.mem.startsWith(u8, seg, "data[")) {
             const close = std.mem.indexOfScalar(u8, seg, ']') orelse return;
@@ -314,8 +314,8 @@ test "instantiate: merged variant shows full source values with overrides applie
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     const inst = res.roots[0];
     try testing.expectEqualStrings("Cyl Variant", inst.name);
-    // 展開成功: overrides は空、ソースの Transform が component として現れ、
-    // override 適用済みの Scale (1, 2, 1) を全列挙で持つ。
+    // Expansion succeeds: overrides empty, the source Transform appears as a component,
+    // holding the override-applied Scale (1, 2, 1) in full enumeration.
     try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
     try testing.expectEqual(@as(usize, 0), inst.overrides.len);
     try testing.expectEqual(@as(usize, 1), inst.components.len);
@@ -333,14 +333,14 @@ test "instantiate: missing asset degrades and reports neededSources with side" {
     const arena = arena_state.allocator();
     const empty: Assets = .empty;
 
-    // added 方向: 縮退表示(override 全列挙)のまま、side は after。
+    // added direction: stays in the degraded view (full override enumeration), side is after.
     const added = try root.diffBytesWithAssets(arena, "", test_variant, &empty);
     try testing.expectEqual(@as(usize, 1), added.needed_sources.len);
     try testing.expectEqualStrings("srcguid", added.needed_sources[0].guid);
     try testing.expectEqual(model.SourceSide.after, added.needed_sources[0].side);
     try testing.expect(added.roots[0].overrides.len != 0);
 
-    // removed 方向: side は before。
+    // removed direction: side is before.
     const removed = try root.diffBytesWithAssets(arena, test_variant, "", &empty);
     try testing.expectEqual(@as(usize, 1), removed.needed_sources.len);
     try testing.expectEqual(model.SourceSide.before, removed.needed_sources[0].side);
@@ -350,8 +350,8 @@ test "instantiate: cyclic source reference terminates" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // ソース自身が同じ guid の PrefabInstance を含む(壊れたデータ)。
-    // 祖先チェーンの循環ガードで停止し、needed にも載らないことだけを確認する。
+    // The source itself contains a PrefabInstance of the same guid (corrupt data).
+    // Just verify the ancestor-chain cycle guard stops it and it doesn't land in needed either.
     const cyclic_source =
         \\--- !u!1001 &7
         \\PrefabInstance:
@@ -377,7 +377,7 @@ test "instantiate: unparseable source degrades to the override view" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // parser の max_nesting_depth(128)を確実に超える壊れたソース。
+    // A broken source that reliably exceeds the parser's max_nesting_depth (128).
     var hostile: std.ArrayList(u8) = .empty;
     try hostile.appendSlice(arena, "--- !u!1 &1\nGameObject:\n");
     for (1..200) |depth| {
@@ -386,7 +386,7 @@ test "instantiate: unparseable source degrades to the override view" {
     }
     var assets: Assets = .empty;
     try assets.put(arena, "srcguid", hostile.items);
-    // diff 全体は成功し、instance は縮退表示(override が残る)のまま。
+    // The whole diff succeeds and the instance stays in the degraded view (overrides remain).
     const res = try root.diffBytesWithAssets(arena, "", test_variant, &assets);
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     try testing.expect(res.roots[0].overrides.len != 0);
@@ -425,7 +425,7 @@ test "instantiate: removed components are dropped from the merged tree" {
     try assets.put(arena, "srcguid", source);
     const res = try root.diffBytesWithAssets(arena, "", variant, &assets);
     const inst = res.roots[0];
-    // BoxCollider (fileID 50) は除去済み: Transform だけが残る。
+    // BoxCollider (fileID 50) is removed: only the Transform remains.
     for (inst.components) |c| try testing.expect(c.class_id != 65);
 }
 
@@ -433,10 +433,10 @@ test "instantiate: outer overrides push down through nested instances" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 3 段構成: outer -> variant (guid varguid) -> base (guid baseguid)。
-    // Unity は入れ子オブジェクトを「instance fileID XOR ソース fileID」で参照する。
-    // outer の mod は variant 内の instance (&100) 越しに base の Transform (&40) を
-    // 狙う: target fileID = 100 ^ 40 = 76。
+    // 3-level structure: outer -> variant (guid varguid) -> base (guid baseguid).
+    // Unity references nested objects as "instance fileID XOR source fileID".
+    // outer's mod targets base's Transform (&40) through the instance (&100) inside the variant:
+    // target fileID = 100 ^ 40 = 76.
     const base =
         \\--- !u!1 &10
         \\GameObject:
@@ -475,11 +475,11 @@ test "instantiate: outer overrides push down through nested instances" {
     try testing.expectEqual(@as(usize, 0), res.needed_sources.len);
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     const inst = res.roots[0];
-    // 単一 instance root は外側ノードへ畳まれ、二重ノードにならない。
+    // The single instance root collapses into the outer node, not a duplicate node.
     try testing.expectEqual(@as(usize, 0), inst.children.len);
     try testing.expectEqual(@as(usize, 0), inst.overrides.len);
     try testing.expectEqual(@as(usize, 1), inst.components.len);
-    // 外側の override が最後に適用され、variant の 1 ではなく 9 が勝つ。
+    // The outer override applies last, so 9 wins over the variant's 1.
     try testing.expectEqualStrings("Position", inst.components[0].fields[0].path);
     try testing.expectEqualStrings("(9, 0, 0)", inst.components[0].fields[0].after.?.scalar);
 }
@@ -488,9 +488,9 @@ test "instantiate: pushed-down overrides win in the degraded view" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // push-down テストと同じ 3 段構成だが base 側の asset を供給しない。
-    // 内側 instance は縮退表示になり、押し下げられた外側の値(9)が
-    // variant 自身の値(1)に後勝ちして行に出る。
+    // Same 3-level structure as the push-down test, but the base-side asset is not supplied.
+    // The inner instance falls into the degraded view, and the pushed-down outer value (9)
+    // wins last over the variant's own value (1) and appears as a row.
     const variant =
         \\--- !u!1001 &100
         \\PrefabInstance:
@@ -543,7 +543,7 @@ test "instantiate: unappliable overrides stay visible as rows" {
     try assets.put(arena, "srcguid", test_source);
     const res = try root.diffBytesWithAssets(arena, "", variant, &assets);
     const inst = res.roots[0];
-    // Scale.y は合成へ適用済み。適用できない otherguid 行は黙って消さず残す。
+    // Scale.y is applied to the merge. The unapplicable otherguid row is kept, not silently dropped.
     try testing.expectEqual(@as(usize, 1), inst.components.len);
     try testing.expectEqualStrings("(1, 2, 1)", inst.components[0].fields[0].after.?.scalar);
     try testing.expectEqual(@as(usize, 1), inst.overrides.len);
@@ -565,17 +565,17 @@ test "instantiate: setByPropertyPath handles nested and array paths" {
     );
     var value = model.Node{ .scalar = "9" };
 
-    // ネストしたパス。
+    // Nested path.
     setByPropertyPath(docs[0].body, "m_LocalScale.y", &value);
     const scale = model.findValue(docs[0].body.map, "m_LocalScale").?;
     try testing.expectEqualStrings("9", model.findValue(scale.map, "y").?.scalar);
 
-    // Array.data[i] パス(leaf 差し替え)。
+    // Array.data[i] path (leaf replacement).
     setByPropertyPath(docs[0].body, "m_Materials.Array.data[1]", &value);
     const mats = model.findValue(docs[0].body.map, "m_Materials").?;
     try testing.expectEqualStrings("9", mats.seq[1].scalar);
 
-    // 不在パスと範囲外 index は no-op(panic しない)。
+    // A missing path and an out-of-range index are no-ops (no panic).
     setByPropertyPath(docs[0].body, "m_Missing.x", &value);
     setByPropertyPath(docs[0].body, "m_Materials.Array.data[99]", &value);
 }

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -21,7 +21,7 @@ pub fn serialize(arena: std.mem.Allocator, res: model.DiffResult, resolved: ?*co
     }
     try w.writeByte(']');
 
-    // ホストに内容取得を求めるソースプレハブ。空なら省略(additive な拡張)。
+    // Source prefabs whose content the host is asked to fetch. Omitted when empty (additive extension).
     if (res.needed_sources.len != 0) {
         try w.writeAll(",\"neededSources\":[");
         for (res.needed_sources, 0..) |ns, i| {
@@ -34,8 +34,8 @@ pub fn serialize(arena: std.mem.Allocator, res: model.DiffResult, resolved: ?*co
     }
 
     if (resolved) |r| {
-        // diff が実際に参照した guid だけに絞る(プロジェクト index 全体を
-        // 出さない)。順序は unresolvedGuids と同じで決定的。
+        // Restrict to only the guids the diff actually referenced (don't emit the
+        // whole project index). Order matches unresolvedGuids and is deterministic.
         try w.writeAll(",\"resolved\":{");
         var first = true;
         for (res.unresolved_guids) |g| {
@@ -167,7 +167,7 @@ fn writeValue(w: *std.Io.Writer, node: ?*const Node) !void {
             if (r.type_id) |t| try w.print("{d}", .{t}) else try w.writeAll("null");
             try w.writeAll("}}");
         },
-        // map/seq が leaf に来るのは稀(通常は再帰される)。コンパクトに表現する。
+        // map/seq rarely reach a leaf (normally recursed into). Represent them compactly.
         .map => try w.writeAll("\"<map>\""),
         .seq => try w.writeAll("\"<seq>\""),
     }
@@ -248,11 +248,11 @@ test "json: needed sources are emitted only when unresolved" {
         \\      value: 2
         \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
     ;
-    // assets 未供給: ホストへの取得要求として neededSources が載る。
+    // assets not supplied: neededSources appears as a fetch request to the host.
     const out = try root.diffToJson(arena, "", after);
     try testing.expect(std.mem.indexOf(u8, out, "\"neededSources\":[{\"guid\":\"aaa\",\"side\":\"after\"}]") != null);
 
-    // 供給済み: 展開されて neededSources は emit されない(空なら省略)。
+    // Supplied: expanded, so neededSources is not emitted (omitted when empty).
     var assets: root.Assets = .empty;
     try assets.put(arena, "aaa", "--- !u!1 &10\nGameObject:\n  m_Name: Src\n");
     const merged = try root.diffToJsonWithAssets(arena, "", after, &assets);
@@ -311,8 +311,8 @@ test "json: v2 root node shape matches golden" {
         \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
     ;
     const out = try root.diffToJson(arena, before, after);
-    // roots 側のノード全形状 (gameObject + components + 子 prefabInstance +
-    // overrides + 構造サマリ) を byte-for-byte で固定する回帰ピン。
+    // Regression pin fixing the full node shape on the roots side (gameObject + components + child
+    // prefabInstance + overrides + structural summary) byte-for-byte.
     const golden =
         \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"neededSources":[{"guid":"aaa","side":"after"}],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
     ;
@@ -386,8 +386,8 @@ test "json: resolved is scoped to referenced guids, ordered like unresolvedGuids
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // 2 つの .meta から構築したプロジェクト index。guidA と guidC はどちらも
-    // 解決可能だが、diff が参照するのは guidA のみ。
+    // A project index built from two .meta files. Both guidA and guidC are
+    // resolvable, but the diff references only guidA.
     var resolver = Resolver.init(arena);
     try resolver.put("guidA", "Assets/Scripts/A.cs");
     try resolver.put("guidC", "Assets/Scripts/C.cs");
@@ -400,9 +400,9 @@ test "json: resolved is scoped to referenced guids, ordered like unresolvedGuids
     };
 
     const out = try serialize(arena, res, &resolver);
-    // "resolved" には参照された guid だけが載り、
+    // "resolved" carries only the referenced guid,
     try testing.expect(std.mem.indexOf(u8, out, "\"resolved\":{\"guidA\":\"Assets/Scripts/A.cs\"}") != null);
-    // 参照されていない guidC は解決可能でも出力に漏れない。
+    // the unreferenced guidC does not leak into the output even though it is resolvable.
     try testing.expect(std.mem.indexOf(u8, out, "guidC") == null);
 }
 
@@ -415,7 +415,7 @@ test "json: resolved follows unresolvedGuids order, skipping guids the resolver 
     try resolver.put("guidA", "Assets/Scripts/A.cs");
     try resolver.put("guidB", "Assets/Scripts/B.cs");
 
-    // 参照順は B, A。guidX は参照されているがプロジェクト index に存在しない。
+    // Reference order is B, A. guidX is referenced but absent from the project index.
     var unresolved_guids = [_][]const u8{ "guidB", "guidA", "guidX" };
     const res: model.DiffResult = .{
         .roots = &.{},
@@ -426,7 +426,7 @@ test "json: resolved follows unresolvedGuids order, skipping guids the resolver 
     const out = try serialize(arena, res, &resolver);
     try testing.expect(std.mem.indexOf(u8, out, "\"resolved\":{\"guidB\":\"Assets/Scripts/B.cs\",\"guidA\":\"Assets/Scripts/A.cs\"}") != null);
     try testing.expect(std.mem.indexOf(u8, out, "guidX\":") == null);
-    // guidX は unresolved のまま残る。
+    // guidX stays unresolved.
     try testing.expect(std.mem.indexOf(u8, out, "\"unresolvedGuids\":[\"guidB\",\"guidA\",\"guidX\"]") != null);
 }
 
@@ -435,7 +435,7 @@ test "json: control characters are escaped" {
     defer arena_state.deinit();
     const arena = arena_state.allocator();
     var aw: std.Io.Writer.Allocating = .init(arena);
-    // 名前つきエスケープ(\n 等)はそれを、その他の制御文字は \u00XX を使う。
+    // Named escapes (\n etc.) use them; other control characters use \u00XX.
     try writeJsonString(&aw.writer, "a\nb\x01c");
     try testing.expectEqualStrings("\"a\\nb\\u0001c\"", aw.written());
 }
@@ -455,6 +455,6 @@ test "json: string escaping" {
         \\  m_Name: "a\"b"
     ;
     const out = try root.diffToJson(arena, before, after);
-    // 値の中の引用符は JSON 出力でエスケープされる。
+    // Quotes inside the value are escaped in the JSON output.
     try testing.expect(std.mem.indexOf(u8, out, "a\\\"b") != null);
 }

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-// 外部または内部への参照: `{fileID: N}` または `{fileID: N, guid: ..., type: N}`。
+// External or internal reference: `{fileID: N}` or `{fileID: N, guid: ..., type: N}`.
 pub const Ref = struct {
     file_id: i64,
     guid: ?[]const u8 = null,
@@ -8,11 +8,11 @@ pub const Ref = struct {
 };
 
 pub const Entry = struct {
-    key: []const u8, // 入力バッファへのスライス
+    key: []const u8, // slice into the input buffer
     value: *Node,
 };
 
-// パース済み Unity YAML の値。scalar/key/guid は入力バッファへのスライス。
+// A parsed Unity YAML value. scalar/key/guid are slices into the input buffer.
 pub const Node = union(enum) {
     map: []Entry,
     seq: []*Node,
@@ -54,36 +54,36 @@ fn strEqOpt(a: ?[]const u8, b: ?[]const u8) bool {
     return std.mem.eql(u8, a.?, b.?);
 }
 
-// map のエントリからキーで値を引く(線形探索。Unity の map は小さい)。
+// Look up a value by key in a map's entries (linear scan; Unity maps are small).
 pub fn findValue(entries: []const Entry, key: []const u8) ?*Node {
     for (entries) |e| if (std.mem.eql(u8, e.key, key)) return e.value;
     return null;
 }
 
-// Unity の 1 ドキュメント: `--- !u!<class_id> &<file_id>` + 本体の mapping。
+// One Unity document: `--- !u!<class_id> &<file_id>` + the body mapping.
 pub const Document = struct {
     class_id: u32,
     file_id: i64,
-    type_name: []const u8, // 唯一のトップレベルキー("GameObject" 等)
+    type_name: []const u8, // the sole top-level key ("GameObject" etc.)
     stripped: bool = false,
-    body: *Node, // ドキュメントのフィールドを持つ .map ノード
+    body: *Node, // the .map node holding the document's fields
 };
 
 pub const Status = enum { added, removed, modified, unchanged };
 
 pub const ObjectKind = enum { game_object, prefab_instance };
 
-// PrefabInstance の (target, propertyPath) 単位の override diff。
+// Per-(target, propertyPath) override diff for a PrefabInstance.
 pub const OverrideDiff = struct {
     group: []const u8, // "Transform" | "GameObject" | "Overrides"
-    label: []const u8, // humanize 済み ("Position.x")
+    label: []const u8, // humanized ("Position.x")
     status: Status,
     before: ?*const Node = null,
     after: ?*const Node = null,
 };
 
 pub const FieldDiff = struct {
-    path: []const u8, // ドット/添字区切りのパス(arena 上に構築)
+    path: []const u8, // dot/index-separated path (built on the arena)
     status: Status,
     before: ?*const Node = null,
     after: ?*const Node = null,
@@ -94,7 +94,7 @@ pub const ComponentDiff = struct {
     class_id: u32,
     type_name: []const u8,
     script_guid: ?[]const u8 = null,
-    // m_EditorClassIdentifier 末尾のクラス名 ("Cylinder1")。guid 解決の第 2 候補。
+    // Class name at the tail of m_EditorClassIdentifier ("Cylinder1"). Second candidate for guid resolution.
     class_name: ?[]const u8 = null,
     status: Status,
     fields: []FieldDiff,
@@ -105,16 +105,16 @@ pub const ObjectDiff = struct {
     file_id: i64,
     name: []const u8,
     status: Status,
-    // prefab_instance のみ: m_SourcePrefab の guid。
+    // prefab_instance only: the m_SourcePrefab guid.
     source_guid: ?[]const u8 = null,
-    // prefab_instance のみ: (target, propertyPath) キーの override diff。
+    // prefab_instance only: override diff keyed by (target, propertyPath).
     overrides: []OverrideDiff = &.{},
     components: []ComponentDiff,
     children: []ObjectDiff,
 };
 
-// ホストに内容の供給を求めるソースプレハブ。side は取得すべき ref
-// (added instance -> after/head、removed instance -> before/base)。
+// A source prefab whose content the host is asked to supply. side is the ref to fetch
+// (added instance -> after/head, removed instance -> before/base).
 pub const SourceSide = enum { before, after };
 pub const NeededSource = struct { guid: []const u8, side: SourceSide };
 
@@ -126,38 +126,38 @@ pub const DiffResult = struct {
 };
 
 test "Node.eql: scalars, refs, seqs, maps" {
-    // スカラー
+    // scalars
     var s1 = Node{ .scalar = "100" };
     var s2 = Node{ .scalar = "100" };
     var s3 = Node{ .scalar = "150" };
     try std.testing.expect(Node.eql(&s1, &s2));
     try std.testing.expect(!Node.eql(&s1, &s3));
 
-    // 参照
+    // refs
     var r1 = Node{ .ref = .{ .file_id = 234, .guid = "abc", .type_id = 3 } };
     var r2 = Node{ .ref = .{ .file_id = 234, .guid = "abc", .type_id = 3 } };
     var r3 = Node{ .ref = .{ .file_id = 234, .guid = "xyz", .type_id = 3 } };
     try std.testing.expect(Node.eql(&r1, &r2));
     try std.testing.expect(!Node.eql(&r1, &r3));
 
-    // 種別が異なるノードは常に不等
+    // nodes of different kinds are always unequal
     try std.testing.expect(!Node.eql(&s1, &r1));
 
-    // シーケンス(順序込みで比較)
+    // sequences (compared with order)
     var seq_a = [_]*Node{ &s1, &s3 };
     var seq_b = [_]*Node{ &s2, &s3 };
     var q1 = Node{ .seq = &seq_a };
     var q2 = Node{ .seq = &seq_b };
     try std.testing.expect(Node.eql(&q1, &q2));
 
-    // マップ(キー順序は不問)
+    // maps (key order irrelevant)
     var e_a = [_]Entry{ .{ .key = "x", .value = &s1 }, .{ .key = "y", .value = &s3 } };
     var e_b = [_]Entry{ .{ .key = "y", .value = &s3 }, .{ .key = "x", .value = &s2 } };
     var m1 = Node{ .map = &e_a };
     var m2 = Node{ .map = &e_b };
     try std.testing.expect(Node.eql(&m1, &m2));
 
-    // 要素数が同じでもキー集合が異なるマップは不等。
+    // maps with the same count but different key sets are unequal.
     var e_c = [_]Entry{ .{ .key = "x", .value = &s1 }, .{ .key = "z", .value = &s3 } };
     var m3 = Node{ .map = &e_c };
     try std.testing.expect(!Node.eql(&m1, &m3));

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -105,7 +105,7 @@ test "parse: ref with guid and type, and a non-ref flow map (vector)" {
     try testing.expectEqual(@as(i64, 3), script.ref.type_id.?);
 
     const pos = model.findValue(doc.body.map, "m_LocalPosition").?;
-    // fileID を持たない flow map は .ref にならず .map のまま。
+    // A flow map without fileID stays a .map, not a .ref.
     const x = model.findValue(pos.map, "x").?;
     try testing.expectEqualStrings("1", x.scalar);
 
@@ -146,8 +146,8 @@ test "parse: non-empty flow sequence of refs and scalars" {
         \\GameObject:
         \\  m_List: [{fileID: 7}, 2]
     ;
-    // parseFlowSeq の非空経路: 入れ子の flow map があってもトップレベルの
-    // カンマだけで分割され、要素ごとに ref/scalar として parse される。
+    // parseFlowSeq's non-empty path: even with nested flow maps, split only on top-level
+    // commas, parsing each element as a ref/scalar.
     const doc = try parseOne(arena, src);
     const list = model.findValue(doc.body.map, "m_List").?;
     try testing.expectEqual(@as(usize, 2), list.seq.len);
@@ -220,8 +220,8 @@ test "parse: deeply nested flow value is rejected instead of overflowing the sta
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // かつてスタックを溢れさせた深さ(~14000 段でクラッシュ)を再現する規模。
-    // 5000 は正気な上限をはるかに超え、かつ 200 KB のファイル予算には収まる。
+    // A scale that reproduces the depth that once overflowed the stack (crashed at ~14000 levels).
+    // 5000 is far beyond any sane limit yet fits within the 200 KB file budget.
     const depth = 5000;
     var src: std.ArrayList(u8) = .empty;
     try src.appendSlice(arena, "--- !u!114 &1\nMonoBehaviour:\n  m_Field: ");
@@ -236,8 +236,8 @@ test "parse: sequence document body degrades to an empty map instead of crashing
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Unity はドキュメント本体にシーケンスを書かないが、敵対的入力では起こり得る。
-    // 下流は body.map を無条件に読むため、body は常に map でなければならない。
+    // Unity never writes a sequence as a document body, but hostile input can. Downstream
+    // reads body.map unconditionally, so body must always be a map.
     const src =
         \\--- !u!1 &1
         \\GameObject:
@@ -302,7 +302,7 @@ test "parse: double-quoted scalar resolves backslash escapes" {
         \\GameObject:
         \\  m_Name: "a\"b\\c"
     ;
-    // scalar はソース表記ではなくリテラル値を持つ(\" -> "、\\ -> \)。
+    // scalar holds the literal value, not the source form (\" -> ", \\ -> \).
     const doc = try parseOne(arena, src);
     try testing.expectEqualStrings("a\"b\\c", model.findValue(doc.body.map, "m_Name").?.scalar);
 }
@@ -316,8 +316,8 @@ test "parse: malformed class id and anchor default to 0" {
         \\GameObject:
         \\  m_Name: A
     ;
-    // diff の first-occurrence-wins(重複 fileID)はこの 0 への縮退を前提と
-    // するため、parse エラーではなく 0 に落ちることを固定する。
+    // diff's first-occurrence-wins (duplicate fileID) relies on this fall-through to 0,
+    // so pin that it degrades to 0 rather than a parse error.
     const doc = try parseOne(arena, src);
     try testing.expectEqual(@as(u32, 0), doc.class_id);
     try testing.expectEqual(@as(i64, 0), doc.file_id);
@@ -353,8 +353,8 @@ const Parser = struct {
     }
 };
 
-// 意味のある論理行(インデント + 内容)に分解する。空行・`%` ディレクティブ・
-// `#` コメントは落とす。
+// Break into meaningful logical lines (indent + content). Drop blank lines, `%` directives,
+// and `#` comments.
 fn tokenize(arena: std.mem.Allocator, source: []const u8) ![]Line {
     var lines: std.ArrayList(Line) = .empty;
     var it = std.mem.splitScalar(u8, source, '\n');
@@ -405,11 +405,11 @@ fn parseDocument(p: *Parser) !Document {
     var body: *Node = undefined;
     if (p.peek()) |first| {
         if (!std.mem.startsWith(u8, first.text, "---")) {
-            _ = p.advance(); // indent 0 の "TypeName:" 行
+            _ = p.advance(); // the "TypeName:" line at indent 0
             type_name = stripTrailingColon(first.text);
             body = try parseBlock(p, indentOfNext(p, 2), 0);
-            // 下流は body.map を無条件に読む。シーケンスとして parse された
-            // 不正な body を map 以外のノードとして外に出してはならない。
+            // Downstream reads body.map unconditionally. A malformed body parsed as a
+            // sequence must not escape as a non-map node.
             if (body.* != .map) body = try emptyMap(p.arena);
         } else {
             body = try emptyMap(p.arena);
@@ -427,18 +427,18 @@ fn parseDocument(p: *Parser) !Document {
     };
 }
 
-// 本体の最初のフィールドのインデント(Unity は 2 だが寛容に扱う): 次の行を
-// 覗き、0 より深ければそのインデント、そうでなければ default。
+// Indent of the body's first field (Unity uses 2, handled leniently): peek at the next line,
+// use its indent if deeper than 0, otherwise the default.
 fn indentOfNext(p: *const Parser, default_indent: usize) usize {
     if (p.peek()) |l| if (l.indent > 0 and !std.mem.startsWith(u8, l.text, "---")) return l.indent;
     return default_indent;
 }
 
-// Unity YAML の入れ子は高々数段。スタックを溢れさせる敵対的入力を
-// 事前に拒否するための、十分に余裕を持った上限。
+// Unity YAML nesting is at most a few levels. A generously margined cap to reject
+// hostile input that would overflow the stack up front.
 const max_nesting_depth: usize = 128;
 
-// エントリがちょうど `indent` に並ぶブロック(mapping または sequence)を parse する。
+// Parse a block (mapping or sequence) whose entries line up exactly at `indent`.
 fn parseBlock(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
     if (depth > max_nesting_depth) return error.NestingTooDeep;
     const first = p.peek() orelse return emptyMap(p.arena);
@@ -466,10 +466,10 @@ fn parseMap(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
     return makeNode(p.arena, .{ .map = try entries.toOwnedSlice(p.arena) });
 }
 
-// コロンの後に何もない "key:" 行の値: より深いインデントの入れ子ブロック、
-// またはキー自身のインデントにダッシュが揃うブロックシーケンス(Unity の
-// 慣習。`m_Component:` の直後に同じ桁で `- component: {...}` が続く形)。
-// どちらでもなければ空 map。
+// Value of a "key:" line with nothing after the colon: a deeper-indented nested block,
+// or a block sequence whose dashes line up at the key's own indent (a Unity convention,
+// where `m_Component:` is immediately followed by `- component: {...}` at the same column).
+// If neither, an empty map.
 fn parseNestedValue(p: *Parser, key_indent: usize, depth: usize) anyerror!*Node {
     if (p.peek()) |next| {
         const is_dash = std.mem.startsWith(u8, next.text, "- ") or std.mem.eql(u8, next.text, "-");
@@ -488,11 +488,11 @@ fn parseSeq(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
         _ = p.advance();
         const rest = if (line.text.len >= 2) std.mem.trimStart(u8, line.text[1..], " ") else "";
         if (rest.len == 0) {
-            // "-" 単独: この項目の入れ子ブロックがより深いインデントに続く。
+            // Lone "-": this item's nested block continues at a deeper indent.
             const ci = indentOfNext(p, indent + 2);
             try items.append(p.arena, try parseBlock(p, ci, depth + 1));
         } else if (looksLikeMapEntry(rest)) {
-            // コンパクトな map 項目: 先頭エントリはダッシュ行、続きは indent+2。
+            // Compact map item: the first entry is on the dash line, the rest at indent+2.
             try items.append(p.arena, try parseSeqMapItem(p, indent, rest, depth));
         } else {
             try items.append(p.arena, try parseValue(p.arena, rest, depth));
@@ -501,13 +501,13 @@ fn parseSeq(p: *Parser, indent: usize, depth: usize) anyerror!*Node {
     return makeNode(p.arena, .{ .seq = try items.toOwnedSlice(p.arena) });
 }
 
-// mapping であるシーケンス項目。例:
+// A sequence item that is a mapping. Example:
 //   - target: {fileID: 0}
 //     propertyPath: m_Name
 //     value: Foo
 fn parseSeqMapItem(p: *Parser, dash_indent: usize, first_line: []const u8, depth: usize) anyerror!*Node {
     var entries: std.ArrayList(Entry) = .empty;
-    // 項目のキーはすべて "- " の直後の桁に並ぶ。
+    // All of the item's keys line up at the column right after "- ".
     const key_indent = dash_indent + 2;
     const kv = splitKeyValue(first_line);
     if (kv.value.len == 0) {
@@ -515,7 +515,7 @@ fn parseSeqMapItem(p: *Parser, dash_indent: usize, first_line: []const u8, depth
     } else {
         try entries.append(p.arena, .{ .key = kv.key, .value = try parseValue(p.arena, kv.value, depth) });
     }
-    // 継続エントリはダッシュより 2 つ深い("- " の直後に揃う)。
+    // Continuation entries are 2 deeper than the dash (aligned right after "- ").
     while (p.peek()) |line| {
         if (line.indent != key_indent) break;
         if (std.mem.startsWith(u8, line.text, "- ") or std.mem.eql(u8, line.text, "-")) break;
@@ -550,10 +550,10 @@ fn stripTrailingColon(s: []const u8) []const u8 {
 
 const KV = struct { key: []const u8, value: []const u8, has_colon: bool };
 
-// "key: value" / "key:" を最初の ": " または末尾の ":" で分割する。
-// flow 値の内側では分割しない(値は最初のコロンの後から始まる)。
+// Split "key: value" / "key:" at the first ": " or a trailing ":".
+// Don't split inside a flow value (the value starts after the first colon).
 fn splitKeyValue(line: []const u8) KV {
-    // 空白または行末が続く最初の ":" を探す。
+    // Find the first ":" followed by a space or end of line.
     var i: usize = 0;
     while (i < line.len) : (i += 1) {
         if (line[i] == ':' and (i + 1 == line.len or line[i + 1] == ' ')) {
@@ -566,7 +566,7 @@ fn splitKeyValue(line: []const u8) KV {
 }
 
 fn looksLikeMapEntry(s: []const u8) bool {
-    if (s.len > 0 and s[0] == '{') return false; // flow 値であって map エントリではない
+    if (s.len > 0 and s[0] == '{') return false; // a flow value, not a map entry
     const kv = splitKeyValue(s);
     return kv.has_colon and kv.key.len > 0;
 }
@@ -580,7 +580,7 @@ fn parseValue(arena: std.mem.Allocator, raw: []const u8, depth: usize) anyerror!
     return makeNode(arena, .{ .scalar = try unquote(arena, s) });
 }
 
-// flow mapping `{a: b, c: d}` を parse する。`fileID` キーを持てば Ref ノードを返す。
+// Parse a flow mapping `{a: b, c: d}`. Returns a Ref node if it has a `fileID` key.
 fn parseFlow(arena: std.mem.Allocator, s: []const u8, depth: usize) anyerror!*Node {
     const inner = stripBrackets(s, '{', '}');
     var entries: std.ArrayList(Entry) = .empty;
@@ -634,9 +634,9 @@ fn stripBrackets(s: []const u8, open: u8, close: u8) []const u8 {
     return t;
 }
 
-// 囲みの引用符を外す。double-quote のスカラーは YAML のバックスラッシュ
-// エスケープ `\"` と `\\`(Unity が出力する唯一のエスケープ)も解決し、
-// scalar がソース表記ではなくリテラル値を持つようにする。
+// Strip enclosing quotes. Double-quoted scalars also resolve YAML backslash
+// escapes `\"` and `\\` (the only escapes Unity emits), so that scalar
+// holds the literal value rather than the source form.
 fn unquote(arena: std.mem.Allocator, s: []const u8) anyerror![]const u8 {
     if (s.len >= 2 and s[0] == '\'' and s[s.len - 1] == '\'') {
         return s[1 .. s.len - 1];
@@ -660,7 +660,7 @@ fn unquote(arena: std.mem.Allocator, s: []const u8) anyerror![]const u8 {
     return s;
 }
 
-// brace/bracket の深さ 0 にあるカンマで区切られた部分のイテレータ。
+// Iterator over comma-separated parts at brace/bracket depth 0.
 const TopLevelIter = struct {
     s: []const u8,
     i: usize = 0,

--- a/core/src/perf.zig
+++ b/core/src/perf.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const root = @import("root.zig");
 
-// n 個の GameObject(各 Transform + MonoBehaviour つき)からなる合成シーンを
-// 1 つの YAML バッファとして生成する。
+// Generate a synthetic scene of n GameObjects (each with a Transform + MonoBehaviour)
+// as a single YAML buffer.
 fn buildScene(arena: std.mem.Allocator, n: usize, hp: usize) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(arena);
     const w = &aw.writer;
@@ -32,7 +32,7 @@ fn buildScene(arena: std.mem.Allocator, n: usize, hp: usize) ![]u8 {
     return aw.toOwnedSlice();
 }
 
-// n オブジェクトの before/after diff 1 回の所要ナノ秒を返す。
+// Return the nanoseconds taken for one before/after diff of n objects.
 pub fn timeDiff(io: std.Io, arena: std.mem.Allocator, n: usize) !u64 {
     const before = try buildScene(arena, n, 1);
     const after = try buildScene(arena, n, 2);
@@ -47,7 +47,7 @@ test "perf: small scene diff completes well under budget" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    const ns = try timeDiff(std.testing.io, arena, 200); // 200 オブジェクト ≒ 小さめの prefab
-    // debug ビルドのテスト向けの緩い上限(本来の予算は `zig build perf` が強制する)。
+    const ns = try timeDiff(std.testing.io, arena, 200); // 200 objects ≈ a smallish prefab
+    // A loose ceiling for the debug-build test (the real budget is enforced by `zig build perf`).
     try std.testing.expect(ns < 500 * std.time.ns_per_ms);
 }

--- a/core/src/perf_main.zig
+++ b/core/src/perf_main.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 const perf = @import("perf.zig");
 
-// 予算は CI ランナーのノイズを見込んで名目値より緩めてある。名目値は
-// spec §5.7(通常 < 5ms、~10MB シーン < 150ms)。~10MB 相当のシーンを
-// 生成し、CI 上限内で diff できることを検証する。
-const big_objects = 50_000; // 1 オブジェクト ~200 bytes として YAML ~10 MB
-const ci_ceiling_ms = 600; // 名目 150ms の 4 倍。真の退行でのみ失敗する
+// The budget is loosened above the nominal value to allow for CI-runner noise. Nominal
+// values are from spec §5.7 (typically < 5ms, ~10MB scene < 150ms). Generate a scene of
+// ~10MB and verify it diffs within the CI ceiling.
+const big_objects = 50_000; // at ~200 bytes per object, ~10 MB of YAML
+const ci_ceiling_ms = 600; // 4x the nominal 150ms. Fails only on a true regression
 
 pub fn main(init: std.process.Init) !void {
     var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -16,8 +16,8 @@ pub fn diffBytes(arena: std.mem.Allocator, before_src: []const u8, after_src: []
     return diffBytesWithAssets(arena, before_src, after_src, &no_assets);
 }
 
-// assets(guid -> ソース prefab bytes)を供給された sole-status instance は
-// 合成ツリーへ展開される。供給が無い guid は needed_sources に載る。
+// A sole-status instance supplied with assets (guid -> source prefab bytes) is
+// expanded into the merged tree. Guids with no supply go into needed_sources.
 pub fn diffBytesWithAssets(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8, assets: *const Assets) !model.DiffResult {
     const fd = try diff.compute(arena, before_src, after_src);
     var res = try tree.build(arena, fd);

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -8,11 +8,11 @@ const diffmod = @import("diff.zig");
 const ComponentDiff = model.ComponentDiff;
 const ObjectDiff = model.ObjectDiff;
 
-// パース済みドキュメント(before+after の和集合)への索引。
+// Index into parsed documents (union of before+after).
 const Index = struct {
-    // file_id -> DocDiff(status + fields)。コンポーネント構築を速くする。
+    // file_id -> DocDiff (status + fields). Speeds up component construction.
     diff_by_id: std.AutoHashMap(i64, diffmod.DocDiff),
-    // file_id -> 構造解決用(after 優先)の *Document。
+    // file_id -> *Document for structural resolution (after preferred).
     doc_by_id: std.AutoHashMap(i64, *model.Document),
 
     fn structuralDoc(self: *Index, file_id: i64) ?*model.Document {
@@ -33,7 +33,7 @@ fn gameObjectIdOfComponent(doc: *model.Document) ?i64 {
 }
 
 fn transformOf(idx: *Index, go_id: i64) ?*model.Document {
-    // GameObject が列挙するコンポーネントから Transform/RectTransform のものを探す。
+    // Find the Transform/RectTransform among the components the GameObject lists.
     const go = idx.structuralDoc(go_id) orelse return null;
     const comps = model.findValue(go.body.map, "m_Component") orelse return null;
     if (comps.* != .seq) return null;
@@ -58,7 +58,7 @@ fn sourcePrefabGuid(doc: *const model.Document) ?[]const u8 {
     };
 }
 
-// m_Name override をインスタンス名として拾う(after 優先の structural doc から)。
+// Pick up the m_Name override as the instance name (from the after-preferred structural doc).
 fn instanceName(idx: *Index, pi_id: i64) []const u8 {
     const doc = idx.structuralDoc(pi_id) orelse return "";
     const m = model.findValue(doc.body.map, "m_Modification") orelse return "";
@@ -78,12 +78,12 @@ fn instanceName(idx: *Index, pi_id: i64) []const u8 {
     return "";
 }
 
-// 入れ子チェーン歩行の hop 上限。壊れたファイルで stripped PrefabInstance
-// 同士が循環参照しても停止する(実プロジェクトの入れ子深度は数段)。
+// Hop limit for walking the nesting chain. Stops even if stripped PrefabInstances
+// reference each other cyclically in a broken file (real projects nest a few levels).
 const max_instance_hops = 8;
 
-// stripped な PrefabInstance の m_PrefabInstance チェーンを外側へ辿り、
-// 実体(非 stripped)の PrefabInstance の file_id を返す。
+// Walk the m_PrefabInstance chain of a stripped PrefabInstance outward and
+// return the file_id of the real (non-stripped) PrefabInstance.
 fn resolveInstanceChain(idx: *Index, start_id: i64) ?i64 {
     var id = start_id;
     var hops: usize = 0;
@@ -96,8 +96,8 @@ fn resolveInstanceChain(idx: *Index, start_id: i64) ?i64 {
     return null;
 }
 
-// Transform の file_id から親ノード(GameObject または PrefabInstance)の id。
-// stripped Transform は m_PrefabInstance を辿って所属インスタンスに橋渡し。
+// From a Transform's file_id to the id of the parent node (GameObject or PrefabInstance).
+// A stripped Transform bridges to its owning instance via m_PrefabInstance.
 fn ownerNodeIdOfTransform(idx: *Index, tr_id: i64) ?i64 {
     if (tr_id == 0) return null;
     const tr = idx.structuralDoc(tr_id) orelse return null;
@@ -150,14 +150,14 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         .doc_by_id = std.AutoHashMap(i64, *model.Document).init(arena),
     };
     for (fd.docs) |d| try idx.diff_by_id.put(d.file_id, d);
-    // 構造解決用 doc: after 優先、removed オブジェクトは before に fallback。
+    // Structural-resolution docs: after preferred, removed objects fall back to before.
     for (fd.before) |*d| try idx.doc_by_id.put(d.file_id, d);
-    for (fd.after) |*d| try idx.doc_by_id.put(d.file_id, d); // 上書きにより after が勝つ
+    for (fd.after) |*d| try idx.doc_by_id.put(d.file_id, d); // overwrite makes after win
 
-    // ドキュメントを仕分ける: GameObject、PrefabInstance、その所属コンポーネント、loose。
+    // Sort documents into: GameObject, PrefabInstance, their owned components, and loose.
     var go_ids: std.ArrayList(i64) = .empty;
     var pi_ids: std.ArrayList(i64) = .empty;
-    // 所属先 GameObject/PrefabInstance の id でグループ化したコンポーネント
+    // Components grouped by the id of their owning GameObject/PrefabInstance
     var comps_by_owner = std.AutoHashMap(i64, std.ArrayList(ComponentDiff)).init(arena);
     var loose: std.ArrayList(ComponentDiff) = .empty;
 
@@ -173,36 +173,36 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         const owner = blk: {
             const doc = idx.structuralDoc(d.file_id) orelse break :blk null;
             const go_id = gameObjectIdOfComponent(doc) orelse break :blk null;
-            // 所有者になれるのは GameObject と確認できた doc のみ。解決不能な
-            // 参照({fileID: 0} や宙ぶらりん)を許すと、コンポーネントが
-            // 幻の id の下に仕分けられて消えてしまう。
+            // Only a doc confirmed to be a GameObject can be an owner. Allowing an
+            // unresolvable reference ({fileID: 0} or dangling) would sort the component
+            // under a phantom id and make it vanish.
             const go_doc = idx.structuralDoc(go_id) orelse break :blk null;
             if (go_doc.class_id != 1) break :blk null;
-            // stripped GameObject(入れ子インスタンスの root が外側ドキュメントに
-            // 置かれたもの)はノードにならない。所属 PrefabInstance に橋渡しして
-            // コンポーネントが黙って消えないようにする。所属インスタンス自体も
-            // stripped の場合(入れ子 prefab)があるため、チェーンを実体化される
-            // 最寄りのインスタンスまで辿る。
+            // A stripped GameObject (a nested instance's root placed in the outer
+            // document) does not become a node. Bridge to its owning PrefabInstance so
+            // the component doesn't silently vanish. The owning instance itself can also
+            // be stripped (nested prefab), so walk the chain to the nearest instance that
+            // gets materialized.
             const owner_id = if (go_doc.stripped) inner: {
                 const pi_id = refFileId(model.findValue(go_doc.body.map, "m_PrefabInstance")) orelse break :blk null;
                 break :inner resolveInstanceChain(&idx, pi_id) orelse break :blk null;
             } else go_id;
-            // stripped doc は fd.docs から除外されノードにならない。
-            // コンポーネントを引き取れるのは実体化する所有者だけ。
+            // A stripped doc is excluded from fd.docs and does not become a node.
+            // Only a materializing owner can take on the component.
             break :blk if (idx.diff_by_id.contains(owner_id)) owner_id else null;
         };
         if (owner) |owner_id| {
             const gop = try comps_by_owner.getOrPut(owner_id);
             if (!gop.found_existing) gop.value_ptr.* = .empty;
-            // fields を持たない unchanged コンポーネントは畳む。
+            // Collapse unchanged components that have no fields.
             if (d.status != .unchanged) try gop.value_ptr.append(arena, makeComponent(d));
         } else {
-            // 所属 GameObject/PrefabInstance なし -> loose(ScriptableObject 等)。
+            // No owning GameObject/PrefabInstance -> loose (ScriptableObject etc.).
             if (d.status != .unchanged) try loose.append(arena, makeComponent(d));
         }
     }
 
-    // GameObject ごとの ObjectDiff を構築する(children はまだ空)。
+    // Build an ObjectDiff per GameObject (children still empty).
     var obj_by_id = std.AutoHashMap(i64, ObjectDiff).init(arena);
     for (go_ids.items) |go_id| {
         const gd = idx.diff_by_id.get(go_id).?;
@@ -231,7 +231,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         });
     }
 
-    // 親子リンクを組み立てる。
+    // Assemble parent-child links.
     var children_of = std.AutoHashMap(i64, std.ArrayList(i64)).init(arena);
     var roots_ids: std.ArrayList(i64) = .empty;
     for (go_ids.items) |go_id|
@@ -239,7 +239,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     for (pi_ids.items) |pi_id|
         try linkToParent(arena, &obj_by_id, &children_of, &roots_ids, instanceParentId(&idx, pi_id), pi_id);
 
-    // 再帰的に実体化し、変更された子孫を持たない unchanged な部分木を刈る。
+    // Materialize recursively, pruning unchanged subtrees with no changed descendants.
     var roots: std.ArrayList(ObjectDiff) = .empty;
     for (roots_ids.items) |rid| {
         if (try materialize(arena, &obj_by_id, &children_of, rid)) |node| {
@@ -254,7 +254,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     };
 }
 
-// 親が実在ノードなら children_of へ、そうでなければ root へ振り分ける。
+// If the parent is a real node, route to children_of; otherwise to the roots.
 fn linkToParent(
     arena: std.mem.Allocator,
     obj_by_id: *std.AutoHashMap(i64, ObjectDiff),
@@ -274,8 +274,8 @@ fn linkToParent(
     try roots_ids.append(arena, id);
 }
 
-// `go_id` の ObjectDiff を残った children ごと構築する。ノードと部分木全体が
-// unchanged で残すコンポーネントもなければ null を返す。
+// Build the ObjectDiff for `go_id` together with its surviving children. Returns null
+// if the node and its whole subtree are unchanged with no components to keep.
 fn materialize(
     arena: std.mem.Allocator,
     obj_by_id: *std.AutoHashMap(i64, ObjectDiff),
@@ -344,9 +344,9 @@ test "tree: GameObject groups its components; modified component bubbles up" {
     const res = try root.diffBytes(arena, before, after);
     const go = findRoot(res, 1).?;
     try testing.expectEqualStrings("Player", go.name);
-    // Player 自体は unchanged だが、子コンポーネントに変更があるので残る。
+    // Player itself is unchanged but survives because a child component changed.
     try testing.expectEqual(model.Status.unchanged, go.status);
-    // コンポーネント: unchanged で fields もない Transform は畳まれ、MonoBehaviour は残る。
+    // Components: the unchanged, field-less Transform is collapsed; the MonoBehaviour remains.
     var saw_modified_mb = false;
     for (go.components) |c| {
         if (c.file_id == 5) {
@@ -382,7 +382,7 @@ test "tree: child GameObject nests under parent via Transform m_Father" {
         \\  m_GameObject: {fileID: 2}
         \\  m_Father: {fileID: 4}
     ;
-    // after: 子をリネーム
+    // after: rename the child
     const src_after =
         \\--- !u!1 &1
         \\GameObject:
@@ -424,8 +424,8 @@ test "tree: removed GameObject surfaces as a removed root with its name" {
         \\  m_GameObject: {fileID: 1}
         \\  m_Father: {fileID: 0}
     ;
-    // after 側に doc がなくても、構造解決が before に fallback するので
-    // 名前解決とコンポーネントの帰属が機能する(loose に漏れない)。
+    // Even with no doc on the after side, structural resolution falls back to before, so
+    // name resolution and component ownership work (they don't leak into loose).
     const res = try root.diffBytes(arena, before, "");
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     try testing.expectEqual(@as(usize, 0), res.loose.len);
@@ -534,7 +534,7 @@ test "tree: prefab instance nests under parent GameObject with name from m_Name 
     try testing.expectEqualStrings("aaa", inst.source_guid.?);
     try testing.expectEqual(model.Status.added, inst.status);
     try testing.expect(inst.overrides.len != 0);
-    // stripped Transform はどこにも現れない。
+    // The stripped Transform appears nowhere.
     try testing.expectEqual(@as(usize, 0), inst.components.len);
 }
 
@@ -631,8 +631,8 @@ test "tree: component whose m_GameObject resolves to a non-GameObject document b
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // fileID 999 は存在するが GameObject ではなく MonoBehaviour。fileID: 0 とは
-    // 別種の、実質的に宙ぶらりんな参照(そこに GameObject はいない)。
+    // fileID 999 exists but is a MonoBehaviour, not a GameObject. A different kind of
+    // effectively dangling reference from fileID: 0 (there's no GameObject there).
     const before =
         \\--- !u!114 &7
         \\MonoBehaviour:
@@ -653,7 +653,7 @@ test "tree: component whose m_GameObject resolves to a non-GameObject document b
     ;
     const res = try root.diffBytes(arena, before, after);
     try testing.expectEqual(@as(usize, 0), res.roots.len);
-    // コンポーネント 999 は unchanged で畳まれ、7 は消えずに loose へ。
+    // Component 999 is collapsed as unchanged; 7 goes to loose instead of vanishing.
     try testing.expectEqual(@as(usize, 1), res.loose.len);
     try testing.expectEqual(@as(i64, 7), res.loose[0].file_id);
     try testing.expectEqual(model.Status.modified, res.loose[0].status);
@@ -663,9 +663,9 @@ test "tree: component of a stripped GameObject attaches to the owning prefab ins
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // prefab インスタンスが配置した GameObject に追加されたコンポーネント:
-    // インスタンスの root GameObject は外側ドキュメントでは stripped で、
-    // 実体の MonoBehaviour doc が m_GameObject でそれを指す。
+    // A component added to a GameObject placed by a prefab instance:
+    // the instance's root GameObject is stripped in the outer document, and the real
+    // MonoBehaviour doc points to it via m_GameObject.
     const before =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -722,8 +722,8 @@ test "tree: component of a stripped GameObject with unresolvable m_PrefabInstanc
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // stripped GameObject の m_PrefabInstance が解決不能な先(存在しない
-    // fileID 9999)を指す: それでもコンポーネントを消してはならない。
+    // A stripped GameObject's m_PrefabInstance points to an unresolvable target
+    // (nonexistent fileID 9999): the component must still not vanish.
     const before =
         \\--- !u!1 &2 stripped
         \\GameObject:
@@ -755,9 +755,9 @@ test "tree: component bridged to a stripped nested prefab instance becomes loose
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 橋渡し先の stripped な入れ子 PrefabInstance が自身の m_PrefabInstance
-    // 参照を持たないケース: 外側インスタンスへのチェーンが切れているので、
-    // コンポーネントは消えるのではなく loose に落ちる。
+    // The bridged-to stripped nested PrefabInstance has no m_PrefabInstance reference
+    // of its own: the chain to the outer instance is broken, so the component falls to
+    // loose rather than vanishing.
     const before =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -807,7 +807,7 @@ test "tree: component bridged to a stripped nested prefab instance becomes loose
         \\  hp: 2
     ;
     const res = try root.diffBytes(arena, before, after);
-    // 外側インスタンスは unchanged なので通常どおり刈られ、コンポーネントは見え続ける。
+    // The outer instance is unchanged so it is pruned as usual, and the component stays visible.
     try testing.expectEqual(@as(usize, 0), res.roots.len);
     try testing.expectEqual(@as(usize, 1), res.loose.len);
     try testing.expectEqual(@as(i64, 3), res.loose[0].file_id);
@@ -818,10 +818,10 @@ test "tree: component of a nested stripped chain attaches to the outer prefab in
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 入れ子インスタンス内の GameObject に追加されたコンポーネント: 内側の
-    // PrefabInstance は外側ドキュメントでは stripped で、外側インスタンスへの
-    // m_PrefabInstance 参照を自身が持つ。このチェーンを辿って、loose に落とす
-    // のではなく外側の(実体化される)インスタンスノードに付け替える。
+    // A component added to a GameObject inside a nested instance: the inner
+    // PrefabInstance is stripped in the outer document and holds its own m_PrefabInstance
+    // reference to the outer instance. Walk this chain and reattach the component to the
+    // outer (materialized) instance node rather than dropping it to loose.
     const before =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -889,8 +889,8 @@ test "tree: cyclic stripped instance chain falls back to loose, not an infinite 
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 壊れたファイル: stripped な PrefabInstance 2 つが互いを参照する。
-    // hop 上限が循環を断ち切り、コンポーネントは loose の床を維持する。
+    // Broken file: two stripped PrefabInstances reference each other.
+    // The hop limit breaks the cycle, and the component holds the loose floor.
     const before =
         \\--- !u!1001 &2002 stripped
         \\PrefabInstance:
@@ -934,9 +934,9 @@ test "tree: instance parented inside a nested instance nests under the outer ins
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // 実体の PrefabInstance の m_TransformParent が、stripped な入れ子
-    // インスタンスに属する stripped Transform を指すケース: チェーンを外側の
-    // 実体インスタンスまで辿り、子を root に平坦化しない。
+    // A real PrefabInstance's m_TransformParent points to a stripped Transform belonging
+    // to a stripped nested instance: walk the chain to the outer real instance, and don't
+    // flatten the child to a root.
     const after =
         \\--- !u!1001 &1001
         \\PrefabInstance:

--- a/core/src/wasm.zig
+++ b/core/src/wasm.zig
@@ -1,5 +1,5 @@
-// WASM C ABI ラッパ(親仕様 §5.6)。diff 1 回 = 1 arena、グローバル可変状態なし。
-// 戻り値は u32(LE)長さ前置の JSON バイト列。呼び出し側が free(ptr, 4 + len) で解放する。
+// WASM C ABI wrapper (parent spec §5.6). One diff = one arena, no global mutable state.
+// Returns a JSON byte string prefixed with a u32 (LE) length. The caller frees it with free(ptr, 4 + len).
 const std = @import("std");
 const core = @import("root.zig");
 
@@ -26,8 +26,8 @@ export fn diff(
     return run(slice(before_ptr, before_len), slice(after_ptr, after_len), null);
 }
 
-// assets はバイナリ TLV(LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }。
-// JSON 文字列エスケープを避けるため、ソース prefab bytes はそのまま渡す。
+// assets is a binary TLV (LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }.
+// Source prefab bytes are passed as-is to avoid JSON string escaping.
 export fn diff_with_assets(
     before_ptr: ?[*]const u8,
     before_len: usize,
@@ -65,7 +65,7 @@ fn computeJson(arena: std.mem.Allocator, before: []const u8, after: []const u8, 
     return core.diffToJsonWithAssets(arena, before, after, &assets);
 }
 
-// 壊れた TLV は error を返し、error.v1 ペイロードに落ちる(trap しない)。
+// A broken TLV returns an error and falls through to the error.v1 payload (no trap).
 fn parseAssets(arena: std.mem.Allocator, bytes: []const u8) !core.Assets {
     var assets: core.Assets = .empty;
     if (bytes.len == 0) return assets;
@@ -95,7 +95,7 @@ fn readChunk(bytes: []const u8, off: *usize) ![]const u8 {
     return s;
 }
 
-// arena の外(呼び出し側所有)へコピーして長さ前置する。
+// Copy outside the arena (caller-owned) and prefix the length.
 fn packResult(json: []const u8) ?[*]u8 {
     const out = gpa.alloc(u8, 4 + json.len) catch return null;
     std.mem.writeInt(u32, out[0..4], @intCast(json.len), .little);

--- a/core/tests/wasm_golden.test.mjs
+++ b/core/tests/wasm_golden.test.mjs
@@ -12,7 +12,7 @@ function callDiff(before, after) {
   const a = enc.encode(after);
   const bp = b.length ? exports.alloc(b.length) : 0;
   const ap = a.length ? exports.alloc(a.length) : 0;
-  // ビューは最後の alloc の後に作る: memory.grow で古い ArrayBuffer は detach される
+  // Build views after the last alloc: memory.grow detaches the old ArrayBuffer
   new Uint8Array(exports.memory.buffer, bp, b.length).set(b);
   new Uint8Array(exports.memory.buffer, ap, a.length).set(a);
   const rp = exports.diff(bp, b.length, ap, a.length);
@@ -48,7 +48,7 @@ test("empty before (added file) still yields a diff.v2 document", () => {
 });
 
 test("hostile nesting returns a clean error.v1 payload, not a trap", () => {
-  // parser の max_nesting_depth は 128(core/src/parser.zig)。200 段で確実に超える。
+  // The parser's max_nesting_depth is 128 (core/src/parser.zig). 200 levels reliably exceeds it.
   let src = "--- !u!1 &1\nGameObject:\n";
   for (let depth = 1; depth <= 200; depth++) src += `${"  ".repeat(depth)}a:\n`;
   const json = JSON.parse(callDiff(src, src));
@@ -60,9 +60,9 @@ test("repeated calls do not leak or corrupt state (pure, re-entrant)", () => {
   for (let i = 0; i < 50; i++) assert.equal(callDiff(BEFORE, AFTER), GOLDEN);
 });
 
-// ---- diff_with_assets(ソース prefab の合成)----
+// ---- diff_with_assets (merging a source prefab) ----
 
-// assets TLV(LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }
+// assets TLV (LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }
 function buildAssetsTlv(entries) {
   const enc = new TextEncoder();
   const parts = [];
@@ -96,7 +96,7 @@ function callDiffWithAssets(before, after, assetsTlv) {
   const bp = b.length ? exports.alloc(b.length) : 0;
   const ap = a.length ? exports.alloc(a.length) : 0;
   const tp = t.length ? exports.alloc(t.length) : 0;
-  // ビューは最後の alloc の後に作る: memory.grow で古い ArrayBuffer は detach される
+  // Build views after the last alloc: memory.grow detaches the old ArrayBuffer
   new Uint8Array(exports.memory.buffer, bp, b.length).set(b);
   new Uint8Array(exports.memory.buffer, ap, a.length).set(a);
   new Uint8Array(exports.memory.buffer, tp, t.length).set(t);

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -11,18 +11,18 @@ using UnityEditor;
 
 namespace PrefabLens
 {
-    /// prefablens CLI の探索・ダウンロード・実行。git ロジックは全て CLI 側に置く(親仕様 §6.3)。
+    /// Locate, download, and run the prefablens CLI. All git logic lives in the CLI (parent spec §6.3).
     public static class Cli
     {
-        /// ダウンロードする CLI のバージョン(GitHub Releases のタグ v{Version} と一致させる)。
+        /// Version of the CLI to download (kept in sync with the GitHub Releases tag v{Version}).
         public const string Version = "0.3.0";
         public const string CliPathPref = "PrefabLens.CliPath";
 
-        /// CLI 実行の上限。CLI 内部の git タイムアウト(60 秒)より長く取り、git ハング時は
-        /// CLI 自身の具体的なエラーを先に出させる。ここは Unity メインスレッド凍結の最終安全網。
+        /// Upper bound on CLI execution. Set longer than the CLI's internal git timeout (60s) so that on a git hang
+        /// the CLI surfaces its own specific error first. This is the last-resort safety net against freezing the Unity main thread.
         public const int RunTimeoutMs = 90_000;
 
-        // ---- 純関数(EditMode テスト対象) ----
+        // ---- Pure functions (EditMode test targets) ----
 
         public static string ReleaseAssetName(bool isWindows, bool isMac, bool isArm64)
         {
@@ -38,7 +38,7 @@ namespace PrefabLens
 
         public static string[] BuildArgs(string assetPath) => new[] { "--git", "HEAD", assetPath, "--json" };
 
-        /// ProcessStartInfo.Arguments 用の最小クオート(スペース入りアセットパス対策)。
+        /// Minimal quoting for ProcessStartInfo.Arguments (handles asset paths with spaces).
         public static string QuoteArgs(string[] args)
         {
             var quoted = new string[args.Length];
@@ -47,8 +47,8 @@ namespace PrefabLens
             return string.Join(" ", quoted);
         }
 
-        /// `sha256sum` 形式("<hex>  <name>"、バイナリモードは "<hex> *<name>")から
-        /// assetName の行のハッシュを取り出す。見つからなければ null。
+        /// Extract the hash of assetName's line from `sha256sum` format ("<hex>  <name>", binary mode "<hex> *<name>").
+        /// Returns null if not found.
         public static string ParseSha256Sums(string sums, string assetName)
         {
             foreach (var raw in sums.Split('\n'))
@@ -73,15 +73,15 @@ namespace PrefabLens
             return sb.ToString();
         }
 
-        // ---- Editor 連携 ----
+        // ---- Editor integration ----
 
         public static string BinaryName =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "prefablens.exe" : "prefablens";
 
-        /// 既定の配置先。cwd(= Unity プロジェクトルート)相対の Library 配下。
+        /// Default install location. Under Library, relative to cwd (= Unity project root).
         public static string DefaultPath => Path.Combine("Library", "PrefabLens", Version, BinaryName);
 
-        /// EditorPrefs の手動指定が最優先。無ければ既定の配置先。どちらも無ければ null。
+        /// A manual EditorPrefs override takes precedence. Otherwise the default location. If neither exists, null.
         public static string Find()
         {
             var manual = EditorPrefs.GetString(CliPathPref, "");
@@ -90,7 +90,7 @@ namespace PrefabLens
             return File.Exists(DefaultPath) ? DefaultPath : null;
         }
 
-        /// GitHub Releases から取得して Library 配下に展開する。成功時は実行パス、失敗時は throw。
+        /// Fetch from GitHub Releases and extract under Library. Returns the executable path on success, throws on failure.
         public static string Download()
         {
             var asset = ReleaseAssetName(
@@ -111,7 +111,7 @@ namespace PrefabLens
                 using var zip = new ZipArchive(new MemoryStream(bytes));
                 foreach (var entry in zip.Entries)
                 {
-                    // ZipFileExtensions(ExtractToFile)は netstandard で参照できないため手動コピー
+                    // ZipFileExtensions (ExtractToFile) isn't referenceable under netstandard, so copy manually
                     var dest = Path.Combine(dir, entry.Name);
                     using var src = entry.Open();
                     using var dst = File.Create(dest);
@@ -128,8 +128,8 @@ namespace PrefabLens
             return DefaultPath;
         }
 
-        /// リリースの SHA256SUMS と zip を照合する。SHA256SUMS が無い(404 = v0.2.0 以前の
-        /// リリース)場合のみスキップし、それ以外の取得失敗と不一致は throw。
+        /// Verify the zip against the release's SHA256SUMS. Skip only when SHA256SUMS is absent (404 = a release
+        /// before v0.2.0); any other fetch failure or mismatch throws.
         static void VerifyChecksum(HttpClient http, string assetName, byte[] zipBytes)
         {
             var res = http.GetAsync(DownloadUrl(Version, "SHA256SUMS")).Result;
@@ -152,7 +152,7 @@ namespace PrefabLens
             public bool TimedOut;
         }
 
-        /// プロジェクトルートを cwd に CLI を実行する(--git は cwd のリポジトリを見る)。
+        /// Run the CLI with the project root as cwd (--git looks at the repository in cwd).
         public static Result Run(string cliPath, string assetPath)
         {
             return RunProcess(cliPath, QuoteArgs(BuildArgs(assetPath)), Directory.GetCurrentDirectory(), RunTimeoutMs);
@@ -169,22 +169,22 @@ namespace PrefabLens
                 WorkingDirectory = workDir,
             };
             using var p = Process.Start(psi);
-            // 双方向 ReadToEnd のデッドロックを避ける: 片方は async で読む
+            // Avoid a two-way ReadToEnd deadlock: read one side asynchronously
             var stdout = p.StandardOutput.ReadToEndAsync();
             var stderr = p.StandardError.ReadToEndAsync();
             if (!p.WaitForExit(timeoutMs))
             {
-                // ハングした CLI から Unity メインスレッドを守る。Kill 後も stdio を掴む
-                // 孫プロセスが残ると Read タスクは完了しないため、読み残しは待たない。
+                // Protect the Unity main thread from a hung CLI. If a grandchild process that holds stdio
+                // survives the Kill, the Read tasks never complete, so don't wait for the remaining output.
                 try
                 {
                     p.Kill();
                 }
                 catch (InvalidOperationException)
-                { /* タイムアウトと終了の競合 */
+                { /* race between timeout and exit */
                 }
                 catch (System.ComponentModel.Win32Exception)
-                { /* 既に終了処理中 */
+                { /* already terminating */
                 }
                 return new Result
                 {

--- a/editor/Editor/DiffModel.cs
+++ b/editor/Editor/DiffModel.cs
@@ -13,12 +13,12 @@ namespace PrefabLens
         Unchanged,
     }
 
-    /// diff.v2 のフィールド値: scalar / ref / null の 3 態。
+    /// A diff.v2 field value: one of three states — scalar / ref / null.
     public sealed class Value
     {
-        public string Scalar; // scalar のときのみ
-        public string RefFileId; // ref のときのみ
-        public string RefGuid; // ref かつ外部参照のときのみ
+        public string Scalar; // only when scalar
+        public string RefFileId; // only when ref
+        public string RefGuid; // only when ref and an external reference
         public bool IsRef;
         public bool IsNull;
 
@@ -70,8 +70,8 @@ namespace PrefabLens
         public List<OverrideDiff> Overrides = new();
     }
 
-    /// prefablens.diff.v2(core/src/json.zig の出力)の読み取り側モデル。
-    /// 未知の kind やフィールド欠損は落とさず読み飛ばす(CLI が新しい場合に Editor 側が壊れない)。
+    /// Reader-side model for prefablens.diff.v2 (the output of core/src/json.zig).
+    /// Unknown kinds and missing fields are skipped rather than failing (so the Editor doesn't break when the CLI is newer).
     public sealed class DiffModel
     {
         public List<string> UnresolvedGuids = new();
@@ -83,8 +83,8 @@ namespace PrefabLens
 
         public static DiffModel Parse(string json)
         {
-            // MiniJSON は不正入力で throw せず null を返す。Window の「Could not parse
-            // CLI output」分岐(Exception を握る)を成立させるため、ここで throw に戻す。
+            // MiniJSON returns null on malformed input rather than throwing. Convert back to a throw here
+            // so the Window's "Could not parse CLI output" branch (which catches the Exception) works.
             if (Json.Deserialize(json) is not Dictionary<string, object> o)
                 throw new FormatException("diff json root is not an object");
             var m = new DiffModel();
@@ -104,7 +104,7 @@ namespace PrefabLens
             return m;
         }
 
-        /// Editor 内では AssetDatabase で guid を完全解決できる(Chrome 版より強い)。
+        /// Inside the Editor, AssetDatabase can fully resolve guids (stronger than the Chrome build).
         public void ResolveWith(Func<string, string> guidToPath)
         {
             foreach (var g in UnresolvedGuids)
@@ -125,7 +125,7 @@ namespace PrefabLens
             {
                 "gameObject" => new GameObjectDiff(),
                 "prefabInstance" => ParsePrefabInstance(o),
-                _ => null, // 未知の kind は読み飛ばす
+                _ => null, // skip unknown kinds
             };
             if (n == null)
                 return null;
@@ -198,7 +198,7 @@ namespace PrefabLens
             return new Value { Scalar = ScalarString(t) };
         }
 
-        /// scalar は CLI が文字列で出すが、数値 / bool が来ても JSON 表記のまま文字列化する。
+        /// The CLI emits scalars as strings, but if a number / bool arrives, stringify it in JSON notation.
         static string ScalarString(object t) =>
             t switch
             {

--- a/editor/Editor/MiniJson.cs
+++ b/editor/Editor/MiniJson.cs
@@ -26,8 +26,8 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-// PrefabLens への同梱元: https://gist.github.com/darktable/1411710(rev 513f1c0、MIT)
-// 変更点: namespace MiniJSON -> PrefabLens.MiniJson のみ。
+// Bundled into PrefabLens from: https://gist.github.com/darktable/1411710 (rev 513f1c0, MIT)
+// Change: namespace MiniJSON -> PrefabLens.MiniJson only.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -7,7 +7,7 @@ using UnityEngine.UIElements;
 
 namespace PrefabLens
 {
-    /// 選択アセットの「HEAD vs 作業ツリー」意味的 diff を表示する(Phase 3 ウォーキングスケルトン)。
+    /// Displays the "HEAD vs working tree" semantic diff of the selected asset (Phase 3 walking skeleton).
     public sealed class PrefabLensWindow : EditorWindow
     {
         [SerializeField]
@@ -92,7 +92,7 @@ namespace PrefabLens
             var res = Cli.Run(cli, assetPath);
             if (res.ExitCode != 0)
             {
-                // CLI の stderr が一次情報(非 git リポジトリ・不正 ref 等)
+                // The CLI's stderr is the primary source (non-git repository, invalid ref, etc.)
                 Note(string.IsNullOrEmpty(res.Stderr) ? $"prefablens exited with {res.ExitCode}" : res.Stderr.Trim());
                 return;
             }
@@ -149,8 +149,8 @@ namespace PrefabLens
             );
         }
 
-        // ---- ツリー描画(Chrome 版レンダラと同じ配色トーン・記法) ----
-        // rich text は使わない: リポジトリ由来文字列をマークアップ解釈させない(Chrome 版の XSS テストと同じ思想)。
+        // ---- Tree rendering (same color tone and notation as the Chrome renderer) ----
+        // No rich text: don't let repository-derived strings be interpreted as markup (same rationale as the Chrome build's XSS test).
 
         static class Palette
         {

--- a/editor/Editor/UnityYamlPaths.cs
+++ b/editor/Editor/UnityYamlPaths.cs
@@ -2,9 +2,9 @@ using System;
 
 namespace PrefabLens
 {
-    /// Unity がテキストシリアライズ(UnityYAML)するアセット拡張子の判定。
-    /// unityyamlmerge の対象と同じ集合。.meta(!u! ドキュメント形式でない)と
-    /// .asmdef 等の JSON は対象外。
+    /// Decides which asset extensions Unity text-serializes (UnityYAML).
+    /// The same set as unityyamlmerge targets. Excludes .meta (not !u! document format) and
+    /// JSON such as .asmdef.
     public static class UnityYamlPaths
     {
         static readonly string[] Extensions =

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -59,7 +59,7 @@ namespace PrefabLens.Tests
         [Test]
         public void ParseSha256SumsFindsTheAssetLine()
         {
-            // release.yml の `sha256sum *.zip` が生成するそのままの形。
+            // Exactly the form release.yml's `sha256sum *.zip` produces.
             var sums =
                 "1111111111111111111111111111111111111111111111111111111111111111  prefablens-linux-x64.zip\n"
                 + "2222222222222222222222222222222222222222222222222222222222222222  prefablens-macos-arm64.zip\n";
@@ -73,7 +73,7 @@ namespace PrefabLens.Tests
         [Test]
         public void ParseSha256SumsHandlesCrlfAndBinaryMarker()
         {
-            // CRLF 改行と、sha256sum バイナリモードの "*" 前置も受理する。
+            // Also accepts CRLF line endings and sha256sum binary mode's leading "*".
             var sums = "cafe01 *prefablens-windows-x64.zip\r\n";
             Assert.AreEqual("cafe01", Cli.ParseSha256Sums(sums, "prefablens-windows-x64.zip"));
         }
@@ -81,7 +81,7 @@ namespace PrefabLens.Tests
         [Test]
         public void Sha256HexMatchesTheStandardTestVector()
         {
-            // FIPS 180-2 の既知ベクタ: sha256("abc")
+            // Known vector from FIPS 180-2: sha256("abc")
             Assert.AreEqual(
                 "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
                 Cli.Sha256Hex(Encoding.ASCII.GetBytes("abc"))
@@ -91,7 +91,7 @@ namespace PrefabLens.Tests
         [Test]
         public void RunProcessKillsAHungProcessAndReportsTimeout()
         {
-            // 実プロセス(sleep)で検証: タイムアウトで殺され、60 秒待たされないこと。
+            // Verify with a real process (sleep): it is killed on timeout and doesn't make us wait 60s.
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var file = isWindows ? "cmd.exe" : "/bin/sh";
             var args = isWindows ? "/c ping -n 60 127.0.0.1 > NUL" : "-c \"sleep 60\"";
@@ -119,7 +119,7 @@ namespace PrefabLens.Tests
         [Test]
         public void RunProcessCapturesStderrAndExitCode()
         {
-            // ExitCode != 0 のとき Window は stderr を一次情報として表示する。その配線の検証。
+            // When ExitCode != 0 the Window shows stderr as the primary source. Verifies that wiring.
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var file = isWindows ? "cmd.exe" : "/bin/sh";
             var args = isWindows ? "/c echo boom 1>&2 & exit 3" : "-c \"echo boom 1>&2; exit 3\"";
@@ -132,9 +132,9 @@ namespace PrefabLens.Tests
         [Test]
         public void RunProcessDrainsBothPipesPastTheOsBuffer()
         {
-            // stdout / stderr の両方を OS のパイプバッファ(通常 64KB)より多く書く子でも
-            // デッドロックせず全量読めること。RunProcess の非同期読みを同期 ReadToEnd ×2 に
-            // 「単純化」すると、子が stderr 書き込みでブロックしたままタイムアウトして fail する。
+            // Even a child that writes both stdout and stderr past the OS pipe buffer (typically 64KB)
+            // can be read in full without deadlock. "Simplifying" RunProcess's async reads into two synchronous
+            // ReadToEnd calls leaves the child blocked on the stderr write and the test fails on timeout.
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var file = isWindows ? "cmd.exe" : "/bin/sh";
             var line = new string('x', 40);
@@ -144,7 +144,7 @@ namespace PrefabLens.Tests
             var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs);
             Assert.IsFalse(res.TimedOut);
             Assert.AreEqual(0, res.ExitCode);
-            // 4000 行 × 41 バイト ≈ 160KB。バッファ超えを確実にしつつ取りこぼしも検出する。
+            // 4000 lines × 41 bytes ≈ 160KB. Reliably exceeds the buffer while also detecting dropped output.
             Assert.Greater(res.Stdout.Length, 100_000);
             Assert.Greater(res.Stderr.Length, 100_000);
         }

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -4,7 +4,7 @@ namespace PrefabLens.Tests
 {
     public class DiffModelTests
     {
-        // core/tests/wasm_golden.test.mjs の GOLDEN と同一(スキーマ互換の回帰点)
+        // Identical to the GOLDEN in core/tests/wasm_golden.test.mjs (a schema-compat regression point)
         const string Golden =
             "{\"schema\":\"prefablens.diff.v2\",\"unresolvedGuids\":[\"def\"],\"roots\":[],\"loose\":[{\"kind\":\"component\",\"fileId\":\"11400000\",\"classId\":114,\"typeName\":\"MonoBehaviour\",\"scriptGuid\":\"def\",\"className\":null,\"status\":\"modified\",\"fields\":[{\"path\":\"Volume\",\"status\":\"modified\",\"before\":\"0.5\",\"after\":\"0.8\"}]}]}";
 
@@ -74,7 +74,7 @@ namespace PrefabLens.Tests
                 ""loose"":[]
             }";
             var m = DiffModel.Parse(json);
-            Assert.AreEqual(1, m.Roots.Count); // 未知 kind は読み飛ばし、欠損フィールドは既定値
+            Assert.AreEqual(1, m.Roots.Count); // unknown kinds are skipped, missing fields default
             Assert.AreEqual("", m.Roots[0].Name);
             Assert.AreEqual(DiffStatus.Unchanged, m.Roots[0].Status);
         }
@@ -82,7 +82,7 @@ namespace PrefabLens.Tests
         [Test]
         public void EmptyDiffIsEmpty()
         {
-            // 変更なしのとき Window は IsEmpty を見て "No semantic changes" を出す。その分岐の根拠。
+            // On no changes the Window checks IsEmpty and shows "No semantic changes". The basis for that branch.
             var m = DiffModel.Parse(
                 @"{""schema"":""prefablens.diff.v2"",""unresolvedGuids"":[],""roots"":[],""loose"":[]}"
             );
@@ -92,8 +92,8 @@ namespace PrefabLens.Tests
         [Test]
         public void ParsesResolvedMapAndRemovedStatus()
         {
-            // resolved は CLI 側で解決済みの guid -> パス(ResolveWith が上書きしないのは別テストで検証)。
-            // removed は 4 status のうち他テストが通っていない残り 1 つ。
+            // resolved is the guid -> path already resolved by the CLI (that ResolveWith doesn't overwrite it is verified in another test).
+            // removed is the one remaining status of the four not covered by other tests.
             const string json =
                 @"{
                 ""unresolvedGuids"":[],
@@ -114,11 +114,11 @@ namespace PrefabLens.Tests
         [Test]
         public void ThrowsOnMalformedOrNonObjectJson()
         {
-            // 同梱の MiniJSON は不正入力で throw せず null を返す流儀だが、DiffModel.Parse は
-            // throw する契約(Window が「Could not parse CLI output」表示に変換する)を保つ。
+            // The bundled MiniJSON returns null on malformed input rather than throwing, but DiffModel.Parse
+            // keeps the contract of throwing (which the Window converts into the "Could not parse CLI output" display).
             Assert.That(() => DiffModel.Parse("not json at all"), Throws.Exception);
             Assert.That(() => DiffModel.Parse(""), Throws.Exception);
-            Assert.That(() => DiffModel.Parse("[]"), Throws.Exception); // ルートが object でない
+            Assert.That(() => DiffModel.Parse("[]"), Throws.Exception); // root is not an object
         }
 
         [Test]
@@ -127,14 +127,14 @@ namespace PrefabLens.Tests
             var m = DiffModel.Parse(Golden);
             m.Resolved["def"] = "Assets/Preexisting.cs";
             m.ResolveWith(_ => "Assets/FromAssetDatabase.cs");
-            Assert.AreEqual("Assets/Preexisting.cs", m.Resolved["def"]); // 既存の解決が先勝ち
+            Assert.AreEqual("Assets/Preexisting.cs", m.Resolved["def"]); // an existing resolution wins
 
             var fresh = DiffModel.Parse(Golden);
             fresh.ResolveWith(g => g == "def" ? "Assets/Scripts/Sound.cs" : "");
             Assert.AreEqual("Assets/Scripts/Sound.cs", fresh.Resolved["def"]);
 
             var none = DiffModel.Parse(Golden);
-            none.ResolveWith(_ => ""); // AssetDatabase が空を返したら未解決のまま
+            none.ResolveWith(_ => ""); // if AssetDatabase returns empty, it stays unresolved
             Assert.IsFalse(none.Resolved.ContainsKey("def"));
         }
     }

--- a/editor/Tests/Editor/UnityYamlPathsTests.cs
+++ b/editor/Tests/Editor/UnityYamlPathsTests.cs
@@ -4,8 +4,8 @@ namespace PrefabLens.Tests
 {
     public class UnityYamlPathsTests
     {
-        // unityyamlmerge が対象とするテキストシリアライズ済み拡張子の全集合。
-        // Unity の実出力どおりの camelCase(.overrideController 等)で列挙する。
+        // The full set of text-serialized extensions unityyamlmerge targets.
+        // Listed in the camelCase Unity actually emits (.overrideController, etc.).
         static readonly string[] Supported =
         {
             ".prefab",
@@ -46,7 +46,7 @@ namespace PrefabLens.Tests
         [Test]
         public void IsCaseInsensitive()
         {
-            // Unity は小文字拡張子で書き出すが、手動リネームされたファイルも受け付ける
+            // Unity writes lowercase extensions, but manually renamed files are accepted too
             Assert.IsTrue(UnityYamlPaths.IsSupported("Assets/FOO.PREFAB"));
             Assert.IsTrue(UnityYamlPaths.IsSupported("Assets/Sample.Mat"));
         }
@@ -54,7 +54,7 @@ namespace PrefabLens.Tests
         [Test]
         public void RejectsNonUnityYamlPaths()
         {
-            // .meta は !u! ドキュメント形式でなく、.asmdef は JSON。部分一致(.matx)も不可
+            // .meta isn't !u! document format and .asmdef is JSON. A partial match (.matx) is rejected too
             Assert.IsFalse(UnityYamlPaths.IsSupported("Assets/Foo.prefab.meta"));
             Assert.IsFalse(UnityYamlPaths.IsSupported("Assets/Code.asmdef"));
             Assert.IsFalse(UnityYamlPaths.IsSupported("Assets/T.matx"));

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -16,8 +16,8 @@ await build({
   outdir: "dist",
 });
 
-// --e2e: full-stack E2E がローカル HTTP サーバを「GHES」として使えるよう 127.0.0.1 を事前許可する
-// (permissions.request は許可済みオリジンならプロンプトなしで true を返す)
+// --e2e: pre-grant 127.0.0.1 so full-stack E2E can use a local HTTP server as "GHES"
+// (permissions.request returns true without a prompt for an already-granted origin)
 const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 if (process.argv.includes("--e2e")) manifest.host_permissions.push("http://127.0.0.1/*");
 writeFileSync("dist/manifest.json", JSON.stringify(manifest, null, 2));

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
-// 本物の拡張(--load-extension)で 検出 → 実 background → 実 WASM → 描画 を端から端まで通す。
-// ローカル HTTP サーバを A1 の GHES 動的登録経由で「GitHub」として使う(--e2e build が 127.0.0.1 を事前許可)。
+// Runs detection → real background → real WASM → render end-to-end with the actual extension (--load-extension).
+// Uses a local HTTP server as "GitHub" via A1's GHES dynamic registration (the --e2e build pre-grants 127.0.0.1).
 
 import { readFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
@@ -10,14 +10,14 @@ import { type BrowserContext, chromium, expect, test } from "@playwright/test";
 const DIST = fileURLToPath(new URL("../dist", import.meta.url));
 const fixture = readFileSync(new URL("./fixtures/pr-files.html", import.meta.url), "utf8");
 
-// core/tests/wasm_golden.test.mjs と同じミニマル prefab: 出力が golden で確定している
+// Same minimal prefab as core/tests/wasm_golden.test.mjs: the output is pinned by the golden
 const BEFORE = `--- !u!114 &11400000
 MonoBehaviour:
   m_Script: {fileID: 0, guid: def, type: 3}
   volume: 0.5
 `;
 const AFTER = BEFORE.replace("0.5", "0.8");
-// ドキュメントなしの 26MB = 25MB ガードを踏み、force 後は空 diff で軽く終わる
+// 26MB with no documents trips the 25MB guard; after force it finishes cheaply with an empty diff
 const BIG = "x".repeat(26 * 1024 * 1024);
 
 function startServer(): Promise<{ server: Server; port: number }> {
@@ -67,14 +67,14 @@ let port: number;
 test.beforeAll(async () => {
   ({ server, port } = await startServer());
   context = await chromium.launchPersistentContext("", {
-    channel: "chromium", // headless で拡張を使うには chromium channel が必要
+    channel: "chromium", // the chromium channel is required to use extensions headlessly
     args: [`--disable-extensions-except=${DIST}`, `--load-extension=${DIST}`],
   });
   let sw = context.serviceWorkers()[0];
   sw ??= await context.waitForEvent("serviceworker");
   const extensionId = new URL(sw.url()).host;
 
-  // Options で PAT とローカルサーバを保存 → applyGhes が 127.0.0.1 を動的登録する
+  // Save the PAT and local server in Options → applyGhes dynamically registers 127.0.0.1
   const options = await context.newPage();
   await options.goto(`chrome-extension://${extensionId}/options.html`);
   await options.fill("#pat", "tok");
@@ -97,7 +97,7 @@ test("renders a real wasm diff with code-search guid resolution", async () => {
   await header.getByRole("button", { name: "Semantic" }).click();
 
   const view = page.locator("[data-prefablens-view]");
-  // Code Search 経由で guid def → Sound.cs に実名解決され、型名ではなくスクリプト名が出る
+  // Via Code Search, guid def resolves to Sound.cs, so the script name shows instead of the type name
   await expect(view).toContainText("Sound");
   await expect(view).toContainText("Volume");
   await expect(view).toContainText("0.5");

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -5,8 +5,8 @@ import { expect, type Page, test } from "@playwright/test";
 
 const fixture = readFileSync(new URL("./fixtures/pr-files.html", import.meta.url), "utf8");
 
-// content script は起動時に chrome.storage.local から viewMode を読む。
-// スタブに storage が無いと init が落ちて全テストが壊れるため、必ず与える。
+// The content script reads viewMode from chrome.storage.local on startup.
+// If the stub lacks storage, init throws and breaks every test, so always provide it.
 function stubChrome(page: Page, res: unknown, viewMode?: string) {
   return page.addInitScript(
     ({ res, viewMode }) => {
@@ -52,28 +52,28 @@ const cannedResponse = {
 };
 
 test("detects a Unity file, toggles to Semantic, renders the tree", async ({ page }) => {
-  // content script は URL(/pull/N/files)を見る: フィクスチャを PR の URL で返す
+  // The content script inspects the URL (/pull/N/files): serve the fixture at a PR URL
   await page.route("**/pull/1/files", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
-  // background を固定応答でスタブ(この面の本物は handler.test.ts が担保)
+  // Stub background with a fixed response (handler.test.ts covers the real path here)
   await stubChrome(page, cannedResponse);
 
   await page.goto("https://prefablens.test/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
-  // 検出: Unity ファイルにだけトグルが付く
+  // Detection: the toggle is attached only to Unity files
   const unityHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
   await expect(unityHeader.getByRole("button", { name: "Semantic" })).toBeVisible();
   const mdHeader = page.locator('.file-header[data-path="README.md"]');
   await expect(mdHeader.locator("[data-prefablens-toggle]")).toHaveCount(0);
 
-  // トグル → 描画(Playwright は open shadow root を自動貫通する)
+  // Toggle → render (Playwright pierces open shadow roots automatically)
   await unityHeader.getByRole("button", { name: "Semantic" }).click();
   const view = page.locator("[data-prefablens-view]");
   await expect(view).toContainText("MonoBehaviour");
   await expect(view).toContainText("volume");
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();
 
-  // Raw に戻せる
+  // Can switch back to Raw
   await unityHeader.getByRole("button", { name: "Raw" }).click();
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeVisible();
   await expect(view).toBeHidden();
@@ -82,7 +82,7 @@ test("detects a Unity file, toggles to Semantic, renders the tree", async ({ pag
 test("sends a prefetch message on pr page arrival", async ({ page }) => {
   await page.route("**/pull/1/files", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
   await stubChrome(page, cannedResponse);
-  // stubChrome の sendMessage を包んで記録する
+  // Wrap stubChrome's sendMessage to record calls
   await page.addInitScript(() => {
     const w = window as unknown as {
       chrome: { runtime: { sendMessage: (m: unknown) => Promise<unknown> } };
@@ -105,7 +105,7 @@ test("sends a prefetch message on pr page arrival", async ({ page }) => {
             .length,
       ),
     )
-    .toBe(1); // 同一 PR では 1 回だけ
+    .toBe(1); // only once per PR
 });
 
 test("attaches toggles to files added after the initial scan (SPA lazy loading)", async ({ page }) => {
@@ -115,7 +115,7 @@ test("attaches toggles to files added after the initial scan (SPA lazy loading)"
   await page.goto("https://prefablens.test/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
-  // GitHub は Files changed をスクロールで遅延ロードする: 初回スキャン後の追加を MutationObserver が拾う
+  // GitHub lazy-loads Files changed on scroll: the MutationObserver picks up additions after the initial scan
   await page.evaluate(() => {
     const file = document.createElement("div");
     file.className = "file";
@@ -129,14 +129,14 @@ test("attaches toggles to files added after the initial scan (SPA lazy loading)"
 
 test("recovers after an error response", async ({ page }) => {
   await page.route("**/pull/1/files", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
-  // 1回目は pat-missing エラー、2回目以降は正常応答を返す(エラーはキャッシュされず再フェッチされることを確認)
-  // カウンタ用に専用スタブを使うが、init が落ちないよう storage/onMessage は stubChrome と同じ形にする
+  // First call returns a pat-missing error, later calls return a normal response (verifies errors are not cached and are re-fetched)
+  // Use a dedicated stub for the counter, but keep storage/onMessage the same shape as stubChrome so init does not throw
   await page.addInitScript((res) => {
     (window as unknown as Record<string, unknown>).__prefablensCalls = 0;
     (window as unknown as Record<string, unknown>).chrome = {
       runtime: {
-        // prefetch はカウント対象外にする: attach() が pull ページ到達時に必ず 1 通送るため、
-        // 素朴な全件カウントだと 1 回目の semanticDiff がずれてエラー→成功の検証が壊れる
+        // Exclude prefetch from the count: attach() always sends one on pull-page arrival, so
+        // a naive count-everything would offset the first semanticDiff and break the error→success check
         sendMessage: (msg: { type?: string }) => {
           if (msg?.type !== "semanticDiff") return Promise.resolve();
           const w = window as unknown as Record<string, number>;
@@ -162,11 +162,11 @@ test("recovers after an error response", async ({ page }) => {
   const unityHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
   const view = page.locator("[data-prefablens-view]");
 
-  // 1回目のトグル: エラー表示
+  // First toggle: shows the error
   await unityHeader.getByRole("button", { name: "Semantic" }).click();
   await expect(view).toContainText("Set a GitHub token");
 
-  // Raw → Semantic と再トグルすると再フェッチされ、正常結果に回復する
+  // Re-toggling Raw → Semantic re-fetches and recovers to the normal result
   await unityHeader.getByRole("button", { name: "Raw" }).click();
   await unityHeader.getByRole("button", { name: "Semantic" }).click();
   await expect(view).toContainText("MonoBehaviour");
@@ -174,20 +174,20 @@ test("recovers after an error response", async ({ page }) => {
 
 test("applies the persisted semantic default to every unity file and late additions", async ({ page }) => {
   await page.route("**/pull/1/files", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
-  await stubChrome(page, cannedResponse, "semantic"); // 前回の選択が semantic で保存済み
+  await stubChrome(page, cannedResponse, "semantic"); // the previous choice was saved as semantic
 
   await page.goto("https://prefablens.test/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
-  // クリックなしで両方の Unity ファイルが semantic 描画になっている
+  // Both Unity files render as semantic without a click
   await expect(page.locator("[data-prefablens-view]")).toHaveCount(2);
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();
 
-  // 全体トグルも既定を反映して Semantic 押下状態で現れる
+  // The global toggle also reflects the default and appears in the Semantic pressed state
   const global = page.locator("[data-prefablens-global]");
   await expect(global.locator('button[data-view="semantic"]')).toHaveAttribute("aria-pressed", "true");
 
-  // 遅延ロードで現れたファイルも既定を継承する(「押したのに raw」が起きない核心)
+  // A lazy-loaded file also inherits the default (the crux of preventing "pressed but still raw")
   await page.evaluate(() => {
     const file = document.createElement("div");
     file.className = "file";
@@ -206,26 +206,26 @@ test("global toggle switches all files and resets per-file overrides", async ({ 
   await page.goto("https://prefablens.test/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
-  // 全体トグルは最初の Unity ファイルの直前に 1 つだけ注入される
+  // The global toggle is injected exactly once, right before the first Unity file
   const global = page.locator("[data-prefablens-global]");
   await expect(global).toHaveCount(1);
 
-  // 位置契約: バーは最初の Unity ファイルの .file コンテナ直前に入る
+  // Position contract: the bar goes right before the first Unity file's .file container
   await expect(
     page.locator('[data-prefablens-global] + .file .file-header[data-path="Assets/Foo.prefab"]'),
   ).toHaveCount(1);
 
-  // 全体 Semantic → 全 Unity ファイルが切り替わる(README は対象外)
+  // Global Semantic → all Unity files switch (README is excluded)
   await global.getByRole("button", { name: "Semantic" }).click();
   await expect(page.locator("[data-prefablens-view]")).toHaveCount(2);
 
-  // 個別に Raw へ上書き → そのファイルだけ raw に戻る
+  // Per-file override to Raw → only that file reverts to raw
   const fooHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
   await fooHeader.getByRole("button", { name: "Raw" }).click();
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeVisible();
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Big.unity"]) .js-file-content')).toBeHidden();
 
-  // 全体 Raw → Semantic と操作すると上書きがリセットされ、必ず全ファイルが揃う
+  // Toggling global Raw → Semantic resets overrides, so all files always line up
   await global.getByRole("button", { name: "Raw" }).click();
   await global.getByRole("button", { name: "Semantic" }).click();
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();

--- a/extension/scripts/check-wasm-size.mjs
+++ b/extension/scripts/check-wasm-size.mjs
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 
-const TARGET_KB = 80; // 親仕様 §5.7 の目標
-const LIMIT_KB = 150; // 超過で CI 失敗
+const TARGET_KB = 80; // target from parent spec §5.7
+const LIMIT_KB = 150; // CI fails if exceeded
 
 const wasmUrl = new URL("../../zig-out/bin/prefablens.wasm", import.meta.url);
 const gz = gzipSync(readFileSync(wasmUrl), { level: 9 }).length;

--- a/extension/src/background/diffStore.test.ts
+++ b/extension/src/background/diffStore.test.ts
@@ -4,7 +4,7 @@ import { createSessionDiffStore } from "./diffStore";
 
 const DIFF: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: [], roots: [], loose: [] };
 
-// chrome.storage.session の必要部分だけを Map で模した fake。set は failWhen で溢れを再現する。
+// A fake that mimics only the needed subset of chrome.storage.session with a Map. set reproduces overflow via failWhen.
 function fakeArea(failWhen?: () => boolean) {
   const data = new Map<string, unknown>();
   const area = {
@@ -42,7 +42,7 @@ describe("createSessionDiffStore", () => {
   });
 
   it("skips diffs larger than the session budget without touching storage", async () => {
-    // 大物はメモリキャッシュだけに任せる(session は 10MB しかない)
+    // Leave large ones to the memory cache only (session is only 10MB)
     const area = fakeArea();
     const store = createSessionDiffStore(area);
     const big: DiffV2 = { ...DIFF, unresolvedGuids: [" ".repeat(600 * 1024)] };
@@ -51,30 +51,30 @@ describe("createSessionDiffStore", () => {
   });
 
   it("flushes stale diff entries and retries once when the quota overflows", async () => {
-    // 一度埋まると以後 SW 再起動のたびに全再計算になる恒久劣化を防ぐ:
-    // 溢れたら溜まった diff を一掃して 1 回だけ書き直す
-    const area = fakeArea(); // 既定 set は成功。1 回目だけ下で溢れさせる
-    // 既存の diff エントリと、無関係なキーを 1 つ仕込む
+    // Prevents the permanent degradation where, once full, every SW restart recomputes everything:
+    // on overflow, wipe the accumulated diffs and rewrite once
+    const area = fakeArea(); // the default set succeeds. Only the first is made to overflow below
+    // Seed existing diff entries and one unrelated key
     area.data.set("diff:old1", DIFF);
     area.data.set("diff:old2", DIFF);
-    area.data.set("viewMode", "semantic"); // diff: 以外は消さない
+    area.data.set("viewMode", "semantic"); // don't delete anything but diff:
     const store = createSessionDiffStore(area);
 
-    // 1 回目の set は溢れる → flush → retry(既定 set)は通す
+    // The first set overflows → flush → retry (the default set) succeeds
     area.set.mockImplementationOnce(async () => {
       throw new Error("quota exceeded");
     });
     await store.save("new", DIFF);
 
-    expect(area.remove).toHaveBeenCalledWith(["diff:old1", "diff:old2"]); // diff: だけ一掃
-    expect(area.data.has("viewMode")).toBe(true); // 無関係キーは残す
-    expect(area.data.get("diff:new")).toEqual(DIFF); // 再試行で書けている
-    expect(area.set).toHaveBeenCalledTimes(2); // 溢れ 1 回 + retry 1 回だけ(ループ化への退行を固定)
+    expect(area.remove).toHaveBeenCalledWith(["diff:old1", "diff:old2"]); // wipe only diff:
+    expect(area.data.has("viewMode")).toBe(true); // keep unrelated keys
+    expect(area.data.get("diff:new")).toEqual(DIFF); // the retry wrote it
+    expect(area.set).toHaveBeenCalledTimes(2); // just 1 overflow + 1 retry (pins against a regression to looping)
   });
 
   it("gives up quietly if the retry also fails", async () => {
-    // flush しても書けない(単一 diff が quota 超): メモリキャッシュで続行、例外は投げない
-    const area = fakeArea(() => true); // 常に溢れる
+    // Still unwritable after flush (a single diff over quota): continue with the memory cache, don't throw
+    const area = fakeArea(() => true); // always overflows
     const store = createSessionDiffStore(area);
     await expect(store.save("k", DIFF)).resolves.toBeUndefined();
   });

--- a/extension/src/background/diffStore.ts
+++ b/extension/src/background/diffStore.ts
@@ -1,9 +1,9 @@
 import type { DiffV2 } from "../types";
 
 const PREFIX = "diff:";
-const MAX_BYTES = 512 * 1024; // storage.session は 10MB: 大物はメモリキャッシュだけに任せる(SW が死んだら再計算)
+const MAX_BYTES = 512 * 1024; // storage.session is 10MB: leave large ones to the memory cache only (recompute if the SW dies)
 
-// chrome.storage.session の必要部分だけを受ける(テストで fake に差し替え可能にするため)
+// Accepts only the needed subset of chrome.storage.session (so tests can swap in a fake)
 type Area = {
   get(keys: string | string[] | null): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
@@ -15,9 +15,9 @@ export type DiffStore = {
   save(key: string, json: DiffV2): Promise<void>;
 };
 
-/** raw diff を sha キーで storage.session に載せ、SW 再起動をまたいで再利用する。
- *  quota が溢れたら溜まった diff を一掃して 1 回だけ書き直す: これをしないと一度埋まると
- *  以後 SW 再起動のたびに全再計算になり、無言で恒久劣化する(内容は sha キーで再計算可能)。 */
+/** Stores raw diffs in storage.session under a sha key, reusing them across SW restarts.
+ *  On quota overflow, wipe the accumulated diffs and rewrite once: without this, once it fills up
+ *  every SW restart thereafter recomputes everything and it silently degrades permanently (content is recomputable from the sha key). */
 export function createSessionDiffStore(area: Area): DiffStore {
   return {
     async load(key) {
@@ -31,14 +31,14 @@ export function createSessionDiffStore(area: Area): DiffStore {
       } catch {
         await flushDiffs(area);
         await area.set({ [PREFIX + key]: json }).catch(() => {
-          // flush しても書けない(単一 diff が quota 超など): メモリキャッシュで続行する
+          // Still unwritable after flush (a single diff over quota, etc.): continue with the memory cache
         });
       }
     },
   };
 }
 
-/** diff: 付きのキーだけを一掃する(viewMode など無関係な session キーは残す)。 */
+/** Wipes only keys with the diff: prefix (keeps unrelated session keys like viewMode). */
 async function flushDiffs(area: Area): Promise<void> {
   const all = await area.get(null).catch(() => ({}));
   const keys = Object.keys(all).filter((k) => k.startsWith(PREFIX));

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -20,8 +20,8 @@ function makeDeps(overrides?: {
   diff?: Differ["diff"];
   diffWithAssets?: Differ["diffWithAssets"];
   pat?: string | undefined;
-  search?: Record<string, string | null>; // guid → asset path(null = 未ヒット)
-  cached?: Record<string, string>; // guidCache の初期内容
+  search?: Record<string, string | null>; // guid → asset path (null = no hit)
+  cached?: Record<string, string>; // initial contents of guidCache
 }) {
   const files = overrides?.files ?? [{ path: "Assets/Foo.prefab", status: "modified" }];
   const contents = overrides?.contents ?? { "Assets/Foo.prefab@base-sha": "b", "Assets/Foo.prefab@head-sha": "a" };
@@ -63,7 +63,7 @@ function makeDeps(overrides?: {
       diffStoreData[key] = json;
     }),
   };
-  // Task 11 の makeFakes と同型(loadGuids/saveGuids/loadIndex/saveIndex)。テストごとに空で始まる。
+  // Same shape as Task 11's makeFakes (loadGuids/saveGuids/loadIndex/saveIndex). Starts empty per test.
   const guidsData: Record<string, Record<string, string>> = {};
   const indexData: Record<string, { treeSha: string; guids: Record<string, string> }> = {};
   const repoIndexStore = {
@@ -90,7 +90,7 @@ function makeDeps(overrides?: {
   return { deps, client, differ, guidCache, diffStore, repoIndexStore };
 }
 
-/** pending 応答の後始末: done push が来るまで待ってから検証する。 */
+/** Cleanup for a pending response: wait until the done push arrives before asserting. */
 async function serveAndResolve(
   handler: Handler,
   req: SemanticDiffRequest,
@@ -133,7 +133,7 @@ describe("createHandler", () => {
       (c) => c[2] === "Assets/Foo.prefab" && c[3] === "base-sha",
     );
     expect(baseFetches).toHaveLength(0);
-    expect(diff.mock.calls[0]?.[0]).toHaveLength(0); // before は空
+    expect(diff.mock.calls[0]?.[0]).toHaveLength(0); // before is empty
   });
 
   it("uses an empty after for removed files without fetching the head side", async () => {
@@ -144,11 +144,11 @@ describe("createHandler", () => {
       (c) => c[2] === "Assets/Foo.prefab" && c[3] === "head-sha",
     );
     expect(headFetches).toHaveLength(0);
-    expect(diff.mock.calls[0]?.[1]).toHaveLength(0); // after は空
+    expect(diff.mock.calls[0]?.[1]).toHaveLength(0); // after is empty
   });
 
   it("diffs a file missing from the PR list as modified (files API caps at 3000)", async () => {
-    // 3000 ファイル超の PR では一覧 API が打ち切られ、UI にあるファイルが一覧に無いことがある
+    // In a PR with over 3000 files, the listing API is truncated, so a file present in the UI may be absent from the listing
     const { deps, client } = makeDeps({ files: [{ path: "Assets/Other.prefab", status: "modified" }] });
     const res = await createHandler(deps).semanticDiff(REQ);
     expect(res.ok).toBe(true);
@@ -157,7 +157,7 @@ describe("createHandler", () => {
   });
 
   it("fetches the base and head blobs in parallel", async () => {
-    // 初回トグルのレイテンシは blob フェッチ 2 本が支配的なので、直列化への退行を固定する
+    // First-toggle latency is dominated by the two blob fetches, so pin against a regression to serialization
     let inFlight = 0;
     let maxInFlight = 0;
     const { deps, client } = makeDeps();
@@ -200,7 +200,7 @@ describe("createHandler", () => {
       vi.setSystemTime(Date.now() + 59_000);
       await handle.semanticDiff(REQ);
       expect(client.getPrRefs).toHaveBeenCalledTimes(1);
-      vi.setSystemTime(Date.now() + 2_000); // 計 61 秒
+      vi.setSystemTime(Date.now() + 2_000); // 61 seconds total
       await handle.semanticDiff(REQ);
       expect(client.getPrRefs).toHaveBeenCalledTimes(2);
     } finally {
@@ -209,7 +209,7 @@ describe("createHandler", () => {
   });
 
   it("retries the PR context after a failed load instead of caching the failure", async () => {
-    // 一時的なネットワーク失敗が 60 秒キャッシュに乗ると、再トグルしても直らなくなる
+    // If a transient network failure lands in the 60s cache, re-toggling would no longer fix it
     const { deps, client } = makeDeps();
     client.listPrFiles.mockRejectedValueOnce(new Error("socket"));
     const handle = createHandler(deps);
@@ -223,7 +223,7 @@ describe("createHandler", () => {
     await handle.semanticDiff(REQ);
     await handle.semanticDiff(REQ);
     const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === "Assets/Foo.prefab");
-    expect(fooFetches).toHaveLength(2); // base + head の 2 回だけ(2 回目の handle では再フェッチしない)
+    expect(fooFetches).toHaveLength(2); // only twice, base + head (the second handle doesn't re-fetch)
   });
 
   it("resolves remaining guids via code search and persists them", async () => {
@@ -259,7 +259,7 @@ describe("createHandler", () => {
   });
 
   it("does not re-search a missed guid within the worker lifetime", async () => {
-    const { deps, client } = makeDeps(); // search 未ヒット
+    const { deps, client } = makeDeps(); // search misses
     const handle = createHandler(deps);
     await handle.semanticDiff(REQ);
     await handle.semanticDiff(REQ);
@@ -267,20 +267,20 @@ describe("createHandler", () => {
   });
 
   it("serves cached names even for guids that once missed in code search", async () => {
-    // 索引解決が guidCache に入る設計になったため、miss 記録済み guid がキャッシュに現れるケースが実在する。
-    // misses は「再検索しない」の門番であって「名前を出さない」の門番ではない
-    const { deps, client, guidCache } = makeDeps(); // search 未ヒット → g1 が misses に入る
+    // Since index resolutions now land in guidCache, a guid recorded as a miss can genuinely appear in the cache.
+    // misses is the gatekeeper for "don't re-search", not for "don't emit the name"
+    const { deps, client, guidCache } = makeDeps(); // search misses → g1 goes into misses
     const handler = createHandler(deps);
     await handler.semanticDiff(REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
-    guidCache.data["https://api.github.com/o/r"] = { g1: "Assets/Later.cs" }; // 索引解決が後から書いた体
+    guidCache.data["https://api.github.com/o/r"] = { g1: "Assets/Later.cs" }; // as if an index resolution wrote it later
     const res = await handler.semanticDiff(REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/Later.cs" } } });
-    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1); // 再検索はしない
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1); // no re-search
   });
 
   it("dedupes concurrent code searches for the same guid", async () => {
-    // semantic 既定では複数ファイルが同時に解決を走らせる: 同一 guid の検索は 1 回に畳む
+    // With the semantic default, multiple files run resolution concurrently: searches for the same guid fold into one
     const { deps, client } = makeDeps({ search: { g1: "Assets/S.cs" } });
     let release!: (v: string) => void;
     client.searchMetaByGuid.mockImplementation(
@@ -311,7 +311,7 @@ describe("createHandler", () => {
     const proto: DiffV2 = { ...DIFF, unresolvedGuids: ["constructor"] };
     const { deps, client } = makeDeps({ diff: () => proto, cached: { g9: "Assets/X.cs" } });
     const res = await createHandler(deps).semanticDiff(REQ);
-    // 'constructor' はキャッシュヒットではなく検索に回り、未ヒットで未解決のまま
+    // 'constructor' goes to search rather than a cache hit, and stays unresolved after missing
     expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "constructor");
     expect(res).toEqual({ ok: true, json: { ...proto, resolved: {} } });
   });
@@ -324,7 +324,7 @@ describe("createHandler", () => {
   });
 
   it("does not count cached guids against the search cap", async () => {
-    // 12 guid 中 2 つがキャッシュ済みなら、検索枠 10 は未知の 10 guid にまるごと使える
+    // If 2 of 12 guids are cached, the search budget of 10 can be spent entirely on the 10 unknown guids
     const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
     const { deps, client } = makeDeps({ diff: () => many, cached: { g0: "Assets/A.cs", g1: "Assets/B.cs" } });
     const res = await createHandler(deps).semanticDiff(REQ);
@@ -350,14 +350,14 @@ describe("createHandler", () => {
   });
 
   it("returns too-large above 25MB unless forced", async () => {
-    const big = new Uint8Array(13 * 1024 * 1024); // base+head で 26MB
+    const big = new Uint8Array(13 * 1024 * 1024); // 26MB across base+head
     const diff = vi.fn(() => DIFF);
     const { deps, client } = makeDeps({ diff });
     client.getFileAtRef.mockResolvedValue(big);
     const handle = createHandler(deps);
     expect(await handle.semanticDiff(REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
     expect(diff).not.toHaveBeenCalled();
-    // force で描画に進む。blob は sha キャッシュに乗っており再フェッチもない
+    // force proceeds to render. The blob is in the sha cache, so no re-fetch either
     const fetches = client.getFileAtRef.mock.calls.length;
     expect((await handle.semanticDiff({ ...REQ, force: true })).ok).toBe(true);
     expect(diff).toHaveBeenCalledTimes(1);
@@ -378,7 +378,7 @@ describe("createHandler", () => {
   });
 
   describe("source prefab merging", () => {
-    // phase 1 がソース供給を要求する diff。src1 のパスは Code Search で解決される。
+    // A diff where phase 1 requests source supply. src1's path is resolved via Code Search.
     const NEEDS: DiffV2 = {
       ...DIFF,
       unresolvedGuids: ["src1"],
@@ -399,11 +399,11 @@ describe("createHandler", () => {
         },
       });
       const res = await createHandler(deps).semanticDiff(REQ);
-      // side=after なので head からソースを取り、その bytes が assets に載る。
+      // side=after, so the source is fetched from head and its bytes land in assets.
       expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Cyl.prefab", "head-sha");
       const assets = diffWithAssets.mock.calls[0]?.[2];
       expect(new TextDecoder().decode(assets.get("src1")!)).toBe("SRC");
-      // 再 diff 後も resolved は guidCache から復元されて残る。
+      // Even after the re-diff, resolved is restored from guidCache and persists.
       expect(res).toEqual({ ok: true, json: { ...MERGED, resolved: { src1: "Assets/Cyl.prefab" } } });
     });
 
@@ -425,15 +425,15 @@ describe("createHandler", () => {
 
     it("keeps the phase-1 diff when the source path cannot be resolved", async () => {
       const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
-      const { deps } = makeDeps({ diff: () => NEEDS, diffWithAssets }); // search 未ヒット
+      const { deps } = makeDeps({ diff: () => NEEDS, diffWithAssets }); // search misses
       const res = await createHandler(deps).semanticDiff(REQ);
-      // パス不明のソースは諦め、縮退表示(phase 1 の json)のまま返す。
+      // An unknown-path source is given up on, returning the degraded view (phase 1's json) as-is.
       expect(diffWithAssets).not.toHaveBeenCalled();
       expect(res).toEqual({ ok: true, json: { ...NEEDS, resolved: {} } });
     });
 
     it("does not loop when the merged output still needs the same source", async () => {
-      // 供給しても縮退したまま(壊れたソース等)の場合、同じ guid で無限に回らない。
+      // If supplying still leaves it degraded (a broken source, etc.), don't loop forever on the same guid.
       const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => NEEDS);
       const { deps } = makeDeps({
         diff: () => NEEDS,
@@ -451,7 +451,7 @@ describe("createHandler", () => {
     });
 
     it("still merges sources when serving a prefetched diff", async () => {
-      // raw diff だけをキャッシュする設計の要: 後段(resolve → mergeSources)はキャッシュヒットでも毎回走る
+      // The crux of caching only the raw diff: the later stages (resolve → mergeSources) run every time, even on a cache hit
       const withSource: DiffV2 = {
         ...DIFF,
         unresolvedGuids: ["src1"],
@@ -475,10 +475,10 @@ describe("createHandler", () => {
       });
       const handler = createHandler(deps);
       await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
-      expect(diffWithAssets).not.toHaveBeenCalled(); // プリフェッチは raw まで
+      expect(diffWithAssets).not.toHaveBeenCalled(); // prefetch stops at raw
       const res = await handler.semanticDiff(REQ);
       expect(res.ok).toBe(true);
-      expect(diffWithAssets).toHaveBeenCalledTimes(1); // serve 時に合成が走る
+      expect(diffWithAssets).toHaveBeenCalledTimes(1); // merging runs at serve time
     });
   });
 });
@@ -488,11 +488,11 @@ describe("prefetch", () => {
     const { deps, client } = makeDeps();
     const handler = createHandler(deps);
     await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
-    expect(client.searchMetaByGuid).not.toHaveBeenCalled(); // prefetch は 10 req/min の Code Search に触れない
+    expect(client.searchMetaByGuid).not.toHaveBeenCalled(); // prefetch doesn't touch the 10 req/min Code Search
     const fetchesAfterPrefetch = client.getFileAtRef.mock.calls.length;
     const res = await handler.semanticDiff(REQ);
     expect(res.ok).toBe(true);
-    expect(client.getFileAtRef.mock.calls.length).toBe(fetchesAfterPrefetch); // blob 再フェッチなし
+    expect(client.getFileAtRef.mock.calls.length).toBe(fetchesAfterPrefetch); // no blob re-fetch
   });
 
   it("persists prefetched diffs to the diff store (sw restart survival)", async () => {
@@ -502,9 +502,9 @@ describe("prefetch", () => {
   });
 
   it("serves a diff persisted by a previous worker from the store", async () => {
-    // SW は 30 秒で死ぬ: 前世でプリフェッチした結果を storage.session 経由で拾えること
+    // The SW dies after 30 seconds: a result prefetched in a prior life must be recoverable via storage.session
     const { deps, client, diffStore } = makeDeps();
-    diffStore.data["base-sha:head-sha:Assets/Foo.prefab"] = DIFF; // 前世の SW が保存した体でシード
+    diffStore.data["base-sha:head-sha:Assets/Foo.prefab"] = DIFF; // seeded as if saved by a prior SW life
     const res = await createHandler(deps).semanticDiff(REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef).not.toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "base-sha");
@@ -520,7 +520,7 @@ describe("prefetch", () => {
     await createHandler(deps).prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
     const paths = new Set(client.getFileAtRef.mock.calls.map((c) => c[2]));
     expect(paths.has("README.md")).toBe(false);
-    expect(paths.size).toBe(100); // 上限で打ち切り
+    expect(paths.size).toBe(100); // cut off at the cap
   });
 
   it("skips oversized files without caching them", async () => {
@@ -530,7 +530,7 @@ describe("prefetch", () => {
     const handler = createHandler(deps);
     await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
     expect(deps.diffStore.save).not.toHaveBeenCalled();
-    // 後からの手動トグルでは従来通り too-large ゲートが出る
+    // A later manual toggle still shows the too-large gate as before
     expect(await handler.semanticDiff(REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
   });
 
@@ -550,7 +550,7 @@ describe("prefetch", () => {
 });
 
 it("dedupes a concurrent user toggle against an in-flight prefetch compute", async () => {
-  // プリフェッチ中にユーザーがクリックしても diff 計算・blob フェッチが二重にならない
+  // Even if the user clicks during prefetch, diff computation and blob fetches don't double up
   const { deps, client } = makeDeps();
   const handler = createHandler(deps);
   const [, res] = await Promise.all([
@@ -559,14 +559,14 @@ it("dedupes a concurrent user toggle against an in-flight prefetch compute", asy
   ]);
   expect(res.ok).toBe(true);
   const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === "Assets/Foo.prefab");
-  expect(fooFetches).toHaveLength(2); // base + head の 2 回だけ
+  expect(fooFetches).toHaveLength(2); // only twice, base + head
 });
 
 describe("semanticDiff with push (two-stage)", () => {
   it("responds immediately with pending and pushes code-search results in the final json", async () => {
     const { deps, guidCache } = makeDeps({ search: { g1: "Assets/Scripts/S.cs" } });
     const { res, pushes } = await serveAndResolve(createHandler(deps), REQ);
-    // 応答は即返り、resolved は空 + pending。名前は push で届く(B4 の核心)
+    // The response returns immediately with empty resolved + pending. Names arrive via push (the crux of B4)
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: {} }, pending: true });
     const last = pushes.at(-1)!;
     expect(last.done).toBe(true);
@@ -588,7 +588,7 @@ describe("semanticDiff with push (two-stage)", () => {
     });
     const { res, pushes } = await serveAndResolve(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/S.cs" } } });
-    expect(pushes).toEqual([]); // 全部解決済み・ソース合成も不要なら push は無い
+    expect(pushes).toEqual([]); // if everything is resolved and no source merge is needed, there's no push
   });
 
   it("resolves via the repo index and only searches the leftover", async () => {
@@ -599,7 +599,7 @@ describe("semanticDiff with push (two-stage)", () => {
     client.listMetaTree.mockResolvedValue({ truncated: false, metas: [{ path: "Assets/S.cs.meta", sha: "sha1" }] });
     client.batchBlobTexts.mockResolvedValue({ sha1: "guid: g1\n" });
     const { pushes } = await serveAndResolve(createHandler(deps), REQ);
-    // 索引で g1 が先に届き(中間 push)、索引に無い g2 だけが Code Search に回る(3 段解決)
+    // g1 arrives first from the index (intermediate push), and only g2, absent from the index, goes to Code Search (3-stage resolution)
     expect(pushes[0]).toMatchObject({ resolved: { g1: "Assets/S.cs" }, done: false });
     expect(pushes.at(-1)?.json?.resolved).toEqual({ g1: "Assets/S.cs", g2: "Assets/Other.cs" });
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
@@ -619,12 +619,12 @@ describe("semanticDiff with push (two-stage)", () => {
     const handler = createHandler(deps);
     await serveAndResolve(handler, REQ);
     await serveAndResolve(handler, REQ);
-    expect(client.listMetaTree).toHaveBeenCalledTimes(1); // SW 生存期間はフォールバック固定
+    expect(client.listMetaTree).toHaveBeenCalledTimes(1); // pinned to fallback for the SW lifetime
   });
 
   it("re-merges sources in the async stage once the source guid resolves", async () => {
-    // mergeSources 整合の核心: stage 1 は未合成のまま即応答し、
-    // repo index でソース guid が解けたら合成し直した json が最終 push で届く
+    // The crux of mergeSources consistency: stage 1 responds immediately without merging,
+    // and once the repo index resolves the source guid, the re-merged json arrives in the final push
     const withSource: DiffV2 = { ...DIFF, unresolvedGuids: ["src1"], neededSources: [{ guid: "src1", side: "after" }] };
     const merged: DiffV2 = { ...DIFF, unresolvedGuids: ["src1"], resolved: { src1: "Assets/Src.prefab" } };
     const diffWithAssets = vi.fn(() => merged);
@@ -642,13 +642,13 @@ describe("semanticDiff with push (two-stage)", () => {
       metas: [{ path: "Assets/Src.prefab.meta", sha: "sha1" }],
     });
     client.batchBlobTexts.mockResolvedValue({ sha1: "guid: src1\n" });
-    // 注: serveAndResolve は done push を待つため、その後段では diffWithAssets が必ず既に呼ばれている
-    // (done:true は mergeSources 完了後にしか出ない)。「まだ呼ばれていない」の検証は
-    // 即応答の直後(push 完了を待つ前)に行う必要があるため、ここだけ手動で組み立てる。
+    // Note: serveAndResolve waits for the done push, so by that point diffWithAssets has always been called
+    // (done:true is only emitted after mergeSources completes). Asserting "not yet called" must be done
+    // right after the immediate response (before waiting for the push to finish), so this one is assembled manually.
     const pushes: GuidResolvedPush[] = [];
     const res = await createHandler(deps).semanticDiff(REQ, (m) => pushes.push(m));
     expect(res.ok && res.pending).toBe(true);
-    expect(diffWithAssets).not.toHaveBeenCalled(); // stage 1 では合成しない(即応答優先)
+    expect(diffWithAssets).not.toHaveBeenCalled(); // stage 1 doesn't merge (immediate response takes priority)
     await vi.waitFor(() => expect(diffWithAssets).toHaveBeenCalledTimes(1));
     await vi.waitFor(() => expect(pushes.at(-1)?.done).toBe(true));
     expect(pushes.at(-1)?.json).toMatchObject({ resolved: { src1: "Assets/Src.prefab" } });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -27,34 +27,34 @@ export type Handler = {
 type PrContext = { refs: PrRefs; files: PrFile[]; guidIndex: Map<string, string> };
 
 const EMPTY = new Uint8Array(0);
-const MAX_SEARCHES = 10; // Code Search は認証済み 10 req/min — 1 応答で使い切らない
-const MAX_SOURCE_ROUNDS = 3; // 入れ子ソースの再 diff 上限(core 側の深さ上限 8 とは独立)
-const CONTEXT_TTL_MS = 60_000; // push で headSha が変わるため PR コンテキストは短命
+const MAX_SEARCHES = 10; // Code Search is authenticated 10 req/min — don't burn it all in one response
+const MAX_SOURCE_ROUNDS = 3; // re-diff cap for nested sources (independent of core's depth cap of 8)
+const CONTEXT_TTL_MS = 60_000; // PR context is short-lived because a push changes headSha
 const BLOB_CACHE_MAX = 32;
-const TOO_LARGE_BYTES = 25 * 1024 * 1024; // 親仕様 §5.7: 25MB 超はクリックで描画
-const PREFETCH_MAX = 100; // spec B2: 1 PR あたりの先読み上限
+const TOO_LARGE_BYTES = 25 * 1024 * 1024; // parent spec §5.7: over 25MB renders on click
+const PREFETCH_MAX = 100; // spec B2: prefetch cap per PR
 const PREFETCH_CONCURRENCY = 4;
 
 type DiffOutcome = { ok: true; json: DiffV2 } | { ok: false; error: "too-large"; bytes: number };
 
 export function createHandler(deps: Deps): Handler {
-  // PR 単位のコンテキストキャッシュ。SW はいつ殺されてもよく、その場合は再取得するだけ。
+  // Per-PR context cache. The SW may be killed at any time; then we just re-fetch.
   const contexts = new Map<string, { at: number; ctx: Promise<PrContext> }>();
-  // sha+path → bytes の Promise。格納が Promise なので prefetch と手動トグルの同時要求が 1 フェッチに畳まれる。
+  // sha+path → bytes Promise. Storing a Promise folds concurrent prefetch and manual-toggle requests into one fetch.
   const blobs = new Map<string, Promise<Uint8Array | null>>();
-  // Code Search の未ヒット guid。索引遅延があるため永続化せず SW 生存期間のみ
+  // guids that missed in Code Search. Indexing lag means we don't persist these — SW lifetime only
   const misses = new Set<string>();
-  // repoKey:guid → 実行中の検索。同時多発の同一 guid 検索を 1 回に畳む(10 req/min 保護)
+  // repoKey:guid → in-flight search. Folds concurrent searches for the same guid into one (protects the 10 req/min)
   const searches = new Map<string, Promise<string | null>>();
-  // baseSha:headSha:path → raw diff 計算の Promise。成功のみ保持(too-large/失敗は再計算を許す)
+  // baseSha:headSha:path → raw diff computation Promise. Keeps only successes (too-large/failure allow recomputation)
   const diffs = new Map<string, Promise<DiffOutcome>>();
-  // repoKey@ref → repo 全体索引の Promise(Task 11)。null は索引不可(truncated/上限超/失敗)
+  // repoKey@ref → whole-repo index Promise (Task 11). null means not indexable (truncated/over the cap/failure)
   const indexes = new Map<string, Promise<Record<string, string> | null>>();
-  // レート制限を踏んだ repo は SW 生存期間フォールバック(索引を諦めて Code Search のみに委ねる)
+  // A repo that hit a rate limit falls back for the SW lifetime (gives up on the index and defers to Code Search only)
   const indexFallback = new Set<string>();
 
-  /** guid[] をキャッシュ → Code Search の順で解決する(searchUnresolved の中身そのもの)。
-   *  検索の失敗(レート制限含む)で diff は落とさない: 解決できた分だけ返す。 */
+  /** Resolves guid[] in cache → Code Search order (the body of searchUnresolved itself).
+   *  A search failure (including rate limits) doesn't drop the diff: returns only what was resolved. */
   async function searchGuids(
     guids: string[],
     client: ClientLike,
@@ -63,9 +63,9 @@ export function createHandler(deps: Deps): Handler {
     repoKey: string,
   ): Promise<Record<string, string>> {
     if (!guids.length) return {};
-    // hasOwn: guid は任意文字列なので 'constructor' 等が Object.prototype に誤ヒットしない
-    // cached lookup は misses を経由しない全 guid が対象: 索引解決も guidCache に載るため、
-    // misses(検索の門番)に入っていてもキャッシュ済みの名前は必ず出す
+    // hasOwn: guids are arbitrary strings, so 'constructor' etc. don't falsely hit Object.prototype
+    // The cached lookup covers all guids without going through misses: since index resolutions also land in guidCache,
+    // a cached name is always emitted even if it's in misses (the search gatekeeper)
     const cached = await deps.guidCache.load(repoKey);
     const resolved: Record<string, string> = {};
     const unknown: string[] = [];
@@ -82,7 +82,7 @@ export function createHandler(deps: Deps): Handler {
         if (!p) {
           p = client.searchMetaByGuid(owner, repo, g);
           searches.set(key, p);
-          void p.catch(() => {}).then(() => searches.delete(key)); // 完了後は guidCache/misses が引き継ぐ
+          void p.catch(() => {}).then(() => searches.delete(key)); // after completion, guidCache/misses take over
         }
         const path = await p;
         if (path) resolved[g] = found[g] = path;
@@ -96,8 +96,8 @@ export function createHandler(deps: Deps): Handler {
     return resolved;
   }
 
-  /** PR 内 .meta で解決できなかった guid を キャッシュ → Code Search の順で解決する薄いラッパ。
-   *  mergeSources が内部で呼ぶため、シグネチャと挙動を変えない。 */
+  /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search order.
+   *  mergeSources calls it internally, so keep the signature and behavior unchanged. */
   async function searchUnresolved(
     json: DiffV2,
     client: ClientLike,
@@ -111,7 +111,7 @@ export function createHandler(deps: Deps): Handler {
     return { ...json, resolved: { ...resolved, ...found } };
   }
 
-  /** repo 全体の guid 索引を取得・メモ化する。レート制限を踏んだ repo は SW 生存期間フォールバック固定。 */
+  /** Fetches and memoizes the whole-repo guid index. A repo that hit a rate limit is pinned to fallback for the SW lifetime. */
   function getRepoIndex(
     client: ClientLike,
     owner: string,
@@ -124,7 +124,7 @@ export function createHandler(deps: Deps): Handler {
     const hit = indexes.get(key);
     if (hit) return hit;
     const p = syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref).catch((err: unknown) => {
-      indexes.delete(key); // 失敗はキャッシュしない: 次回訪問で再試行
+      indexes.delete(key); // don't cache failures: retry on the next visit
       if (err instanceof RateLimitError) indexFallback.add(repoKey);
       return null;
     });
@@ -140,16 +140,16 @@ export function createHandler(deps: Deps): Handler {
     sha: string,
   ): Promise<Uint8Array | null> {
     const key = `${sha}:${path}`;
-    const hit = blobs.get(key); // 格納値は Promise<Uint8Array | null> なので undefined = 未キャッシュ
+    const hit = blobs.get(key); // the stored value is Promise<Uint8Array | null>, so undefined = not cached
     if (hit !== undefined) return hit;
     const p = client.getFileAtRef(owner, repo, path, sha);
-    p.catch(() => blobs.delete(key)); // 失敗は残さない: 次回呼び出しで再フェッチできる
+    p.catch(() => blobs.delete(key)); // don't keep failures: the next call can re-fetch
     blobs.set(key, p);
     if (blobs.size > BLOB_CACHE_MAX) blobs.delete(blobs.keys().next().value!);
     return p;
   }
 
-  /** before/after の blob を取り出す(status/previousPath の規則は files API 準拠)。 */
+  /** Retrieves the before/after blobs (status/previousPath rules follow the files API). */
   async function fetchPair(
     client: ClientLike,
     ctx: PrContext,
@@ -168,10 +168,10 @@ export function createHandler(deps: Deps): Handler {
     ]);
   }
 
-  /** neededSources(added/removed instance のソース prefab)を resolved パス経由で
-   *  取得し、assets を添えて再 diff する。ソース guid は m_SourcePrefab 参照として
-   *  unresolvedGuids に載るため、パス解決は searchUnresolved が済ませている。
-   *  解決・取得・合成の失敗はその時点の diff で縮退する(全体は落とさない)。 */
+  /** Fetches neededSources (the source prefab of an added/removed instance) via the resolved
+   *  path and re-diffs with assets attached. The source guid rides on unresolvedGuids as an
+   *  m_SourcePrefab reference, so searchUnresolved has already done the path resolution.
+   *  Failure to resolve/fetch/merge degrades to the diff at that point (doesn't drop the whole thing). */
   async function mergeSources(
     first: DiffV2,
     differ: Differ,
@@ -197,7 +197,7 @@ export function createHandler(deps: Deps): Handler {
         try {
           bytes = await fetchBlob(client, owner, repo, path, sha);
         } catch {
-          return current; // rate limit 等: phase 1 の結果で縮退表示
+          return current; // rate limit etc.: degrade to the phase 1 result
         }
         if (!bytes) continue;
         assets.set(s.guid, bytes);
@@ -208,9 +208,9 @@ export function createHandler(deps: Deps): Handler {
       try {
         merged = differ.diffWithAssets(before, after, assets);
       } catch {
-        return current; // 合成失敗はその時点の結果で縮退
+        return current; // a merge failure degrades to the current result
       }
-      // 合成でソース内の外部参照(script/material)が新たに現れるので解決し直す。
+      // Merging surfaces new external references (script/material) inside the source, so resolve again.
       current = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
     }
     return current;
@@ -232,12 +232,12 @@ export function createHandler(deps: Deps): Handler {
       return { refs, files, guidIndex };
     })();
     contexts.set(key, { at: Date.now(), ctx });
-    ctx.catch(() => contexts.delete(key)); // 失敗はキャッシュしない
+    ctx.catch(() => contexts.delete(key)); // don't cache failures
     return ctx;
   }
 
-  /** blob 取得 → 25MB ガード → 素の diff まで。解決や mergeSources はここに入れない
-   *  (resolved は Code Search で後から良くなるため、sha だけで決まる raw diff がキャッシュ単位)。 */
+  /** blob fetch → 25MB guard → plain diff, no further. Don't put resolution or mergeSources here
+   *  (resolved improves later via Code Search, so the raw diff determined by sha alone is the cache unit). */
   async function computeDiff(
     client: ClientLike,
     ctx: PrContext,
@@ -246,7 +246,7 @@ export function createHandler(deps: Deps): Handler {
     path: string,
     force: boolean,
   ): Promise<DiffOutcome> {
-    // 一覧に無い場合(files API は 3000 件で打ち切り)は modified 扱い: 無い側は 404 → EMPTY に落ちるだけ(fetchPair 側の規則)
+    // If not in the listing (the files API cuts off at 3000 entries), treat as modified: the missing side just 404s → EMPTY (fetchPair's rule)
     const [before, after] = await fetchPair(client, ctx, owner, repo, path);
     if (!force && before.length + after.length > TOO_LARGE_BYTES) {
       return { ok: false, error: "too-large", bytes: before.length + after.length };
@@ -255,7 +255,7 @@ export function createHandler(deps: Deps): Handler {
     return { ok: true, json: differ.diff(before, after) };
   }
 
-  /** sha キーなので push されたら自然に別キーになる(無効化不要)。 */
+  /** sha-keyed, so a push naturally produces a different key (no invalidation needed). */
   function getDiff(
     client: ClientLike,
     ctx: PrContext,
@@ -268,7 +268,7 @@ export function createHandler(deps: Deps): Handler {
     const hit = diffs.get(key);
     if (hit) return hit;
     const p = (async (): Promise<DiffOutcome> => {
-      const stored = await deps.diffStore.load(key); // 前世の SW が残した結果
+      const stored = await deps.diffStore.load(key); // a result left by a prior SW life
       if (stored) return { ok: true, json: stored };
       const outcome = await computeDiff(client, ctx, owner, repo, path, force);
       if (outcome.ok) void deps.diffStore.save(key, outcome.json);
@@ -277,15 +277,15 @@ export function createHandler(deps: Deps): Handler {
     diffs.set(key, p);
     p.then(
       (o) => {
-        if (!o.ok) diffs.delete(key); // too-large は force 再計算を許す
+        if (!o.ok) diffs.delete(key); // too-large allows a force recomputation
       },
       () => diffs.delete(key),
     );
     return p;
   }
 
-  /** 3 段解決の続き(索引 → Code Search)とソース再合成を裏で走らせ、push で結果を届ける。
-   *  push 無しの互換経路とは異なり、失敗しても catch で done push を出して待ち手を解放する。 */
+  /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.
+   *  Unlike the push-less compatibility path, on failure it emits a done push in catch to release waiters. */
   async function resolveRemaining(
     first: DiffV2,
     remaining: string[],
@@ -298,7 +298,7 @@ export function createHandler(deps: Deps): Handler {
     const repoKey = `${base}/${req.owner}/${req.repo}`;
     const at = { owner: req.owner, repo: req.repo, prNumber: req.prNumber, path: req.path };
     try {
-      // remaining が空(ソース再合成のみ)なら索引を待たない: 初回索引構築は数十秒かかり得て解決に寄与しない
+      // If remaining is empty (source re-merge only), don't wait on the index: the first index build can take tens of seconds and doesn't help resolution
       const index = remaining.length
         ? await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha)
         : null;
@@ -308,24 +308,24 @@ export function createHandler(deps: Deps): Handler {
         for (const g of remaining) if (Object.hasOwn(index, g)) fromIndex[g] = index[g]!;
         leftover = remaining.filter((g) => !Object.hasOwn(fromIndex, g));
         if (Object.keys(fromIndex).length) {
-          // guidCache にも載せる: mergeSources 内部の searchUnresolved は applyResolved で
-          // resolved を ctx.guidIndex ベースに作り直すため、guidCache 経由でないと索引由来の
-          // 解決がソース再合成後に消える(Code Search 由来が既にこの経路で復元されるのと同じ理屈)。
+          // Also land it in guidCache: searchUnresolved inside mergeSources rebuilds resolved
+          // from ctx.guidIndex via applyResolved, so without going through guidCache the index-derived
+          // resolutions would vanish after the source re-merge (same reasoning as Code-Search-derived ones already restored this way).
           await deps.guidCache.save(repoKey, fromIndex);
-          // 名前が既に出せる分は先に届ける(構造は後続の最終 push で確定)
+          // Deliver the already-available names first (the structure is finalized by the later final push)
           push({ type: "guidResolved", ...at, resolved: fromIndex, done: false });
         }
       }
-      // 索引不可、または索引に無い guid だけが Code Search に回る(spec B3 の 3 段目)
+      // Only guids that aren't indexable or aren't in the index go to Code Search (stage 3 of spec B3)
       const fromSearch = leftover.length ? await searchGuids(leftover, client, req.owner, req.repo, repoKey) : {};
       let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...fromSearch } };
       if (json.neededSources?.length) {
-        // 解決が進んだのでソース合成をやり直す(ソース guid が今回解けたケースを拾う)
+        // Resolution advanced, so redo source merging (picks up the case where the source guid resolved this time)
         const differ = await deps.getDiffer();
         const [before, after] = await fetchPair(client, ctx, req.owner, req.repo, req.path);
         json = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
       }
-      push({ type: "guidResolved", ...at, resolved: {}, json, done: true }); // 最終 push は json 置換
+      push({ type: "guidResolved", ...at, resolved: {}, json, done: true }); // the final push replaces json
     } catch (err) {
       console.debug("prefablens: guid resolution aborted", err);
       push({ type: "guidResolved", ...at, resolved: {}, done: true });
@@ -348,7 +348,7 @@ export function createHandler(deps: Deps): Handler {
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
 
       if (!push) {
-        // 互換経路: 従来の同期フルパイプライン(既存テスト・呼び出しの挙動を変えない)
+        // Compatibility path: the traditional synchronous full pipeline (doesn't change the behavior of existing tests/callers)
         const first = await searchUnresolved(withPr, client, req.owner, req.repo, repoKey);
         if (!first.neededSources?.length) return { ok: true, json: first };
         const differ = await deps.getDiffer();
@@ -359,7 +359,7 @@ export function createHandler(deps: Deps): Handler {
         };
       }
 
-      // 2 段階経路: diff は即返し、解決とソース合成は裏で続けて push で届ける(B4)
+      // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push (B4)
       const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));
       if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
       void resolveRemaining(withPr, remaining, client, req, base, ctx, push);
@@ -368,12 +368,12 @@ export function createHandler(deps: Deps): Handler {
       if (err instanceof RateLimitError) return { ok: false, error: "rate-limited" };
       if (err instanceof AuthError) return { ok: false, error: "auth-failed" };
       if (err instanceof DiffError) return { ok: false, error: "diff-failed" };
-      return { ok: false, error: "fetch-failed" }; // raw エラーは応答に載せない
+      return { ok: false, error: "fetch-failed" }; // don't put raw errors in the response
     }
   }
 
-  /** raw diff のプリコンピュートのみ。resolve/search/mergeSources は行わない
-   *  — Code Search は 10 req/min の希少資源で、mergeSources は解決結果依存のため serve 時に任せる。 */
+  /** Precomputes the raw diff only. No resolve/search/mergeSources
+   *  — Code Search is a scarce 10 req/min resource and mergeSources depends on resolution, so leave them to serve time. */
   async function prefetch(req: PrefetchRequest): Promise<void> {
     try {
       const settings = await deps.getSettings();
@@ -381,7 +381,7 @@ export function createHandler(deps: Deps): Handler {
       const base = apiBase(settings.baseUrl);
       const client = deps.makeClient(base, settings.pat, "prefetch");
       const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
-      // raw diff の先読みとは独立に走らせる(索引 sync は serve 時の 3 段解決を高速化する)
+      // Run independently of raw-diff prefetch (index sync speeds up the 3-stage resolution at serve time)
       void getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
       const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
       for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
@@ -389,14 +389,14 @@ export function createHandler(deps: Deps): Handler {
         await Promise.all(
           chunk.map((f) =>
             getDiff(client, ctx, req.owner, req.repo, f.path, false).catch((err) => {
-              if (err instanceof RateLimitError) throw err; // レート制限だけは全体を止める
-              // ファイル単位の失敗は握りつぶす: 手動トグル時に改めてエラー表示される
+              if (err instanceof RateLimitError) throw err; // only a rate limit stops the whole thing
+              // Swallow per-file failures: the error is shown again on manual toggle
             }),
           ),
         );
       }
     } catch (err) {
-      // プリフェッチは静かに諦める。エラー UI はユーザー操作経路だけが出す
+      // Prefetch gives up quietly. Only the user-action path surfaces error UI
       console.debug("prefablens: prefetch aborted", err);
     }
   }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -7,8 +7,8 @@ import { createQueue } from "./queue";
 
 let differ: Promise<Differ> | undefined;
 
-// REST/GraphQL 全体で同時 6 本(spec B2)。GraphQL も fetchFn 経由なので同じ枠を共有する。
-// ユーザー操作由来は front で行列を追い越す
+// Six concurrent across all REST/GraphQL (spec B2). GraphQL also goes through fetchFn, so it shares the same budget.
+// User-action-originated requests jump the queue via front
 const queue = createQueue(6);
 const queuedFetch =
   (front: boolean): typeof fetch =>
@@ -22,7 +22,7 @@ const handler = createHandler({
   },
   makeClient: (base, token, lane) => new GithubClient(base, token, queuedFetch(lane === "user")),
   getDiffer() {
-    // 遅延シングルトン。SW が再起動したらフェッチし直すだけ。
+    // Lazy singleton. If the SW restarts, just re-fetch.
     differ ??= fetch(chrome.runtime.getURL("prefablens.wasm"))
       .then((r) => r.arrayBuffer())
       .then(createDiffer);
@@ -52,7 +52,7 @@ const handler = createHandler({
       const stored = await chrome.storage.local.get([key]);
       await chrome.storage.local
         .set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } })
-        .catch(() => {}); // quota 超過はメモリのみで続行
+        .catch(() => {}); // on quota overflow, continue in memory only
     },
     async loadIndex(repo) {
       const key = `guidIndex:${repo}`;
@@ -71,8 +71,8 @@ chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendRespon
     const push =
       tabId === undefined ? undefined : (m: GuidResolvedPush) => void chrome.tabs.sendMessage(tabId, m).catch(() => {});
     void handler.semanticDiff(msg, push).then(sendResponse);
-    return true; // 非同期応答
+    return true; // async response
   }
   if (msg?.type === "prefetch") void handler.prefetch(msg);
-  return undefined; // prefetch は応答しない(fire-and-forget)
+  return undefined; // prefetch doesn't respond (fire-and-forget)
 });

--- a/extension/src/background/queue.test.ts
+++ b/extension/src/background/queue.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createQueue } from "./queue";
 
-// 手動で解決できる deferred を並べ、実行順と同時実行数を観測する
+// Line up manually-resolvable deferreds to observe execution order and concurrency
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void;
   const promise = new Promise<void>((r) => {
@@ -25,14 +25,14 @@ describe("createQueue", () => {
       }),
     );
     await new Promise((r) => setTimeout(r, 0));
-    expect(maxActive).toBe(2); // secondary rate limit 回避: 同時 2 本を超えない
+    expect(maxActive).toBe(2); // avoids the secondary rate limit: never exceeds 2 concurrent
     gate.resolve();
     await Promise.all(tasks);
     expect(maxActive).toBe(2);
   });
 
   it("runs front tasks before queued ones", async () => {
-    // ユーザークリックがプリフェッチの行列に並ばされない
+    // A user click isn't made to wait behind the prefetch queue
     const queue = createQueue(1);
     const order: string[] = [];
     const gate = deferred();
@@ -55,7 +55,7 @@ describe("createQueue", () => {
   });
 
   it("keeps pumping after a task rejects", async () => {
-    // 1 つの失敗でキューが詰まると、以降の全フェッチが永久に待つ
+    // If one failure jams the queue, every subsequent fetch waits forever
     const queue = createQueue(1);
     await expect(
       queue(async () => {
@@ -66,7 +66,7 @@ describe("createQueue", () => {
   });
 
   it("normalizes a synchronous throw into a rejection without losing a slot", async () => {
-    // task() が Promise を返す前に throw しても active が漏れない: limit 1 で後続が動けば漏れていない
+    // Even if task() throws before returning a Promise, active doesn't leak: with limit 1, a following task running means nothing leaked
     const queue = createQueue(1);
     const syncThrow = (() => {
       throw new Error("sync boom");
@@ -76,7 +76,7 @@ describe("createQueue", () => {
   });
 
   it("keeps pumping when a queued task throws synchronously on dispatch", async () => {
-    // pump() の .finally 内から起動されるタスクの同期 throw が未処理拒否にならず、呼び出し元の Promise が確定する
+    // A synchronous throw from a task dispatched inside pump()'s .finally doesn't become an unhandled rejection, and the caller's Promise settles
     const queue = createQueue(1);
     const gate = deferred();
     const first = queue(async () => {

--- a/extension/src/background/queue.ts
+++ b/extension/src/background/queue.ts
@@ -2,8 +2,8 @@ type Job = { run: () => Promise<unknown>; resolve: (v: unknown) => void; reject:
 
 export type Queue = <T>(task: () => Promise<T>, opts?: { front?: boolean }) => Promise<T>;
 
-/** REST の同時実行数を絞る(GitHub secondary rate limit はバーストで発動する)。
- *  front はユーザー操作由来の割り込み用: プリフェッチの行列を追い越す。 */
+/** Throttles REST concurrency (GitHub secondary rate limits trigger on bursts).
+ *  front is for user-action interrupts: it jumps the prefetch queue. */
 export function createQueue(limit: number): Queue {
   const pending: Job[] = [];
   let active = 0;
@@ -11,7 +11,7 @@ export function createQueue(limit: number): Queue {
     while (active < limit && pending.length) {
       const job = pending.shift()!;
       active++;
-      // 同期 throw も reject に正規化する: ここで漏れると active が戻らず、キューが永久に詰まる
+      // Normalize even a synchronous throw into a rejection: a leak here leaves active undecremented and jams the queue forever
       Promise.resolve()
         .then(job.run)
         .then(job.resolve, job.reject)

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -35,7 +35,7 @@ describe("parsePrUrl", () => {
 
 describe("parsePrPage", () => {
   it("matches every pr tab, not just files", () => {
-    // プリフェッチは conversation タブ到達時から始める(spec B2)
+    // Prefetch starts on arrival at the conversation tab (spec B2)
     expect(parsePrPage("/o/r/pull/12")).toEqual({ owner: "o", repo: "r", prNumber: 12 });
     expect(parsePrPage("/o/r/pull/12/commits")).toEqual({ owner: "o", repo: "r", prNumber: 12 });
     expect(parsePrPage("/o/r/pull/12/files")).toEqual({ owner: "o", repo: "r", prNumber: 12 });
@@ -61,8 +61,8 @@ describe("scanUnityFiles", () => {
   });
 
   it("finds every UnityYAML asset extension beyond the original trio", () => {
-    // unityyamlmerge が対象とするテキストシリアライズ済みアセット群。
-    // 大文字小文字は Unity の実出力(.overrideController 等の camelCase)に合わせる。
+    // The set of text-serialized assets that unityyamlmerge targets.
+    // Case matches Unity's actual output (camelCase like .overrideController).
     const paths = [
       "Assets/M.mat",
       "Assets/A.anim",
@@ -100,7 +100,7 @@ describe("scanUnityFiles", () => {
   });
 
   it("skips YAML-but-not-UnityYAML and JSON assets", () => {
-    // .meta は !u! ドキュメント形式でなく、.asmdef/.shadergraph は JSON。
+    // .meta is not !u! document format, and .asmdef/.shadergraph are JSON.
     const paths = ["Assets/Foo.prefab.meta", "Assets/Code.asmdef", "Assets/S.shadergraph", "Assets/T.png"];
     document.body.innerHTML = paths
       .map(

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -7,13 +7,13 @@ export function parsePrUrl(pathname: string): { owner: string; repo: string; prN
   return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
 }
 
-/** PR のどのタブでもマッチする(プリフェッチ起点)。files 限定の parsePrUrl とは役割が違う。 */
+/** Matches any PR tab (the prefetch trigger). Different role from the files-only parsePrUrl. */
 export function parsePrPage(pathname: string): { owner: string; repo: string; prNumber: number } | null {
   const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(\/|$)/.exec(pathname);
   return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
 }
 
-// GitHub の Files changed(クラシック DOM)を防御的に探す。合わなければ空配列で無害に終わる。
+// Defensively searches GitHub's Files changed (classic DOM). If it doesn't match, ends harmlessly with an empty array.
 export function scanUnityFiles(root: ParentNode): FileEntry[] {
   const out: FileEntry[] = [];
   for (const header of root.querySelectorAll<HTMLElement>(".file-header[data-path]")) {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -19,19 +19,19 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
   "diff-failed": "Could not compute a semantic diff for this file.",
 };
 
-// path → 描画先。push(guidResolved)が届いたら resolved をマージして再描画する
+// path → render target. When a push (guidResolved) arrives, merge resolved and re-render
 const views = new Map<string, { root: ShadowRoot; json: DiffV2 }>();
 
 function countUnresolved(json: DiffV2): number {
   return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g)).length;
 }
 
-// 全体切り替えの適用先: attach 済みファイルのトグル + 表示を外から駆動する
+// Targets of the global switch: drives the toggle + display of already-attached files from outside
 type Applier = { header: HTMLElement; apply(view: View): void };
 const appliers = new Set<Applier>();
 let globalToggle: Toggle | undefined;
-let currentPr = ""; // 上書きは PR 滞在中のみ有効: PR が変わったら捨てる
-let prefetchedPr = ""; // conversation タブ含む全 PR タブで 1 回だけプリフェッチを送る
+let currentPr = ""; // overrides are valid only while on the PR: discard when the PR changes
+let prefetchedPr = ""; // send prefetch just once across all PR tabs, including the conversation tab
 
 function attach(state: ViewState): void {
   const page = parsePrPage(location.pathname);
@@ -39,7 +39,7 @@ function attach(state: ViewState): void {
   const pageKey = `${page.owner}/${page.repo}#${page.prNumber}`;
   if (pageKey !== prefetchedPr) {
     prefetchedPr = pageKey;
-    // fire-and-forget: 応答は待たず、失敗も無視(手動トグル経路が別に生きている)
+    // fire-and-forget: don't wait on the response, ignore failures (the manual-toggle path is separately alive)
     void (
       chrome.runtime.sendMessage({ type: "prefetch", ...page } satisfies PrefetchRequest) as Promise<unknown>
     ).catch(() => {});
@@ -50,17 +50,17 @@ function attach(state: ViewState): void {
   if (key !== currentPr) {
     currentPr = key;
     state.clearOverrides();
-    // PR をまたいだら死んだ DOM への参照も捨てる(soft leak 防止)
+    // Crossing PRs also drops references to dead DOM (prevents a soft leak)
     for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
-    for (const [k, v] of views) if (!v.root.host.isConnected) views.delete(k); // 遷移で死んだ view への late push を無視するだけでなく参照も切る
+    for (const [k, v] of views) if (!v.root.host.isConnected) views.delete(k); // not only ignore late pushes to views killed by navigation, but also cut the reference
   }
   const entries = scanUnityFiles(document);
   if (entries.length) ensureGlobalToggle(state, entries[0]!);
   for (const entry of entries) attachToggle(state, pr, entry);
 }
 
-/** 最初の Unity ファイルの .file コンテナ直前に全体トグルを 1 つだけ注入する。
- *  ツールバー DOM は GitHub 側の変更が激しいため、確実に存在する .file を錨にする。 */
+/** Injects exactly one global toggle right before the first Unity file's .file container.
+ *  The toolbar DOM changes heavily on GitHub's side, so anchor on the reliably-present .file. */
 function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
   if (globalToggle?.element.closest("[data-prefablens-global]")?.isConnected) return;
   const container = first.header.closest(".file");
@@ -98,7 +98,7 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
       entry.content.after(host);
     }
     host.style.display = "";
-    if (requested) return; // 成功結果のみファイル単位でキャッシュ(再トグルで再フェッチしない)
+    if (requested) return; // cache only successful results per file (re-toggle doesn't re-fetch)
     const root = host.shadowRoot!;
     const request = (force?: boolean): void => {
       requested = true;
@@ -106,10 +106,10 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
       void requestDiff({ type: "semanticDiff", ...pr, path: entry.path, force }).then((res) => {
         if (res.ok) {
           views.set(viewKey, { root, json: res.json });
-          // pending の間は必ず表示する: 名前が全解決でもソース合成が残っていることがある
+          // Always show it while pending: even if all names are resolved, source merging may remain
           return render(root, res.json, { resolving: res.pending ? Math.max(countUnresolved(res.json), 1) : 0 });
         }
-        requested = false; // エラーはキャッシュしない: 次回トグルで再フェッチさせる
+        requested = false; // don't cache errors: let the next toggle re-fetch
         if (res.error === "too-large") renderTooLarge(root, res.bytes, () => request(true));
         else renderError(root, ERROR_TEXT[res.error]);
       });
@@ -118,7 +118,7 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
   };
 
   const toggle = createToggle((view) => {
-    state.setOverride(entry.path, view); // クリックはこのファイルだけの上書き
+    state.setOverride(entry.path, view); // a click overrides just this file
     show(view);
   }, state.effective(entry.path));
   entry.header.append(toggle.element);
@@ -130,8 +130,8 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
     },
   });
 
-  // 既定が semantic なら attach 時点で描画開始: 遅延ロードされたファイルもここを通るので
-  // 「全体は semantic なのに後から来たファイルだけ raw」は起きない
+  // If the default is semantic, start rendering at attach time: lazy-loaded files also pass through here, so
+  // "the global is semantic but a later-arriving file is raw" doesn't happen
   if (state.effective(entry.path) === "semantic") show("semantic");
 }
 
@@ -150,30 +150,30 @@ async function init(): Promise<void> {
     globalToggle?.set(view);
     for (const a of [...appliers]) {
       if (!a.header.isConnected) {
-        appliers.delete(a); // SPA 遷移で死んだ DOM の掃除
+        appliers.delete(a); // clean up DOM killed by an SPA navigation
         continue;
       }
       a.apply(view);
     }
   });
-  // 他タブでの既定変更に追随(set 元タブのエコーは applyExternal 側で無視される)
+  // Follow default changes in other tabs (the echo to the originating set tab is ignored inside applyExternal)
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local") return;
     const next = changes.viewMode?.newValue;
     if (next === "raw" || next === "semantic") state.applyExternal(next);
   });
 
-  // background からの guid 解決 push(2 段階応答の後段): 該当 view があれば再描画する
+  // guid resolution push from background (the second stage of the two-stage response): re-render if the matching view exists
   chrome.runtime.onMessage.addListener((msg: GuidResolvedPush) => {
     if (msg?.type !== "guidResolved") return;
     const view = views.get(`${msg.owner}/${msg.repo}#${msg.prNumber}:${msg.path}`);
-    if (!view) return; // 既に別 PR へ遷移した等: 黙って捨てる
-    // 最終 push は json 置換(mergeSources で構造が変わり得る)、中間 push は resolved のマージ
+    if (!view) return; // already navigated to a different PR, etc.: drop silently
+    // The final push replaces json (mergeSources may change the structure), an intermediate push merges resolved
     view.json = msg.json ?? { ...view.json, resolved: { ...view.json.resolved, ...msg.resolved } };
     render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(countUnresolved(view.json), 1) });
   });
 
-  // GitHub は SPA: 初回スキャン + MutationObserver で遅延ロード・タブ遷移に追従(200ms デバウンス)。
+  // GitHub is an SPA: an initial scan + MutationObserver follows lazy loading and tab navigation (200ms debounce).
   attach(state);
   let scheduled = false;
   new MutationObserver(() => {

--- a/extension/src/content/toggle.test.ts
+++ b/extension/src/content/toggle.test.ts
@@ -18,7 +18,7 @@ describe("createToggle", () => {
   });
 
   it("starts on the given initial view", () => {
-    // 永続既定が semantic のとき、遅延ロードで現れたファイルのトグルも semantic 押下状態で生まれる
+    // When the persistent default is semantic, a lazy-loaded file's toggle is also born in the semantic pressed state
     const toggle = createToggle(vi.fn(), "semantic");
     document.body.append(toggle.element);
     const [raw, semantic] = [...toggle.element.querySelectorAll("button")];
@@ -27,7 +27,7 @@ describe("createToggle", () => {
   });
 
   it("updates visuals via set() without firing onSelect", () => {
-    // 全体トグルからの一括適用: 個別トグルの見た目だけ追随させ、onSelect の副作用(再フェッチ)は起こさない
+    // Bulk apply from the global toggle: only the per-file toggle's look follows along, without triggering onSelect's side effect (re-fetch)
     const onSelect = vi.fn();
     const toggle = createToggle(onSelect);
     document.body.append(toggle.element);

--- a/extension/src/content/toggle.ts
+++ b/extension/src/content/toggle.ts
@@ -8,7 +8,7 @@ export function createToggle(onSelect: (view: View) => void, initial: View = "ra
   wrap.style.cssText = "display:inline-flex;gap:0;margin-left:8px;vertical-align:middle;";
 
   const buttons: HTMLButtonElement[] = [];
-  // set は表示のみ更新する: 全体適用時に onSelect(再フェッチ側)を巻き込まないため
+  // set updates only the display: to avoid pulling in onSelect (the re-fetch side) during a global apply
   const select = (view: View): void => {
     for (const b of buttons) {
       const active = b.dataset.view === view;

--- a/extension/src/content/viewstate.test.ts
+++ b/extension/src/content/viewstate.test.ts
@@ -7,11 +7,11 @@ describe("createViewState", () => {
     expect(state.effective("a.prefab")).toBe("raw");
     state.setOverride("a.prefab", "semantic");
     expect(state.effective("a.prefab")).toBe("semantic");
-    expect(state.effective("b.prefab")).toBe("raw"); // 上書きは対象ファイルだけ
+    expect(state.effective("b.prefab")).toBe("raw"); // an override affects only its target file
   });
 
   it("setDefault persists, clears overrides, and notifies listeners", () => {
-    // 「全体を押したら必ず全ファイルが揃う」の核: 個別上書きは全体トグルでリセットされる
+    // The crux of "pressing global always lines up every file": per-file overrides are reset by the global toggle
     const persist = vi.fn();
     const state = createViewState("raw", persist);
     const listener = vi.fn();
@@ -20,12 +20,12 @@ describe("createViewState", () => {
     state.setDefault("semantic");
     expect(persist).toHaveBeenCalledWith("semantic");
     expect(listener).toHaveBeenCalledWith("semantic");
-    expect(state.effective("a.prefab")).toBe("semantic"); // 上書きは消えている
+    expect(state.effective("a.prefab")).toBe("semantic"); // the override is cleared
   });
 
   it("same-value setDefault still clears overrides without persisting", () => {
-    // 「全体を押したら必ず全部揃う」: 既に押されている側をもう一度押しても上書きは消える。
-    // storage への再書き込みだけはしない(onChanged エコーの無駄打ち防止)
+    // "Pressing global always lines everything up": pressing the already-pressed side again still clears overrides.
+    // Only the rewrite to storage is skipped (avoids a wasted onChanged echo)
     const persist = vi.fn();
     const state = createViewState("semantic", persist);
     const listener = vi.fn();
@@ -38,7 +38,7 @@ describe("createViewState", () => {
   });
 
   it("same-value setDefault with no overrides is a pure no-op", () => {
-    // 上書きが無ければ通知も不要: appliers の全再適用を無駄に走らせない
+    // With no overrides, no notification is needed either: don't wastefully re-apply all appliers
     const persist = vi.fn();
     const state = createViewState("semantic", persist);
     const listener = vi.fn();
@@ -49,19 +49,19 @@ describe("createViewState", () => {
   });
 
   it("applyExternal updates without persisting (storage.onChanged echo)", () => {
-    // storage.onChanged は set した本人のタブでも発火する: 再永続化すると無限ループになる
+    // storage.onChanged fires even on the tab that did the set: re-persisting would cause an infinite loop
     const persist = vi.fn();
     const state = createViewState("raw", persist);
     const listener = vi.fn();
     state.onDefaultChange(listener);
     state.setOverride("a.prefab", "raw");
     state.applyExternal("semantic");
-    expect(state.effective("a.prefab")).toBe("semantic"); // 他タブ由来の切り替えでも全ファイルが揃う
+    expect(state.effective("a.prefab")).toBe("semantic"); // a switch from another tab still lines up every file
     expect(state.defaultView()).toBe("semantic");
     expect(persist).not.toHaveBeenCalled();
     expect(listener).toHaveBeenCalledWith("semantic");
     listener.mockClear();
-    state.applyExternal("semantic"); // 同値エコーは無視
+    state.applyExternal("semantic"); // ignore a same-value echo
     expect(listener).not.toHaveBeenCalled();
   });
 

--- a/extension/src/content/viewstate.ts
+++ b/extension/src/content/viewstate.ts
@@ -10,7 +10,7 @@ export type ViewState = {
   onDefaultChange(fn: (view: View) => void): void;
 };
 
-/** 既定モード(永続)+ ページ滞在中のファイル単位上書き。全体切り替えは上書きを必ずリセットする。 */
+/** Default mode (persistent) + per-file overrides while on the page. A global switch always resets the overrides. */
 export function createViewState(initial: View, persist: (view: View) => void): ViewState {
   let def = initial;
   const overrides = new Map<string, View>();
@@ -27,14 +27,14 @@ export function createViewState(initial: View, persist: (view: View) => void): V
     clearOverrides: () => overrides.clear(),
     setDefault: (view) => {
       if (view === def) {
-        // 同値クリックでも「全体を押したら必ず全部揃う」: 上書きを消して再適用し、storage には書かない
+        // Even a same-value click keeps "pressing global always lines everything up": clear overrides and re-apply, but don't write to storage
         if (overrides.size) change(view);
         return;
       }
       change(view);
       persist(view);
     },
-    // storage.onChanged は set 元のタブでも発火するため、同値は無視して永続化もしない
+    // storage.onChanged fires even on the originating set tab, so ignore a same value and don't persist
     applyExternal: (view) => {
       if (view !== def) change(view);
     },

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { ApiError, AuthError, apiBase, GithubClient, graphqlUrl, RateLimitError } from "./client";
 
-// パス→レスポンスの固定表を返す fetch フェイク。呼び出しも記録する。
-// 照合は url.includes(key) なのでキーは一意な部分文字列にすること
-// (例: 'page=1' は 'per_page=100' にもマッチしてしまう — '&page=1' を使う)。
+// fetch fake that returns a fixed path→response table. It also records calls.
+// Matching is url.includes(key), so keys must be unique substrings
+// (e.g. 'page=1' also matches 'per_page=100' — use '&page=1').
 function fakeFetch(routes: Record<string, () => Response>) {
   const calls: Array<{ url: string; headers: Record<string, string> }> = [];
   const fn = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -29,7 +29,7 @@ describe("apiBase", () => {
     expect(apiBase("https://ghe.example.com")).toBe("https://ghe.example.com/api/v3");
   });
   it("tolerates scheme-less and trailing-slash input from the options form", () => {
-    // "github.com" と入力すると new URL が throw し fetch-failed に化けていた実障害の回帰テスト
+    // Regression test for a real bug where entering "github.com" made new URL throw and turned into fetch-failed
     expect(apiBase("github.com")).toBe("https://api.github.com");
     expect(apiBase("github.com/")).toBe("https://api.github.com");
     expect(apiBase("https://github.com/")).toBe("https://api.github.com");
@@ -39,8 +39,8 @@ describe("apiBase", () => {
 
 describe("GithubClient", () => {
   it("default fetchFn survives strict-this runtimes (Chrome Illegal invocation)", async () => {
-    // Chrome の fetch はグローバル以外の this で呼ばれると Illegal invocation を投げる。
-    // Node の fetch は this を無視するため、この strict スタブで実機挙動を模す。
+    // Chrome's fetch throws Illegal invocation when called with a non-global this.
+    // Node's fetch ignores this, so this strict stub mimics the real-runtime behavior.
     const realFetch = globalThis.fetch;
     function strictFetch(this: unknown, ..._args: Parameters<typeof fetch>) {
       if (this !== undefined && this !== globalThis) {
@@ -50,7 +50,7 @@ describe("GithubClient", () => {
     }
     globalThis.fetch = strictFetch as typeof fetch;
     try {
-      const client = new GithubClient("https://api.github.com", "tok"); // fetchFn 省略 = 既定値
+      const client = new GithubClient("https://api.github.com", "tok"); // fetchFn omitted = default
       await expect(client.getFileAtRef("o", "r", "a.prefab", "sha")).resolves.not.toBeNull();
     } finally {
       globalThis.fetch = realFetch;
@@ -127,7 +127,7 @@ describe("GithubClient", () => {
       fakeFetch({ "/search/code": () => json({ items: [{ path: "README.md" }] }) }).fn,
     );
     expect(await odd.searchMetaByGuid("o", "r", "g")).toBeNull();
-    // 422: リポジトリ未インデックス等。ApiError ではなく「未解決」として扱う
+    // 422: repository not indexed, etc. Treated as "unresolved" rather than an ApiError
     const unindexed = new GithubClient(
       "https://api.github.com",
       "tok",
@@ -146,9 +146,9 @@ describe("GithubClient", () => {
   });
 
   it("maps rate-limit responses to RateLimitError, not AuthError", async () => {
-    // GitHub の rate limit: primary は 403 + x-ratelimit-remaining: 0、
-    // secondary は 403 + retry-after、新しめの API は 429。
-    // secondary はヘッダなし(ボディの message のみ)のこともある — octokit も message で判定している。
+    // GitHub rate limits: primary is 403 + x-ratelimit-remaining: 0,
+    // secondary is 403 + retry-after, and newer APIs use 429.
+    // secondary sometimes has no header (only the body message) — octokit also decides by the message.
     const at = (status: number, headers: Record<string, string>, body = "") =>
       new GithubClient(
         "https://api.github.com",
@@ -167,7 +167,7 @@ describe("GithubClient", () => {
         1,
       ),
     ).rejects.toBeInstanceOf(RateLimitError);
-    // 権限系 403(rate limit ではない)は引き続き AuthError
+    // Permission-related 403 (not a rate limit) is still AuthError
     await expect(
       at(
         403,
@@ -194,9 +194,9 @@ describe("listMetaTree", () => {
             truncated: false,
             tree: [
               { path: "Assets/S.cs.meta", type: "blob", sha: "sha1" },
-              { path: "Assets/S.cs", type: "blob", sha: "sha2" }, // .meta 以外は除外
+              { path: "Assets/S.cs", type: "blob", sha: "sha2" }, // non-.meta is excluded
               { path: "Assets/Dir.meta", type: "blob", sha: "sha3" },
-              { path: "Assets", type: "tree", sha: "sha4" }, // tree ノードは除外
+              { path: "Assets", type: "tree", sha: "sha4" }, // tree nodes are excluded
             ],
           }),
           { status: 200 },
@@ -225,17 +225,17 @@ describe("batchBlobTexts", () => {
     );
     const client = new GithubClient("https://ghes.example.com/api/v3", "tok", fetchFn);
     const res = await client.batchBlobTexts("o", "r", ["sha1", "sha2"]);
-    expect(fetchFn.mock.calls[0]?.[0]).toBe("https://ghes.example.com/api/graphql"); // GHES は /api/graphql
+    expect(fetchFn.mock.calls[0]?.[0]).toBe("https://ghes.example.com/api/graphql"); // GHES uses /api/graphql
     const init = fetchFn.mock.calls[0]?.[1] as RequestInit;
     expect(init.method).toBe("POST");
     const body = JSON.parse(init.body as string) as { query: string };
     expect(body.query).toContain('b0: object(oid: "sha1")');
     expect(body.query).toContain('b1: object(oid: "sha2")');
-    expect(res).toEqual({ sha1: "guid: g1\n", sha2: null }); // 取得不可の blob は null
+    expect(res).toEqual({ sha1: "guid: g1\n", sha2: null }); // an unfetchable blob is null
   });
 
   it("maps graphql RATE_LIMITED errors to RateLimitError", async () => {
-    // GraphQL は HTTP 200 で errors 配列を返すことがある: ここを見逃すと索引が黙って空になる
+    // GraphQL can return an errors array with HTTP 200: missing this silently empties the index
     const fetchFn = vi.fn(
       async () => new Response(JSON.stringify({ errors: [{ type: "RATE_LIMITED" }] }), { status: 200 }),
     );

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -2,15 +2,15 @@ export class AuthError extends Error {}
 export class RateLimitError extends Error {}
 export class ApiError extends Error {
   constructor(readonly status: number) {
-    super(`GitHub API error (HTTP ${status})`); // raw ボディは持たない(漏洩防止)
+    super(`GitHub API error (HTTP ${status})`); // does not carry the raw body (leak prevention)
   }
 }
 
 export type PrFile = { path: string; status: string; previousPath?: string };
 export type PrRefs = { baseSha: string; headSha: string };
 
-// Options フォームの入力はスキームなし("github.com")のことがある。
-// 素の new URL は throw し、握りつぶされて fetch-failed に化けるため補完する。
+// Input from the Options form may be scheme-less ("github.com").
+// A bare new URL throws and gets swallowed into fetch-failed, so we fill in the scheme.
 export function originOf(baseUrl: string): string {
   const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(baseUrl) ? baseUrl : `https://${baseUrl}`;
   return new URL(withScheme).origin;
@@ -22,8 +22,8 @@ export function apiBase(baseUrl: string | undefined): string {
   return origin === "https://github.com" ? "https://api.github.com" : `${origin}/api/v3`;
 }
 
-/** REST の base から GraphQL エンドポイントを導く。GHES は /api/v3 → /api/graphql。
- *  引数名は apiBase 関数と紛れないよう restBase とする。 */
+/** Derives the GraphQL endpoint from the REST base. GHES: /api/v3 → /api/graphql.
+ *  The argument is named restBase to avoid confusion with the apiBase function. */
 export function graphqlUrl(restBase: string): string {
   return restBase.endsWith("/api/v3") ? `${restBase.slice(0, -"/api/v3".length)}/api/graphql` : `${restBase}/graphql`;
 }
@@ -32,16 +32,16 @@ export class GithubClient {
   constructor(
     private readonly base: string,
     private readonly token: string,
-    // 素の `fetch` を既定値にすると `this.fetchFn(...)` の this がインスタンスになり
-    // Chrome では Illegal invocation で落ちる(Node の fetch は this を無視する)。
+    // Defaulting to bare `fetch` makes `this` in `this.fetchFn(...)` the instance,
+    // which fails with Illegal invocation on Chrome (Node's fetch ignores this).
     private readonly fetchFn: typeof fetch = (input, init) => fetch(input, init),
   ) {}
 
   private async rawRequest(url: string, init: RequestInit): Promise<Response> {
     const res = await this.fetchFn(url, init);
     if (res.status === 403 || res.status === 429) {
-      // primary は 403 + x-ratelimit-remaining: 0、secondary は 403 + retry-after または
-      // ヘッダなし(ボディの message のみ)、新 API は 429。ボディは分類にだけ使い、保持しない。
+      // primary is 403 + x-ratelimit-remaining: 0, secondary is 403 + retry-after or
+      // no header (only the body message), newer API is 429. The body is used only for classification, not retained.
       const body = await res.text().catch(() => "");
       const rateLimited =
         res.status === 429 ||
@@ -71,7 +71,7 @@ export class GithubClient {
     return res.json() as Promise<T>;
   }
 
-  // before 側は merge-base: GitHub の PR diff は base ブランチ先端ではなく merge-base 比較。
+  // The before side is the merge-base: GitHub's PR diff compares against the merge-base, not the base branch tip.
   async getPrRefs(owner: string, repo: string, prNumber: number): Promise<PrRefs> {
     const pr = await this.json<{ base: { sha: string }; head: { sha: string } }>(
       `/repos/${owner}/${repo}/pulls/${prNumber}`,
@@ -93,8 +93,8 @@ export class GithubClient {
     }
   }
 
-  /** Code Search で guid → asset path(.meta を剥いだもの)を引く。未ヒット・未インデックス(422)は null。
-   *  legacy 構文(extension:meta)= GHES 互換。索引はデフォルトブランチのみ・認証済み 10 req/min。 */
+  /** Looks up guid → asset path (with .meta stripped) via Code Search. No hit / not indexed (422) → null.
+   *  legacy syntax (extension:meta) = GHES-compatible. The index covers only the default branch, authenticated 10 req/min. */
   async searchMetaByGuid(owner: string, repo: string, guid: string): Promise<string | null> {
     const q = encodeURIComponent(`"${guid}" repo:${owner}/${repo} extension:meta`);
     const res = await this.request(`/search/code?q=${q}&per_page=1`, "application/vnd.github+json");
@@ -104,7 +104,7 @@ export class GithubClient {
     return path?.endsWith(".meta") ? path.slice(0, -".meta".length) : null;
   }
 
-  /** ref 時点の生バイト列。その側にファイルが無ければ null。 */
+  /** Raw bytes at ref. null if the file is absent on that side. */
   async getFileAtRef(owner: string, repo: string, path: string, ref: string): Promise<Uint8Array | null> {
     const encoded = path.split("/").map(encodeURIComponent).join("/");
     const res = await this.request(
@@ -116,7 +116,7 @@ export class GithubClient {
     return new Uint8Array(await res.arrayBuffer());
   }
 
-  /** ref(commit SHA 可)時点の全 .meta の path + blob SHA。truncated は 10 万エントリ超の打ち切り。 */
+  /** path + blob SHA of every .meta at ref (a commit SHA is allowed). truncated means the listing was cut off past 100k entries. */
   async listMetaTree(
     owner: string,
     repo: string,
@@ -131,7 +131,7 @@ export class GithubClient {
     return { truncated: body.truncated, metas };
   }
 
-  /** GraphQL で blob text を一括取得(分割は呼び出し側)。GraphQL は 5,000 pt/h の独立枠。 */
+  /** Batch-fetches blob text via GraphQL (chunking is the caller's job). GraphQL has an independent 5,000 pt/h budget. */
   async batchBlobTexts(owner: string, repo: string, oids: string[]): Promise<Record<string, string | null>> {
     const aliases = oids
       .map((oid, i) => `b${i}: object(oid: ${JSON.stringify(oid)}) { ... on Blob { text } }`)
@@ -151,7 +151,7 @@ export class GithubClient {
       data?: { repository?: Record<string, { text?: string | null } | null> } | null;
       errors?: Array<{ type?: string }>;
     };
-    // GraphQL は HTTP 200 のまま errors を返す: RATE_LIMITED はここで拾う
+    // GraphQL returns errors while still HTTP 200: RATE_LIMITED is caught here
     if (body.errors?.some((e) => e.type === "RATE_LIMITED")) throw new RateLimitError("GitHub rate limit exceeded");
     const blobs = body.data?.repository;
     if (!blobs) throw new ApiError(res.status);

--- a/extension/src/github/guids.test.ts
+++ b/extension/src/github/guids.test.ts
@@ -36,7 +36,7 @@ describe("buildGuidIndex", () => {
     expect(index.get("oldguid")).toBe("Assets/Old.cs");
     expect(fetched).toContainEqual(["Assets/Scripts/Player.cs.meta", "head"]);
     expect(fetched).toContainEqual(["Assets/Old.cs.meta", "base"]);
-    expect(fetched).toHaveLength(2); // .meta 以外は fetch しない
+    expect(fetched).toHaveLength(2); // does not fetch anything but .meta
   });
 
   it("skips metas that fail to fetch or parse", async () => {
@@ -47,7 +47,7 @@ describe("buildGuidIndex", () => {
   });
 
   it("propagates rate limits instead of degrading the index silently", async () => {
-    // 握りつぶすと劣化インデックスが SW 生存期間キャッシュされ、再トグルでも直らない
+    // Swallowing would cache a degraded index for the SW's lifetime, and re-toggling would not fix it
     await expect(
       buildGuidIndex(files, async () => {
         throw new RateLimitError("limited");
@@ -89,8 +89,8 @@ describe("applyResolved", () => {
       ["zzz", "Assets/Z.cs"],
     ]);
     const out = applyResolved(diff, index);
-    expect(out.resolved).toEqual({ aaa: "Assets/A.cs" }); // bbb 未解決、zzz は参照外
-    expect(out).not.toBe(diff); // 入力は破壊しない
+    expect(out.resolved).toEqual({ aaa: "Assets/A.cs" }); // bbb unresolved, zzz not referenced
+    expect(out).not.toBe(diff); // does not mutate the input
     expect(diff.resolved).toBeUndefined();
   });
 });

--- a/extension/src/github/guids.ts
+++ b/extension/src/github/guids.ts
@@ -1,7 +1,7 @@
 import type { DiffV2 } from "../types";
 import { type PrFile, RateLimitError } from "./client";
 
-/** cli/src/resolve.zig の parseGuid と同じ規則: 行頭(trim 後)の "guid:" を拾う。 */
+/** Same rule as parseGuid in cli/src/resolve.zig: picks up "guid:" at the start of a line (after trim). */
 export function parseGuidFromMeta(meta: string): string | undefined {
   for (const line of meta.split("\n")) {
     const t = line.trim();
@@ -12,8 +12,8 @@ export function parseGuidFromMeta(meta: string): string | undefined {
 
 export type MetaFetcher = (path: string, side: "base" | "head") => Promise<string | null>;
 
-/** Code Search で解決した guid→asset path の永続キャッシュ(repo キーは `<apiBase>/<owner>/<repo>`)。
- *  guid→path は安定なので TTL なし。save はマージ。 */
+/** Persistent cache of guid→asset path resolved via Code Search (repo key is `<apiBase>/<owner>/<repo>`).
+ *  guid→path is stable, so no TTL. save merges. */
 export type GuidCache = {
   load(repo: string): Promise<Record<string, string>>;
   save(repo: string, entries: Record<string, string>): Promise<void>;
@@ -21,15 +21,15 @@ export type GuidCache = {
 
 const MAX_CONCURRENT_META_FETCHES = 8;
 
-/** PR 内で変更された .meta のみから guid → asset path 索引を作る(設計スコープ)。removed は base 側から読む。
- *  同時フェッチ数を上限 8 に抑える(大量 .meta 変更での GitHub secondary rate limit 回避)。 */
+/** Builds a guid → asset path index only from .meta files changed in the PR (design scope). removed ones are read from the base side.
+ *  Caps concurrent fetches at 8 (avoids GitHub secondary rate limits on large .meta changes). */
 export async function buildGuidIndex(files: PrFile[], fetchMeta: MetaFetcher): Promise<Map<string, string>> {
   const index = new Map<string, string>();
   const metas = files.filter((f) => f.path.endsWith(".meta"));
 
   const indexOne = async (f: PrFile): Promise<void> => {
     const side = f.status === "removed" ? "base" : "head";
-    // rate limit だけは伝播させる: 握りつぶすと劣化インデックスが SW 生存期間キャッシュされる
+    // Only rate limits propagate: swallowing them would cache a degraded index for the SW's lifetime
     const text = await fetchMeta(f.path, side).catch((err) => {
       if (err instanceof RateLimitError) throw err;
       return null;
@@ -47,7 +47,7 @@ export async function buildGuidIndex(files: PrFile[], fetchMeta: MetaFetcher): P
   return index;
 }
 
-/** ホスト側解決の seam(親仕様 §4.3)。core の "resolved" と同じスコープ規則で付与する。 */
+/** Host-side resolution seam (parent spec §4.3). Attaches with the same scoping rule as core's "resolved". */
 export function applyResolved(diff: DiffV2, index: Map<string, string>): DiffV2 {
   const resolved: Record<string, string> = {};
   for (const g of diff.unresolvedGuids) {

--- a/extension/src/github/repoIndex.test.ts
+++ b/extension/src/github/repoIndex.test.ts
@@ -37,13 +37,13 @@ describe("syncRepoIndex", () => {
   it("builds guid → asset path from meta blobs and persists both layers", async () => {
     const { client, store } = makeFakes({ texts: { sha1: "fileFormatVersion: 2\nguid: g1\n" } });
     const res = await syncRepoIndex(client, store, "o", "r", "repoKey", "H");
-    expect(res).toEqual({ g1: "Assets/S.cs" }); // .meta を剥いだパス
+    expect(res).toEqual({ g1: "Assets/S.cs" }); // path with .meta stripped
     expect(store.saveGuids).toHaveBeenCalledWith("repoKey", { sha1: "g1" });
     expect(store.saveIndex).toHaveBeenCalledWith("repoKey", { treeSha: "H", guids: { g1: "Assets/S.cs" } });
   });
 
   it("returns the stored index without any api call when the tree sha is unchanged", async () => {
-    // push が無ければ tree も blob も取り直さない(2 回目以降の訪問はゼロコスト)
+    // Without a push, neither the tree nor blobs are re-fetched (repeat visits are zero-cost)
     const stored = { treeSha: "H", guids: { g1: "Assets/S.cs" } };
     const { client, store } = makeFakes({ storedIndex: stored });
     const res = await syncRepoIndex(client, store, "o", "r", "repoKey", "H");
@@ -52,7 +52,7 @@ describe("syncRepoIndex", () => {
   });
 
   it("fetches only meta blobs missing from the persistent sha cache", async () => {
-    // blobSha → guid は内容由来の永久キャッシュ: 変わった .meta だけ GraphQL に回る
+    // blobSha → guid is a content-derived permanent cache: only changed .meta go through GraphQL
     const { client, store } = makeFakes({
       metas: [
         { path: "Assets/A.cs.meta", sha: "known-sha" },

--- a/extension/src/github/repoIndex.ts
+++ b/extension/src/github/repoIndex.ts
@@ -10,11 +10,11 @@ export type RepoIndexStore = {
   saveIndex(repo: string, index: { treeSha: string; guids: Record<string, string> }): Promise<void>;
 };
 
-const INDEX_MAX_METAS = 50_000; // spec B3: これ超は storage quota 保護で索引を諦める
+const INDEX_MAX_METAS = 50_000; // spec B3: above this, give up on the index to protect the storage quota
 const GRAPHQL_BATCH = 100;
 
-/** repo 全体の guid → asset path 索引。索引不可(truncated / 上限超)は null で Code Search に委ねる。
- *  blobSha → guid は内容由来なので永久キャッシュでき、push 後は変わった .meta だけ取得する。 */
+/** Whole-repo guid → asset path index. Not indexable (truncated / over the cap) → null, deferring to Code Search.
+ *  blobSha → guid is content-derived, so it can be cached forever; after a push, only changed .meta are fetched. */
 export async function syncRepoIndex(
   client: ClientLike,
   store: RepoIndexStore,
@@ -28,7 +28,7 @@ export async function syncRepoIndex(
   const tree = await client.listMetaTree(owner, repo, ref);
   if (tree.truncated || tree.metas.length > INDEX_MAX_METAS) return null;
   const known = await store.loadGuids(repoKey);
-  // hasOwn: guid キャッシュ同様、プロトタイプ誤ヒットを避ける
+  // hasOwn: like the guid cache, avoids false prototype hits
   const missing = tree.metas.filter((m) => !Object.hasOwn(known, m.sha));
   const fetched: Record<string, string> = {};
   for (let i = 0; i < missing.length; i += GRAPHQL_BATCH) {
@@ -40,7 +40,7 @@ export async function syncRepoIndex(
     );
     for (const m of chunk) {
       const text = texts[m.sha];
-      if (!text) continue; // バイナリ・取得不可はスキップ
+      if (!text) continue; // skip binary / unfetchable
       const guid = parseGuidFromMeta(text);
       if (guid) fetched[m.sha] = guid;
     }

--- a/extension/src/options/ghes.test.ts
+++ b/extension/src/options/ghes.test.ts
@@ -48,7 +48,7 @@ describe("applyGhes", () => {
     const c = fakeChrome(false);
     expect(await applyGhes("ghe.corp.com", c)).toBe("declined");
     expect(c.scripting.registerContentScripts).not.toHaveBeenCalled();
-    // 拒否でも旧 GHES 向けの stale な登録は掃除する
+    // Even on denial, clean up stale registration for an old GHES
     expect(c.scripting.unregisterContentScripts).toHaveBeenCalledWith({ ids: ["prefablens-ghes"] });
   });
 

--- a/extension/src/options/ghes.ts
+++ b/extension/src/options/ghes.ts
@@ -10,7 +10,7 @@ export type ChromeGhes = {
 
 const ID = "prefablens-ghes";
 
-/** baseUrl が GHES を指すときの content script 注入対象。match pattern はポート不可(ポートなしは全ポート一致)。 */
+/** The content-script injection target when baseUrl points at GHES. A match pattern can't include a port (port-less matches all ports). */
 export function ghesOrigins(baseUrl: string): string[] | null {
   if (!baseUrl) return null;
   const origin = originOf(baseUrl);
@@ -19,12 +19,12 @@ export function ghesOrigins(baseUrl: string): string[] | null {
   return [`${u.protocol}//${u.hostname}/*`];
 }
 
-/** Save クリック(user gesture)内で呼ぶ: 権限要求 → content script 動的登録。登録は永続なので起動時処理は不要。
- *  permissions.request は gesture 失効を避けるため他の await より先に呼ぶ。 */
+/** Call inside the Save click (user gesture): permission request → dynamic content-script registration. Registration persists, so no startup handling is needed.
+ *  Call permissions.request before any other await to avoid the gesture expiring. */
 export async function applyGhes(baseUrl: string, c: ChromeGhes): Promise<"ok" | "declined"> {
-  const origins = ghesOrigins(baseUrl); // 不正 URL はここで throw → 呼び出し側が 'failed' 扱い
+  const origins = ghesOrigins(baseUrl); // an invalid URL throws here → the caller treats it as 'failed'
   const granted = !origins || (await c.permissions.request({ origins }));
-  await c.scripting.unregisterContentScripts({ ids: [ID] }).catch(() => {}); // 未登録だと reject する
+  await c.scripting.unregisterContentScripts({ ids: [ID] }).catch(() => {}); // rejects if not registered
   if (!origins) return "ok";
   if (!granted) return "declined";
   await c.scripting.registerContentScripts([{ id: ID, matches: origins, js: ["content.js"], runAt: "document_idle" }]);

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -26,7 +26,7 @@ function fakeGhes(granted = true) {
   } satisfies ChromeGhes;
 }
 
-// click ハンドラの async チェーンが status を書き終わるまで待つ(マクロタスクで flush)
+// Wait until the click handler's async chain finishes writing status (flush via a macrotask)
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe("initOptions", () => {
@@ -75,10 +75,10 @@ describe("initOptions", () => {
     const storage = fakeStorage();
     await initOptions(document, storage, fakeGhes());
     document.querySelector<HTMLInputElement>("#pat")!.value = "tok";
-    document.querySelector<HTMLInputElement>("#baseUrl")!.value = "https://"; // originOf が throw する不正 URL
+    document.querySelector<HTMLInputElement>("#baseUrl")!.value = "https://"; // an invalid URL that makes originOf throw
     document.querySelector<HTMLButtonElement>("#save")?.click();
     await flush();
-    expect(storage.data.pat).toBe("tok"); // PAT は捨てない
+    expect(storage.data.pat).toBe("tok"); // don't discard the PAT
     expect(document.querySelector("#status")?.textContent).toBe("Saved (GHES setup failed)");
   });
 
@@ -93,7 +93,7 @@ describe("initOptions", () => {
     document.querySelector<HTMLInputElement>("#baseUrl")!.value = "ghe.corp.com";
     document.querySelector<HTMLButtonElement>("#save")?.click();
     await flush();
-    // 保存に失敗したのに登録だけ進む中途半端な状態を作らない
+    // Don't create a half-done state where the save fails but registration proceeds anyway
     expect(ghes.scripting.registerContentScripts).not.toHaveBeenCalled();
     expect(document.querySelector("#status")?.textContent).toBe("Save failed");
   });

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -1,6 +1,6 @@
 import { applyGhes, type ChromeGhes } from "./ghes";
 
-// フォーム本体を TS 側に持つ: options.html と jsdom テストで同一マークアップを共有する。
+// Keep the form body on the TS side: options.html and the jsdom tests share the same markup.
 export const OPTIONS_BODY = `
   <h1>PrefabLens</h1>
   <p>
@@ -33,7 +33,7 @@ export async function initOptions(doc: Document, storage: StorageLike, ghes?: Ch
 
   doc.querySelector<HTMLButtonElement>("#save")?.addEventListener("click", () => {
     void (async () => {
-      // 保存が最優先: GHES 登録の失敗で設定(特に PAT)を捨てない
+      // Saving comes first: a GHES registration failure must not discard settings (especially the PAT)
       await storage.set({ pat: pat.value.trim(), baseUrl: baseUrl.value.trim() });
       const grant = ghes ? await applyGhes(baseUrl.value.trim(), ghes).catch(() => "failed" as const) : "ok";
       status.textContent =
@@ -43,7 +43,7 @@ export async function initOptions(doc: Document, storage: StorageLike, ghes?: Ch
             ? "Saved (host permission declined)"
             : "Saved (GHES setup failed)";
     })().catch(() => {
-      status.textContent = "Save failed"; // ここに来るのは storage 失敗のみ
+      status.textContent = "Save failed"; // only a storage failure reaches here
     });
   });
 }

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -172,7 +172,7 @@ describe("render", () => {
     expect(text).toContain("components");
     expect(text).toContain("Transform");
     expect(text).toContain("Position");
-    // override カードは開いている。
+    // The override card is open.
     const card = root.querySelector(".pl-components details") as HTMLDetailsElement;
     expect(card.open).toBe(true);
   });
@@ -203,7 +203,7 @@ describe("render", () => {
     const card = root.querySelector(".pl-components details") as HTMLDetailsElement;
     expect(card.classList.contains("pl-modified")).toBe(true);
     expect(card.querySelector("summary .pl-badge")?.textContent).toBe("~");
-    // 行自体は元の status のまま。
+    // The rows themselves keep their original status.
     expect(card.querySelector(".pl-field.pl-added")?.textContent).toContain("Scale.y");
   });
 
@@ -275,10 +275,10 @@ describe("render", () => {
     render(root, diff);
     const cards = [...root.querySelectorAll(".pl-components > details")] as HTMLDetailsElement[];
     expect(cards).toHaveLength(2);
-    // added を閉じると「Cylinder1 だけ折り畳まれる」非対称な見え方になるため、状態によらず常に開く
-    expect(cards[0]?.open).toBe(true); // added Cylinder1 も開
-    expect(cards[0]?.textContent).toContain("Cylinder1"); // className フォールバック
-    expect(cards[1]?.open).toBe(true); // modified Transform は開
+    // Closing added would look asymmetric ("only Cylinder1 collapsed"), so always open regardless of status
+    expect(cards[0]?.open).toBe(true); // added Cylinder1 is open too
+    expect(cards[0]?.textContent).toContain("Cylinder1"); // className fallback
+    expect(cards[1]?.open).toBe(true); // modified Transform is open
   });
 
   it("falls back instance name to resolved source prefab stem", () => {
@@ -340,7 +340,7 @@ describe("render", () => {
   });
 
   it("drops the indicator on re-render after resolution completes", () => {
-    // push の done で再描画されたときに消えること(mount が全置換するので自然に消える)
+    // It disappears when re-rendered on the push's done (mount fully replaces, so it naturally goes away)
     const root = freshRoot();
     const diff = { schema: "prefablens.diff.v2" as const, unresolvedGuids: ["g1"], roots: [], loose: [] };
     render(root, diff, { resolving: 1 });
@@ -383,9 +383,9 @@ describe("detectTheme", () => {
   });
 
   it("follows the OS scheme via matchMedia when data-color-mode is auto", () => {
-    // GitHub の既定は auto: dark/light どちらでもない値は matchMedia に委ねる
+    // GitHub's default is auto: a value that is neither dark nor light defers to matchMedia
     document.documentElement.setAttribute("data-color-mode", "auto");
-    expect(detectTheme(document)).toBe("light"); // jsdom に matchMedia は無い → light に倒す
+    expect(detectTheme(document)).toBe("light"); // jsdom has no matchMedia → fall back to light
     const win = document.defaultView!;
     win.matchMedia = ((query: string) => ({
       matches: query === "(prefers-color-scheme: dark)",

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -43,7 +43,7 @@ export function detectTheme(doc: Document): "light" | "dark" {
 
 export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: number }): void {
   const container = mount(root);
-  // 解決中の合図(spec B4): diff 本体は最初から正しく、参照名だけが後から埋まる
+  // Resolving indicator (spec B4): the diff body is correct from the start, only reference names fill in later
   if (opts?.resolving) container.append(note("pl-resolving", `Resolving ${opts.resolving} reference(s)…`));
   for (const node of diff.roots) container.append(renderNode(node, diff));
   for (const c of diff.loose) container.append(renderComponent(c, diff));
@@ -60,7 +60,7 @@ export function renderLoading(root: ShadowRoot): void {
   mount(root).append(note("pl-loading", "Computing semantic diff…"));
 }
 
-/** 25MB 超ガード(親仕様 §5.7): 自動描画せず明示クリックを待つ。 */
+/** Over-25MB guard (parent spec §5.7): doesn't auto-render, waits for an explicit click. */
 export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => void): void {
   const container = mount(root);
   const button = document.createElement("button");
@@ -115,7 +115,7 @@ function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
   }
   details.append(summary);
 
-  // 表示次元の規則: コンポーネント/override カードは components セクション配下のみ。
+  // Display-hierarchy rule: component/override cards live only under the components section.
   const cards: HTMLElement[] = [];
   if (node.kind === "prefabInstance") cards.push(...renderOverrideGroups(node.overrides, diff));
   cards.push(...node.components.map((c) => renderComponent(c, diff)));
@@ -140,11 +140,11 @@ function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElem
     else groups.push({ name: ov.group, rows: [ov] });
   }
   return groups.map(({ name, rows }) => {
-    // 見出しの status: グループ内で一様ならその status、混在なら modified。
+    // The heading status: that status if uniform within the group, otherwise modified.
     const [first] = rows;
     const status = first && rows.every((r) => r.status === first.status) ? first.status : "modified";
     const el = openDetails("pl-comp", status);
-    el.open = true; // override カードは常に開(spec: 縮約サマリのみで軽い)
+    el.open = true; // override cards are always open (spec: light, just a collapsed summary)
     el.append(summaryLine(status, name));
     for (const r of rows) el.append(fieldRow(r.label, r.status, r.before, r.after, diff));
     return el;
@@ -174,7 +174,7 @@ function fieldRow(label: string, status: Status, before: FieldValue, after: Fiel
   path.className = "pl-path";
   path.textContent = label;
   row.append(path);
-  // 構造サマリ行 (before=after=null) は件数がラベルに含まれ、値を持たない。
+  // A structure summary row (before=after=null) has the count in its label and no value.
   if (before === null && after === null) return row;
   if (status === "modified") {
     row.append(valueSpan("pl-before", before, diff));
@@ -220,6 +220,6 @@ function formatValue(value: FieldValue, diff: DiffV2): string {
   if (value === null) return "—";
   if (typeof value === "string") return value;
   const { fileId, guid } = value.ref;
-  if (guid === null) return `#${fileId}`; // ローカル参照
-  return diff.resolved?.[guid] ?? `guid:${guid}`; // 外部参照(未解決は生 guid のまま)
+  if (guid === null) return `#${fileId}`; // local reference
+  return diff.resolved?.[guid] ?? `guid:${guid}`; // external reference (unresolved stays a raw guid)
 }

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -1,4 +1,4 @@
-// prefablens.diff.v2 (core/src/json.zig の出力と 1:1)
+// prefablens.diff.v2 (1:1 with the output of core/src/json.zig)
 export type Status = "added" | "removed" | "modified" | "unchanged";
 
 export type RefValue = { ref: { fileId: string; guid: string | null; type: number | null } };
@@ -8,7 +8,7 @@ export type FieldDiff = { path: string; status: Status; before: FieldValue; afte
 
 export type OverrideDiff = {
   group: string; // "Transform" | "GameObject" | "Overrides"
-  label: string; // humanize 済み ("Position.x")
+  label: string; // already humanized ("Position.x")
   status: Status;
   before: FieldValue;
   after: FieldValue;
@@ -47,29 +47,29 @@ export type PrefabInstanceDiff = {
 
 export type NodeDiff = GameObjectDiff | PrefabInstanceDiff;
 
-// core が内容の供給を求めるソースプレハブ。side は取得すべき ref
-// (added instance -> after/head、removed instance -> before/base)。
+// Source prefab whose content core asks to be supplied. side is the ref to fetch
+// (added instance -> after/head, removed instance -> before/base).
 export type NeededSource = { guid: string; side: "before" | "after" };
 
 export type DiffV2 = {
   schema: "prefablens.diff.v2";
   unresolvedGuids: string[];
-  neededSources?: NeededSource[]; // 空なら省略される(additive)
-  resolved?: Record<string, string>; // ホスト側(applyResolved)が付与
+  neededSources?: NeededSource[]; // omitted when empty (additive)
+  resolved?: Record<string, string>; // attached by the host side (applyResolved)
   roots: NodeDiff[];
   loose: ComponentDiff[];
 };
 
 export type DiffErrorV1 = { schema: "prefablens.error.v1"; error: string };
 
-// content ↔ background メッセージ(chrome.runtime は JSON 直列化のみ)
+// content ↔ background messages (chrome.runtime only serializes JSON)
 export type SemanticDiffRequest = {
   type: "semanticDiff";
   owner: string;
   repo: string;
   prNumber: number;
   path: string;
-  force?: boolean; // 25MB ガードを越えて描画する(「Render anyway」クリック)
+  force?: boolean; // render past the 25MB guard ("Render anyway" click)
 };
 
 export type PrefetchRequest = { type: "prefetch"; owner: string; repo: string; prNumber: number };
@@ -82,7 +82,7 @@ export type SemanticDiffResponse =
   | { ok: false; error: BackgroundError }
   | { ok: false; error: "too-large"; bytes: number };
 
-// background → content の非同期 push(2 段階応答の後段)。
+// Async push from background → content (the second stage of the two-stage response).
 export type GuidResolvedPush = {
   type: "guidResolved";
   owner: string;
@@ -90,6 +90,6 @@ export type GuidResolvedPush = {
   prNumber: number;
   path: string;
   resolved: Record<string, string>;
-  json?: DiffV2; // mergeSources で構造が更新されたとき最終 push に載る(content は view を置換)
-  done: boolean; // true が来たら解決作業は終わり(空 resolved でも送る = インジケータ消灯の合図)
+  json?: DiffV2; // carried on the final push when mergeSources updated the structure (content replaces the view)
+  done: boolean; // when true, resolution is finished (sent even with empty resolved = the cue to turn off the indicator)
 };

--- a/extension/src/unity.ts
+++ b/extension/src/unity.ts
@@ -1,9 +1,9 @@
-// Unity がテキストシリアライズ(UnityYAML)する拡張子。unityyamlmerge の対象と同じ集合。
-// .meta(!u! ドキュメント形式でない)と .asmdef 等の JSON は対象外。
+// Extensions that Unity text-serializes (UnityYAML). Same set as unityyamlmerge targets.
+// Excludes .meta (not !u! document format) and JSON like .asmdef.
 const UNITY_PATH =
   /\.(prefab|unity|asset|mat|anim|controller|overrideController|physicMaterial|physicsMaterial2D|playable|mask|brush|flare|fontsettings|guiskin|giparams|renderTexture|spriteatlas|spriteatlasv2|terrainlayer|mixer|shadervariants|preset|signal|lighting|scenetemplate)$/i;
 
-/** content の検出と background のプリフェッチが同じ判定を共有する。 */
+/** Content detection and background prefetch share the same check. */
 export function isUnityPath(path: string): boolean {
   return UNITY_PATH.test(path);
 }

--- a/extension/src/wasm/differ.test.ts
+++ b/extension/src/wasm/differ.test.ts
@@ -62,11 +62,11 @@ Transform:
   m_GameObject: {fileID: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}`);
 
-    // assets なし: core が供給を要求する。
+    // Without assets: core requests the supply.
     const first = differ.diff(new Uint8Array(0), variant);
     expect(first.neededSources).toEqual([{ guid: "srcguid", side: "after" }]);
 
-    // assets あり: 合成されて neededSources は消え、override 適用済みの全列挙になる。
+    // With assets: merged, so neededSources disappears and it becomes a full enumeration with overrides applied.
     const merged = differ.diffWithAssets(new Uint8Array(0), variant, new Map([["srcguid", source]]));
     expect(merged.neededSources).toBeUndefined();
     const inst = merged.roots[0]!;

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -15,8 +15,8 @@ type Exports = {
   diff_with_assets(bp: number, bl: number, ap: number, al: number, tp: number, tl: number): number;
 };
 
-/** assets TLV(LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }。
- *  core/src/wasm.zig の parseAssets と 1:1。 */
+/** assets TLV (LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }.
+ *  1:1 with parseAssets in core/src/wasm.zig. */
 export function encodeAssets(assets: Map<string, Uint8Array>): Uint8Array {
   const enc = new TextEncoder();
   const guids = [...assets.keys()].map((g) => enc.encode(g));
@@ -48,7 +48,7 @@ export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
   function call(before: Uint8Array, after: Uint8Array, assets?: Uint8Array): DiffV2 {
     const bufs = assets === undefined ? [before, after] : [before, after, assets];
     const ptrs = bufs.map((b) => (b.length ? exp.alloc(b.length) : 0));
-    // コピーは最後の alloc の後: memory.grow で古いビューは detach される
+    // Copy after the last alloc: memory.grow detaches older views
     bufs.forEach((b, i) => {
       new Uint8Array(exp.memory.buffer, ptrs[i]!, b.length).set(b);
     });

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
-      "description": "extension の npm devDependencies は minor/patch をまとめて 1 本の PR にする",
+      "description": "Group extension npm devDependencies minor/patch updates into a single PR",
       "matchManagers": [
         "npm"
       ],
@@ -30,14 +30,14 @@
       "groupName": "extension devDependencies"
     },
     {
-      "description": "@types/node は mise の node runtime (24) に追従させ major を上げない。node のメジャーを上げたら allowedVersions も一緒に更新する",
+      "description": "Pin @types/node to the mise node runtime (24) and never bump its major; when the node major changes, update allowedVersions too",
       "matchPackageNames": [
         "@types/node"
       ],
       "allowedVersions": "24"
     },
     {
-      "description": "GitHub Actions は tag 運用を維持し SHA ピン留めせずまとめて更新する",
+      "description": "Keep GitHub Actions on tag references (no SHA pinning) and update them together",
       "matchManagers": [
         "github-actions"
       ],
@@ -48,7 +48,7 @@
       ]
     },
     {
-      "description": "mise のツールチェーン (zig/zls/node/dotnet/bump-my-version) は build 全体に影響するため automerge せず CI レビューを必須にする",
+      "description": "The mise toolchain (zig/zls/node/dotnet/bump-my-version) affects the whole build, so require CI review instead of automerge",
       "matchManagers": [
         "mise"
       ],
@@ -59,7 +59,7 @@
       ]
     },
     {
-      "description": "major はグループから外して個別 PR にし major ラベルで目立たせる",
+      "description": "Split major updates out of groups into individual PRs and flag them with the major label",
       "matchUpdateTypes": [
         "major"
       ],


### PR DESCRIPTION
## Summary

Translate every in-code Japanese comment and description string to English across the whole repository, so the code language matches the already-English docs (README, SECURITY.md). Comments and config descriptions only — no logic changes.

## Motivation

Closes #55.

The user-facing docs are English while in-code comments were mostly Japanese. That (a) makes intent hard to read for non-Japanese contributors and (b) duplicates the language split between docs and code, raising maintenance cognitive load. Unifying on English prepares the repo for outside contribution and OSS visibility.

## Changes

- Translated Japanese comments to English in `core/` (14 files), `cli/` (7), `extension/` (34), and `editor/` (8), plus `build.zig` comments and the `renovate.json` `description` fields.
- Also covered hidden config files that the issue's grep command misses (ripgrep skips dot-directories unless `--hidden` is passed): `.gitattributes`, `.github/workflows/ci.yml`, `.github/workflows/release.yml`.
- `cli/src/mcp.zig`: the "truncateTree never splits a multibyte utf-8 character" test used the intentional literal `"あああ"`. Replaced it with `"€€€"` — U+20AC is also exactly 3 bytes in UTF-8, so the input byte layout and every assertion (`len` = 50008, cut at byte 49999) are unchanged and the test still exercises a mid-character cut. Surrounding comments now reference `'€'`. This keeps the repo fully CJK-free without weakening the regression test.
- Verified via diff analysis that only comment text changed: every non-comment-marker line in the diff is a `code; // comment` pair whose code portion is byte-identical between the removed and added side.

While translating, I corrected one apparent typo in `.gitattributes`: `CSRF` -> `CRLF`. The surrounding comment is about preventing automatic line-ending conversion on Windows checkout, where `CSRF` (a security term) is meaningless; the intent is clearly `CRLF`. Flagging it explicitly since this issue is scoped to translation.

## Testing

Reproduced the CI matrix locally — all green:

- CJK grep repo-wide including hidden dirs: `rg --hidden '[\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{3000}-\x{303F}\x{FF00}-\x{FFEF}]'` -> 0 hits
- core: `zig build lint`, `zig build test`, `zig build perf` -> all pass (perf: 50000 objects in 174 ms, ceiling 600 ms)
- extension: `zig build wasm`, `node --test core/tests/*.test.mjs` (7 pass), `npm run size|lint|typecheck|test|build` -> all pass (vitest 142 pass, 13 files)
- editor: `dotnet csharpier check . --no-msbuild-check` -> pass (8 files)
- Extension E2E (Playwright) was not run locally (comment-only change; typecheck and build pass) and is left to CI.

**Follow-up candidates (out of scope here — translation only, not fixed):**
- `cli/src/main.zig:494` — stale `Task 9` reference (was already English).
- `editor/Editor/Cli.cs:131` — comment ties the absence of `SHA256SUMS` to "a release before v0.2.0"; worth verifying against the actual release history.