### PR TITLE
build: set pnpm minimumReleaseAge to 3 days

### DIFF
--- a/extension/pnpm-workspace.yaml
+++ b/extension/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 allowBuilds:
   esbuild: true
+
+# Supply-chain cooldown: refuse packages published less than 3 days ago at install
+# time. This is a deliberate, explicit opt-in (pnpm 11 already defaults this to 1 day);
+# stating it here documents intent and survives any future change to the pnpm default.
+# It is defense-in-depth alongside Renovate's 7-day minimumReleaseAge, which only gates
+# Renovate-proposed direct-dependency PRs and cannot see transitive deps pulled in at
+# install time. Keep this <= Renovate's value so Renovate updates always clear this gate.
+# Setting it explicitly also enables strict mode (fail-closed) instead of the silent
+# fallback the built-in default uses. 4320 = 3 days in minutes.
+minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary

Make the extension's install-time supply-chain cooldown explicit and set it to 3 days: add `minimumReleaseAge: 4320` (3 days, in minutes) to `extension/pnpm-workspace.yaml`.

## Motivation

pnpm 11 already enforces a built-in `minimumReleaseAge` default of 1 day (1440 min) at install time, but it is implicit -- invisible in the repo and subject to change if pnpm changes its default. This states the policy explicitly and raises it to 3 days.

This is deliberate defense-in-depth alongside Renovate's 7-day `minimumReleaseAge` in `renovate.json`. The two layers are not redundant. Renovate's own docs recommend configuring minimum release age in **both** Renovate and the package manager, because Renovate "operates independently and cannot read the package manager's config," and "when Renovate delegates lockfile updates to the package manager, transitive dependencies may be introduced that bypass Renovate's checks." Renovate gates only the update PRs it proposes for direct dependencies; pnpm's gate is the only install-time enforcement (CI + local, all deps including transitive), and it caught exactly that gap during the TypeScript v7 bump (#70).

Why 3 days: recent supply-chain compromises are typically caught within hours to a couple of days (Shai-Hulud ~12h, the debug/chalk incident ~2.5h), and analyses find most malicious-package exploitation windows close before day 7. Three days blocks the short-lived blast radius while staying well under Renovate's 7-day gate. Keeping pnpm's value <= Renovate's guarantees Renovate-proposed updates always clear this gate, so the two layers never conflict (the divergence that produces broken update PRs).

## Changes

- Add `minimumReleaseAge: 4320` (3 days) to `extension/pnpm-workspace.yaml`, with a comment documenting the intent and the "keep <= Renovate" rule.
- Configuring it explicitly enables pnpm's strict mode (fail-closed): a package that violates the cooldown now fails resolution loudly instead of the built-in default's silent fallback / auto-exclude.
- No dependency, lockfile, or source changes.

## Testing

- `pnpm install --frozen-lockfile` (CI's install step) against the current lockfile -> exit 0, "Lockfile passes supply-chain policies (160 entries)". Confirms no existing dependency is younger than 3 days, so the gate does not break the current tree.
- Full extension CI sequence on this branch:
  - `pnpm run size` -> exit 0 (WASM 40.0 KB, within target)
  - `pnpm run lint` -> exit 0
  - `pnpm run typecheck` -> exit 0
  - `pnpm test` -> 142 passed (13 files)
  - `pnpm run build` -> exit 0

Coordination with #70: independent change (different files). Merge #70 first so its cooldown stays on the current 1-day basis (clears 2026-07-09 15:55 UTC); merging this 3-day policy into main before #70 would extend #70's wait to 2026-07-11.