### PR TITLE
ci: use client-id for github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

Switch the Release workflow's App-token step from the deprecated `app-id` input to `client-id`.

## Motivation

`actions/create-github-app-token@v3` deprecated the `app-id` input in favor of `client-id`. The v0.4.0 release run logged `Input 'app-id' has been deprecated with message: Use 'client-id' instead`. The warning is harmless today, but `app-id` may be removed in a future major, so move to `client-id` now.

## Changes

- Replace `app-id: ${{ secrets.APP_ID }}` with `client-id: ${{ secrets.APP_CLIENT_ID }}` in the `create-github-app-token` step. Requires a new `APP_CLIENT_ID` secret holding the App's Client ID.

## Testing

- `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml')"` -> `YAML parse: OK`
- End-to-end is verified post-merge on the next Release run; the v0.4.0 run already confirmed the App-token push path itself works.