### PR TITLE
feat: fold components group below the object row

### DIFF
--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -273,7 +273,7 @@ describe("render", () => {
       loose: [],
     };
     render(root, diff);
-    const cards = [...root.querySelectorAll(".pl-components > details")] as HTMLDetailsElement[];
+    const cards = [...root.querySelectorAll(".pl-components .pl-kids > details")] as HTMLDetailsElement[];
     expect(cards).toHaveLength(2);
     // Closing added would look asymmetric ("only Cylinder1 collapsed"), so always open regardless of status
     expect(cards[0]?.open).toBe(true); // added Cylinder1 is open too
@@ -368,9 +368,60 @@ describe("render", () => {
       ],
     };
     render(root, diff);
-    const summary = root.querySelector("details > summary");
+    const summary = root.querySelector("details.pl-comp > summary");
     expect(summary?.textContent).toContain("Cylinder1");
     expect(summary?.textContent).not.toContain("MonoBehaviour");
+  });
+
+  it("renders the components group as an open collapsible with chevron and count", () => {
+    const root = freshRoot();
+    render(root, DIFF);
+    // The group folds independently of the GameObject row, so the hierarchy can be
+    // scanned with all component noise collapsed.
+    const group = root.querySelector<HTMLDetailsElement>("details.pl-components");
+    expect(group).not.toBeNull();
+    expect(group?.open).toBe(true); // open by default: a diff view must show its changes
+    const head = group?.querySelector("summary.pl-components-label");
+    expect(head).not.toBeNull();
+    expect(head?.querySelector(".pl-chevron svg")).not.toBeNull();
+    // The count keeps the collapsed state informative ("1 changed component hidden").
+    expect(head?.textContent).toContain("components (1)");
+  });
+
+  it("indents component cards one level deeper than child GameObjects", () => {
+    const root = freshRoot();
+    render(root, DIFF);
+    const kids = root.querySelector("details.pl-go > .pl-kids")!;
+    // Gear cards live inside the group's own kids box (extra indent + guide line)...
+    expect(kids.querySelector("details.pl-components > .pl-kids > details.pl-comp")).not.toBeNull();
+    // ...while the child GameObject stays directly on the hierarchy spine.
+    const childGo = kids.querySelector("details.pl-go");
+    expect(childGo?.parentElement).toBe(kids);
+    expect(kids.querySelector("details.pl-components details.pl-go")).toBeNull();
+  });
+
+  it("wraps root-level loose components in a components group", () => {
+    const root = freshRoot();
+    const diff: DiffV2 = {
+      schema: "prefablens.diff.v2",
+      unresolvedGuids: [],
+      roots: [],
+      loose: [
+        {
+          kind: "component",
+          fileId: "5",
+          classId: 114,
+          typeName: "MonoBehaviour",
+          scriptGuid: null,
+          className: "Cylinder1",
+          status: "modified",
+          fields: [{ path: "Hp", status: "modified", before: "1", after: "2" }],
+        },
+      ],
+    };
+    render(root, diff);
+    // Consistent visual language: gear rows always appear inside a components group.
+    expect(root.querySelector(".pl-root > details.pl-components details.pl-comp")).not.toBeNull();
   });
 
   it("renders unity-style rows: chevron, icon and status badge", () => {

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -98,8 +98,9 @@ describe("render", () => {
     expect(text).toContain("volume");
     expect(text).toContain("0.5");
     expect(text).toContain("0.8");
-    expect(text).toContain("Sound"); // resolved guid → file stem, not the full path
-    expect(text).toContain("‹Script›");
+    expect(text).toContain("Sound"); // resolved guid → file stem as the display name
+    // The meta carries the full source path (mirrors the ‹Prefab: …› form on instances).
+    expect(text).toContain("‹Script: Assets/Scripts/Sound.cs›");
   });
 
   it("shows only the current value for added fields, without a before placeholder", () => {
@@ -371,6 +372,8 @@ describe("render", () => {
     const summary = root.querySelector("details.pl-comp > summary");
     expect(summary?.textContent).toContain("Cylinder1");
     expect(summary?.textContent).not.toContain("MonoBehaviour");
+    // No resolved path yet → the meta stays the bare ‹Script› tag.
+    expect(summary?.textContent).toContain("‹Script›");
   });
 
   it("renders the components group as an open collapsible with chevron and count", () => {

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -221,7 +221,9 @@ function renderComponent(c: ComponentDiff, diff: DiffV2): HTMLElement {
   const details = openDetails("pl-comp", c.status);
   const resolved = c.scriptGuid ? diff.resolved?.[c.scriptGuid] : undefined;
   const display = resolved ? stem(resolved) : (c.className ?? c.typeName);
-  const summary = summaryRow(c.status, GEAR, "pl-icon", display, c.scriptGuid ? "‹Script›" : undefined);
+  // Mirror the ‹Prefab: …› meta on instances: full source path once the guid resolves.
+  const meta = c.scriptGuid ? (resolved ? `‹Script: ${resolved}›` : "‹Script›") : undefined;
+  const summary = summaryRow(c.status, GEAR, "pl-icon", display, meta);
   const kids = kidsBox();
   for (const f of c.fields) kids.append(fieldRow(f.path, f.status, f.before, f.after, diff));
   return finish(details, summary, kids);

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -23,7 +23,8 @@ export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: numb
     container.append(busy);
   }
   for (const node of diff.roots) container.append(renderNode(node, diff));
-  for (const c of diff.loose) container.append(renderComponent(c, diff));
+  const loose = diff.loose.map((c) => renderComponent(c, diff));
+  if (loose.length) container.append(componentsSection(loose));
   if (!diff.roots.length && !diff.loose.length) {
     container.append(note("pl-empty", "No semantic changes", CHECK));
   }
@@ -174,17 +175,27 @@ function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
   const cards: HTMLElement[] = [];
   if (node.kind === "prefabInstance") cards.push(...renderOverrideGroups(node.overrides, diff));
   cards.push(...node.components.map((c) => renderComponent(c, diff)));
-  if (cards.length) {
-    const section = document.createElement("div");
-    section.className = "pl-components";
-    const label = document.createElement("div");
-    label.className = "pl-components-label";
-    label.textContent = "components";
-    section.append(label, ...cards);
-    kids.append(section);
-  }
+  if (cards.length) kids.append(componentsSection(cards));
   for (const child of node.children) kids.append(renderNode(child, diff));
   return finish(details, summary, kids);
+}
+
+/** Components fold as their own group one level below the object row, so cube rows
+ *  alone form the hierarchy spine (Unity puts components in the Inspector, not the tree). */
+function componentsSection(cards: HTMLElement[]): HTMLElement {
+  const details = document.createElement("details");
+  details.open = true;
+  details.className = "pl-components";
+  const summary = document.createElement("summary");
+  summary.className = "pl-components-label";
+  summary.append(glyph(CHEVRON, "pl-chevron"));
+  const label = document.createElement("span");
+  label.textContent = `components (${cards.length})`;
+  summary.append(label);
+  const kids = kidsBox();
+  kids.append(...cards);
+  details.append(summary, kids);
+  return details;
 }
 
 function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElement[] {

--- a/extension/src/renderer/styles.ts
+++ b/extension/src/renderer/styles.ts
@@ -70,10 +70,13 @@ export const STYLES = `
   details.pl-modified > summary > .pl-badge { color: var(--pl-modified); background: var(--pl-modified-bg); }
   .pl-kids { margin-left: 11px; border-left: 1px solid var(--pl-hairline); padding-left: 8px; }
   .pl-components-label {
+    display: grid; grid-template-columns: 16px 1fr; align-items: center;
+    min-height: 22px; padding: 0 4px; border-radius: 4px;
+    cursor: pointer; user-select: none;
     color: var(--pl-muted); font-size: 10px; font-weight: 600;
-    text-transform: uppercase; letter-spacing: 0.6px; user-select: none;
-    margin: 2px 0 0 4px;
+    text-transform: uppercase; letter-spacing: 0.6px;
   }
+  .pl-components-label:hover { background: var(--pl-hover); }
   .pl-field {
     display: flex; align-items: center; flex-wrap: wrap; column-gap: 6px;
     min-height: 22px; padding: 0 4px 0 38px; border-radius: 4px;


### PR DESCRIPTION
## Summary

Components now render inside their own collapsible group, one indent level below the object row, so GameObject rows alone form the hierarchy spine — the semantic tree reads like Unity's Hierarchy window again. Script components additionally show their resolved source path in the meta tag, mirroring the existing `‹Prefab: …›` form.

## Motivation

Component cards and child GameObjects sat at the same indent, so gear rows (Inspector content in Unity's mental model) visually competed with cube rows (the hierarchy). The bare `‹Script›` tag also hid which asset a MonoBehaviour came from even after guid resolution. Dogfooding feedback on the redesigned UI from #73.

## Changes

- The `components` eyebrow label becomes the `<summary>` of a `<details>` group: it folds independently of the object row and carries a card count that stays informative while collapsed
- Component/override cards live in a nested kids box (extra indent + own guide line), one level deeper than sibling child GameObjects
- Root-level loose components are wrapped in the same group so gear rows always appear inside a components group
- The label row gains hover lift and a rotating chevron, reusing the existing row idioms
- Script component meta shows the resolved source path (`‹Script: Assets/Scripts/Foo.cs›`); unresolved guids keep the bare `‹Script›` tag

## Testing

- `pnpm vitest run` — 156 passed (new tests: group collapsibility and count, component cards one level deeper than child GameObjects, loose component wrapping, resolved/unresolved script meta)
- `pnpm typecheck` — clean
- `pnpm lint` — 49 warnings (48 pre-existing on main; +1 `noNonNullAssertion` in a test, matching the file's existing idiom)
- `pnpm e2e` — 8 passed
- Visual check via a Playwright harness driving the real renderer: light/dark themes, open and collapsed group states, script path and nested prefab instance metas