### PR TITLE
feat: add GitHub sign-in via OAuth device flow

### DIFF
--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -77,12 +77,10 @@ test.beforeAll(async () => {
   sw ??= await context.waitForEvent("serviceworker");
   const extensionId = new URL(sw.url()).host;
 
-  // Save the PAT in Options (the API base is now baked in at build time, not entered here)
+  // Seed the token directly in storage (sign-in is the only UI path; the fake server ignores its value)
   const options = await context.newPage();
   await options.goto(`chrome-extension://${extensionId}/options.html`);
-  await options.fill("#pat", "tok");
-  await options.click("#save");
-  await expect(options.locator("#status")).toHaveText("Saved");
+  await options.evaluate(() => chrome.storage.local.set({ pat: "tok" }));
   await options.close();
 });
 

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -164,7 +164,7 @@ test("recovers after an error response", async ({ page }) => {
 
   // First toggle: shows the error
   await unityHeader.getByRole("button", { name: "Semantic" }).click();
-  await expect(view).toContainText("Set a GitHub token");
+  await expect(view).toContainText("Sign in with GitHub");
 
   // Re-toggling Raw → Semantic re-fetches and recovers to the normal result
   await unityHeader.getByRole("button", { name: "Raw" }).click();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.4.0",
   "description": "Semantic diffs for Unity YAML files in GitHub pull requests",
   "permissions": ["storage"],
-  "host_permissions": ["https://api.github.com/*"],
+  "host_permissions": ["https://api.github.com/*", "https://github.com/*"],
   "background": { "service_worker": "background.js" },
   "content_scripts": [
     {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -12,7 +12,7 @@ import { createToggle, type Toggle, type View } from "./toggle";
 import { createViewState, type ViewState } from "./viewstate";
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
-  "pat-missing": "Set a GitHub token in the PrefabLens options page.",
+  "pat-missing": "Sign in with GitHub in the PrefabLens options page.",
   "auth-failed": "GitHub authentication failed. Check your token in the PrefabLens options page.",
   "rate-limited": "GitHub rate limit exceeded. Wait a while and toggle again.",
   "fetch-failed": "Could not fetch file contents from GitHub.",

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -13,7 +13,7 @@ import { createViewState, type ViewState } from "./viewstate";
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
   "pat-missing": "Sign in with GitHub in the PrefabLens options page.",
-  "auth-failed": "GitHub authentication failed. Check your token in the PrefabLens options page.",
+  "auth-failed": "GitHub authentication failed. Sign in again in the PrefabLens options page.",
   "rate-limited": "GitHub rate limit exceeded. Wait a while and toggle again.",
   "fetch-failed": "Could not fetch file contents from GitHub.",
   "diff-failed": "Could not compute a semantic diff for this file.",

--- a/extension/src/options/deviceFlow.test.ts
+++ b/extension/src/options/deviceFlow.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { CLIENT_ID, type DeviceCode, pollForToken, requestDeviceCode } from "./deviceFlow";
+
+// Queue-based fetch fake: each call shifts the next canned Response and records the request.
+function fakeFetch(responses: Response[]) {
+  const queue = [...responses];
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    const next = queue.shift();
+    if (!next) throw new Error("fake fetch queue exhausted");
+    return next;
+  }) as typeof fetch;
+  return { fn, calls };
+}
+
+// Fake sleep: records the requested delay and resolves immediately, so polling tests run instantly.
+function fakeSleep() {
+  const delays: number[] = [];
+  const fn = async (ms: number) => {
+    delays.push(ms);
+  };
+  return { fn, delays };
+}
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const code: DeviceCode = {
+  deviceCode: "dc1",
+  userCode: "ABCD-1234",
+  verificationUri: "https://github.com/login/device",
+  interval: 5,
+  expiresIn: 900,
+};
+
+describe("requestDeviceCode", () => {
+  it("posts client_id and scope, mapping the snake_case response to camelCase", async () => {
+    const { fn, calls } = fakeFetch([
+      json({
+        device_code: "dc1",
+        user_code: "ABCD-1234",
+        verification_uri: "https://github.com/login/device",
+        interval: 5,
+        expires_in: 900,
+      }),
+    ]);
+    const result = await requestDeviceCode(fn);
+    expect(result).toEqual(code);
+    expect(calls[0]?.url).toBe("https://github.com/login/device/code");
+    expect(calls[0]?.init.method).toBe("POST");
+    expect((calls[0]?.init.headers as Record<string, string>).accept).toBe("application/json");
+    expect(String(calls[0]?.init.body)).toBe(`client_id=${CLIENT_ID}&scope=repo`);
+  });
+
+  it("throws on a non-OK response", async () => {
+    const { fn } = fakeFetch([json({}, 500)]);
+    await expect(requestDeviceCode(fn)).rejects.toThrow();
+  });
+
+  it("throws when the JSON body carries an error field", async () => {
+    const { fn } = fakeFetch([json({ error: "invalid_client", error_description: "bad client id" })]);
+    await expect(requestDeviceCode(fn)).rejects.toThrow("bad client id");
+  });
+});
+
+describe("pollForToken", () => {
+  it("returns the token on the first poll, sleeping once for the initial interval", async () => {
+    const { fn, calls } = fakeFetch([json({ access_token: "tok123" })]);
+    const { fn: sleep, delays } = fakeSleep();
+    const result = await pollForToken(fn, sleep, code);
+    expect(result).toEqual({ status: "ok", token: "tok123" });
+    expect(delays).toEqual([5000]); // sleep(interval * 1000) runs before every poll, including the first
+    expect(calls[0]?.url).toBe("https://github.com/login/oauth/access_token");
+    expect((calls[0]?.init.headers as Record<string, string>).accept).toBe("application/json");
+    expect(String(calls[0]?.init.body)).toBe(
+      `client_id=${CLIENT_ID}&device_code=dc1&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code`,
+    );
+  });
+
+  it("keeps polling through authorization_pending until the token arrives", async () => {
+    const { fn } = fakeFetch([
+      json({ error: "authorization_pending" }),
+      json({ error: "authorization_pending" }),
+      json({ access_token: "tok123" }),
+    ]);
+    const { fn: sleep, delays } = fakeSleep();
+    const result = await pollForToken(fn, sleep, code);
+    expect(result).toEqual({ status: "ok", token: "tok123" });
+    expect(delays).toEqual([5000, 5000, 5000]); // interval is unchanged while pending
+  });
+
+  it("slow_down without an interval field adds 5s to the current interval", async () => {
+    const { fn } = fakeFetch([json({ error: "slow_down" }), json({ access_token: "tok123" })]);
+    const { fn: sleep, delays } = fakeSleep();
+    await pollForToken(fn, sleep, code);
+    expect(delays).toEqual([5000, 10000]); // 5 (initial) + 5 (slow_down bump)
+  });
+
+  it("slow_down with an interval field uses it as-is instead of adding 5s", async () => {
+    const { fn } = fakeFetch([json({ error: "slow_down", interval: 8 }), json({ access_token: "tok123" })]);
+    const { fn: sleep, delays } = fakeSleep();
+    await pollForToken(fn, sleep, code);
+    // If the +5 fallback fired unconditionally this would be 10000 (5+5); 8000 proves the
+    // response's own interval wins when the server supplies one.
+    expect(delays).toEqual([5000, 8000]);
+  });
+
+  it("maps expired_token to an expired status", async () => {
+    const { fn } = fakeFetch([json({ error: "expired_token" })]);
+    const result = await pollForToken(fn, fakeSleep().fn, code);
+    expect(result).toEqual({ status: "expired" });
+  });
+
+  it("maps access_denied to a denied status", async () => {
+    const { fn } = fakeFetch([json({ error: "access_denied" })]);
+    const result = await pollForToken(fn, fakeSleep().fn, code);
+    expect(result).toEqual({ status: "denied" });
+  });
+
+  it("throws on an unrecognized error code", async () => {
+    const { fn } = fakeFetch([json({ error: "incorrect_client_credentials" })]);
+    await expect(pollForToken(fn, fakeSleep().fn, code)).rejects.toThrow();
+  });
+
+  it("throws on a non-OK response", async () => {
+    const { fn } = fakeFetch([json({}, 500)]);
+    await expect(pollForToken(fn, fakeSleep().fn, code)).rejects.toThrow();
+  });
+});

--- a/extension/src/options/deviceFlow.ts
+++ b/extension/src/options/deviceFlow.ts
@@ -1,0 +1,73 @@
+// Public client id of the GitHub OAuth App (device flow enabled). Replace once the app is registered.
+export const CLIENT_ID = "REPLACE_WITH_OAUTH_APP_CLIENT_ID";
+
+export type DeviceCode = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  interval: number;
+  expiresIn: number;
+};
+
+export type PollResult = { status: "ok"; token: string } | { status: "denied" } | { status: "expired" };
+
+type DeviceCodeResponse =
+  | { device_code: string; user_code: string; verification_uri: string; interval: number; expires_in: number }
+  | { error: string; error_description?: string };
+
+type TokenResponse = { access_token: string } | { error: string; interval?: number };
+
+export async function requestDeviceCode(fetchFn: typeof fetch): Promise<DeviceCode> {
+  const res = await fetchFn("https://github.com/login/device/code", {
+    method: "POST",
+    headers: { accept: "application/json" },
+    body: new URLSearchParams({ client_id: CLIENT_ID, scope: "repo" }),
+  });
+  if (!res.ok) throw new Error(`device code request failed (HTTP ${res.status})`);
+  const body = (await res.json()) as DeviceCodeResponse;
+  if ("error" in body) throw new Error(body.error_description ?? body.error);
+  return {
+    deviceCode: body.device_code,
+    userCode: body.user_code,
+    verificationUri: body.verification_uri,
+    interval: body.interval,
+    expiresIn: body.expires_in,
+  };
+}
+
+export async function pollForToken(
+  fetchFn: typeof fetch,
+  sleep: (ms: number) => Promise<void>,
+  code: DeviceCode,
+): Promise<PollResult> {
+  let interval = code.interval;
+  for (;;) {
+    await sleep(interval * 1000);
+    const res = await fetchFn("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: { accept: "application/json" },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        device_code: code.deviceCode,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      }),
+    });
+    if (!res.ok) throw new Error(`device token poll failed (HTTP ${res.status})`);
+    const body = (await res.json()) as TokenResponse;
+    if ("access_token" in body) return { status: "ok", token: body.access_token };
+    switch (body.error) {
+      case "authorization_pending":
+        continue;
+      case "slow_down":
+        // GitHub's own interval already accounts for the requested backoff; fall back to +5s otherwise.
+        interval = body.interval ?? interval + 5;
+        continue;
+      case "expired_token":
+        return { status: "expired" };
+      case "access_denied":
+        return { status: "denied" };
+      default:
+        throw new Error(body.error ?? "device token poll failed: unexpected response");
+    }
+  }
+}

