### PR TITLE
ci: publish releases as the github app identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,5 +77,6 @@ jobs:
           build x86_64-windows   windows-x64  prefablens.exe
       - name: Create release
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Publish as the App so the release isn't attributed to github-actions[bot].
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh release create "v$VERSION" dist/*.zip --generate-notes


### PR DESCRIPTION
## Summary

Use the GitHub App token for `gh release create` so the published GitHub Release is attributed to the App (`unidog-bot`) instead of `github-actions[bot]`.

## Motivation

Release commits are already authored and committed by the App (v0.4.0, commit `4aa154c`), but the Release object itself was still published by `github-actions[bot]` because the `Create release` step used the default `GITHUB_TOKEN`. The token that runs `gh release create` determines the release publisher, which is a separate identity from the commit committer. This aligns the publisher with the commit identity. It applies to future releases; the already-published v0.4.0 release publisher is left as-is.

## Changes

- `Create release` step now uses `GH_TOKEN: ${{ steps.app-token.outputs.token }}` (the App token) instead of `${{ github.token }}`.

## Testing

- `ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml')"` -> `YAML OK`
- Mechanism mirrors the committer fix already verified in the v0.4.0 re-release (commit `4aa154c` author/committer = `unidog-bot[bot]`); publisher attribution will take effect on the next dispatched release.