### PR TITLE
docs: make code comments self-contained

### DIFF
--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -1,5 +1,5 @@
 // Integration tests against real data from the verification PR (hashiiiii/unity-yaml-playground#1).
-// Expected values are the spec's approved mocks (docs/superpowers/specs/2026-07-03-semantic-diff-inspector-model-design.md).
+// Expected values are the approved reference mocks for the inspector diff model.
 const std = @import("std");
 const root = @import("root.zig");
 const model = @import("model.zig");

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -1,4 +1,4 @@
-// Source-prefab merging for PrefabInstance (parent spec: docs/superpowers/specs/2026-07-06-prefab-source-resolution-design.md).
+// Source-prefab merging for PrefabInstance.
 // Merge = parse the source -> apply m_Modifications to the Document -> reuse the existing
 // one-sided compute + tree.build -> graft onto the instance node. core owns no I/O;
 // the host supplies guid -> bytes (Assets). Guids with no supply go into needed_sources.

--- a/core/src/perf_main.zig
+++ b/core/src/perf_main.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const perf = @import("perf.zig");
 
 // The budget is loosened above the nominal value to allow for CI-runner noise. Nominal
-// values are from spec §5.7 (typically < 5ms, ~10MB scene < 150ms). Generate a scene of
+// values are the performance targets (typically < 5ms, ~10MB scene < 150ms). Generate a scene of
 // ~10MB and verify it diffs within the CI ceiling.
 const big_objects = 50_000; // at ~200 bytes per object, ~10 MB of YAML
 const ci_ceiling_ms = 600; // 4x the nominal 150ms. Fails only on a true regression

