### PR TITLE
ci: push release via github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,14 @@ jobs:
       GIT_COMMITTER_NAME: github-actions[bot]
       GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install tools
         uses: jdx/mise-action@v4
       - name: Validate input


### PR DESCRIPTION
## Summary

Push the release commit and tag to `main` as the `unidog-bot` GitHub App so the Release workflow passes the branch ruleset.

## Motivation

The `main` ruleset now requires pull requests and passing status checks. The Release workflow pushes the version-bump commit directly to `main` with `GITHUB_TOKEN`, which the ruleset rejects with `GH013: ... Changes must be made through a pull request`. The v0.4.0 `workflow_dispatch` run failed at the "Bump, commit, and tag" step for this reason — the tag was pushed but the commit was rejected, leaving an orphan tag (since cleaned up).

A dedicated GitHub App (`unidog-bot`, Contents: write) is added to the ruleset bypass list, and the workflow pushes as that App. This keeps the ruleset intact for everyone else while letting the manual release push through.

## Changes

- Add an `actions/create-github-app-token@v3` step that mints a short-lived installation token from the `APP_ID` / `APP_PRIVATE_KEY` secrets.
- Pass that token to `actions/checkout` so the later `git push origin main "v$VERSION"` runs as `unidog-bot`, which is on the ruleset bypass list. `Validate input` and `Create release` keep using `GITHUB_TOKEN` (read / release-create only).

## Testing

- `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml')"` -> `YAML parse: OK`
- End-to-end push verified post-merge by re-running the Release workflow (`workflow_dispatch`, version `0.4.0`); it cannot be exercised pre-merge because the bypass applies to pushes to `main`.