### PR TITLE
ci: atomic push and inline release committer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,45 +24,31 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - name: Set the release committer to the app identity
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
-        run: |
-          set -euo pipefail
-          # GitHub links a commit to the App only when the committer email is
-          # <app-user-id>+<slug>[bot]@users.noreply.github.com; resolve the id from the slug.
-          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
-          {
-            echo "GIT_AUTHOR_NAME=${APP_SLUG}[bot]"
-            echo "GIT_AUTHOR_EMAIL=${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
-            echo "GIT_COMMITTER_NAME=${APP_SLUG}[bot]"
-            echo "GIT_COMMITTER_EMAIL=${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
-          } >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Install tools
         uses: jdx/mise-action@v4
       - name: Validate input
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [ "$GITHUB_REF_NAME" = "main" ] || { echo "::error::run this workflow from main (got $GITHUB_REF_NAME)"; exit 1; }
-          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/v$VERSION" >/dev/null 2>&1; then
-            echo "::error::tag v$VERSION already exists; delete it first to re-release: git push origin :refs/tags/v$VERSION"
-            exit 1
-          fi
       - name: Bump, commit, and tag
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
+          # Author the commit as the app; the +<id> email links it to the bot account.
+          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           bump-my-version bump --new-version "$VERSION"
           pnpm -C extension version "$VERSION" --no-git-tag-version --allow-same-version --no-git-checks
           git add -u
           git diff --cached --quiet || git commit -m "chore: release v$VERSION"
           git tag "v$VERSION"
-          git push origin main "v$VERSION"
+          git push --atomic origin main "v$VERSION"
       - name: Build CLI for all targets
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Streamline the release workflow: make the push atomic, inline the app-identity `git config` into the commit step (removing the separate committer step), and drop the tag-exists precheck now that the atomic push makes a duplicate safe.

## Motivation

Backports refinements settled while adapting this workflow for another repo (hashiiiii/rules-for-ai). `git push origin main "vX"` updates two refs non-atomically: if the branch push is rejected while the tag push succeeds, a dangling remote tag is left behind and the re-run then fails on "tag already exists". `--atomic` makes it both-or-nothing. The separate `$GITHUB_ENV` committer step folds into the single commit step via `git config` with no behavior change (only one commit is made), and with the atomic push the friendly tag-exists precheck is no longer load-bearing.

## Changes

- `.github/workflows/release.yml`:
  - `git push` -> `git push --atomic origin main "v$VERSION"`.
  - Fold the app committer identity into the "Bump, commit, and tag" step via `git config user.name/email` (resolving the bot user id), and delete the separate "Set the release committer" step; add `GH_TOKEN` / `APP_SLUG` env there.
  - Drop the tag-exists check (and its now-unused `GH_TOKEN`) from "Validate input"; the atomic push handles collisions cleanly.
  - Unchanged on purpose: `bump-my-version` + `pnpm` bump, `git diff --cached --quiet || git commit` (kept — supports same-version re-runs via `--allow-same-version`), the CLI build, `set -euo pipefail`, and step granularity.

## Testing

Not exercised end-to-end (a real release publishes artifacts). Verified the workflow parses as valid YAML and the diff is limited to the three intended changes:

```
$ ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml')" && echo OK
OK
```

`.bumpversion.toml` has `commit = false` / `tag = false`, so folding the committer into the commit step is safe: bump-my-version only edits files, and the manual `git commit` / `git tag` stay the single commit/tag point.