--- a/core/src/wasm.zig
+++ b/core/src/wasm.zig
@@ -1,4 +1,4 @@
-// WASM C ABI wrapper (parent spec §5.6). One diff = one arena, no global mutable state.
+// WASM C ABI wrapper. One diff = one arena, no global mutable state.
 // Returns a JSON byte string prefixed with a u32 (LE) length. The caller frees it with free(ptr, 4 + len).
 const std = @import("std");
 const core = @import("root.zig");

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -8,7 +8,7 @@ using UnityEditor;
 
 namespace PrefabLens
 {
-    /// Locate, download, and run the prefablens CLI. All git logic lives in the CLI (parent spec §6.3).
+    /// Locate, download, and run the prefablens CLI. All git logic lives in the CLI.
     public static class Cli
     {
         /// Version of the CLI to download (kept in sync with the GitHub Releases tag v{Version}).

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -7,7 +7,7 @@ using UnityEngine.UIElements;
 
 namespace PrefabLens
 {
-    /// Displays the "HEAD vs working tree" semantic diff of the selected asset (Phase 3 walking skeleton).
+    /// Displays the "HEAD vs working tree" semantic diff of the selected asset.
     public sealed class PrefabLensWindow : EditorWindow
     {
         [SerializeField]

--- a/extension/scripts/check-wasm-size.mjs
+++ b/extension/scripts/check-wasm-size.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { gzipSync } from "node:zlib";
 
-const TARGET_KB = 80; // target from parent spec §5.7
+const TARGET_KB = 80; // WASM bundle size budget in KB
 const LIMIT_KB = 150; // CI fails if exceeded
 
 const wasmUrl = new URL("../../zig-out/bin/prefablens.wasm", import.meta.url);

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -63,7 +63,7 @@ function makeDeps(overrides?: {
       diffStoreData[key] = json;
     }),
   };
-  // Same shape as Task 11's makeFakes (loadGuids/saveGuids/loadIndex/saveIndex). Starts empty per test.
+  // Mirrors the RepoIndexStore interface (loadGuids/saveGuids/loadIndex/saveIndex). Starts empty per test.
   const guidsData: Record<string, Record<string, string>> = {};
   const indexData: Record<string, { treeSha: string; guids: Record<string, string> }> = {};
   const repoIndexStore = {
@@ -394,7 +394,7 @@ describe("createHandler", () => {
   });
 
   describe("source prefab merging", () => {
-    // A diff where phase 1 requests source supply. src1's path is resolved via Code Search.
+    // A diff where the first pass requests source supply. src1's path is resolved via Code Search.
     const NEEDS: DiffV2 = {
       ...DIFF,
       unresolvedGuids: ["src1"],
@@ -439,11 +439,11 @@ describe("createHandler", () => {
       expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Cyl.prefab", "base-sha");
     });
 
-    it("keeps the phase-1 diff when the source path cannot be resolved", async () => {
+    it("keeps the first-pass diff when the source path cannot be resolved", async () => {
       const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
       const { deps } = makeDeps({ diff: () => NEEDS, diffWithAssets }); // search misses
       const res = await resolveFully(createHandler(deps), REQ);
-      // An unknown-path source is given up on, returning the degraded view (phase 1's json) as-is.
+      // An unknown-path source is given up on, returning the degraded view (the first-pass json) as-is.
       expect(diffWithAssets).not.toHaveBeenCalled();
       expect(res).toEqual({ ok: true, json: { ...NEEDS, resolved: {} } });
     });
@@ -639,7 +639,7 @@ describe("semanticDiff with push (two-stage)", () => {
   });
 
   it("re-merges sources in the async stage once the source guid resolves", async () => {
-    // The crux of mergeSources consistency: stage 1 responds immediately without merging,
+    // The crux of mergeSources consistency: the immediate response comes back without merging,
     // and once the repo index resolves the source guid, the re-merged json arrives in the final push
     const withSource: DiffV2 = { ...DIFF, unresolvedGuids: ["src1"], neededSources: [{ guid: "src1", side: "after" }] };
     const merged: DiffV2 = { ...DIFF, unresolvedGuids: ["src1"], resolved: { src1: "Assets/Src.prefab" } };
@@ -664,7 +664,7 @@ describe("semanticDiff with push (two-stage)", () => {
     const pushes: GuidResolvedPush[] = [];
     const res = await createHandler(deps).semanticDiff(REQ, (m) => pushes.push(m));
     expect(res.ok && res.pending).toBe(true);
-    expect(diffWithAssets).not.toHaveBeenCalled(); // stage 1 doesn't merge (immediate response takes priority)
+    expect(diffWithAssets).not.toHaveBeenCalled(); // the immediate response doesn't merge (it takes priority)
     await vi.waitFor(() => expect(diffWithAssets).toHaveBeenCalledTimes(1));
     await vi.waitFor(() => expect(pushes.at(-1)?.done).toBe(true));
     expect(pushes.at(-1)?.json).toMatchObject({ resolved: { src1: "Assets/Src.prefab" } });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -31,8 +31,8 @@ const MAX_SEARCHES = 10; // Code Search is authenticated 10 req/min — don't bu
 const MAX_SOURCE_ROUNDS = 3; // re-diff cap for nested sources (independent of core's depth cap of 8)
 const CONTEXT_TTL_MS = 60_000; // PR context is short-lived because a push changes headSha
 const BLOB_CACHE_MAX = 32;
-const TOO_LARGE_BYTES = 25 * 1024 * 1024; // parent spec §5.7: over 25MB renders on click
-const PREFETCH_MAX = 100; // spec B2: prefetch cap per PR
+const TOO_LARGE_BYTES = 25 * 1024 * 1024; // over 25MB renders on click
+const PREFETCH_MAX = 100; // prefetch cap per PR (bounds API usage)
 const PREFETCH_CONCURRENCY = 4;
 
 type DiffOutcome = { ok: true; json: DiffV2 } | { ok: false; error: "too-large"; bytes: number };
@@ -48,7 +48,7 @@ export function createHandler(deps: Deps): Handler {
   const searches = new Map<string, Promise<string | null>>();
   // baseSha:headSha:path → raw diff computation Promise. Keeps only successes (too-large/failure allow recomputation)
   const diffs = new Map<string, Promise<DiffOutcome>>();
-  // repoKey@ref → whole-repo index Promise (Task 11). null means not indexable (truncated/over the cap/failure)
+  // repoKey@ref → whole-repo index Promise. null means not indexable (truncated/over the cap/failure)
   const indexes = new Map<string, Promise<Record<string, string> | null>>();
   // A repo that hit a rate limit falls back for the SW lifetime (gives up on the index and defers to Code Search only)
   const indexFallback = new Set<string>();
@@ -197,7 +197,7 @@ export function createHandler(deps: Deps): Handler {
         try {
           bytes = await fetchBlob(client, owner, repo, path, sha);
         } catch {
-          return current; // rate limit etc.: degrade to the phase 1 result
+          return current; // rate limit etc.: degrade to the first-pass diff
         }
         if (!bytes) continue;
         assets.set(s.guid, bytes);
@@ -316,7 +316,7 @@ export function createHandler(deps: Deps): Handler {
           push({ type: "guidResolved", ...at, resolved: fromIndex, done: false });
         }
       }
-      // Only guids that aren't indexable or aren't in the index go to Code Search (stage 3 of spec B3)
+      // Only guids that aren't indexable or aren't in the index go to Code Search
       const fromSearch = leftover.length ? await searchGuids(leftover, client, req.owner, req.repo, repoKey) : {};
       let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...fromSearch } };
       if (json.neededSources?.length) {
@@ -346,7 +346,7 @@ export function createHandler(deps: Deps): Handler {
       if (!outcome.ok) return outcome;
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
 
-      // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push (B4)
+      // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push
       const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));
       if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
       void resolveRemaining(withPr, remaining, client, req, base, ctx, push);

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -7,7 +7,7 @@ import { createQueue } from "./queue";
 
 let differ: Promise<Differ> | undefined;
 
-// Six concurrent across all REST/GraphQL (spec B2). GraphQL also goes through fetchFn, so it shares the same budget.
+// Six concurrent across all REST/GraphQL. GraphQL also goes through fetchFn, so it shares the same budget.
 // User-action-originated requests jump the queue via front
 const queue = createQueue(6);
 const queuedFetch =

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -35,7 +35,7 @@ describe("parsePrUrl", () => {
 
 describe("parsePrPage", () => {
   it("matches every pr tab, not just files", () => {
-    // Prefetch starts on arrival at the conversation tab (spec B2)
+    // Prefetch starts on arrival at the conversation tab
     expect(parsePrPage("/o/r/pull/12")).toEqual({ owner: "o", repo: "r", prNumber: 12 });
     expect(parsePrPage("/o/r/pull/12/commits")).toEqual({ owner: "o", repo: "r", prNumber: 12 });
     expect(parsePrPage("/o/r/pull/12/files")).toEqual({ owner: "o", repo: "r", prNumber: 12 });

--- a/extension/src/github/guids.ts
+++ b/extension/src/github/guids.ts
@@ -21,7 +21,7 @@ export type GuidCache = {
 
 const MAX_CONCURRENT_META_FETCHES = 8;
 
-/** Builds a guid → asset path index only from .meta files changed in the PR (design scope). removed ones are read from the base side.
+/** Builds a guid → asset path index only from .meta files changed in the PR. removed ones are read from the base side.
  *  Caps concurrent fetches at 8 (avoids GitHub secondary rate limits on large .meta changes). */
 export async function buildGuidIndex(files: PrFile[], fetchMeta: MetaFetcher): Promise<Map<string, string>> {
   const index = new Map<string, string>();
@@ -47,7 +47,7 @@ export async function buildGuidIndex(files: PrFile[], fetchMeta: MetaFetcher): P
   return index;
 }
 
-/** Host-side resolution seam (parent spec §4.3). Attaches with the same scoping rule as core's "resolved". */
+/** Host-side resolution seam. Attaches with the same scoping rule as core's "resolved". */
 export function applyResolved(diff: DiffV2, index: Map<string, string>): DiffV2 {
   const resolved: Record<string, string> = {};
   for (const g of diff.unresolvedGuids) {

--- a/extension/src/github/repoIndex.ts
+++ b/extension/src/github/repoIndex.ts
@@ -10,7 +10,7 @@ export type RepoIndexStore = {
   saveIndex(repo: string, index: { treeSha: string; guids: Record<string, string> }): Promise<void>;
 };
 
-const INDEX_MAX_METAS = 50_000; // spec B3: above this, give up on the index to protect the storage quota
+const INDEX_MAX_METAS = 50_000; // above this, give up on the index to protect the storage quota
 const GRAPHQL_BATCH = 100;
 
 /** Whole-repo guid → asset path index. Not indexable (truncated / over the cap) → null, deferring to Code Search.

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -43,7 +43,7 @@ export function detectTheme(doc: Document): "light" | "dark" {
 
 export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: number }): void {
   const container = mount(root);
-  // Resolving indicator (spec B4): the diff body is correct from the start, only reference names fill in later
+  // Resolving indicator: the diff body is correct from the start, only reference names fill in later
   if (opts?.resolving) container.append(note("pl-resolving", `Resolving ${opts.resolving} reference(s)…`));
   for (const node of diff.roots) container.append(renderNode(node, diff));
   for (const c of diff.loose) container.append(renderComponent(c, diff));
@@ -60,7 +60,7 @@ export function renderLoading(root: ShadowRoot): void {
   mount(root).append(note("pl-loading", "Computing semantic diff…"));
 }
 
-/** Over-25MB guard (parent spec §5.7): doesn't auto-render, waits for an explicit click. */
+/** Over-25MB guard: doesn't auto-render, waits for an explicit click. */
 export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => void): void {
   const container = mount(root);
   const button = document.createElement("button");


### PR DESCRIPTION
## Summary

Rewrite committed code comments that referenced uncommitted planning artifacts so each explains the code on its own terms.

## Motivation

Closes #60.

PrefabLens's spec-driven planning artifacts under `docs/superpowers/` and `.superpowers/` are git-ignored and never committed, so comments pointing at them (or at internal "spec B2/B3/B4", "Task N", "Phase N", "parent spec §X.Y" labels) dangle for any external reader. Same spirit as the recent comment-translation cleanup (#57).

## Changes

- Delete pointers to uncommitted `docs/superpowers/...` design docs (`core/src/fixture_test.zig`, `core/src/instantiate.zig`).
- Replace `spec B2/B3/B4` and `(B4)` labels with the standalone rationale (`handler.ts`, `index.ts`, `repoIndex.ts`, `render.ts`, `detect.test.ts`).
- Drop `(Task 11)` / `Phase 3 walking skeleton` / `(design scope)` pointers, keeping the surrounding explanation (`handler.ts`, `handler.test.ts`, `PrefabLensWindow.cs`, `guids.ts`).
- Rewrite the internal `parent spec §X.Y` references to the actual constraint they encode (`wasm.zig`, `perf_main.zig`, `Cli.cs`, `check-wasm-size.mjs`, `guids.ts`, `render.ts`, `handler.ts`). These were beyond the issue's enumerated list but share the same dangling-doc problem, so they are cleaned here too.
- Rename the borderline `phase 1` / `stage 1` numbering to `first-pass` / `immediate response` (`handler.ts`, `handler.test.ts`).

Comment-only: no runtime behavior, values, or logic changed. The CONTRIBUTING note suggested in the issue is deferred to the in-flight CONTRIBUTING PR (#54) to avoid a conflicting file.

## Testing

- `rg -n 'superpowers|spec B[0-9]|Task [0-9]|walking skeleton'` over committed files → no hits.
- `zig build lint` + `zig build test` → pass.
- `extension`: `tsc --noEmit` clean, `biome ci .` exit 0, `vitest run` → 142 passed, `npm run build` → ok.
- `dotnet csharpier check .` → 8 files, no diffs.