### PR TITLE
feat: redesign extension ui

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -67,8 +67,8 @@ function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
   if (!container?.parentElement) return;
   const bar = document.createElement("div");
   bar.setAttribute("data-prefablens-global", "");
-  bar.style.cssText = "display:flex;align-items:center;gap:8px;margin:0 0 8px;font:12px system-ui;";
   const label = document.createElement("span");
+  label.className = "prefablens-eyebrow";
   label.textContent = "PrefabLens";
   const toggle = createToggle((view) => state.setDefault(view), state.defaultView());
   bar.append(label, toggle.element);

--- a/extension/src/content/toggle.test.ts
+++ b/extension/src/content/toggle.test.ts
@@ -36,4 +36,18 @@ describe("createToggle", () => {
     expect(semantic?.getAttribute("aria-pressed")).toBe("true");
     expect(onSelect).not.toHaveBeenCalled();
   });
+
+  it("injects the page stylesheet exactly once", () => {
+    createToggle(vi.fn());
+    createToggle(vi.fn());
+    expect(document.head.querySelectorAll("style[data-prefablens-style]")).toHaveLength(1);
+  });
+
+  it("renders as a segmented control styled via aria-pressed", () => {
+    const toggle = createToggle(vi.fn());
+    expect(toggle.element.classList.contains("prefablens-seg")).toBe(true);
+    // No inline style juggling: the selected look is keyed off aria-pressed in CSS
+    const [raw] = [...toggle.element.querySelectorAll("button")];
+    expect(raw?.getAttribute("style")).toBeNull();
+  });
 });

--- a/extension/src/content/toggle.ts
+++ b/extension/src/content/toggle.ts
@@ -2,27 +2,63 @@ export type View = "raw" | "semantic";
 
 export type Toggle = { element: HTMLElement; set(view: View): void };
 
