### PR TITLE
build: add fmt script to extension

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -8,6 +8,7 @@
     "build": "node build.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "biome ci .",
+    "fmt": "biome check --write .",
     "test": "vitest run",
     "size": "node scripts/check-wasm-size.mjs",
     "e2e": "node build.mjs --e2e && playwright test"


### PR DESCRIPTION
## Summary

Add a `fmt` script to `extension/package.json` so formatting and safe lint fixes can be applied from the CLI.

## Motivation

`pnpm run lint` (`biome ci .`) checks formatting and fails CI on drift, but the only way to apply formatting was VSCode's format-on-save. Edits made outside VSCode (CLI, other editors, coding agents) had no one-liner to fix violations. The Zig side already has this pairing (`zig build lint` / `zig build fmt`); this closes the same gap on the extension side.

## Changes

- Add `"fmt": "biome check --write ."` to `extension/package.json`. `biome check --write` is the apply-mode counterpart of `biome ci`, covering formatting, safe lint fixes, and import sorting, so `pnpm run fmt` followed by `pnpm run lint` always passes.

## Testing

- `pnpm run fmt` — exit 0, `No fixes applied.` on the already-formatted tree (56 pre-existing `noNonNullAssertion` warnings, same as `biome ci` reports; warnings do not fail either command)
- `pnpm run lint` — passed