### PR TITLE
refactor: drop retired backward-compat code

### DIFF
--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -5,8 +5,7 @@ const main = @import("main.zig");
 
 pub const default_protocol_version = "2025-06-18";
 // 2025-03-26 makes batch requests a MUST, but major clients don't send them, so we accept it while leaving batching unsupported.
-// 2024-10-07 is a prerelease, but the old TS SDK accepted it, so keep it for parity.
-const supported_versions = [_][]const u8{ "2025-06-18", "2025-03-26", "2024-11-05", "2024-10-07" };
+const supported_versions = [_][]const u8{ "2025-06-18", "2025-03-26", "2024-11-05" };
 
 /// result payload for tools/list. description and inputSchema are a faithful port of the old TS host
 /// (the zod definitions in mcp/src/index.ts). build.zig's smoke golden @embedFiles the same
@@ -387,14 +386,6 @@ test "mcp: truncateTree caps tree output like the ts host" {
     const cut = try truncateTree(arena, big);
     try testing.expect(std.mem.endsWith(u8, cut, "\n[truncated: 50001 chars total]\n"));
     try testing.expectEqual(tree_char_limit, std.mem.indexOf(u8, cut, "\n[truncated").?);
-}
-
-test "mcp: initialize echoes the legacy 2024-10-07 version like the ts sdk" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const res = try roundtrip(arena, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-10-07\"}}\n");
-    try testing.expect(std.mem.indexOf(u8, res, "\"protocolVersion\":\"2024-10-07\"") != null);
 }
 
 test "mcp: float and oversized integer ids are echoed verbatim" {

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -101,10 +101,25 @@ async function serveAndResolve(
   return { res, pushes };
 }
 
+/** Drives semanticDiff to completion — the immediate response plus every push — and returns the
+ *  fully-resolved response. Errors and fully-in-PR-resolved diffs pass through unchanged; a pending
+ *  diff resolves to the final push's json, i.e. what the pipeline ultimately produces. */
+async function resolveFully(
+  handler: Handler,
+  req: SemanticDiffRequest,
+): Promise<Awaited<ReturnType<Handler["semanticDiff"]>>> {
+  const pushes: GuidResolvedPush[] = [];
+  const res = await handler.semanticDiff(req, (m) => pushes.push(m));
+  if (!res.ok || !res.pending) return res;
+  await vi.waitFor(() => expect(pushes.at(-1)?.done).toBe(true));
+  const final = pushes.at(-1);
+  return final?.json ? { ok: true, json: final.json } : res;
+}
+
 describe("createHandler", () => {
   it("returns pat-missing without touching the network", async () => {
     const { deps, client } = makeDeps({ pat: undefined });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: false, error: "pat-missing" });
     expect(client.getPrRefs).not.toHaveBeenCalled();
   });
@@ -121,14 +136,14 @@ describe("createHandler", () => {
         "Assets/S.cs.meta@head-sha": "guid: g1\n",
       },
     });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/S.cs" } } });
   });
 
   it("uses an empty before for added files without fetching the base side", async () => {
     const diff = vi.fn<Differ["diff"]>(() => DIFF);
     const { deps, client } = makeDeps({ files: [{ path: "Assets/Foo.prefab", status: "added" }], diff });
-    await createHandler(deps).semanticDiff(REQ);
+    await resolveFully(createHandler(deps), REQ);
     const baseFetches = client.getFileAtRef.mock.calls.filter(
       (c) => c[2] === "Assets/Foo.prefab" && c[3] === "base-sha",
     );
@@ -139,7 +154,7 @@ describe("createHandler", () => {
   it("uses an empty after for removed files without fetching the head side", async () => {
     const diff = vi.fn<Differ["diff"]>(() => DIFF);
     const { deps, client } = makeDeps({ files: [{ path: "Assets/Foo.prefab", status: "removed" }], diff });
-    await createHandler(deps).semanticDiff(REQ);
+    await resolveFully(createHandler(deps), REQ);
     const headFetches = client.getFileAtRef.mock.calls.filter(
       (c) => c[2] === "Assets/Foo.prefab" && c[3] === "head-sha",
     );
@@ -150,7 +165,7 @@ describe("createHandler", () => {
   it("diffs a file missing from the PR list as modified (files API caps at 3000)", async () => {
     // In a PR with over 3000 files, the listing API is truncated, so a file present in the UI may be absent from the listing
     const { deps, client } = makeDeps({ files: [{ path: "Assets/Other.prefab", status: "modified" }] });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "base-sha");
     expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "head-sha");
@@ -168,7 +183,7 @@ describe("createHandler", () => {
       inFlight--;
       return new TextEncoder().encode("x");
     });
-    await createHandler(deps).semanticDiff(REQ);
+    await resolveFully(createHandler(deps), REQ);
     expect(maxInFlight).toBe(2);
   });
 
@@ -177,7 +192,7 @@ describe("createHandler", () => {
       files: [{ path: "Assets/Foo.prefab", status: "renamed", previousPath: "Assets/Old.prefab" }],
       contents: { "Assets/Old.prefab@base-sha": "b", "Assets/Foo.prefab@head-sha": "a" },
     });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Old.prefab", "base-sha");
   });
@@ -185,8 +200,8 @@ describe("createHandler", () => {
   it("caches PR context across calls (refs/files/guid index fetched once)", async () => {
     const { deps, client } = makeDeps();
     const handle = createHandler(deps);
-    await handle.semanticDiff(REQ);
-    await handle.semanticDiff({ ...REQ, path: "Assets/Foo.prefab" });
+    await resolveFully(handle, REQ);
+    await resolveFully(handle, { ...REQ, path: "Assets/Foo.prefab" });
     expect(client.getPrRefs).toHaveBeenCalledTimes(1);
     expect(client.listPrFiles).toHaveBeenCalledTimes(1);
   });
@@ -196,12 +211,13 @@ describe("createHandler", () => {
     try {
       const { deps, client } = makeDeps();
       const handle = createHandler(deps);
-      await handle.semanticDiff(REQ);
+      // Fake timers make resolveFully's vi.waitFor hang; this test only needs the immediate response.
+      await handle.semanticDiff(REQ, () => {});
       vi.setSystemTime(Date.now() + 59_000);
-      await handle.semanticDiff(REQ);
+      await handle.semanticDiff(REQ, () => {});
       expect(client.getPrRefs).toHaveBeenCalledTimes(1);
       vi.setSystemTime(Date.now() + 2_000); // 61 seconds total
-      await handle.semanticDiff(REQ);
+      await handle.semanticDiff(REQ, () => {});
       expect(client.getPrRefs).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
@@ -213,22 +229,22 @@ describe("createHandler", () => {
     const { deps, client } = makeDeps();
     client.listPrFiles.mockRejectedValueOnce(new Error("socket"));
     const handle = createHandler(deps);
-    expect(await handle.semanticDiff(REQ)).toEqual({ ok: false, error: "fetch-failed" });
-    expect((await handle.semanticDiff(REQ)).ok).toBe(true);
+    expect(await resolveFully(handle, REQ)).toEqual({ ok: false, error: "fetch-failed" });
+    expect((await resolveFully(handle, REQ)).ok).toBe(true);
   });
 
   it("fetches each sha+path blob only once (immutable content)", async () => {
     const { deps, client } = makeDeps();
     const handle = createHandler(deps);
-    await handle.semanticDiff(REQ);
-    await handle.semanticDiff(REQ);
+    await resolveFully(handle, REQ);
+    await resolveFully(handle, REQ);
     const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === "Assets/Foo.prefab");
     expect(fooFetches).toHaveLength(2); // only twice, base + head (the second handle doesn't re-fetch)
   });
 
   it("resolves remaining guids via code search and persists them", async () => {
     const { deps, guidCache } = makeDeps({ search: { g1: "Assets/Scripts/S.cs" } });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/Scripts/S.cs" } } });
     expect(guidCache.save).toHaveBeenCalledWith("https://api.github.com/o/r", { g1: "Assets/Scripts/S.cs" });
   });
@@ -246,14 +262,14 @@ describe("createHandler", () => {
       },
       search: { g1: "Assets/Elsewhere.cs" },
     });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/S.cs" } } });
     expect(client.searchMetaByGuid).not.toHaveBeenCalled();
   });
 
   it("serves cached guids without searching", async () => {
     const { deps, client } = makeDeps({ cached: { g1: "Assets/Cached.cs" } });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/Cached.cs" } } });
     expect(client.searchMetaByGuid).not.toHaveBeenCalled();
   });
@@ -261,8 +277,8 @@ describe("createHandler", () => {
   it("does not re-search a missed guid within the worker lifetime", async () => {
     const { deps, client } = makeDeps(); // search misses
     const handle = createHandler(deps);
-    await handle.semanticDiff(REQ);
-    await handle.semanticDiff(REQ);
+    await resolveFully(handle, REQ);
+    await resolveFully(handle, REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
   });
 
@@ -271,10 +287,10 @@ describe("createHandler", () => {
     // misses is the gatekeeper for "don't re-search", not for "don't emit the name"
     const { deps, client, guidCache } = makeDeps(); // search misses → g1 goes into misses
     const handler = createHandler(deps);
-    await handler.semanticDiff(REQ);
+    await resolveFully(handler, REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
     guidCache.data["https://api.github.com/o/r"] = { g1: "Assets/Later.cs" }; // as if an index resolution wrote it later
-    const res = await handler.semanticDiff(REQ);
+    const res = await resolveFully(handler, REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/Later.cs" } } });
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1); // no re-search
   });
@@ -290,7 +306,7 @@ describe("createHandler", () => {
         }),
     );
     const handler = createHandler(deps);
-    const [a, b] = [handler.semanticDiff(REQ), handler.semanticDiff(REQ)];
+    const [a, b] = [resolveFully(handler, REQ), resolveFully(handler, REQ)];
     await vi.waitFor(() => expect(client.searchMetaByGuid).toHaveBeenCalled());
     release("Assets/S.cs");
     const [ra, rb] = await Promise.all([a, b]);
@@ -303,14 +319,14 @@ describe("createHandler", () => {
     const twoGuids: DiffV2 = { ...DIFF, unresolvedGuids: ["g1", "g2"] };
     const { deps, client } = makeDeps({ diff: () => twoGuids });
     client.searchMetaByGuid.mockResolvedValueOnce("Assets/First.cs").mockRejectedValueOnce(new RateLimitError("x"));
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...twoGuids, resolved: { g1: "Assets/First.cs" } } });
   });
 
   it("does not treat Object.prototype members as cache hits (hostile guid)", async () => {
     const proto: DiffV2 = { ...DIFF, unresolvedGuids: ["constructor"] };
     const { deps, client } = makeDeps({ diff: () => proto, cached: { g9: "Assets/X.cs" } });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     // 'constructor' goes to search rather than a cache hit, and stays unresolved after missing
     expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "constructor");
     expect(res).toEqual({ ok: true, json: { ...proto, resolved: {} } });
@@ -319,7 +335,7 @@ describe("createHandler", () => {
   it("caps code searches at 10 per request", async () => {
     const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
     const { deps, client } = makeDeps({ diff: () => many });
-    await createHandler(deps).semanticDiff(REQ);
+    await resolveFully(createHandler(deps), REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
   });
 
@@ -327,7 +343,7 @@ describe("createHandler", () => {
     // If 2 of 12 guids are cached, the search budget of 10 can be spent entirely on the 10 unknown guids
     const many: DiffV2 = { ...DIFF, unresolvedGuids: Array.from({ length: 12 }, (_, i) => `g${i}`) };
     const { deps, client } = makeDeps({ diff: () => many, cached: { g0: "Assets/A.cs", g1: "Assets/B.cs" } });
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
     expect(res).toEqual({ ok: true, json: { ...many, resolved: { g0: "Assets/A.cs", g1: "Assets/B.cs" } } });
   });
@@ -335,18 +351,18 @@ describe("createHandler", () => {
   it("maps AuthError / DiffError / other failures to stable error codes", async () => {
     const auth = makeDeps();
     auth.client.getPrRefs.mockRejectedValue(new AuthError("x"));
-    expect(await createHandler(auth.deps).semanticDiff(REQ)).toEqual({ ok: false, error: "auth-failed" });
+    expect(await resolveFully(createHandler(auth.deps), REQ)).toEqual({ ok: false, error: "auth-failed" });
 
     const bad = makeDeps({
       diff: () => {
         throw new DiffError("NestingTooDeep");
       },
     });
-    expect(await createHandler(bad.deps).semanticDiff(REQ)).toEqual({ ok: false, error: "diff-failed" });
+    expect(await resolveFully(createHandler(bad.deps), REQ)).toEqual({ ok: false, error: "diff-failed" });
 
     const net = makeDeps();
     net.client.listPrFiles.mockRejectedValue(new Error("socket"));
-    expect(await createHandler(net.deps).semanticDiff(REQ)).toEqual({ ok: false, error: "fetch-failed" });
+    expect(await resolveFully(createHandler(net.deps), REQ)).toEqual({ ok: false, error: "fetch-failed" });
   });
 
   it("returns too-large above 25MB unless forced", async () => {
@@ -355,11 +371,11 @@ describe("createHandler", () => {
     const { deps, client } = makeDeps({ diff });
     client.getFileAtRef.mockResolvedValue(big);
     const handle = createHandler(deps);
-    expect(await handle.semanticDiff(REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
+    expect(await resolveFully(handle, REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
     expect(diff).not.toHaveBeenCalled();
     // force proceeds to render. The blob is in the sha cache, so no re-fetch either
     const fetches = client.getFileAtRef.mock.calls.length;
-    expect((await handle.semanticDiff({ ...REQ, force: true })).ok).toBe(true);
+    expect((await resolveFully(handle, { ...REQ, force: true })).ok).toBe(true);
     expect(diff).toHaveBeenCalledTimes(1);
     expect(client.getFileAtRef.mock.calls.length).toBe(fetches);
   });
@@ -368,13 +384,13 @@ describe("createHandler", () => {
     const half = new Uint8Array((25 * 1024 * 1024) / 2);
     const { deps, client } = makeDeps();
     client.getFileAtRef.mockResolvedValue(half);
-    expect((await createHandler(deps).semanticDiff(REQ)).ok).toBe(true);
+    expect((await resolveFully(createHandler(deps), REQ)).ok).toBe(true);
   });
 
   it("maps RateLimitError to rate-limited", async () => {
     const limited = makeDeps();
     limited.client.getPrRefs.mockRejectedValue(new RateLimitError("x"));
-    expect(await createHandler(limited.deps).semanticDiff(REQ)).toEqual({ ok: false, error: "rate-limited" });
+    expect(await resolveFully(createHandler(limited.deps), REQ)).toEqual({ ok: false, error: "rate-limited" });
   });
 
   describe("source prefab merging", () => {
@@ -398,7 +414,7 @@ describe("createHandler", () => {
           "Assets/Cyl.prefab@head-sha": "SRC",
         },
       });
-      const res = await createHandler(deps).semanticDiff(REQ);
+      const res = await resolveFully(createHandler(deps), REQ);
       // side=after, so the source is fetched from head and its bytes land in assets.
       expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Cyl.prefab", "head-sha");
       const assets = diffWithAssets.mock.calls[0]?.[2];
@@ -419,14 +435,14 @@ describe("createHandler", () => {
           "Assets/Cyl.prefab@base-sha": "OLD",
         },
       });
-      await createHandler(deps).semanticDiff(REQ);
+      await resolveFully(createHandler(deps), REQ);
       expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Cyl.prefab", "base-sha");
     });
 
     it("keeps the phase-1 diff when the source path cannot be resolved", async () => {
       const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
       const { deps } = makeDeps({ diff: () => NEEDS, diffWithAssets }); // search misses
-      const res = await createHandler(deps).semanticDiff(REQ);
+      const res = await resolveFully(createHandler(deps), REQ);
       // An unknown-path source is given up on, returning the degraded view (phase 1's json) as-is.
       expect(diffWithAssets).not.toHaveBeenCalled();
       expect(res).toEqual({ ok: true, json: { ...NEEDS, resolved: {} } });
@@ -445,7 +461,7 @@ describe("createHandler", () => {
           "Assets/Cyl.prefab@head-sha": "SRC",
         },
       });
-      const res = await createHandler(deps).semanticDiff(REQ);
+      const res = await resolveFully(createHandler(deps), REQ);
       expect(diffWithAssets).toHaveBeenCalledTimes(1);
       expect(res.ok).toBe(true);
     });
@@ -476,7 +492,7 @@ describe("createHandler", () => {
       const handler = createHandler(deps);
       await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
       expect(diffWithAssets).not.toHaveBeenCalled(); // prefetch stops at raw
-      const res = await handler.semanticDiff(REQ);
+      const res = await resolveFully(handler, REQ);
       expect(res.ok).toBe(true);
       expect(diffWithAssets).toHaveBeenCalledTimes(1); // merging runs at serve time
     });
@@ -490,7 +506,7 @@ describe("prefetch", () => {
     await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
     expect(client.searchMetaByGuid).not.toHaveBeenCalled(); // prefetch doesn't touch the 10 req/min Code Search
     const fetchesAfterPrefetch = client.getFileAtRef.mock.calls.length;
-    const res = await handler.semanticDiff(REQ);
+    const res = await resolveFully(handler, REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef.mock.calls.length).toBe(fetchesAfterPrefetch); // no blob re-fetch
   });
@@ -505,7 +521,7 @@ describe("prefetch", () => {
     // The SW dies after 30 seconds: a result prefetched in a prior life must be recoverable via storage.session
     const { deps, client, diffStore } = makeDeps();
     diffStore.data["base-sha:head-sha:Assets/Foo.prefab"] = DIFF; // seeded as if saved by a prior SW life
-    const res = await createHandler(deps).semanticDiff(REQ);
+    const res = await resolveFully(createHandler(deps), REQ);
     expect(res.ok).toBe(true);
     expect(client.getFileAtRef).not.toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "base-sha");
   });
@@ -531,7 +547,7 @@ describe("prefetch", () => {
     await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
     expect(deps.diffStore.save).not.toHaveBeenCalled();
     // A later manual toggle still shows the too-large gate as before
-    expect(await handler.semanticDiff(REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
+    expect(await resolveFully(handler, REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
   });
 
   it("aborts silently on rate limit instead of surfacing an error", async () => {
@@ -555,7 +571,7 @@ it("dedupes a concurrent user toggle against an in-flight prefetch compute", asy
   const handler = createHandler(deps);
   const [, res] = await Promise.all([
     handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 }),
-    handler.semanticDiff(REQ),
+    resolveFully(handler, REQ),
   ]);
   expect(res.ok).toBe(true);
   const fooFetches = client.getFileAtRef.mock.calls.filter((c) => c[2] === "Assets/Foo.prefab");

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -20,7 +20,7 @@ export type Deps = {
 };
 
 export type Handler = {
-  semanticDiff(req: SemanticDiffRequest, push?: (msg: GuidResolvedPush) => void): Promise<SemanticDiffResponse>;
+  semanticDiff(req: SemanticDiffRequest, push: (msg: GuidResolvedPush) => void): Promise<SemanticDiffResponse>;
   prefetch(req: PrefetchRequest): Promise<void>;
 };
 
@@ -285,7 +285,7 @@ export function createHandler(deps: Deps): Handler {
   }
 
   /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.
-   *  Unlike the push-less compatibility path, on failure it emits a done push in catch to release waiters. */
+   *  On failure it still emits a done push in catch to release waiters. */
   async function resolveRemaining(
     first: DiffV2,
     remaining: string[],
@@ -334,7 +334,7 @@ export function createHandler(deps: Deps): Handler {
 
   async function semanticDiff(
     req: SemanticDiffRequest,
-    push?: (msg: GuidResolvedPush) => void,
+    push: (msg: GuidResolvedPush) => void,
   ): Promise<SemanticDiffResponse> {
     try {
       const settings = await deps.getSettings();
@@ -344,20 +344,7 @@ export function createHandler(deps: Deps): Handler {
       const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
       const outcome = await getDiff(client, ctx, req.owner, req.repo, req.path, req.force === true);
       if (!outcome.ok) return outcome;
-      const repoKey = `${base}/${req.owner}/${req.repo}`;
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
-
-      if (!push) {
-        // Compatibility path: the traditional synchronous full pipeline (doesn't change the behavior of existing tests/callers)
-        const first = await searchUnresolved(withPr, client, req.owner, req.repo, repoKey);
-        if (!first.neededSources?.length) return { ok: true, json: first };
-        const differ = await deps.getDiffer();
-        const [before, after] = await fetchPair(client, ctx, req.owner, req.repo, req.path);
-        return {
-          ok: true,
-          json: await mergeSources(first, differ, before, after, ctx, client, req.owner, req.repo, repoKey),
-        };
-      }
 
       // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push (B4)
       const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -68,8 +68,10 @@ const handler = createHandler({
 chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendResponse) => {
   if (msg?.type === "semanticDiff") {
     const tabId = sender.tab?.id;
-    const push =
-      tabId === undefined ? undefined : (m: GuidResolvedPush) => void chrome.tabs.sendMessage(tabId, m).catch(() => {});
+    // semanticDiff requests always originate in a tab content script; guard defensively so a non-tab sender no-ops.
+    const push = (m: GuidResolvedPush) => {
+      if (tabId !== undefined) void chrome.tabs.sendMessage(tabId, m).catch(() => {});
+    };
     void handler.semanticDiff(msg, push).then(sendResponse);
     return true; // async response
   }


### PR DESCRIPTION
## Summary

Remove three pieces of code kept only to preserve compatibility with retired internal implementations: the prerelease MCP protocol version `2024-10-07`, and the extension's push-less synchronous diff pipeline.

## Motivation

Closes #59.

PrefabLens is pre-1.0, so no deprecation cycle is required. The `2024-10-07` MCP version was accepted only because the (now-removed) TypeScript SDK/host echoed it; it is not a released MCP spec version. The extension's `if (!push)` "Compatibility path" is a second, fully synchronous pipeline that no production caller uses — every `semanticDiff` request originates in a tab content script, which always supplies `push`.

## Changes

- `cli/src/mcp.zig`: drop `2024-10-07` from `supported_versions` and its comment. A client that sends it now negotiates to the default `2025-06-18` (already covered by the "falls back to the default version for unknown ones" test). Remove the `2024-10-07`-echo regression test.
- `extension/src/background/handler.ts`: make `push` required on `Handler.semanticDiff`, delete the push-less compatibility branch (and the then-dead `repoKey` local), and update the `resolveRemaining` comment that referenced it. The two-stage push pipeline is now the only path.
- `extension/src/background/index.ts`: supply `push` unconditionally via a thin adapter that no-ops for a (non-existent) non-tab sender, instead of passing `undefined`.
- `extension/src/background/handler.test.ts`: migrate the suite to the push API. A new `resolveFully` helper drives a request to its final push and returns the fully-resolved response, so the resolution assertions read the pipeline's end state unchanged.

## Testing

- `zig build lint` → clean; `zig build test` → pass; `zig build perf` → 50000 objects in 140 ms (ceiling 600 ms).
- `extension`: `tsc --noEmit` → clean, `biome ci .` → exit 0, `vitest run` → 142 passed (13 files), `npm run build` → ok.