### PR TITLE
fix: hide semantic view when file is collapsed

### DIFF
--- a/extension/e2e/fixtures/pr-files.html
+++ b/extension/e2e/fixtures/pr-files.html
@@ -1,24 +1,31 @@
 <!doctype html>
 <html data-color-mode="light">
-  <head><meta charset="utf-8" /><title>PR fixture</title></head>
+  <head>
+    <meta charset="utf-8" /><title>PR fixture</title>
+    <style>
+      /* Primer's collapse rule from github.com: the chevron / Viewed checkbox toggles
+         Details--on (and open) on .file, and this hides anything carrying the class. */
+      .Details:not(.Details--on) .Details-content--hidden { display: none !important; }
+    </style>
+  </head>
   <body>
-    <div class="file">
+    <div class="file js-details-container Details Details--on open">
       <div class="file-header" data-path="Assets/Foo.prefab">
         <span class="file-info">Assets/Foo.prefab</span>
       </div>
-      <div class="js-file-content">raw github diff table</div>
+      <div class="js-file-content Details-content--hidden">raw github diff table</div>
     </div>
-    <div class="file">
+    <div class="file js-details-container Details Details--on open">
       <div class="file-header" data-path="Assets/Big.unity">
         <span class="file-info">Assets/Big.unity</span>
       </div>
-      <div class="js-file-content">raw github diff table</div>
+      <div class="js-file-content Details-content--hidden">raw github diff table</div>
     </div>
-    <div class="file">
+    <div class="file js-details-container Details Details--on open">
       <div class="file-header" data-path="README.md">
         <span class="file-info">README.md</span>
       </div>
-      <div class="js-file-content">raw github diff table</div>
+      <div class="js-file-content Details-content--hidden">raw github diff table</div>
     </div>
   </body>
 </html>

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -79,6 +79,29 @@ test("detects a Unity file, toggles to Semantic, renders the tree", async ({ pag
   await expect(view).toBeHidden();
 });
 
+test("github's file collapse hides the semantic view too", async ({ page }) => {
+  await page.route("**/pull/1/files", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
+  await stubChrome(page, cannedResponse);
+
+  await page.goto("https://prefablens.test/owner/repo/pull/1/files");
+  await page.addScriptTag({ path: "dist/content.js" });
+
+  const unityHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await unityHeader.getByRole("button", { name: "Semantic" }).click();
+  const view = page.locator("[data-prefablens-view]");
+  await expect(view).toContainText("MonoBehaviour");
+
+  // Collapse: github's details-behavior only toggles these classes on .file, so the
+  // semantic host must opt into the same Primer CSS that hides .js-file-content
+  const file = page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"])');
+  await file.evaluate((el) => el.classList.remove("Details--on", "open"));
+  await expect(view).toBeHidden();
+
+  // Expand again: the semantic view comes back without touching the toggle
+  await file.evaluate((el) => el.classList.add("Details--on", "open"));
+  await expect(view).toBeVisible();
+});
+
 test("sends a prefetch message on pr page arrival", async ({ page }) => {
   await page.route("**/pull/1/files", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
   await stubChrome(page, cannedResponse);

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -130,6 +130,9 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
     if (!host) {
       host = document.createElement("div");
       host.setAttribute("data-prefablens-view", "");
+      // Same Primer class github puts on .js-file-content: the chevron / Viewed collapse
+      // only toggles Details--on on .file, so the host must opt into that CSS itself
+      host.classList.add("Details-content--hidden");
       host.attachShadow({ mode: "open" });
       entry.content.after(host);
     }


### PR DESCRIPTION
## Summary

Make GitHub's file collapse (chevron / Viewed checkbox) hide the semantic view, not just the raw diff.

## Motivation

While the Semantic view is shown, collapsing a file on the Files changed tab appeared to do nothing: GitHub's collapse CSS only hides `.js-file-content`, and the semantic host is injected as its sibling, so it stayed visible.

GitHub's details-behavior toggles `Details--on` / `open` on `.file`, and Primer hides content via:

```css
.Details:not(.Details--on) .Details-content--hidden { display: none !important; }
```

`.js-file-content` carries `Details-content--hidden`; our host did not.

## Changes

- Add the `Details-content--hidden` Primer class to the semantic view host so it shares the exact collapse fate of `.js-file-content` (verified against the live github.com DOM)
- Model the collapse machinery (`Details` classes + Primer rule) in the e2e fixture
- Add an e2e test: collapse hides the semantic view, expand brings it back

## Testing

- `pnpm e2e` — 10 passed (new test failed before the fix with `expect(view).toBeHidden()` receiving visible)
- `pnpm test` — 169 passed
- `pnpm typecheck` / `pnpm lint` — clean