### PR TITLE
refactor: remove dead checksum verification

### DIFF
--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -491,7 +491,7 @@ pub const Options = struct {
     before: []const u8,
     after: []const u8,
     format: Format = .tree,
-    project_root: ?[]const u8 = null, // for .meta resolution (Task 9)
+    project_root: ?[]const u8 = null, // for .meta resolution
     git_mode: bool = false,
     git_ref_before: []const u8 = "",
     git_ref_after: []const u8 = "",

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -2,11 +2,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
-using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography;
-using System.Text;
 using UnityEditor;
 
 namespace PrefabLens
@@ -47,32 +44,6 @@ namespace PrefabLens
             return string.Join(" ", quoted);
         }
 
-        /// Extract the hash of assetName's line from `sha256sum` format ("<hex>  <name>", binary mode "<hex> *<name>").
-        /// Returns null if not found.
-        public static string ParseSha256Sums(string sums, string assetName)
-        {
-            foreach (var raw in sums.Split('\n'))
-            {
-                var line = raw.Trim();
-                var sep = line.IndexOf(' ');
-                if (sep <= 0)
-                    continue;
-                var name = line.Substring(sep).Trim().TrimStart('*');
-                if (name == assetName)
-                    return line.Substring(0, sep);
-            }
-            return null;
-        }
-
-        public static string Sha256Hex(byte[] bytes)
-        {
-            using var sha = SHA256.Create();
-            var sb = new StringBuilder();
-            foreach (var b in sha.ComputeHash(bytes))
-                sb.Append(b.ToString("x2"));
-            return sb.ToString();
-        }
-
         // ---- Editor integration ----
 
         public static string BinaryName =>
@@ -107,7 +78,6 @@ namespace PrefabLens
                 EditorUtility.DisplayProgressBar("PrefabLens", $"Downloading {asset}…", 0.3f);
                 using var http = new HttpClient();
                 var bytes = http.GetByteArrayAsync(url).Result;
-                VerifyChecksum(http, asset, bytes);
                 using var zip = new ZipArchive(new MemoryStream(bytes));
                 foreach (var entry in zip.Entries)
                 {
@@ -126,22 +96,6 @@ namespace PrefabLens
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 RunProcess("chmod", "+x \"" + DefaultPath + "\"", ".", RunTimeoutMs);
             return DefaultPath;
-        }
-
-        /// Verify the zip against the release's SHA256SUMS. Skip only when SHA256SUMS is absent (404 = a release
-        /// before v0.2.0); any other fetch failure or mismatch throws.
-        static void VerifyChecksum(HttpClient http, string assetName, byte[] zipBytes)
-        {
-            var res = http.GetAsync(DownloadUrl(Version, "SHA256SUMS")).Result;
-            if (res.StatusCode == HttpStatusCode.NotFound)
-                return;
-            res.EnsureSuccessStatusCode();
-            var want = ParseSha256Sums(res.Content.ReadAsStringAsync().Result, assetName);
-            if (want == null)
-                throw new InvalidOperationException($"SHA256SUMS has no entry for {assetName}");
-            var got = Sha256Hex(zipBytes);
-            if (!string.Equals(want, got, StringComparison.OrdinalIgnoreCase))
-                throw new InvalidOperationException($"SHA256 mismatch for {assetName}: expected {want}, got {got}");
         }
 
         public struct Result

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 using NUnit.Framework;
 
 namespace PrefabLens.Tests
@@ -54,38 +53,6 @@ namespace PrefabLens.Tests
                 Cli.QuoteArgs(Cli.BuildArgs("Assets/My Prefab.prefab"))
             );
             Assert.AreEqual("\"a\\\"b\"", Cli.QuoteArgs(new[] { "a\"b" }));
-        }
-
-        [Test]
-        public void ParseSha256SumsFindsTheAssetLine()
-        {
-            // Exactly the form release.yml's `sha256sum *.zip` produces.
-            var sums =
-                "1111111111111111111111111111111111111111111111111111111111111111  prefablens-linux-x64.zip\n"
-                + "2222222222222222222222222222222222222222222222222222222222222222  prefablens-macos-arm64.zip\n";
-            Assert.AreEqual(
-                "2222222222222222222222222222222222222222222222222222222222222222",
-                Cli.ParseSha256Sums(sums, "prefablens-macos-arm64.zip")
-            );
-            Assert.IsNull(Cli.ParseSha256Sums(sums, "prefablens-windows-x64.zip"));
-        }
-
-        [Test]
-        public void ParseSha256SumsHandlesCrlfAndBinaryMarker()
-        {
-            // Also accepts CRLF line endings and sha256sum binary mode's leading "*".
-            var sums = "cafe01 *prefablens-windows-x64.zip\r\n";
-            Assert.AreEqual("cafe01", Cli.ParseSha256Sums(sums, "prefablens-windows-x64.zip"));
-        }
-
-        [Test]
-        public void Sha256HexMatchesTheStandardTestVector()
-        {
-            // Known vector from FIPS 180-2: sha256("abc")
-            Assert.AreEqual(
-                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-                Cli.Sha256Hex(Encoding.ASCII.GetBytes("abc"))
-            );
         }
 
         [Test]


### PR DESCRIPTION
## Summary

Remove the editor's SHA256 checksum verification, which became dead code once the release workflow stopped publishing `SHA256SUMS`.

## Motivation

Closes #58.

`SHA256SUMS` was dropped from `release.yml` in `b80df4c` and only ever shipped with v0.3.0. `Cli.VerifyChecksum` now fetches `.../SHA256SUMS`, gets a 404 for every current and future release, and returns without verifying anything. Its doc comment is also wrong (it claims 404 means "a release before v0.2.0", but v0.2.0 and every later release also lack `SHA256SUMS`). Not publishing `SHA256SUMS` is intentional, so the verification is retired rather than restored.

## Changes

- `editor/Editor/Cli.cs`: remove `VerifyChecksum` (method + its call site in `Download`), plus the verification-only helpers `ParseSha256Sums` and `Sha256Hex`.
- Drop the now-unused usings `System.Security.Cryptography`, `System.Text`, and `System.Net` (`HttpStatusCode` was only referenced by `VerifyChecksum`). `System.Net.Http` stays — `HttpClient` still fetches the release asset.
- `editor/Tests/Editor/CliTests.cs`: remove the three verification tests (`ParseSha256SumsFindsTheAssetLine`, `ParseSha256SumsHandlesCrlfAndBinaryMarker`, `Sha256HexMatchesTheStandardTestVector`) and the then-unused `System.Text` using.
- `cli/src/main.zig`: drop the stale "(Task 9)" reference from the `project_root` comment.
- `DownloadUrl` is retained — it still builds the release asset URL in `Download`.

No behavior change to download/extract: verification was already a no-op (every release 404s on `SHA256SUMS`).

## Testing

- `dotnet csharpier check . --no-msbuild-check` → `Checked 8 files`, no diffs.
- `zig build lint` → clean.
- `zig build test` → pass.