--- a/extension/src/options/deviceFlow.ts
+++ b/extension/src/options/deviceFlow.ts
@@ -1,5 +1,5 @@
-// Public client id of the GitHub OAuth App (device flow enabled). Replace once the app is registered.
-export const CLIENT_ID = "REPLACE_WITH_OAUTH_APP_CLIENT_ID";
+// Public client id of the GitHub OAuth App (device flow enabled).
+export const CLIENT_ID = "Ov23liYYM6t34p7Hxkc1";
 
 export type DeviceCode = {
   deviceCode: string;

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -96,6 +96,8 @@ describe("initOptions", () => {
     await flush();
     expect(document.querySelector("#status")?.textContent).toBe("Authorization denied");
     expect(storage.data.pat).toBeUndefined();
+    // The denied code is consumed: the flow area must not keep showing it
+    expect(document.querySelector<HTMLElement>("#flow")?.hidden).toBe(true);
   });
 
   it("shows an expiry message when the code times out", async () => {
@@ -110,18 +112,18 @@ describe("initOptions", () => {
     await flush();
     expect(document.querySelector("#status")?.textContent).toBe("Code expired — try again");
     expect(storage.data.pat).toBeUndefined();
+    // The expired code is consumed: the flow area must not keep showing it
+    expect(document.querySelector<HTMLElement>("#flow")?.hidden).toBe(true);
   });
 
-  it("shows a failure message when the flow throws", async () => {
+  it("shows a failure message when requesting the device code throws", async () => {
     document.body.innerHTML = OPTIONS_BODY;
     const storage = fakeStorage();
     await initOptions(
       document,
       storage,
       fakeFlow(
-        async () => {
-          throw new Error("network down");
-        },
+        async () => ({ status: "ok", token: "unreached" }),
         async () => {
           throw new Error("network down");
         },
@@ -131,6 +133,32 @@ describe("initOptions", () => {
     await flush();
     expect(document.querySelector("#status")?.textContent).toBe("Sign-in failed");
     expect(storage.data.pat).toBeUndefined();
+  });
+
+  it("hides the flow area and reports failure when the poll throws after the code rendered", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage();
+    // Hand-rolled deferred: lets the test observe the visible flow area before failing the poll
+    let rejectPoll!: (err: Error) => void;
+    const pending = new Promise<PollResult>((_resolve, reject) => {
+      rejectPoll = reject;
+    });
+    await initOptions(
+      document,
+      storage,
+      fakeFlow(() => pending),
+    );
+    document.querySelector<HTMLButtonElement>("#signin")?.click();
+    await flush();
+    // Device code succeeded: the code is rendered and the flow area is visible while the poll runs
+    expect(document.querySelector("#user-code")?.textContent).toBe("ABCD-1234");
+    expect(document.querySelector<HTMLElement>("#flow")?.hidden).toBe(false);
+    rejectPoll(new Error("network down"));
+    await flush();
+    expect(document.querySelector("#status")?.textContent).toBe("Sign-in failed");
+    expect(storage.data.pat).toBeUndefined();
+    // The consumed code must disappear once the flow ends
+    expect(document.querySelector<HTMLElement>("#flow")?.hidden).toBe(true);
   });
 
   it("disables the sign-in button while the poll is in flight and re-enables it on failure", async () => {

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -133,6 +133,29 @@ describe("initOptions", () => {
     expect(storage.data.pat).toBeUndefined();
   });
 
+  it("disables the sign-in button while the poll is in flight and re-enables it on failure", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    // Hand-rolled deferred: keeps the poll unresolved so the mid-flight disabled state is observable
+    let resolvePoll!: (result: PollResult) => void;
+    const pending = new Promise<PollResult>((resolve) => {
+      resolvePoll = resolve;
+    });
+    await initOptions(
+      document,
+      fakeStorage(),
+      fakeFlow(() => pending),
+    );
+    const signin = document.querySelector<HTMLButtonElement>("#signin")!;
+    signin.click();
+    await flush();
+    // Poll still unresolved: a second click must be impossible
+    expect(signin.disabled).toBe(true);
+    resolvePoll({ status: "denied" });
+    await flush();
+    // Flow ended (failure outcome): the user can try again
+    expect(signin.disabled).toBe(false);
+  });
+
   it("copies the user code to the clipboard", async () => {
     document.body.innerHTML = OPTIONS_BODY;
     const flow = fakeFlow(async () => ({ status: "denied" }));

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { initOptions, OPTIONS_BODY } from "./options";
+import type { DeviceCode, PollResult } from "./deviceFlow";
+import { initOptions, OPTIONS_BODY, type SignInFlow } from "./options";
 
 function fakeStorage(initial: Record<string, unknown> = {}) {
   const data = { ...initial };
@@ -15,36 +16,131 @@ function fakeStorage(initial: Record<string, unknown> = {}) {
   };
 }
 
-// Wait until the click handler's async chain finishes writing status (flush via a macrotask)
+function fakeClipboard() {
+  const writes: string[] = [];
+  return {
+    writes,
+    async writeText(text: string) {
+      writes.push(text);
+    },
+  };
+}
+
+const code: DeviceCode = {
+  deviceCode: "dc1",
+  userCode: "ABCD-1234",
+  verificationUri: "https://github.com/login/device",
+  interval: 5,
+  expiresIn: 900,
+};
+
+// Builds a fake flow: requestDeviceCode always resolves to the canned code above (unless overridden),
+// pollForToken resolves to whatever result the test wants, and clipboard writes are recorded for assertions.
+function fakeFlow(
+  pollForToken: () => Promise<PollResult>,
+  requestDeviceCode: () => Promise<DeviceCode> = async () => code,
+): SignInFlow & { clipboard: { writes: string[] } } {
+  return { requestDeviceCode, pollForToken, clipboard: fakeClipboard() };
+}
+
+// Wait for the click handler's async chain (request -> render -> poll -> store) to finish (flush via a macrotask)
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe("initOptions", () => {
-  it("loads the stored pat into the form", async () => {
+  it("shows Signed in when a pat is already stored", async () => {
     document.body.innerHTML = OPTIONS_BODY;
-    await initOptions(document, fakeStorage({ pat: "tok" }));
-    expect(document.querySelector<HTMLInputElement>("#pat")?.value).toBe("tok");
+    await initOptions(
+      document,
+      fakeStorage({ pat: "tok" }),
+      fakeFlow(async () => ({ status: "ok", token: "tok" })),
+    );
+    expect(document.querySelector("#signin-state")?.textContent).toBe("Signed in");
   });
 
-  it("saves the trimmed pat and confirms", async () => {
+  it("shows Not signed in when no pat is stored", async () => {
     document.body.innerHTML = OPTIONS_BODY;
-    const storage = fakeStorage();
-    await initOptions(document, storage);
-    document.querySelector<HTMLInputElement>("#pat")!.value = "  tok  ";
-    document.querySelector<HTMLButtonElement>("#save")?.click();
-    await flush();
-    expect(storage.data.pat).toBe("tok");
-    expect(document.querySelector("#status")?.textContent).toBe("Saved");
+    await initOptions(
+      document,
+      fakeStorage(),
+      fakeFlow(async () => ({ status: "ok", token: "tok" })),
+    );
+    expect(document.querySelector("#signin-state")?.textContent).toBe("Not signed in");
   });
 
-  it("reports a failed save instead of staying silent", async () => {
+  it("renders the code on sign-in and stores the token once the poll succeeds", async () => {
     document.body.innerHTML = OPTIONS_BODY;
     const storage = fakeStorage();
-    storage.set = async () => {
-      throw new Error("quota exceeded");
-    };
-    await initOptions(document, storage);
-    document.querySelector<HTMLButtonElement>("#save")?.click();
+    await initOptions(
+      document,
+      storage,
+      fakeFlow(async () => ({ status: "ok", token: "tok123" })),
+    );
+    document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
-    expect(document.querySelector("#status")?.textContent).toBe("Save failed");
+    expect(document.querySelector("#user-code")?.textContent).toBe("ABCD-1234");
+    expect(document.querySelector<HTMLAnchorElement>("#verify-link")?.href).toBe("https://github.com/login/device");
+    expect(storage.data.pat).toBe("tok123");
+    expect(document.querySelector("#signin-state")?.textContent).toBe("Signed in");
+    expect(document.querySelector<HTMLElement>("#flow")?.hidden).toBe(true);
+  });
+
+  it("shows Authorization denied when the user declines", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage();
+    await initOptions(
+      document,
+      storage,
+      fakeFlow(async () => ({ status: "denied" })),
+    );
+    document.querySelector<HTMLButtonElement>("#signin")?.click();
+    await flush();
+    expect(document.querySelector("#status")?.textContent).toBe("Authorization denied");
+    expect(storage.data.pat).toBeUndefined();
+  });
+
+  it("shows an expiry message when the code times out", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage();
+    await initOptions(
+      document,
+      storage,
+      fakeFlow(async () => ({ status: "expired" })),
+    );
+    document.querySelector<HTMLButtonElement>("#signin")?.click();
+    await flush();
+    expect(document.querySelector("#status")?.textContent).toBe("Code expired — try again");
+    expect(storage.data.pat).toBeUndefined();
+  });
+
+  it("shows a failure message when the flow throws", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage();
+    await initOptions(
+      document,
+      storage,
+      fakeFlow(
+        async () => {
+          throw new Error("network down");
+        },
+        async () => {
+          throw new Error("network down");
+        },
+      ),
+    );
+    document.querySelector<HTMLButtonElement>("#signin")?.click();
+    await flush();
+    expect(document.querySelector("#status")?.textContent).toBe("Sign-in failed");
+    expect(storage.data.pat).toBeUndefined();
+  });
+
+  it("copies the user code to the clipboard", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const flow = fakeFlow(async () => ({ status: "denied" }));
+    await initOptions(document, fakeStorage(), flow);
+    document.querySelector<HTMLButtonElement>("#signin")?.click();
+    await flush();
+    document.querySelector<HTMLButtonElement>("#copy-code")?.click();
+    await flush();
+    expect(flow.clipboard.writes).toEqual(["ABCD-1234"]);
   });
 });

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -1,12 +1,15 @@
+import { type DeviceCode, type PollResult, pollForToken, requestDeviceCode } from "./deviceFlow";
+
 // Keep the form body on the TS side: options.html and the jsdom tests share the same markup.
 export const OPTIONS_BODY = `
   <h1>PrefabLens</h1>
-  <p>
-    <label>GitHub personal access token<br />
-      <input id="pat" type="password" autocomplete="off" size="40" />
-    </label>
-  </p>
-  <button id="save" type="button">Save</button>
+  <p id="signin-state"></p>
+  <button id="signin" type="button">Sign in with GitHub</button>
+  <div id="flow" hidden>
+    <p>Code: <code id="user-code"></code></p>
+    <p><a id="verify-link" href="#" target="_blank" rel="noopener noreferrer">Open GitHub</a></p>
+    <button id="copy-code" type="button">Copy code</button>
+  </div>
   <span id="status" role="status"></span>
 `;
 
@@ -15,26 +18,70 @@ type StorageLike = {
   set(items: Record<string, unknown>): Promise<void>;
 };
 
-export async function initOptions(doc: Document, storage: StorageLike): Promise<void> {
-  const pat = doc.querySelector<HTMLInputElement>("#pat")!;
+type ClipboardLike = {
+  writeText(text: string): Promise<void>;
+};
+
+// Injectable bundle for the device flow: real implementations (fetch/sleep/navigator.clipboard) are
+// bound once at the chrome bootstrap below, so initOptions itself never touches real I/O.
+export type SignInFlow = {
+  requestDeviceCode(): Promise<DeviceCode>;
+  pollForToken(code: DeviceCode): Promise<PollResult>;
+  clipboard: ClipboardLike;
+};
+
+export async function initOptions(doc: Document, storage: StorageLike, flow: SignInFlow): Promise<void> {
+  const signinState = doc.querySelector<HTMLElement>("#signin-state")!;
+  const signinButton = doc.querySelector<HTMLButtonElement>("#signin")!;
+  const flowArea = doc.querySelector<HTMLElement>("#flow")!;
+  const userCode = doc.querySelector<HTMLElement>("#user-code")!;
+  const verifyLink = doc.querySelector<HTMLAnchorElement>("#verify-link")!;
+  const copyButton = doc.querySelector<HTMLButtonElement>("#copy-code")!;
   const status = doc.querySelector<HTMLElement>("#status")!;
 
-  const stored = await storage.get(["pat"]);
-  pat.value = (stored.pat as string | undefined) ?? "";
+  const showSignedIn = (pat: unknown): void => {
+    signinState.textContent = pat ? "Signed in" : "Not signed in";
+  };
 
-  doc.querySelector<HTMLButtonElement>("#save")?.addEventListener("click", () => {
-    void storage
-      .set({ pat: pat.value.trim() })
-      .then(() => {
-        status.textContent = "Saved";
-      })
-      .catch(() => {
-        status.textContent = "Save failed";
-      });
+  const stored = await storage.get(["pat"]);
+  showSignedIn(stored.pat);
+
+  signinButton.addEventListener("click", () => {
+    void (async () => {
+      status.textContent = "";
+      try {
+        const code = await flow.requestDeviceCode();
+        userCode.textContent = code.userCode;
+        verifyLink.href = code.verificationUri;
+        flowArea.hidden = false;
+
+        const result = await flow.pollForToken(code);
+        if (result.status === "ok") {
+          await storage.set({ pat: result.token });
+          showSignedIn(result.token);
+          flowArea.hidden = true;
+        } else if (result.status === "denied") {
+          status.textContent = "Authorization denied";
+        } else {
+          status.textContent = "Code expired — try again";
+        }
+      } catch {
+        status.textContent = "Sign-in failed";
+      }
+    })();
+  });
+
+  copyButton.addEventListener("click", () => {
+    void flow.clipboard.writeText(userCode.textContent ?? "");
   });
 }
 
 if (typeof chrome !== "undefined" && chrome.storage) {
   document.body.innerHTML = OPTIONS_BODY;
-  void initOptions(document, chrome.storage.local);
+  const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+  void initOptions(document, chrome.storage.local, {
+    requestDeviceCode: () => requestDeviceCode(fetch),
+    pollForToken: (code) => pollForToken(fetch, sleep, code),
+    clipboard: navigator.clipboard,
+  });
 }

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -48,6 +48,8 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
 
   signinButton.addEventListener("click", () => {
     void (async () => {
+      // The poll can run for minutes; disabling the button while in flight makes concurrent flows impossible
+      signinButton.disabled = true;
       status.textContent = "";
       try {
         const code = await flow.requestDeviceCode();
@@ -67,6 +69,8 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
         }
       } catch {
         status.textContent = "Sign-in failed";
+      } finally {
+        signinButton.disabled = false;
       }
     })();
   });

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -61,7 +61,6 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
         if (result.status === "ok") {
           await storage.set({ pat: result.token });
           showSignedIn(result.token);
-          flowArea.hidden = true;
         } else if (result.status === "denied") {
           status.textContent = "Authorization denied";
         } else {
@@ -70,6 +69,8 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
       } catch {
         status.textContent = "Sign-in failed";
       } finally {
+        // The code is consumed once the poll ends, whatever the outcome: hide it and allow a retry
+        flowArea.hidden = true;
         signinButton.disabled = false;
       }
     })();


### PR DESCRIPTION
## Summary

Replaces the manually pasted PAT with a "Sign in with GitHub" flow implementing the OAuth 2.0 Device Authorization Grant. The manual PAT input is removed entirely — the sign-in flow is the only way to set a token. The token still lands in the existing `pat` storage key, so `GithubClient` and the background pipeline are untouched.

## Motivation

Closes #74. Creating a classic PAT is high-friction onboarding, and the device flow is the only OAuth flow a browser extension can complete without a backend (GitHub still requires `client_secret` at the code exchange even with PKCE; the device flow explicitly does not). Stacked on #76 (GHES removal), per the no-fallback decision.

## Changes

- New `src/options/deviceFlow.ts`: `requestDeviceCode` + `pollForToken` state machine (`authorization_pending`, `slow_down` with server-supplied interval, `expired_token`, `access_denied`, success), pure logic with injectable fetch/sleep
- Options page rework: signed-in state line, "Sign in with GitHub" button (disabled while a flow is in flight), user code + verification link + copy button, distinct outcome messages; the flow area hides once the flow ends on any outcome
- Design note: the flow runs in the options page rather than the background service worker — the MV3 SW lifetime is unreliable for a multi-minute polling loop, and the options page lives exactly as long as the sign-in UX needs it (issue #74's Design section is updated accordingly)
- Remove the PAT input; `pat-missing` / `auth-failed` messages now direct users to sign in
- `manifest.json`: add `https://github.com/*` to `host_permissions` (lets extension pages fetch the `login/*` endpoints)
- E2E: the token is seeded via `chrome.storage.local.set` from the options page instead of the removed form
- `CLIENT_ID` is a placeholder: registering the OAuth App (with "Enable Device Flow") and committing its public client id is a one-time manual step before release

## Testing

All run in `extension/`:

```
pnpm typecheck   # clean
pnpm lint        # exit 0 (0 new warnings)
pnpm test        # Test Files 13 passed, Tests 153 passed
pnpm e2e         # 8 passed
```

Unit tests use hand-written fakes only (queued Response fetch, delay-recording sleep, deferred poll promises): device-flow state machine incl. both `slow_down` variants, sign-in happy path, denied/expired/thrown outcomes, mid-flight button disable, flow-area teardown, clipboard copy.