+const FONT = `-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif`;
+
+/** Page-level styles for the toggle and global bar. Colors read GitHub's Primer
+ *  variables (always defined on github.com); fallbacks cover the e2e fixture. */
+const PAGE_STYLES = `
+  [data-prefablens-global] { display: flex; align-items: center; gap: 8px; margin: 0 0 8px; }
+  [data-prefablens-global] .prefablens-seg { margin-left: 0; }
+  .prefablens-eyebrow {
+    font: 600 11px/1 ${FONT};
+    letter-spacing: 0.6px; text-transform: uppercase;
+    color: var(--fgColor-muted, #59636e);
+  }
+  .prefablens-seg {
+    display: inline-flex; gap: 2px; padding: 2px; margin-left: 8px; vertical-align: middle;
+    background: var(--bgColor-muted, #f6f8fa);
+    border-radius: 6px;
+  }
+  .prefablens-seg button {
+    font: 500 12px/20px ${FONT};
+    padding: 0 10px; border: 1px solid transparent; border-radius: 4px;
+    background: transparent; color: var(--fgColor-muted, #59636e); cursor: pointer;
+  }
+  .prefablens-seg button:hover { color: var(--fgColor-default, #1f2328); }
+  .prefablens-seg button[aria-pressed="true"] {
+    font-weight: 600;
+    background: var(--bgColor-default, #ffffff);
+    border-color: var(--borderColor-default, #d1d9e0);
+    color: var(--fgColor-default, #1f2328);
+  }
+`;
+
+/** Injects the page stylesheet once. The toggle lives in GitHub's DOM (not a shadow root). */
+export function injectPageStyles(doc: Document = document): void {
+  if (doc.head.querySelector("style[data-prefablens-style]")) return;
+  const style = doc.createElement("style");
+  style.setAttribute("data-prefablens-style", "");
+  style.textContent = PAGE_STYLES;
+  doc.head.append(style);
+}
+
 export function createToggle(onSelect: (view: View) => void, initial: View = "raw"): Toggle {
+  injectPageStyles();
   const wrap = document.createElement("span");
   wrap.setAttribute("data-prefablens-toggle", "");
-  wrap.style.cssText = "display:inline-flex;gap:0;margin-left:8px;vertical-align:middle;";
+  wrap.className = "prefablens-seg";
 
   const buttons: HTMLButtonElement[] = [];
-  // set updates only the display: to avoid pulling in onSelect (the re-fetch side) during a global apply
+  // set updates only the display: to avoid pulling in onSelect (the re-fetch side) during a global apply.
+  // The selected look is keyed entirely off aria-pressed in the injected CSS.
   const select = (view: View): void => {
-    for (const b of buttons) {
-      const active = b.dataset.view === view;
-      b.setAttribute("aria-pressed", String(active));
-      b.style.fontWeight = active ? "600" : "400";
-    }
+    for (const b of buttons) b.setAttribute("aria-pressed", String(b.dataset.view === view));
   };
   const make = (view: View, label: string): HTMLButtonElement => {
     const btn = document.createElement("button");
     btn.type = "button";
     btn.textContent = label;
     btn.dataset.view = view;
-    btn.style.cssText =
-      "font:11px system-ui;padding:1px 8px;border:1px solid #808080;background:transparent;color:inherit;cursor:pointer;";
     btn.addEventListener("click", () => {
       select(view);
       onSelect(view);

--- a/extension/src/renderer/icons.ts
+++ b/extension/src/renderer/icons.ts
@@ -1,0 +1,32 @@
+/** Inline SVG markup for tree glyphs. Static strings only — never interpolate data. */
+const svg = (body: string, size: number): string =>
+  `<svg width="${size}" height="${size}" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">${body}</svg>`;
+
+export const CHEVRON = svg(
+  '<path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>',
+  12,
+);
+
+export const CUBE = svg(
+  '<path d="M8 1.5 14 5v6l-6 3.5L2 11V5l6-3.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>' +
+    '<path d="M2 5l6 3.5L14 5M8 8.5V14" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>',
+  14,
+);
+
+export const GEAR = svg(
+  '<circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.2"/>' +
+    '<path d="M8 1.8v2M8 12.2v2M1.8 8h2M12.2 8h2M3.7 3.7l1.4 1.4M10.9 10.9l1.4 1.4M12.3 3.7l-1.4 1.4M5.1 10.9l-1.4 1.4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>',
+  14,
+);
+
+export const ALERT = svg(
+  '<path d="M8 1.75a.9.9 0 0 1 .78.45l6.3 10.9a.9.9 0 0 1-.78 1.35H1.7a.9.9 0 0 1-.78-1.35l6.3-10.9A.9.9 0 0 1 8 1.75Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>' +
+    '<path d="M8 6v3.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>' +
+    '<circle cx="8" cy="11.6" r=".8" fill="currentColor"/>',
+  14,
+);
+
+export const CHECK = svg(
+  '<path d="M13.5 4.5 6.5 11.5 2.5 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>',
+  14,
+);

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -372,6 +372,36 @@ describe("render", () => {
     expect(summary?.textContent).toContain("Cylinder1");
     expect(summary?.textContent).not.toContain("MonoBehaviour");
   });
+
+  it("renders unity-style rows: chevron, icon and status badge", () => {
+    const root = freshRoot();
+    render(root, DIFF);
+    const summary = root.querySelector("details.pl-go > summary")!;
+    expect(summary.classList.contains("pl-row")).toBe(true);
+    expect(summary.querySelector(".pl-chevron svg")).not.toBeNull();
+    expect(summary.querySelector(".pl-icon svg")).not.toBeNull();
+    expect(summary.querySelector(".pl-badge")?.textContent).toBe("~");
+  });
+
+  it("skips the status badge on unchanged rows and tints the prefab icon", () => {
+    const root = freshRoot();
+    render(root, INSTANCE);
+    // Plane is unchanged: no badge chip at all, not a blank one
+    const plane = root.querySelector("details.pl-go > summary")!;
+    expect(plane.querySelector(".pl-badge")).toBeNull();
+    const icon = root.querySelector("details.pl-pi > summary .pl-icon")!;
+    expect(icon.classList.contains("pl-icon-prefab")).toBe(true);
+  });
+
+  it("marks rows without children as leaves (chevron slot hidden via CSS)", () => {
+    const root = freshRoot();
+    render(root, DIFF);
+    const summaries = [...root.querySelectorAll("details.pl-go > summary")];
+    const weapon = summaries.find((s) => s.textContent?.includes("Weapon"))!;
+    expect(weapon.classList.contains("pl-leaf")).toBe(true);
+    const player = summaries.find((s) => s.textContent?.includes("Player"))!;
+    expect(player.classList.contains("pl-leaf")).toBe(false);
+  });
 });
 
 describe("detectTheme", () => {

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -414,6 +414,18 @@ describe("render", () => {
     // The label lives in aria, not in visible text
     expect(box.textContent).toBe("");
   });
+
+  it("shows a spinner with the resolving indicator", () => {
+    const root = freshRoot();
+    render(root, { schema: "prefablens.diff.v2", unresolvedGuids: ["g1"], roots: [], loose: [] }, { resolving: 1 });
+    expect(root.querySelector(".pl-resolving .pl-spinner")).not.toBeNull();
+  });
+
+  it("shows an alert icon on errors", () => {
+    const root = freshRoot();
+    renderError(root, "Could not fetch file contents from GitHub.");
+    expect(root.querySelector(".pl-error .pl-note-icon svg")).not.toBeNull();
+  });
 });
 
 describe("detectTheme", () => {

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DiffV2 } from "../types";
-import { detectTheme, render, renderError, renderTooLarge } from "./render";
+import { detectTheme, render, renderError, renderLoading, renderTooLarge } from "./render";
 
 const DIFF: DiffV2 = {
   schema: "prefablens.diff.v2",
@@ -401,6 +401,18 @@ describe("render", () => {
     expect(weapon.classList.contains("pl-leaf")).toBe(true);
     const player = summaries.find((s) => s.textContent?.includes("Player"))!;
     expect(player.classList.contains("pl-leaf")).toBe(false);
+  });
+
+  it("renderLoading shows an accessible skeleton tree instead of text", () => {
+    const root = freshRoot();
+    renderLoading(root);
+    const box = root.querySelector(".pl-skeleton")!;
+    expect(box.getAttribute("role")).toBe("status");
+    expect(box.getAttribute("aria-busy")).toBe("true");
+    expect(box.getAttribute("aria-label")).toContain("Computing semantic diff");
+    expect(box.querySelectorAll(".pl-skel-row")).toHaveLength(5);
+    // The label lives in aria, not in visible text
+    expect(box.textContent).toBe("");
   });
 });
 

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -1,38 +1,9 @@
 import type { ComponentDiff, DiffV2, FieldValue, NodeDiff, OverrideDiff, Status } from "../types";
+import { CHECK, CHEVRON, CUBE, GEAR } from "./icons";
+import { STYLES } from "./styles";
 
-const STYLES = `
-  :host { all: initial; }
-  .pl-root {
-    --pl-fg: #1f2328; --pl-muted: #59636e; --pl-border: #d1d9e0;
-    --pl-added: #1a7f37; --pl-removed: #cf222e; --pl-modified: #9a6700;
-    font: 12px/1.5 ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
-    color: var(--pl-fg); padding: 8px 12px; display: block;
-  }
-  .pl-root.pl-dark {
-    --pl-fg: #f0f6fc; --pl-muted: #9198a1; --pl-border: #3d444d;
-    --pl-added: #3fb950; --pl-removed: #f85149; --pl-modified: #d29922;
-  }
-  details { margin: 2px 0; border-left: 1px solid var(--pl-border); padding-left: 10px; }
-  summary { cursor: pointer; user-select: none; }
-  .pl-badge { font-weight: 600; margin-right: 6px; }
-  .pl-added > summary .pl-badge { color: var(--pl-added); }
-  .pl-removed > summary .pl-badge { color: var(--pl-removed); }
-  .pl-modified > summary .pl-badge { color: var(--pl-modified); }
-  .pl-script { color: var(--pl-muted); margin-left: 6px; }
-  .pl-field { padding-left: 14px; }
-  .pl-field .pl-path { color: var(--pl-muted); margin-right: 6px; }
-  .pl-before { color: var(--pl-removed); }
-  .pl-after { color: var(--pl-added); }
-  .pl-arrow { color: var(--pl-muted); margin: 0 4px; }
-  .pl-empty, .pl-error, .pl-loading { color: var(--pl-muted); margin: 0; }
-  .pl-resolving { color: var(--pl-muted); margin: 0 0 4px; }
-  .pl-error { color: var(--pl-removed); }
-  .pl-render { font: inherit; margin-top: 4px; padding: 1px 8px; border: 1px solid var(--pl-border); background: transparent; color: inherit; cursor: pointer; }
-  .pl-components { border-left: 1px solid var(--pl-border); margin: 2px 0 2px 4px; padding-left: 8px; }
-  .pl-components-label { color: var(--pl-muted); font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; user-select: none; }
-`;
-
-const BADGE: Record<Status, string> = { added: "+", removed: "−", modified: "~", unchanged: " " };
+// Unchanged rows carry no chip: the absence of a badge is the "unchanged" signal.
+const BADGE: Record<Exclude<Status, "unchanged">, string> = { added: "+", removed: "−", modified: "~" };
 
 export function detectTheme(doc: Document): "light" | "dark" {
   const mode = doc.documentElement.getAttribute("data-color-mode");
@@ -48,7 +19,7 @@ export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: numb
   for (const node of diff.roots) container.append(renderNode(node, diff));
   for (const c of diff.loose) container.append(renderComponent(c, diff));
   if (!diff.roots.length && !diff.loose.length) {
-    container.append(note("pl-empty", "No semantic changes"));
+    container.append(note("pl-empty", "No semantic changes", CHECK));
   }
 }
 
@@ -81,11 +52,58 @@ function mount(root: ShadowRoot): HTMLElement {
   return container;
 }
 
-function note(className: string, text: string): HTMLElement {
-  const p = document.createElement("p");
-  p.className = className;
-  p.textContent = text;
-  return p;
+function note(className: string, text: string, icon?: string): HTMLElement {
+  const div = document.createElement("div");
+  div.className = `pl-note ${className}`;
+  if (icon) div.append(glyph(icon, "pl-note-icon"));
+  const span = document.createElement("span");
+  span.textContent = text;
+  div.append(span);
+  return div;
+}
+
+function glyph(markup: string, className: string): HTMLElement {
+  const span = document.createElement("span");
+  span.className = className;
+  span.innerHTML = markup; // static constants from icons.ts only
+  return span;
+}
+
+function summaryRow(status: Status, icon: string, iconClass: string, name: string, meta?: string): HTMLElement {
+  const summary = document.createElement("summary");
+  summary.className = "pl-row";
+  summary.append(glyph(CHEVRON, "pl-chevron"), glyph(icon, iconClass));
+  const label = document.createElement("span");
+  label.className = "pl-name";
+  label.textContent = name;
+  if (meta) {
+    const m = document.createElement("span");
+    m.className = "pl-script";
+    m.textContent = meta;
+    label.append(m);
+  }
+  summary.append(label);
+  if (status !== "unchanged") {
+    const badge = document.createElement("span");
+    badge.className = "pl-badge";
+    badge.textContent = BADGE[status];
+    summary.append(badge);
+  }
+  return summary;
+}
+
+/** Appends kids into the details, or marks the summary as a leaf when there are none. */
+function finish(details: HTMLDetailsElement, summary: HTMLElement, kids: HTMLElement): HTMLDetailsElement {
+  details.append(summary);
+  if (kids.childElementCount) details.append(kids);
+  else summary.classList.add("pl-leaf");
+  return details;
+}
+
+function kidsBox(): HTMLElement {
+  const div = document.createElement("div");
+  div.className = "pl-kids";
+  return div;
 }
 
 function stem(path: string): string {
@@ -104,17 +122,22 @@ function nodeName(node: NodeDiff, diff: DiffV2): string {
 }
 
 function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
-  const details = openDetails(node.kind === "prefabInstance" ? "pl-pi" : "pl-go", node.status);
-  const summary = summaryLine(node.status, nodeName(node, diff));
+  const isPrefab = node.kind === "prefabInstance";
+  const details = openDetails(isPrefab ? "pl-pi" : "pl-go", node.status);
+  let meta: string | undefined;
   if (node.kind === "prefabInstance") {
-    const badge = document.createElement("span");
-    badge.className = "pl-script";
     const p = node.sourceGuid ? diff.resolved?.[node.sourceGuid] : undefined;
-    badge.textContent = p ? `‹Prefab: ${p}›` : "‹Prefab›";
-    summary.append(badge);
+    meta = p ? `‹Prefab: ${p}›` : "‹Prefab›";
   }
-  details.append(summary);
+  const summary = summaryRow(
+    node.status,
+    CUBE,
+    isPrefab ? "pl-icon pl-icon-prefab" : "pl-icon",
+    nodeName(node, diff),
+    meta,
+  );
 
+  const kids = kidsBox();
   // Display-hierarchy rule: component/override cards live only under the components section.
   const cards: HTMLElement[] = [];
   if (node.kind === "prefabInstance") cards.push(...renderOverrideGroups(node.overrides, diff));
@@ -126,10 +149,10 @@ function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
     label.className = "pl-components-label";
     label.textContent = "components";
     section.append(label, ...cards);
-    details.append(section);
+    kids.append(section);
   }
-  for (const child of node.children) details.append(renderNode(child, diff));
-  return details;
+  for (const child of node.children) kids.append(renderNode(child, diff));
+  return finish(details, summary, kids);
 }
 
 function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElement[] {
@@ -145,9 +168,9 @@ function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElem
     const status = first && rows.every((r) => r.status === first.status) ? first.status : "modified";
     const el = openDetails("pl-comp", status);
     el.open = true; // override cards are always open (spec: light, just a collapsed summary)
-    el.append(summaryLine(status, name));
-    for (const r of rows) el.append(fieldRow(r.label, r.status, r.before, r.after, diff));
-    return el;
+    const kids = kidsBox();
+    for (const r of rows) kids.append(fieldRow(r.label, r.status, r.before, r.after, diff));
+    return finish(el, summaryRow(status, GEAR, "pl-icon", name), kids);
   });
 }
 
