### PR TITLE
ci: label renovate PRs by semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,10 +42,7 @@
         "github-actions"
       ],
       "groupName": "github-actions",
-      "pinDigests": false,
-      "addLabels": [
-        "github-actions"
-      ]
+      "pinDigests": false
     },
     {
       "description": "The mise toolchain (zig/zls/node/dotnet/bump-my-version) affects the whole build, so require CI review instead of automerge",
@@ -53,18 +50,33 @@
         "mise"
       ],
       "groupName": "toolchain (mise)",
-      "automerge": false,
-      "addLabels": [
-        "toolchain"
-      ]
+      "automerge": false
     },
     {
-      "description": "Split major updates out of groups into individual PRs and flag them with the major label",
+      "description": "Flag major dependency updates",
       "matchUpdateTypes": [
         "major"
       ],
       "addLabels": [
         "major"
+      ]
+    },
+    {
+      "description": "Flag minor dependency updates",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "addLabels": [
+        "minor"
+      ]
+    },
+    {
+      "description": "Flag patch dependency updates",
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "addLabels": [
+        "patch"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Align Renovate PR labels with `dependencies` plus semver (`major` / `minor` / `patch`) and `security`, and drop the unused `github-actions` / `toolchain` labels in favor of path-based `ci` from labeler.

## Motivation

Renovate referenced labels that did not exist on the repo, and manager-specific labels duplicated what labeler already covers for Actions and mise config. A smaller, consistent set makes dependency PRs easier to filter by risk and area.

## Changes

- Keep top-level Renovate label `dependencies`
- Add `packageRules` that add `minor` and `patch` (keep existing `major`)
- Remove `addLabels` for `github-actions` and `toolchain` while preserving grouping / `pinDigests` / `automerge: false`
- Keep `vulnerabilityAlerts.labels`: `dependencies`, `security`
- Create GitHub labels: `dependencies`, `major`, `minor`, `patch`, `security` (labeler area labels unchanged)

## Testing

```text
$ jq -e '(.labels == ["dependencies"]) and (.vulnerabilityAlerts.labels == ["dependencies", "security"]) and (any(.packageRules[]; .matchUpdateTypes == ["minor"] and .addLabels == ["minor"])) and (any(.packageRules[]; .matchUpdateTypes == ["patch"] and .addLabels == ["patch"])) and (any(.packageRules[]; .matchUpdateTypes == ["major"] and .addLabels == ["major"]))' renovate.json && python3 -m json.tool renovate.json > /dev/null && echo OK
OK

$ for name in dependencies major minor patch security core cli editor extension ci documentation; do
    gh label list --json name --jq "any(.[]; .name == \"$name\")" | grep -q true && echo "ok $name"
  done
ok dependencies
ok major
ok minor
ok patch
ok security
ok core
ok cli
ok editor
ok extension
ok ci
ok documentation

$ git diff main...HEAD --stat
 renovate.json | 30 +++++++++++++++++++++---------
 1 file changed, 21 insertions(+), 9 deletions(-)
```