@@ -155,16 +178,10 @@ function renderComponent(c: ComponentDiff, diff: DiffV2): HTMLElement {
   const details = openDetails("pl-comp", c.status);
   const resolved = c.scriptGuid ? diff.resolved?.[c.scriptGuid] : undefined;
   const display = resolved ? stem(resolved) : (c.className ?? c.typeName);
-  const summary = summaryLine(c.status, display);
-  if (c.scriptGuid) {
-    const script = document.createElement("span");
-    script.className = "pl-script";
-    script.textContent = "‹Script›";
-    summary.append(script);
-  }
-  details.append(summary);
-  for (const f of c.fields) details.append(fieldRow(f.path, f.status, f.before, f.after, diff));
-  return details;
+  const summary = summaryRow(c.status, GEAR, "pl-icon", display, c.scriptGuid ? "‹Script›" : undefined);
+  const kids = kidsBox();
+  for (const f of c.fields) kids.append(fieldRow(f.path, f.status, f.before, f.after, diff));
+  return finish(details, summary, kids);
 }
 
 function fieldRow(label: string, status: Status, before: FieldValue, after: FieldValue, diff: DiffV2): HTMLElement {
@@ -196,17 +213,6 @@ function openDetails(kind: string, status: Status): HTMLDetailsElement {
   details.open = true;
   details.className = `${kind} pl-${status}`;
   return details;
-}
-
-function summaryLine(status: Status, text: string): HTMLElement {
-  const summary = document.createElement("summary");
-  const badge = document.createElement("span");
-  badge.className = "pl-badge";
-  badge.textContent = BADGE[status];
-  const label = document.createElement("span");
-  label.textContent = text;
-  summary.append(badge, label);
-  return summary;
 }
 
 function valueSpan(className: string, value: FieldValue, diff: DiffV2): HTMLElement {

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -1,5 +1,5 @@
 import type { ComponentDiff, DiffV2, FieldValue, NodeDiff, OverrideDiff, Status } from "../types";
-import { CHECK, CHEVRON, CUBE, GEAR } from "./icons";
+import { ALERT, CHECK, CHEVRON, CUBE, GEAR } from "./icons";
 import { STYLES } from "./styles";
 
 // Unchanged rows carry no chip: the absence of a badge is the "unchanged" signal.
@@ -15,7 +15,13 @@ export function detectTheme(doc: Document): "light" | "dark" {
 export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: number }): void {
   const container = mount(root);
   // Resolving indicator: the diff body is correct from the start, only reference names fill in later
-  if (opts?.resolving) container.append(note("pl-resolving", `Resolving ${opts.resolving} reference(s)…`));
+  if (opts?.resolving) {
+    const busy = note("pl-resolving", `Resolving ${opts.resolving} reference(s)…`);
+    const spin = document.createElement("span");
+    spin.className = "pl-spinner";
+    busy.prepend(spin);
+    container.append(busy);
+  }
   for (const node of diff.roots) container.append(renderNode(node, diff));
   for (const c of diff.loose) container.append(renderComponent(c, diff));
   if (!diff.roots.length && !diff.loose.length) {
@@ -24,7 +30,7 @@ export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: numb
 }
 
 export function renderError(root: ShadowRoot, message: string): void {
-  mount(root).append(note("pl-error", message));
+  mount(root).append(note("pl-error", message, ALERT));
 }
 
 // Deterministic tree-shaped placeholder: [indent level, name-bar width %]
@@ -65,7 +71,7 @@ export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => 
   button.className = "pl-render";
   button.textContent = "Render anyway";
   button.addEventListener("click", onRender);
-  container.append(note("pl-empty", `Large file (${Math.round(bytes / (1024 * 1024))} MB).`), button);
+  container.append(note("pl-empty", `Large file (${Math.round(bytes / (1024 * 1024))} MB).`, ALERT), button);
 }
 
 function mount(root: ShadowRoot): HTMLElement {

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -27,8 +27,34 @@ export function renderError(root: ShadowRoot, message: string): void {
   mount(root).append(note("pl-error", message));
 }
 
+// Deterministic tree-shaped placeholder: [indent level, name-bar width %]
+const SKELETON_ROWS: Array<[number, number]> = [
+  [0, 40],
+  [1, 55],
+  [2, 35],
+  [1, 60],
+  [0, 30],
+];
+
 export function renderLoading(root: ShadowRoot): void {
-  mount(root).append(note("pl-loading", "Computing semantic diff…"));
+  const box = document.createElement("div");
+  box.className = "pl-skeleton";
+  box.setAttribute("role", "status");
+  box.setAttribute("aria-label", "Computing semantic diff…");
+  box.setAttribute("aria-busy", "true");
+  for (const [indent, width] of SKELETON_ROWS) {
+    const row = document.createElement("div");
+    row.className = "pl-skel-row";
+    row.style.setProperty("--pl-indent", String(indent));
+    const icon = document.createElement("span");
+    icon.className = "pl-skel-icon";
+    const bar = document.createElement("span");
+    bar.className = "pl-skel-bar";
+    bar.style.setProperty("--pl-w", `${width}%`);
+    row.append(icon, bar);
+    box.append(row);
+  }
+  mount(root).append(box);
 }
 
 /** Over-25MB guard: doesn't auto-render, waits for an explicit click. */

--- a/extension/src/renderer/styles.ts
+++ b/extension/src/renderer/styles.ts
@@ -1,0 +1,118 @@
+/** Shadow-DOM stylesheet. Colors read Primer CSS variables (custom properties
+ *  inherit through the shadow boundary on github.com, so every GitHub theme is
+ *  followed automatically) and fall back to a built-in light/dark palette. */
+export const STYLES = `
+  :host { all: initial; }
+  .pl-root {
+    --pl-fg: var(--fgColor-default, #1f2328);
+    --pl-muted: var(--fgColor-muted, #59636e);
+    --pl-accent: var(--fgColor-accent, #0969da);
+    --pl-hairline: var(--borderColor-muted, #d8dee4);
+    --pl-hover: var(--bgColor-muted, #f6f8fa);
+    --pl-skeleton: var(--bgColor-neutral-muted, rgba(129, 139, 152, 0.18));
+    --pl-added: var(--fgColor-success, #1a7f37);
+    --pl-removed: var(--fgColor-danger, #cf222e);
+    --pl-modified: var(--fgColor-attention, #9a6700);
+    --pl-added-bg: var(--bgColor-success-muted, #dafbe1);
+    --pl-removed-bg: var(--bgColor-danger-muted, #ffebe9);
+    --pl-modified-bg: var(--bgColor-attention-muted, #fff8c5);
+    --pl-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+    --pl-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font: 12px/1.5 var(--pl-font);
+    color: var(--pl-fg); padding: 8px 12px; display: block;
+  }
+  .pl-root.pl-dark {
+    --pl-fg: var(--fgColor-default, #f0f6fc);
+    --pl-muted: var(--fgColor-muted, #9198a1);
+    --pl-accent: var(--fgColor-accent, #4493f8);
+    --pl-hairline: var(--borderColor-muted, #3d444d);
+    --pl-hover: var(--bgColor-muted, #151b23);
+    --pl-skeleton: var(--bgColor-neutral-muted, rgba(101, 108, 118, 0.25));
+    --pl-added: var(--fgColor-success, #3fb950);
+    --pl-removed: var(--fgColor-danger, #f85149);
+    --pl-modified: var(--fgColor-attention, #d29922);
+    --pl-added-bg: var(--bgColor-success-muted, rgba(46, 160, 67, 0.15));
+    --pl-removed-bg: var(--bgColor-danger-muted, rgba(248, 81, 73, 0.15));
+    --pl-modified-bg: var(--bgColor-attention-muted, rgba(187, 128, 9, 0.15));
+  }
+  details { margin: 0; }
+  summary { list-style: none; }
+  summary::-webkit-details-marker { display: none; }
+  .pl-row {
+    display: grid;
+    grid-template-columns: 16px 18px 1fr auto;
+    align-items: center;
+    min-height: 24px;
+    padding: 0 4px;
+    border-radius: 4px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .pl-row:hover { background: var(--pl-hover); }
+  .pl-chevron {
+    display: inline-flex; justify-content: center; align-items: center;
+    color: var(--pl-muted); transition: transform 120ms ease;
+  }
+  details[open] > summary .pl-chevron { transform: rotate(90deg); }
+  summary.pl-leaf { cursor: default; }
+  summary.pl-leaf .pl-chevron { visibility: hidden; }
+  .pl-icon { display: inline-flex; align-items: center; color: var(--pl-muted); }
+  .pl-icon-prefab { color: var(--pl-accent); }
+  .pl-name { min-width: 0; overflow-wrap: anywhere; }
+  .pl-script { color: var(--pl-muted); margin-left: 6px; }
+  .pl-badge {
+    font: 600 11px/16px var(--pl-mono);
+    min-width: 16px; text-align: center;
+    border-radius: 4px; padding: 0 3px; margin-left: 8px;
+  }
+  details.pl-added > summary > .pl-badge { color: var(--pl-added); background: var(--pl-added-bg); }
+  details.pl-removed > summary > .pl-badge { color: var(--pl-removed); background: var(--pl-removed-bg); }
+  details.pl-modified > summary > .pl-badge { color: var(--pl-modified); background: var(--pl-modified-bg); }
+  .pl-kids { margin-left: 11px; border-left: 1px solid var(--pl-hairline); padding-left: 8px; }
+  .pl-components-label {
+    color: var(--pl-muted); font-size: 10px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.6px; user-select: none;
+    margin: 2px 0 0 4px;
+  }
+  .pl-field {
+    display: flex; align-items: center; flex-wrap: wrap; column-gap: 6px;
+    min-height: 22px; padding: 0 4px 0 38px; border-radius: 4px;
+    font-family: var(--pl-mono);
+  }
+  .pl-field:hover { background: var(--pl-hover); }
+  .pl-path { color: var(--pl-muted); }
+  .pl-before { color: var(--pl-removed); }
+  .pl-after { color: var(--pl-added); }
+  .pl-arrow { color: var(--pl-muted); }
+  .pl-note { display: flex; align-items: center; gap: 6px; min-height: 24px; color: var(--pl-muted); }
+  .pl-note-icon { display: inline-flex; align-items: center; }
+  .pl-error { color: var(--pl-removed); }
+  .pl-spinner {
+    width: 12px; height: 12px; flex: none; border-radius: 50%;
+    border: 2px solid var(--pl-hairline); border-top-color: var(--pl-muted);
+    animation: pl-spin 1s linear infinite;
+  }
+  .pl-render {
+    font: 500 12px/1 var(--pl-font);
+    margin-top: 4px; padding: 5px 12px;
+    border: 1px solid var(--pl-hairline); border-radius: 6px;
+    background: transparent; color: var(--pl-fg); cursor: pointer;
+  }
+  .pl-render:hover { background: var(--pl-hover); }
+  .pl-skel-row {
+    display: flex; align-items: center; gap: 6px;
+    min-height: 24px; padding-left: calc(var(--pl-indent) * 16px + 4px);
+  }
+  .pl-skel-icon { width: 14px; height: 14px; border-radius: 3px; flex: none; }
+  .pl-skel-bar { height: 8px; border-radius: 4px; width: var(--pl-w); }
+  .pl-skel-icon, .pl-skel-bar {
+    background: linear-gradient(90deg, var(--pl-skeleton) 25%, var(--pl-hover) 45%, var(--pl-skeleton) 65%) 0 0 / 200% 100%;
+    animation: pl-shimmer 1.4s linear infinite;
+  }
+  @keyframes pl-shimmer { to { background-position: -200% 0; } }
+  @keyframes pl-spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) {
+    .pl-chevron { transition: none; }
+    .pl-skel-icon, .pl-skel-bar, .pl-spinner { animation: none; }
+  }
+`;


### PR DESCRIPTION
## Summary

Redesigns the extension's PR-page UI: the Raw/Semantic toggle becomes a Primer-style segmented control, the semantic view gets a Unity-hierarchy-like tree (disclosure chevrons, GameObject/Component icons, indent guides, status badge chips, full-row hover), and a skeleton tree with shimmer replaces the plain "Computing semantic diff…" text while data is loading.

## Motivation

The previous UI was functional but visually bare: plain bordered buttons for the toggle, a text-only loading state, and a tree without any hierarchy affordances. This change makes the toggle read as GitHub-native and translates Unity's hierarchy visual grammar (triangles, cube icons, blue prefab tint, guide lines) into GitHub's Primer palette, following the HashiCorp design-md principles (surface lift instead of shadows, 1px hairlines, restrained 500/600 weights, eyebrow labels, 6px radii).

## Changes

- `renderer/styles.ts` (new): shadow-DOM stylesheet; all colors flow through `--pl-*` tokens defined as Primer CSS variables with light/dark fallbacks, so the view follows every GitHub theme automatically (custom properties inherit through the shadow boundary)
- `renderer/icons.ts` (new): static SVG constants (chevron, cube, gear, alert, check); repo-controlled strings still render via `textContent` only
- `renderer/render.ts`: every row is a CSS grid (`triangle | icon | name | badge`, `align-items: center`) so glyphs are always vertically centered; children live in a `.pl-kids` wrapper whose hairline guide passes under the parent's chevron; unchanged rows carry no badge chip; `renderLoading` renders a deterministic 5-row skeleton (`role="status"`, `aria-busy`, shimmer disabled under `prefers-reduced-motion`); resolving indicator gains a mini spinner, error/empty/too-large notes gain icons and a Primer-secondary-style button
- `content/toggle.ts`: segmented control styled entirely off `aria-pressed` via a stylesheet injected once into `document.head`; inline style juggling removed
- `content/index.ts`: global bar drops inline styles; the "PrefabLens" label becomes an eyebrow

## Testing

- `pnpm test` — 150 passed (13 files), including new tests for row anatomy, badge omission on unchanged rows, leaf marking, skeleton accessibility, spinner/alert icons, and idempotent style injection
- `pnpm e2e` — 8 passed (smoke + full, real wasm diff in Chromium)
- `pnpm typecheck` / `pnpm lint` / `pnpm build` — clean (lint warnings are pre-existing `noNonNullAssertion` style warnings)
- Visual check via Playwright screenshots of the e2e fixture: light/dark tree, skeleton, toggle states