### PR TITLE
feat: match the CLI diff output to the extension semantic view

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ Semantic diff tools for UnityYAML assets. Instead of raw text diffs, PrefabLens 
 ### CLI
 
 ```bash
-# Compare two files (tree output)
-prefablens before.prefab after.prefab
+prefablens                              # HEAD vs working tree, all changed Unity files
+prefablens Assets/Foo.prefab            # HEAD vs working tree, one file
+prefablens main                         # ref vs working tree, all changed Unity files
+prefablens HEAD~1 HEAD Assets/Foo.prefab  # ref vs ref, one file
+prefablens before.prefab after.prefab   # plain two-file compare (no git)
 
-# JSON / HTML output
 prefablens --json before.prefab after.prefab
-prefablens --html before.prefab after.prefab
-
-# Compare two git revisions
-prefablens --git HEAD~1 HEAD Assets/Foo.prefab
-
-# Compare a revision against the working tree (omit afterRef)
-prefablens --git HEAD Assets/Foo.prefab
+prefablens --html main                  # self-contained HTML report on stdout
+prefablens --open main                  # write the report to a temp file and open it
 ```
+
+Operands ending in a Unity YAML extension (`.prefab`, `.unity`, `.asset`, ...) are
+treated as paths; everything else is a git ref.
 
 Also runs as an MCP server: `prefablens mcp`.
 

--- a/cli/src/display.zig
+++ b/cli/src/display.zig
@@ -21,3 +21,27 @@ pub fn componentName(c: model.ComponentDiff, resolved: ?*const core.json.Resolve
     };
     return c.class_name orelse c.type_name;
 }
+
+/// Heading status for the override group starting at `start`: that status if
+/// uniform within the group, modified if mixed.
+pub fn groupHeadingStatus(overrides: []const model.OverrideDiff, start: usize) model.Status {
+    const first = overrides[start];
+    for (overrides[start + 1 ..]) |ov| {
+        if (!std.mem.eql(u8, ov.group, first.group)) break;
+        if (ov.status != first.status) return .modified;
+    }
+    return first.status;
+}
+
+/// Number of consecutive-group cards the overrides collapse into.
+pub fn overrideGroupCount(overrides: []const model.OverrideDiff) usize {
+    var n: usize = 0;
+    var current: []const u8 = "";
+    for (overrides) |ov| {
+        if (!std.mem.eql(u8, current, ov.group)) {
+            current = ov.group;
+            n += 1;
+        }
+    }
+    return n;
+}

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -71,6 +71,12 @@ pub fn changedPaths(
     var argv: std.ArrayList([]const u8) = .empty;
     try argv.appendSlice(arena, &.{ "git", "diff", "--name-only", "-z", "--end-of-options", before_ref });
     if (after_ref.len != 0) try argv.append(arena, after_ref);
+    // No pathspec follows the refs, but the trailing "--" still matters: without it, a ref
+    // operand that fails to resolve as a revision but happens to name a file in the working
+    // tree (e.g. a caller passing a non-Unity path like "Note.txt" as if it were a ref) would
+    // have git silently reinterpret it as a pathspec instead of failing. The explicit "--"
+    // forces every operand before it to be resolved strictly as a revision.
+    try argv.append(arena, "--");
     const res = std.process.run(arena, io, .{
         .argv = argv.items,
         .cwd = .{ .path = repo_dir },
@@ -243,6 +249,30 @@ test "changedPaths lists changes between two refs" {
     const paths = try changedPaths(testing.io, arena, dir, "HEAD~1", "HEAD", default_git_timeout);
     try testing.expectEqual(@as(usize, 1), paths.len);
     try testing.expectEqualStrings("Foo.prefab", paths[0]);
+}
+
+test "changedPaths surfaces a file-named operand as GitDiffFailed" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v1\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Note.txt", .data = "n1\n" });
+    try git(testing.io, arena, dir, &.{ "init", "-q" });
+    try git(testing.io, arena, dir, &.{ "config", "user.email", "t@t.t" });
+    try git(testing.io, arena, dir, &.{ "config", "user.name", "t" });
+    try git(testing.io, arena, dir, &.{ "add", "." });
+    try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
+
+    // Note.txt fails the CLI's Unity extension gate (main.zig's parseArgs), so it gets
+    // classified as a second ref operand rather than a path. Without a trailing "--",
+    // git would fail to resolve "Note.txt" as a revision and silently fall back to
+    // binding it as a pathspec instead, succeeding at exit 0 (diff restricted to that
+    // one file) rather than surfacing the unresolvable ref as an error.
+    try testing.expectError(error.GitDiffFailed, changedPaths(testing.io, arena, dir, "HEAD", "Note.txt", default_git_timeout));
 }
 
 test "changedPaths surfaces a bad ref as GitDiffFailed" {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -53,8 +53,10 @@ pub fn readWorktree(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, 
 }
 
 /// Paths changed between before_ref and after_ref (empty after_ref = the
-/// working tree), one repo-relative path per git output line. Untracked
-/// files are not listed — same semantics as `git diff --name-only`.
+/// working tree), one repo-relative path per git output NUL-separated entry.
+/// Untracked files are not listed — same semantics as `git diff --name-only`.
+/// The -z flag both NUL-separates the output and disables git's quotepath
+/// C-quoting mangling, so non-ASCII filenames come through as literal UTF-8.
 pub fn changedPaths(
     io: std.Io,
     arena: std.mem.Allocator,
@@ -67,7 +69,7 @@ pub fn changedPaths(
     try env.put("LC_ALL", "C");
     try env.put("LANG", "C");
     var argv: std.ArrayList([]const u8) = .empty;
-    try argv.appendSlice(arena, &.{ "git", "diff", "--name-only", "--end-of-options", before_ref });
+    try argv.appendSlice(arena, &.{ "git", "diff", "--name-only", "-z", "--end-of-options", before_ref });
     if (after_ref.len != 0) try argv.append(arena, after_ref);
     const res = std.process.run(arena, io, .{
         .argv = argv.items,
@@ -81,9 +83,9 @@ pub fn changedPaths(
     };
     if (res.term != .exited or res.term.exited != 0) return error.GitDiffFailed;
     var out: std.ArrayList([]const u8) = .empty;
-    var it = std.mem.splitScalar(u8, res.stdout, '\n');
-    while (it.next()) |line| {
-        if (line.len != 0) try out.append(arena, line);
+    var it = std.mem.splitScalar(u8, res.stdout, 0);
+    while (it.next()) |entry| {
+        if (entry.len != 0) try out.append(arena, entry);
     }
     return out.items;
 }
@@ -254,4 +256,29 @@ test "changedPaths surfaces a bad ref as GitDiffFailed" {
     try git(testing.io, arena, dir, &.{ "init", "-q" });
 
     try testing.expectError(error.GitDiffFailed, changedPaths(testing.io, arena, dir, "bogus-ref", "", default_git_timeout));
+}
+
+test "changedPaths preserves non-ASCII filenames (quotepath protection)" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "素材.prefab", .data = "v1\n" });
+    try git(testing.io, arena, dir, &.{ "init", "-q" });
+    try git(testing.io, arena, dir, &.{ "config", "user.email", "t@t.t" });
+    try git(testing.io, arena, dir, &.{ "config", "user.name", "t" });
+    try git(testing.io, arena, dir, &.{ "add", "." });
+    try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
+
+    // Modify the non-ASCII file. Without -z flag, git would emit the C-quoted
+    // form like "\347\264\240\346\235\220.prefab", breaking downstream git show
+    // and file reads. With -z, we get the literal UTF-8 filename back.
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "素材.prefab", .data = "v2\n" });
+
+    const paths = try changedPaths(testing.io, arena, dir, "HEAD", "", default_git_timeout);
+    try testing.expectEqual(@as(usize, 1), paths.len);
+    try testing.expectEqualStrings("素材.prefab", paths[0]);
 }

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -43,7 +43,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     }
 }
 
-/// Working-tree side (the after of --git REF PATH). A missing file is treated as "deleted" = empty side.
+/// Working-tree side (the after side when only one ref is given). A missing file is treated as "deleted" = empty side.
 pub fn readWorktree(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, path: []const u8) ![]u8 {
     const full = try std.fs.path.join(arena, &.{ repo_dir, path });
     return std.Io.Dir.cwd().readFileAlloc(io, full, arena, .limited(max_input_bytes)) catch |err| switch (err) {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -52,6 +52,42 @@ pub fn readWorktree(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, 
     };
 }
 
+/// Paths changed between before_ref and after_ref (empty after_ref = the
+/// working tree), one repo-relative path per git output line. Untracked
+/// files are not listed — same semantics as `git diff --name-only`.
+pub fn changedPaths(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    repo_dir: []const u8,
+    before_ref: []const u8,
+    after_ref: []const u8,
+    timeout: std.Io.Timeout,
+) ![][]const u8 {
+    var env = std.process.Environ.Map.init(arena);
+    try env.put("LC_ALL", "C");
+    try env.put("LANG", "C");
+    var argv: std.ArrayList([]const u8) = .empty;
+    try argv.appendSlice(arena, &.{ "git", "diff", "--name-only", "--end-of-options", before_ref });
+    if (after_ref.len != 0) try argv.append(arena, after_ref);
+    const res = std.process.run(arena, io, .{
+        .argv = argv.items,
+        .cwd = .{ .path = repo_dir },
+        .stdout_limit = .limited(max_input_bytes),
+        .environ_map = &env,
+        .timeout = timeout,
+    }) catch |err| switch (err) {
+        error.Timeout => return error.GitTimeout,
+        else => return err,
+    };
+    if (res.term != .exited or res.term.exited != 0) return error.GitDiffFailed;
+    var out: std.ArrayList([]const u8) = .empty;
+    var it = std.mem.splitScalar(u8, res.stdout, '\n');
+    while (it.next()) |line| {
+        if (line.len != 0) try out.append(arena, line);
+    }
+    return out.items;
+}
+
 fn git(io: std.Io, arena: std.mem.Allocator, dir: []const u8, argv: []const []const u8) !void {
     var full: std.ArrayList([]const u8) = .empty;
     try full.append(arena, "git");
@@ -154,4 +190,68 @@ test "showAtRef does not let a dash-prefixed ref be parsed as a git option" {
         return;
     };
     try testing.expect(false); // file was created -- injection succeeded
+}
+
+test "changedPaths lists worktree changes against a ref, including deletions" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v1\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Note.txt", .data = "n1\n" });
+    try git(testing.io, arena, dir, &.{ "init", "-q" });
+    try git(testing.io, arena, dir, &.{ "config", "user.email", "t@t.t" });
+    try git(testing.io, arena, dir, &.{ "config", "user.name", "t" });
+    try git(testing.io, arena, dir, &.{ "add", "." });
+    try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
+
+    // Modify one file, delete the other: both must be listed. Extension
+    // filtering is the caller's job, so Note.txt appears here too.
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v2\n" });
+    try tmp.dir.deleteFile(testing.io, "Note.txt");
+
+    const paths = try changedPaths(testing.io, arena, dir, "HEAD", "", default_git_timeout);
+    try testing.expectEqual(@as(usize, 2), paths.len);
+    // git emits paths sorted; rely on that for a stable assertion.
+    try testing.expectEqualStrings("Foo.prefab", paths[0]);
+    try testing.expectEqualStrings("Note.txt", paths[1]);
+}
+
+test "changedPaths lists changes between two refs" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v1\n" });
+    try git(testing.io, arena, dir, &.{ "init", "-q" });
+    try git(testing.io, arena, dir, &.{ "config", "user.email", "t@t.t" });
+    try git(testing.io, arena, dir, &.{ "config", "user.name", "t" });
+    try git(testing.io, arena, dir, &.{ "add", "." });
+    try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "v2\n" });
+    try git(testing.io, arena, dir, &.{ "add", "." });
+    try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "second" });
+
+    const paths = try changedPaths(testing.io, arena, dir, "HEAD~1", "HEAD", default_git_timeout);
+    try testing.expectEqual(@as(usize, 1), paths.len);
+    try testing.expectEqualStrings("Foo.prefab", paths[0]);
+}
+
+test "changedPaths surfaces a bad ref as GitDiffFailed" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try git(testing.io, arena, dir, &.{ "init", "-q" });
+
+    try testing.expectError(error.GitDiffFailed, changedPaths(testing.io, arena, dir, "bogus-ref", "", default_git_timeout));
 }

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -668,7 +668,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         },
         // Color when stdout is a TTY is decided in main(); --no-color forces it off.
         .tree => try render_tree.render(stdout, res, resolver_ptr, color and !opt.no_color),
-        .html => try render_html.render(stdout, res, resolver_ptr),
+        .html => try render_html.render(stdout, &.{.{ .path = null, .res = res }}, resolver_ptr),
     }
     return 0;
 }

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -9,6 +9,10 @@ pub const render_tree = @import("render_tree.zig");
 pub const render_html = @import("render_html.zig");
 pub const mcp = @import("mcp.zig");
 
+comptime {
+    _ = @import("unity_path.zig");
+}
+
 test {
     std.testing.refAllDecls(@This());
     _ = resolve;

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const core = @import("core");
 const testing = std.testing;
 
@@ -82,6 +83,29 @@ test "parseArgs: --help short-circuits" {
     try testing.expect(short.help);
 }
 
+test "parseArgs: --open implies html and rejects --json" {
+    const opt = try parseArgs(&.{ "--open", "main" });
+    try testing.expect(opt.open);
+    try testing.expectEqual(Format.html, opt.format);
+    try testing.expectError(ArgError.ConflictingFlags, parseArgs(&.{ "--open", "--json", "main" }));
+    try testing.expectError(ArgError.ConflictingFlags, parseArgs(&.{ "--json", "--open", "main" }));
+}
+
+test "writeReportFile writes the html into the given directory" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+
+    const path = try writeReportFile(testing.io, arena, dir, "Robot", "<!DOCTYPE html>x");
+    try testing.expect(std.mem.indexOf(u8, path, "prefablens-Robot-") != null);
+    try testing.expect(std.mem.endsWith(u8, path, ".html"));
+    const back = try std.Io.Dir.cwd().readFileAlloc(testing.io, path, arena, .limited(1024));
+    try testing.expectEqualStrings("<!DOCTYPE html>x", back);
+}
+
 test "run: bulk mode diffs every changed Unity file and skips others" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -106,7 +130,7 @@ test "run: bulk mode diffs every changed Unity file and skips others" {
     var err_out: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
     // No operands: HEAD vs worktree over all changed supported files.
-    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false, null);
     try testing.expectEqual(@as(u8, 0), code);
     const text = aw.toArrayList().items;
     // The Unity file appears as a header; the text file is filtered out.
@@ -130,7 +154,7 @@ test "run: bulk mode with no matching files reports and exits 0" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var err_out: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
-    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false, null);
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "no Unity YAML changes") != null);
 }
@@ -151,7 +175,7 @@ test "run: bulk json emits an array of path/diff objects" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var err_out: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
-    const code = try run(testing.io, arena, &.{ "--json", "--project", dir }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", dir }, &aw.writer, &aw_err.writer, false, null);
     try testing.expectEqual(@as(u8, 0), code);
     const text = aw.toArrayList().items;
     try testing.expect(std.mem.startsWith(u8, text, "["));
@@ -167,7 +191,7 @@ test "run: --help prints usage on stdout and exits 0" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var err_out: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
-    const code = try run(testing.io, arena, &.{"--help"}, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{"--help"}, &aw.writer, &aw_err.writer, false, null);
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "usage: prefablens") != null);
     try testing.expectEqual(@as(usize, 0), aw_err.toArrayList().items.len);
@@ -191,7 +215,7 @@ test "run: no operands in a repo with no commits fails with a git error" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var err_out: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
-    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false, null);
     try testing.expectEqual(@as(u8, 1), code);
     try testing.expect(std.mem.indexOf(u8, aw_err.toArrayList().items, "git diff failed") != null);
 }
@@ -223,7 +247,7 @@ test "run: --json with two real files prints core JSON" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", before_path, after_path }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", before_path, after_path }, &aw.writer, &aw_err.writer, false, null);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"schema\":\"prefablens.diff.v2\"") != null);
@@ -239,7 +263,7 @@ test "run: unreadable input file reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "/no/such/file.asset", "/no/such/other.asset" }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "/no/such/file.asset", "/no/such/other.asset" }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -276,7 +300,7 @@ test "run: hostile deeply-nested input reports a clean error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ hostile_path, other_path }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ hostile_path, other_path }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -308,7 +332,7 @@ test "run: unreadable --project directory reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -341,7 +365,7 @@ test "run: unreadable --project directory reports error and exits 1 in tree mode
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
     // No --json: the default tree format must honor the same error contract.
-    const code = try run(testing.io, arena, &.{ "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -373,7 +397,7 @@ test "run: unreadable --project directory reports error and exits 1 in html mode
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--html", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--html", "--project", "/no/such/project", before_path, after_path }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -391,7 +415,7 @@ test "run: bad ref reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
@@ -407,7 +431,7 @@ test "run: unknown flag prints error and exits 2" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--bogus", "a.prefab", "b.prefab" }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--bogus", "a.prefab", "b.prefab" }, &aw.writer, &aw_err.writer, false, null);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 2), code);
     try testing.expect(std.mem.indexOf(u8, err_output.items, "unknown flag") != null);
@@ -438,7 +462,7 @@ test "run: color=true colors tree output, --no-color forces it back off" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ before_path, after_path }, &aw.writer, &aw_err.writer, true);
+    const code = try run(testing.io, arena, &.{ before_path, after_path }, &aw.writer, &aw_err.writer, true, null);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\x1b[") != null);
@@ -448,7 +472,7 @@ test "run: color=true colors tree output, --no-color forces it back off" {
     var aw2 = std.Io.Writer.Allocating.fromArrayList(arena, &out2);
     var errbuf2: std.ArrayList(u8) = .empty;
     var aw_err2 = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf2);
-    const code2 = try run(testing.io, arena, &.{ "--no-color", before_path, after_path }, &aw2.writer, &aw_err2.writer, true);
+    const code2 = try run(testing.io, arena, &.{ "--no-color", before_path, after_path }, &aw2.writer, &aw_err2.writer, true, null);
     const output2 = aw2.toArrayList();
     try testing.expectEqual(@as(u8, 0), code2);
     try testing.expect(std.mem.indexOf(u8, output2.items, "\x1b[") == null);
@@ -496,7 +520,7 @@ test "run: --project supplies source prefabs for merged instance diffs" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--no-color", "--project", dir, empty_path, variant_path }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--no-color", "--project", dir, empty_path, variant_path }, &aw.writer, &aw_err.writer, false, null);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "Scale: (1, 2, 1)") != null);
@@ -506,7 +530,7 @@ test "run: --project supplies source prefabs for merged instance diffs" {
     var aw2 = std.Io.Writer.Allocating.fromArrayList(arena, &out2);
     var errbuf2: std.ArrayList(u8) = .empty;
     var aw_err2 = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf2);
-    const code2 = try run(testing.io, arena, &.{ "--no-color", empty_path, variant_path }, &aw2.writer, &aw_err2.writer, false);
+    const code2 = try run(testing.io, arena, &.{ "--no-color", empty_path, variant_path }, &aw2.writer, &aw_err2.writer, false, null);
     const output2 = aw2.toArrayList();
     try testing.expectEqual(@as(u8, 0), code2);
     try testing.expect(std.mem.indexOf(u8, output2.items, "Scale.y: 2") != null);
@@ -556,7 +580,7 @@ test "run: --project points git mode at a repo outside the cwd" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "--project", dir, "HEAD", "Foo.asset" }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", dir, "HEAD", "Foo.asset" }, &aw.writer, &aw_err.writer, false, null);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"after\":\"2\"") != null);
@@ -578,11 +602,12 @@ pub const Options = struct {
     project_root: ?[]const u8 = null, // guid-resolution base and the git repo dir
     no_color: bool = false,
     help: bool = false,
+    open: bool = false,
 };
 
-pub const ArgError = error{ MissingOperands, UnknownFlag, TooManyArguments };
+pub const ArgError = error{ MissingOperands, UnknownFlag, TooManyArguments, ConflictingFlags };
 
-const usage_line = "usage: prefablens [--json|--html] [--project DIR] [--no-color] [<ref>] [<ref>] [<path>] | <before> <after>\n";
+const usage_line = "usage: prefablens [--json|--html] [--open] [--project DIR] [--no-color] [<ref>] [<ref>] [<path>] | <before> <after>\n";
 
 const help_text = usage_line ++
     \\
@@ -599,6 +624,7 @@ const help_text = usage_line ++
     \\options:
     \\  --json         prefablens.diff.v2 JSON ({path, diff} array in bulk mode)
     \\  --html         self-contained HTML report on stdout
+    \\  --open         write the HTML report to a temp file and open it in a browser
     \\  --project DIR  Unity project root for guid resolution (and git repo dir)
     \\  --no-color     disable ANSI colors in tree output
     \\  -h, --help     show this help
@@ -609,6 +635,7 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
     var format: Format = .tree;
     var project_root: ?[]const u8 = null;
     var no_color = false;
+    var open = false;
     var refs: [2][]const u8 = undefined;
     var n_refs: usize = 0;
     var paths: [2][]const u8 = undefined;
@@ -623,6 +650,8 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             format = .html;
         } else if (std.mem.eql(u8, a, "--no-color")) {
             no_color = true;
+        } else if (std.mem.eql(u8, a, "--open")) {
+            open = true;
         } else if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
             return .{ .target = .{ .git = .{ .before_ref = "HEAD", .after_ref = "", .path = null } }, .help = true };
         } else if (std.mem.eql(u8, a, "--project")) {
@@ -641,6 +670,10 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             n_refs += 1;
         }
     }
+    if (open) {
+        if (format == .json) return ArgError.ConflictingFlags;
+        format = .html;
+    }
     if (n_paths == 2) {
         // Plain two-file compare; mixing it with refs has no meaning.
         if (n_refs != 0) return ArgError.TooManyArguments;
@@ -649,6 +682,7 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             .format = format,
             .project_root = project_root,
             .no_color = no_color,
+            .open = open,
         };
     }
     return .{
@@ -660,11 +694,32 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
         .format = format,
         .project_root = project_root,
         .no_color = no_color,
+        .open = open,
     };
 }
 
 fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
     return std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(input.max_input_bytes));
+}
+
+/// Writes the report under `dir` with a collision-resistant name and
+/// returns the full path.
+pub fn writeReportFile(io: std.Io, arena: std.mem.Allocator, dir: []const u8, name_stem: []const u8, html: []const u8) ![]const u8 {
+    // Zig 0.16 clocks go through Io: no std.time.milliTimestamp anymore.
+    const millis: u64 = @intCast(std.Io.Clock.now(.real, io).toMilliseconds());
+    const path = try std.fmt.allocPrint(arena, "{s}/prefablens-{s}-{d}.html", .{ dir, name_stem, millis });
+    try std.Io.Dir.cwd().writeFile(io, .{ .sub_path = path, .data = html });
+    return path;
+}
+
+fn openInBrowser(io: std.Io, arena: std.mem.Allocator, path: []const u8) !void {
+    const argv: []const []const u8 = switch (builtin.os.tag) {
+        .macos => &.{ "open", path },
+        .windows => &.{ "cmd", "/c", "start", "", path },
+        else => &.{ "xdg-open", path },
+    };
+    const res = try std.process.run(arena, io, .{ .argv = argv });
+    if (res.term != .exited or res.term.exited != 0) return error.OpenFailed;
 }
 
 const model = core.model;
@@ -712,12 +767,13 @@ fn writeJsonString(w: *std.Io.Writer, s: []const u8) !void {
     try w.writeByte('"');
 }
 
-pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool) !u8 {
+pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool, environ: ?*const std.process.Environ.Map) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
             ArgError.MissingOperands => try stderr.writeAll(usage_line),
             ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag (see --help)\n"),
             ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments (see --help)\n"),
+            ArgError.ConflictingFlags => try stderr.writeAll("error: --open conflicts with --json\n"),
         }
         return 2;
     };
@@ -840,7 +896,29 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         .html => {
             var files: std.ArrayList(render_html.FileDiff) = .empty;
             for (diffs.items) |d| try files.append(arena, .{ .path = d.path, .res = d.res });
-            try render_html.render(stdout, files.items, resolver_ptr);
+            if (!opt.open) {
+                try render_html.render(stdout, files.items, resolver_ptr);
+            } else {
+                var buf: std.ArrayList(u8) = .empty;
+                var aw = std.Io.Writer.Allocating.fromArrayList(arena, &buf);
+                try render_html.render(&aw.writer, files.items, resolver_ptr);
+                const tmp_dir = if (environ) |env|
+                    env.get("TMPDIR") orelse env.get("TEMP") orelse "/tmp"
+                else
+                    "/tmp";
+                // Single-file reports carry the file stem; bulk mode is just "report".
+                const stem = switch (opt.target) {
+                    .files => |f| std.fs.path.stem(f.after),
+                    .git => |g| if (g.path) |p| std.fs.path.stem(p) else "report",
+                };
+                const report = try writeReportFile(io, arena, tmp_dir, stem, aw.toArrayList().items);
+                try stdout.print("{s}\n", .{report});
+                openInBrowser(io, arena, report) catch {
+                    // The path is already printed; failing to launch a
+                    // browser must not fail the diff.
+                    try stderr.print("warning: could not open a browser for '{s}'\n", .{report});
+                };
+            }
         },
     }
     return 0;
@@ -884,7 +962,7 @@ pub fn main(init: std.process.Init) !u8 {
 
     const color = std.Io.File.stdout().isTty(init.io) catch false;
 
-    const code = try run(init.io, arena, user_args, stdout, stderr, color);
+    const code = try run(init.io, arena, user_args, stdout, stderr, color, init.environ_map);
     try stdout.flush();
     try stderr.flush();
     return code;

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -767,6 +767,30 @@ fn writeJsonString(w: *std.Io.Writer, s: []const u8) !void {
     try w.writeByte('"');
 }
 
+/// Looks up an environment variable, treating a set-but-empty value the same as unset.
+/// Some shells/CI configs export TMPDIR="" rather than leaving it undefined, and an empty
+/// directory string would otherwise win the `orelse` fallback chain below with a bogus path.
+fn envDir(env: *const std.process.Environ.Map, key: []const u8) ?[]const u8 {
+    const v = env.get(key) orelse return null;
+    return if (v.len == 0) null else v;
+}
+
+test "envDir treats a set-but-empty variable as unset and falls through" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var env = std.process.Environ.Map.init(arena);
+    try env.put("TMPDIR", "");
+    try env.put("TEMP", "/tmp/real");
+
+    try testing.expectEqual(@as(?[]const u8, null), envDir(&env, "TMPDIR"));
+    try testing.expectEqualStrings("/tmp/real", envDir(&env, "TEMP").?);
+    // The same fallback chain run() uses: empty TMPDIR must not win over TEMP.
+    try testing.expectEqualStrings("/tmp/real", envDir(&env, "TMPDIR") orelse envDir(&env, "TEMP") orelse "/tmp");
+    // A key missing from the map entirely also falls through to "/tmp".
+    try testing.expectEqualStrings("/tmp", envDir(&env, "NOPE") orelse "/tmp");
+}
+
 pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool, environ: ?*const std.process.Environ.Map) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
@@ -903,7 +927,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                 var aw = std.Io.Writer.Allocating.fromArrayList(arena, &buf);
                 try render_html.render(&aw.writer, files.items, resolver_ptr);
                 const tmp_dir = if (environ) |env|
-                    env.get("TMPDIR") orelse env.get("TEMP") orelse "/tmp"
+                    envDir(env, "TMPDIR") orelse envDir(env, "TEMP") orelse "/tmp"
                 else
                     "/tmp";
                 // Single-file reports carry the file stem; bulk mode is just "report".
@@ -911,7 +935,10 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                     .files => |f| std.fs.path.stem(f.after),
                     .git => |g| if (g.path) |p| std.fs.path.stem(p) else "report",
                 };
-                const report = try writeReportFile(io, arena, tmp_dir, stem, aw.toArrayList().items);
+                const report = writeReportFile(io, arena, tmp_dir, stem, aw.toArrayList().items) catch {
+                    try stderr.print("error: cannot write report to '{s}'\n", .{tmp_dir});
+                    return 1;
+                };
                 try stdout.print("{s}\n", .{report});
                 openInBrowser(io, arena, report) catch {
                     // The path is already printed; failing to launch a

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -667,7 +667,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             try stdout.writeByte('\n');
         },
         // Color when stdout is a TTY is decided in main(); --no-color forces it off.
-        .tree => try render_tree.render(stdout, res, resolver_ptr, color and !opt.no_color),
+        .tree => try render_tree.render(arena, stdout, res, resolver_ptr, color and !opt.no_color),
         .html => try render_html.render(stdout, &.{.{ .path = null, .res = res }}, resolver_ptr),
     }
     return 0;

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -8,10 +8,7 @@ pub const display = @import("display.zig");
 pub const render_tree = @import("render_tree.zig");
 pub const render_html = @import("render_html.zig");
 pub const mcp = @import("mcp.zig");
-
-comptime {
-    _ = @import("unity_path.zig");
-}
+const unity_path = @import("unity_path.zig");
 
 test {
     std.testing.refAllDecls(@This());
@@ -21,93 +18,182 @@ test {
     _ = render_tree;
     _ = render_html;
     _ = mcp;
+    _ = unity_path;
 }
 
-test "parseArgs: two paths default to tree format" {
-    const args = [_][]const u8{ "a.prefab", "b.prefab" };
-    const opt = try parseArgs(&args);
-    try testing.expectEqualStrings("a.prefab", opt.before);
-    try testing.expectEqualStrings("b.prefab", opt.after);
-    try testing.expectEqual(Format.tree, opt.format);
+test "parseArgs: no operands = HEAD vs worktree, bulk" {
+    const opt = try parseArgs(&.{});
+    try testing.expectEqualStrings("HEAD", opt.target.git.before_ref);
+    try testing.expectEqualStrings("", opt.target.git.after_ref);
+    try testing.expectEqual(@as(?[]const u8, null), opt.target.git.path);
 }
 
-test "parseArgs: --json sets json format" {
-    const args = [_][]const u8{ "--json", "a.prefab", "b.prefab" };
-    const opt = try parseArgs(&args);
+test "parseArgs: one path = HEAD vs worktree, single file" {
+    const opt = try parseArgs(&.{"Assets/Foo.prefab"});
+    try testing.expectEqualStrings("HEAD", opt.target.git.before_ref);
+    try testing.expectEqualStrings("Assets/Foo.prefab", opt.target.git.path.?);
+}
+
+test "parseArgs: one ref = ref vs worktree, bulk" {
+    const opt = try parseArgs(&.{"main"});
+    try testing.expectEqualStrings("main", opt.target.git.before_ref);
+    try testing.expectEqualStrings("", opt.target.git.after_ref);
+    try testing.expectEqual(@as(?[]const u8, null), opt.target.git.path);
+}
+
+test "parseArgs: ref and path, order independent of flags" {
+    const opt = try parseArgs(&.{ "main", "Assets/Foo.prefab", "--json" });
+    try testing.expectEqualStrings("main", opt.target.git.before_ref);
+    try testing.expectEqualStrings("Assets/Foo.prefab", opt.target.git.path.?);
     try testing.expectEqual(Format.json, opt.format);
 }
 
-test "parseArgs: --no-color sets no_color, off by default" {
-    const default_args = [_][]const u8{ "a.prefab", "b.prefab" };
-    try testing.expect(!(try parseArgs(&default_args)).no_color);
-
-    const args = [_][]const u8{ "--no-color", "a.prefab", "b.prefab" };
-    const opt = try parseArgs(&args);
-    try testing.expect(opt.no_color);
+test "parseArgs: two refs = ref vs ref, bulk" {
+    const opt = try parseArgs(&.{ "main", "feat/x" });
+    try testing.expectEqualStrings("main", opt.target.git.before_ref);
+    try testing.expectEqualStrings("feat/x", opt.target.git.after_ref);
+    try testing.expectEqual(@as(?[]const u8, null), opt.target.git.path);
 }
 
-test "parseArgs: --git captures refs and path" {
-    const args = [_][]const u8{ "--json", "--git", "HEAD~1", "HEAD", "Foo.prefab" };
-    const opt = try parseArgs(&args);
-    try testing.expect(opt.git_mode);
-    try testing.expectEqualStrings("HEAD~1", opt.git_ref_before);
-    try testing.expectEqualStrings("HEAD", opt.git_ref_after);
-    try testing.expectEqualStrings("Foo.prefab", opt.git_path);
-    try testing.expectEqual(Format.json, opt.format);
+test "parseArgs: two refs and a path" {
+    const opt = try parseArgs(&.{ "HEAD~1", "HEAD", "Assets/Foo.unity" });
+    try testing.expectEqualStrings("HEAD~1", opt.target.git.before_ref);
+    try testing.expectEqualStrings("HEAD", opt.target.git.after_ref);
+    try testing.expectEqualStrings("Assets/Foo.unity", opt.target.git.path.?);
 }
 
-test "parseArgs: flags after --git operands are honored, not dropped" {
-    const args = [_][]const u8{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "--json" };
-    const opt = try parseArgs(&args);
-    try testing.expect(opt.git_mode);
-    try testing.expectEqualStrings("HEAD~1", opt.git_ref_before);
-    try testing.expectEqualStrings("HEAD", opt.git_ref_after);
-    try testing.expectEqualStrings("Foo.prefab", opt.git_path);
-    try testing.expectEqual(Format.json, opt.format);
+test "parseArgs: two paths = plain compare, no git" {
+    const opt = try parseArgs(&.{ "old.prefab", "new.prefab" });
+    try testing.expectEqualStrings("old.prefab", opt.target.files.before);
+    try testing.expectEqualStrings("new.prefab", opt.target.files.after);
 }
 
-test "parseArgs: extra positional after --git operands is a parse error" {
-    const args = [_][]const u8{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" };
-    try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
+test "parseArgs: excess operands are rejected" {
+    // Three refs; two paths and a ref; three paths — all over the limit.
+    try testing.expectError(ArgError.TooManyArguments, parseArgs(&.{ "a", "b", "c" }));
+    try testing.expectError(ArgError.TooManyArguments, parseArgs(&.{ "main", "a.prefab", "b.prefab" }));
+    try testing.expectError(ArgError.TooManyArguments, parseArgs(&.{ "a.prefab", "b.prefab", "c.prefab" }));
 }
 
-test "parseArgs: --git with two operands means ref vs working tree" {
-    const args = [_][]const u8{ "--git", "HEAD", "Foo.prefab", "--json" };
-    const opt = try parseArgs(&args);
-    try testing.expect(opt.git_mode);
-    try testing.expectEqualStrings("HEAD", opt.git_ref_before);
-    try testing.expectEqualStrings("", opt.git_ref_after); // empty = working-tree side
-    try testing.expectEqualStrings("Foo.prefab", opt.git_path);
-    try testing.expectEqual(Format.json, opt.format);
+test "parseArgs: --help short-circuits" {
+    const opt = try parseArgs(&.{ "--help", "whatever" });
+    try testing.expect(opt.help);
+    const short = try parseArgs(&.{"-h"});
+    try testing.expect(short.help);
 }
 
-test "parseArgs: --git with a single operand is missing operands" {
-    const args = [_][]const u8{ "--git", "HEAD" };
-    try testing.expectError(ArgError.MissingOperands, parseArgs(&args));
-}
-
-test "parseArgs: a third plain positional is too many arguments" {
-    const args = [_][]const u8{ "a.prefab", "b.prefab", "c.prefab" };
-    try testing.expectError(ArgError.TooManyArguments, parseArgs(&args));
-}
-
-test "run: extra positional after --git operands exits 2, not silently accepted" {
+test "run: bulk mode diffs every changed Unity file and skips others" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
 
-    // Previously the early return on --git ignored everything past its 3
-    // operands, so a stray trailing operand was silently dropped instead of
-    // rejected. With the loop continuing, it must hit the same unknown-flag
-    // arg-error contract as any other unrecognized positional.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    // MonoBehaviour with a plain multi-char field, like the other run() fixtures
+    // in this file: a bare single-letter field (e.g. "x") is deliberately left
+    // lowercase by the nicifier (core/src/inspector.zig mirrors Unity's
+    // Inspector, which leaves vector components x/y/z/w alone), so it would not
+    // exercise the label capitalization this assertion is meant to check.
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "--- !u!114 &1\nMonoBehaviour:\n  hp: 1\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Note.txt", .data = "n1\n" });
+    try gitInit(arena, dir); // helper shared with the existing --project git tests
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "--- !u!114 &1\nMonoBehaviour:\n  hp: 2\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Note.txt", .data = "n2\n" });
+
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    var errbuf: std.ArrayList(u8) = .empty;
-    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--git", "HEAD~1", "HEAD", "Foo.prefab", "Extra.prefab" }, &aw.writer, &aw_err.writer, false);
-    const err_output = aw_err.toArrayList();
-    try testing.expectEqual(@as(u8, 2), code);
-    try testing.expect(std.mem.indexOf(u8, err_output.items, "too many arguments") != null);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    // No operands: HEAD vs worktree over all changed supported files.
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false);
+    try testing.expectEqual(@as(u8, 0), code);
+    const text = aw.toArrayList().items;
+    // The Unity file appears as a header; the text file is filtered out.
+    try testing.expect(std.mem.indexOf(u8, text, "Foo.prefab") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "Note.txt") == null);
+    try testing.expect(std.mem.indexOf(u8, text, "Hp: 1 → 2") != null);
+}
+
+test "run: bulk mode with no matching files reports and exits 0" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Note.txt", .data = "n1\n" });
+    try gitInit(arena, dir);
+
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "no Unity YAML changes") != null);
+}
+
+test "run: bulk json emits an array of path/diff objects" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "--- !u!4 &4\nTransform:\n  x: 1\n" });
+    try gitInit(arena, dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "--- !u!4 &4\nTransform:\n  x: 2\n" });
+
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", dir }, &aw.writer, &aw_err.writer, false);
+    try testing.expectEqual(@as(u8, 0), code);
+    const text = aw.toArrayList().items;
+    try testing.expect(std.mem.startsWith(u8, text, "["));
+    try testing.expect(std.mem.indexOf(u8, text, "\"path\":\"Foo.prefab\"") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "\"schema\":\"prefablens.diff.v2\"") != null);
+}
+
+test "run: --help prints usage on stdout and exits 0" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    const code = try run(testing.io, arena, &.{"--help"}, &aw.writer, &aw_err.writer, false);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "usage: prefablens") != null);
+    try testing.expectEqual(@as(usize, 0), aw_err.toArrayList().items.len);
+}
+
+test "run: no operands in a repo with no commits fails with a git error" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    // git init with no commit: HEAD is unborn, so `git diff HEAD` fails --
+    // this exercises the same GitDiffFailed path a non-repo would, without
+    // depending on the tmp dir falling outside any enclosing git repository
+    // (testing.tmpDir lives under this worktree's .zig-cache, which git init
+    // shadows with a nested repo).
+    const r = try std.process.run(arena, testing.io, .{ .argv = &.{ "git", "init", "-q" }, .cwd = .{ .path = dir } });
+    try testing.expect(r.term == .exited and r.term.exited == 0);
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false);
+    try testing.expectEqual(@as(u8, 1), code);
+    try testing.expect(std.mem.indexOf(u8, aw_err.toArrayList().items, "git diff failed") != null);
 }
 
 test "run: --json with two real files prints core JSON" {
@@ -294,7 +380,7 @@ test "run: unreadable --project directory reports error and exits 1 in html mode
     try testing.expectEqualStrings("error: cannot read project directory '/no/such/project'\n", err_output.items);
 }
 
-test "run: --git with bad ref reports error and exits 1" {
+test "run: bad ref reports error and exits 1" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -305,26 +391,11 @@ test "run: --git with bad ref reports error and exits 1" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "--git", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "bogus-ref", "HEAD", "Foo.prefab" }, &aw.writer, &aw_err.writer, false);
     const err_output = aw_err.toArrayList();
     try testing.expectEqual(@as(u8, 1), code);
     // Exact match: one clean line, no stack trace or extra noise.
     try testing.expectEqualStrings("error: git show failed for 'bogus-ref:Foo.prefab'\n", err_output.items);
-}
-
-test "run: no operands prints usage and exits 2" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    var errbuf: std.ArrayList(u8) = .empty;
-    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{}, &aw.writer, &aw_err.writer, false);
-    const err_output = aw_err.toArrayList();
-    try testing.expectEqual(@as(u8, 2), code);
-    try testing.expect(std.mem.indexOf(u8, err_output.items, "usage:") != null);
 }
 
 test "run: unknown flag prints error and exits 2" {
@@ -444,6 +515,21 @@ test "run: --project supplies source prefabs for merged instance diffs" {
 /// Lockstep with the release tag v<version>. The single source is build.zig.zon (release.yml bumps it).
 pub const version = @import("build_options").version;
 
+// Builds a one-commit repo out of everything currently in `dir`.
+fn gitInit(arena: std.mem.Allocator, dir: []const u8) !void {
+    const steps = [_][]const []const u8{
+        &.{ "git", "init", "-q" },
+        &.{ "git", "config", "user.email", "t@t.t" },
+        &.{ "git", "config", "user.name", "t" },
+        &.{ "git", "add", "." },
+        &.{ "git", "commit", "-q", "-m", "first" },
+    };
+    for (steps) |argv| {
+        const r = try std.process.run(arena, testing.io, .{ .argv = argv, .cwd = .{ .path = dir } });
+        if (r.term != .exited or r.term.exited != 0) return error.GitFailed;
+    }
+}
+
 test "run: --project points git mode at a repo outside the cwd" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -454,25 +540,12 @@ test "run: --project points git mode at a repo outside the cwd" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
-    const gitc = struct {
-        fn call(io: std.Io, a: std.mem.Allocator, d: []const u8, argv: []const []const u8) !void {
-            var full: std.ArrayList([]const u8) = .empty;
-            try full.append(a, "git");
-            try full.appendSlice(a, argv);
-            const r = try std.process.run(a, io, .{ .argv = full.items, .cwd = .{ .path = d } });
-            if (r.term != .exited or r.term.exited != 0) return error.GitFailed;
-        }
-    }.call;
-    try gitc(testing.io, arena, dir, &.{ "init", "-q" });
-    try gitc(testing.io, arena, dir, &.{ "config", "user.email", "t@t.t" });
-    try gitc(testing.io, arena, dir, &.{ "config", "user.name", "t" });
     try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.asset", .data =
         \\--- !u!114 &1
         \\MonoBehaviour:
         \\  hp: 1
     });
-    try gitc(testing.io, arena, dir, &.{ "add", "Foo.asset" });
-    try gitc(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
+    try gitInit(arena, dir);
     try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.asset", .data =
         \\--- !u!114 &1
         \\MonoBehaviour:
@@ -483,7 +556,7 @@ test "run: --project points git mode at a repo outside the cwd" {
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = try run(testing.io, arena, &.{ "--json", "--project", dir, "--git", "HEAD", "Foo.asset" }, &aw.writer, &aw_err.writer, false);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", dir, "HEAD", "Foo.asset" }, &aw.writer, &aw_err.writer, false);
     const output = aw.toArrayList();
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"after\":\"2\"") != null);
@@ -491,30 +564,55 @@ test "run: --project points git mode at a repo outside the cwd" {
 
 pub const Format = enum { tree, json, html };
 
+pub const Target = union(enum) {
+    /// Two explicit files, no git involved.
+    files: struct { before: []const u8, after: []const u8 },
+    /// Empty after_ref = the working tree. Null path = every changed
+    /// supported file (bulk mode).
+    git: struct { before_ref: []const u8, after_ref: []const u8, path: ?[]const u8 },
+};
+
 pub const Options = struct {
-    before: []const u8,
-    after: []const u8,
+    target: Target,
     format: Format = .tree,
-    project_root: ?[]const u8 = null, // for .meta resolution
-    git_mode: bool = false,
-    git_ref_before: []const u8 = "",
-    git_ref_after: []const u8 = "",
-    git_path: []const u8 = "",
+    project_root: ?[]const u8 = null, // guid-resolution base and the git repo dir
     no_color: bool = false,
+    help: bool = false,
 };
 
 pub const ArgError = error{ MissingOperands, UnknownFlag, TooManyArguments };
 
+const usage_line = "usage: prefablens [--json|--html] [--project DIR] [--no-color] [<ref>] [<ref>] [<path>] | <before> <after>\n";
+
+const help_text = usage_line ++
+    \\
+    \\Operands ending in a Unity YAML extension (.prefab, .unity, .asset, ...)
+    \\are paths; anything else is a git ref.
+    \\
+    \\  (no operands)          HEAD vs working tree, all changed Unity files
+    \\  <path>                 HEAD vs working tree, one file
+    \\  <ref> [<path>]         ref vs working tree
+    \\  <ref> <ref> [<path>]   ref vs ref
+    \\  <before> <after>       compare two files directly (no git)
+    \\  mcp                    run as an MCP server on stdio
+    \\
+    \\options:
+    \\  --json         prefablens.diff.v2 JSON ({path, diff} array in bulk mode)
+    \\  --html         self-contained HTML report on stdout
+    \\  --project DIR  Unity project root for guid resolution (and git repo dir)
+    \\  --no-color     disable ANSI colors in tree output
+    \\  -h, --help     show this help
+    \\
+;
+
 pub fn parseArgs(args: []const []const u8) ArgError!Options {
     var format: Format = .tree;
     var project_root: ?[]const u8 = null;
-    var positionals: [2]?[]const u8 = .{ null, null };
-    var pos_count: usize = 0;
-    var git_mode = false;
-    var git_ref_before: []const u8 = "";
-    var git_ref_after: []const u8 = "";
-    var git_path: []const u8 = "";
     var no_color = false;
+    var refs: [2][]const u8 = undefined;
+    var n_refs: usize = 0;
+    var paths: [2][]const u8 = undefined;
+    var n_paths: usize = 0;
 
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -525,53 +623,40 @@ pub fn parseArgs(args: []const []const u8) ArgError!Options {
             format = .html;
         } else if (std.mem.eql(u8, a, "--no-color")) {
             no_color = true;
+        } else if (std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h")) {
+            return .{ .target = .{ .git = .{ .before_ref = "HEAD", .after_ref = "", .path = null } }, .help = true };
         } else if (std.mem.eql(u8, a, "--project")) {
             i += 1;
             if (i >= args.len) return ArgError.MissingOperands;
             project_root = args[i];
-        } else if (std.mem.eql(u8, a, "--git")) {
-            // --git <beforeRef> [<afterRef>] <path>: consumes 2-3 non-flag operands;
-            // with 2, the after side is the working tree (git_ref_after = ""). Trailing flags are still parsed.
-            var ops: [3][]const u8 = undefined;
-            var n: usize = 0;
-            while (n < 3 and i + 1 < args.len and !std.mem.startsWith(u8, args[i + 1], "--")) : (n += 1) {
-                i += 1;
-                ops[n] = args[i];
-            }
-            if (n < 2) return ArgError.MissingOperands;
-            git_mode = true;
-            git_ref_before = ops[0];
-            git_ref_after = if (n == 3) ops[1] else "";
-            git_path = ops[n - 1];
         } else if (std.mem.startsWith(u8, a, "--")) {
             return ArgError.UnknownFlag;
-        } else if (git_mode) {
-            // --git already consumed its three operands; a bare positional
-            // afterward is an extra operand, not an unrecognized flag.
-            return ArgError.TooManyArguments;
+        } else if (unity_path.isUnityPath(a)) {
+            if (n_paths >= 2) return ArgError.TooManyArguments;
+            paths[n_paths] = a;
+            n_paths += 1;
         } else {
-            if (pos_count >= 2) return ArgError.TooManyArguments;
-            positionals[pos_count] = a;
-            pos_count += 1;
+            if (n_refs >= 2) return ArgError.TooManyArguments;
+            refs[n_refs] = a;
+            n_refs += 1;
         }
     }
-    if (git_mode) {
+    if (n_paths == 2) {
+        // Plain two-file compare; mixing it with refs has no meaning.
+        if (n_refs != 0) return ArgError.TooManyArguments;
         return .{
-            .before = "",
-            .after = "",
+            .target = .{ .files = .{ .before = paths[0], .after = paths[1] } },
             .format = format,
             .project_root = project_root,
-            .git_mode = true,
-            .git_ref_before = git_ref_before,
-            .git_ref_after = git_ref_after,
-            .git_path = git_path,
             .no_color = no_color,
         };
     }
-    if (pos_count != 2) return ArgError.MissingOperands;
     return .{
-        .before = positionals[0].?,
-        .after = positionals[1].?,
+        .target = .{ .git = .{
+            .before_ref = if (n_refs >= 1) refs[0] else "HEAD",
+            .after_ref = if (n_refs == 2) refs[1] else "",
+            .path = if (n_paths == 1) paths[0] else null,
+        } },
         .format = format,
         .project_root = project_root,
         .no_color = no_color,
@@ -582,60 +667,68 @@ fn readFile(io: std.Io, arena: std.mem.Allocator, path: []const u8) ![]u8 {
     return std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(input.max_input_bytes));
 }
 
+const model = core.model;
+
+const NamedDiff = struct { path: ?[]const u8, res: model.DiffResult };
+
+/// Diff one before/after pair, satisfying needed_sources from the project
+/// index when available (nested sources raise new requests, so up to 3
+/// rounds; stop if there's no progress).
+fn diffOne(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    before: []const u8,
+    after: []const u8,
+    idx: ?*core.json.Resolver,
+    assets: *core.Assets,
+) !model.DiffResult {
+    var res = try core.diffBytesWithAssets(arena, before, after, assets);
+    if (idx) |index| {
+        var rounds: usize = 0;
+        while (res.needed_sources.len != 0 and rounds < 3) : (rounds += 1) {
+            var progressed = false;
+            for (res.needed_sources) |ns| {
+                if (assets.contains(ns.guid)) continue;
+                const path = index.get(ns.guid) orelse continue;
+                const bytes = readFile(io, arena, path) catch continue;
+                try assets.put(arena, ns.guid, bytes);
+                progressed = true;
+            }
+            if (!progressed) break;
+            res = try core.diffBytesWithAssets(arena, before, after, assets);
+        }
+    }
+    return res;
+}
+
+fn writeJsonString(w: *std.Io.Writer, s: []const u8) !void {
+    try w.writeByte('"');
+    for (s) |c| switch (c) {
+        '"' => try w.writeAll("\\\""),
+        '\\' => try w.writeAll("\\\\"),
+        0x00...0x1f => try w.print("\\u{x:0>4}", .{c}),
+        else => try w.writeByte(c),
+    };
+    try w.writeByte('"');
+}
+
 pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdout: *std.Io.Writer, stderr: *std.Io.Writer, color: bool) !u8 {
     const opt = parseArgs(args) catch |err| {
         switch (err) {
-            ArgError.MissingOperands => try stderr.writeAll("usage: prefablens [--json|--html] [--project DIR] [--no-color] (<before> <after> | --git <beforeRef> [<afterRef>] <path>)\n"),
-            ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag\n"),
-            ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments\n"),
+            ArgError.MissingOperands => try stderr.writeAll(usage_line),
+            ArgError.UnknownFlag => try stderr.writeAll("error: unknown flag (see --help)\n"),
+            ArgError.TooManyArguments => try stderr.writeAll("error: too many arguments (see --help)\n"),
         }
         return 2;
     };
+    if (opt.help) {
+        try stdout.writeAll(help_text);
+        return 0;
+    }
 
-    // --project doubles as the guid-resolution base and the git repo dir (unset falls back to cwd as before).
+    // --project doubles as the guid-resolution base and the git repo dir.
     const repo_dir = opt.project_root orelse ".";
-    const before = if (opt.git_mode)
-        input.showAtRef(io, arena, repo_dir, opt.git_ref_before, opt.git_path, input.default_git_timeout) catch |err| {
-            if (err == error.GitTimeout)
-                try stderr.print("error: git timed out for '{s}:{s}'\n", .{ opt.git_ref_before, opt.git_path })
-            else
-                try stderr.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_before, opt.git_path });
-            return 1;
-        }
-    else
-        readFile(io, arena, opt.before) catch {
-            try stderr.print("error: cannot read file '{s}'\n", .{opt.before});
-            return 1;
-        };
-    const after = if (opt.git_mode and opt.git_ref_after.len == 0)
-        // one ref = comparison against the working tree (a missing file is deletion = empty side)
-        input.readWorktree(io, arena, repo_dir, opt.git_path) catch {
-            try stderr.print("error: cannot read file '{s}'\n", .{opt.git_path});
-            return 1;
-        }
-    else if (opt.git_mode)
-        input.showAtRef(io, arena, repo_dir, opt.git_ref_after, opt.git_path, input.default_git_timeout) catch |err| {
-            if (err == error.GitTimeout)
-                try stderr.print("error: git timed out for '{s}:{s}'\n", .{ opt.git_ref_after, opt.git_path })
-            else
-                try stderr.print("error: git show failed for '{s}:{s}'\n", .{ opt.git_ref_after, opt.git_path });
-            return 1;
-        }
-    else
-        readFile(io, arena, opt.after) catch {
-            try stderr.print("error: cannot read file '{s}'\n", .{opt.after});
-            return 1;
-        };
-
-    var assets: core.Assets = .empty;
-    var res = core.diffBytesWithAssets(arena, before, after, &assets) catch |err| {
-        if (err == error.NestingTooDeep) {
-            try stderr.writeAll("error: input nested too deeply\n");
-            return 1;
-        }
-        return err;
-    };
-    var resolver_ptr: ?*const core.json.Resolver = null;
+    var resolver_ptr: ?*core.json.Resolver = null;
     var idx: core.json.Resolver = undefined;
     if (opt.project_root) |proj| {
         idx = resolve.buildIndex(io, arena, proj) catch {
@@ -643,34 +736,122 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
             return 1;
         };
         resolver_ptr = &idx;
-        // Satisfy needed_sources with local assets and re-diff (nested sources raise new
-        // requests, so up to 3 rounds; stop if there's no progress). Unreadable assets are
-        // skipped without failing the diff.
-        var rounds: usize = 0;
-        while (res.needed_sources.len != 0 and rounds < 3) : (rounds += 1) {
-            var progressed = false;
-            for (res.needed_sources) |ns| {
-                if (assets.contains(ns.guid)) continue;
-                const path = idx.get(ns.guid) orelse continue;
-                const bytes = readFile(io, arena, path) catch continue;
-                try assets.put(arena, ns.guid, bytes);
-                progressed = true;
-            }
-            if (!progressed) break;
-            res = try core.diffBytesWithAssets(arena, before, after, &assets);
-        }
     }
+    var assets: core.Assets = .empty;
+
+    // Collect (path, before, after) triples for every diff target.
+    var diffs: std.ArrayList(NamedDiff) = .empty;
+    switch (opt.target) {
+        .files => |f| {
+            const before = readFile(io, arena, f.before) catch {
+                try stderr.print("error: cannot read file '{s}'\n", .{f.before});
+                return 1;
+            };
+            const after = readFile(io, arena, f.after) catch {
+                try stderr.print("error: cannot read file '{s}'\n", .{f.after});
+                return 1;
+            };
+            const res = diffOne(io, arena, before, after, resolver_ptr, &assets) catch |err| return diffError(stderr, err);
+            try diffs.append(arena, .{ .path = null, .res = res });
+        },
+        .git => |g| {
+            // Built as a list (not `&.{p}`) so the single-path case doesn't
+            // take the address of a temporary array literal.
+            var path_list: std.ArrayList([]const u8) = .empty;
+            if (g.path) |p| {
+                try path_list.append(arena, p);
+            } else {
+                const all = input.changedPaths(io, arena, repo_dir, g.before_ref, g.after_ref, input.default_git_timeout) catch |err| {
+                    if (err == error.GitTimeout)
+                        try stderr.writeAll("error: git timed out listing changed files\n")
+                    else
+                        try stderr.print("error: git diff failed for '{s}'\n", .{g.before_ref});
+                    return 1;
+                };
+                for (all) |p| if (unity_path.isUnityPath(p)) try path_list.append(arena, p);
+            }
+            const paths = path_list.items;
+            if (paths.len == 0) {
+                try stdout.writeAll("no Unity YAML changes\n");
+                return 0;
+            }
+            for (paths) |p| {
+                const before = input.showAtRef(io, arena, repo_dir, g.before_ref, p, input.default_git_timeout) catch |err| {
+                    if (err == error.GitTimeout)
+                        try stderr.print("error: git timed out for '{s}:{s}'\n", .{ g.before_ref, p })
+                    else
+                        try stderr.print("error: git show failed for '{s}:{s}'\n", .{ g.before_ref, p });
+                    return 1;
+                };
+                const after = if (g.after_ref.len == 0)
+                    // One ref = comparison against the working tree (a
+                    // missing file is deletion = empty side).
+                    input.readWorktree(io, arena, repo_dir, p) catch {
+                        try stderr.print("error: cannot read file '{s}'\n", .{p});
+                        return 1;
+                    }
+                else
+                    input.showAtRef(io, arena, repo_dir, g.after_ref, p, input.default_git_timeout) catch |err| {
+                        if (err == error.GitTimeout)
+                            try stderr.print("error: git timed out for '{s}:{s}'\n", .{ g.after_ref, p })
+                        else
+                            try stderr.print("error: git show failed for '{s}:{s}'\n", .{ g.after_ref, p });
+                        return 1;
+                    };
+                const res = diffOne(io, arena, before, after, resolver_ptr, &assets) catch |err| return diffError(stderr, err);
+                // Single explicit path keeps the headerless single-file output.
+                try diffs.append(arena, .{ .path = if (g.path != null) null else p, .res = res });
+            }
+        },
+    }
+
     switch (opt.format) {
         .json => {
-            const out = try core.json.serialize(arena, res, resolver_ptr);
-            try stdout.writeAll(out);
-            try stdout.writeByte('\n');
+            if (diffs.items.len == 1 and diffs.items[0].path == null) {
+                const out = try core.json.serialize(arena, diffs.items[0].res, resolver_ptr);
+                try stdout.writeAll(out);
+                try stdout.writeByte('\n');
+            } else {
+                try stdout.writeByte('[');
+                for (diffs.items, 0..) |d, i| {
+                    if (i != 0) try stdout.writeByte(',');
+                    try stdout.writeAll("{\"path\":");
+                    try writeJsonString(stdout, d.path.?);
+                    try stdout.writeAll(",\"diff\":");
+                    try stdout.writeAll(try core.json.serialize(arena, d.res, resolver_ptr));
+                    try stdout.writeByte('}');
+                }
+                try stdout.writeAll("]\n");
+            }
         },
         // Color when stdout is a TTY is decided in main(); --no-color forces it off.
-        .tree => try render_tree.render(arena, stdout, res, resolver_ptr, color and !opt.no_color),
-        .html => try render_html.render(stdout, &.{.{ .path = null, .res = res }}, resolver_ptr),
+        .tree => {
+            const use_color = color and !opt.no_color;
+            for (diffs.items, 0..) |d, i| {
+                if (d.path) |p| {
+                    if (i != 0) try stdout.writeByte('\n');
+                    if (use_color) try stdout.writeAll(render_tree.Color.bold);
+                    try stdout.print("{s}\n", .{p});
+                    if (use_color) try stdout.writeAll(render_tree.Color.reset);
+                }
+                try render_tree.render(arena, stdout, d.res, resolver_ptr, use_color);
+            }
+        },
+        .html => {
+            var files: std.ArrayList(render_html.FileDiff) = .empty;
+            for (diffs.items) |d| try files.append(arena, .{ .path = d.path, .res = d.res });
+            try render_html.render(stdout, files.items, resolver_ptr);
+        },
     }
     return 0;
+}
+
+fn diffError(stderr: *std.Io.Writer, err: anyerror) !u8 {
+    if (err == error.NestingTooDeep) {
+        try stderr.writeAll("error: input nested too deeply\n");
+        return 1;
+    }
+    return err;
 }
 
 pub fn main(init: std.process.Init) !u8 {

--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -137,10 +137,12 @@ fn handleToolsCall(io: std.Io, arena: std.mem.Allocator, w: *std.Io.Writer, id: 
         return validationError(w, id, "format must be \\\"tree\\\" or \\\"json\\\"");
 
     // Same argv as the old TS host's buildArgs + cwd=projectRoot (--project doubles as the git repo dir).
+    // `--git` is gone from the grammar (Task 5): a bare ref operand is enough, `path` is
+    // classified as a path by its Unity extension.
     var argv: std.ArrayList([]const u8) = .empty;
     try argv.append(arena, if (is_json) "--json" else "--no-color");
     try argv.appendSlice(arena, &.{ "--project", project_root orelse "." });
-    try argv.appendSlice(arena, &.{ "--git", before });
+    try argv.append(arena, before);
     if (after) |a| try argv.append(arena, a);
     try argv.append(arena, path.?);
 

--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -333,21 +333,22 @@ test "mcp: tools/call diffs a real git fixture with the ts host golden" {
     try req_w.writer.writeAll("}}}\n");
     const res = try roundtrip(arena, req_w.toArrayList().items);
 
-    // Parse the response and compare text against server.test.ts's golden.
+    // Parse the response and compare text against the box-drawing spine layout
+    // (render_tree.zig; formerly matched server.test.ts's now-removed TS host golden).
     const parsed = try std.json.parseFromSliceLeaky(std.json.Value, arena, std.mem.trimEnd(u8, res, "\n"), .{});
     const result = parsed.object.get("result").?.object;
     try testing.expect(result.get("isError") == null);
     const text = result.get("content").?.array.items[0].object.get("text").?.string;
-    try testing.expectEqualStrings("  Plane\n" ++
-        "  ~ Cylinder  <Prefab>\n" ++
-        "      components\n" ++
-        "        ~ Transform\n" ++
-        "          ~ Position.x: 0.41646004 -> 1\n" ++
-        "  + Cylinder Variant  <Prefab>\n" ++
-        "      components\n" ++
-        "        + Transform\n" ++
-        "          + Position: (2.03, 3.63, 1.11797)\n" ++
-        "          + Rotation: (0, 0, 0, 1)\n", text);
+    try testing.expectEqualStrings("◆ Plane\n" ++
+        "├─ ◆ ~ Cylinder ‹Prefab›\n" ++
+        "│  └─ components (1)\n" ++
+        "│     └─ ~ Transform\n" ++
+        "│          Position.x: 0.41646004 → 1\n" ++
+        "└─ ◆ + Cylinder Variant ‹Prefab›\n" ++
+        "   └─ components (1)\n" ++
+        "      └─ + Transform\n" ++
+        "           Position: (2.03, 3.63, 1.11797)\n" ++
+        "           Rotation: (0, 0, 0, 1)\n", text);
 }
 
 test "mcp: tools/call format json returns diff v2 and bad refs surface as isError" {

--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -150,7 +150,9 @@ fn handleToolsCall(io: std.Io, arena: std.mem.Allocator, w: *std.Io.Writer, id: 
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
     var errbuf: std.ArrayList(u8) = .empty;
     var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &errbuf);
-    const code = main.run(io, arena, argv.items, &aw.writer, &aw_err.writer, false) catch |err| {
+    // The MCP tool never emits --open, so there's no browser to launch and
+    // no need for the real process environment here.
+    const code = main.run(io, arena, argv.items, &aw.writer, &aw_err.writer, false, null) catch |err| {
         const msg = try std.fmt.allocPrint(arena, "prefablens failed: {s}", .{@errorName(err)});
         try writeToolText(w, id, msg, true);
         return;

--- a/cli/src/mcp.zig
+++ b/cli/src/mcp.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 const core = @import("core");
 const main = @import("main.zig");
+const unity_path = @import("unity_path.zig");
 
 pub const default_protocol_version = "2025-06-18";
 // 2025-03-26 makes batch requests a MUST, but major clients don't send them, so we accept it while leaving batching unsupported.
@@ -127,6 +128,9 @@ fn handleToolsCall(io: std.Io, arena: std.mem.Allocator, w: *std.Io.Writer, id: 
     const args: ?std.json.Value = if (p == .object) p.object.get("arguments") else null;
     const path = getString(args, "path") catch return validationError(w, id, "path must be a non-empty string");
     if (path == null or path.?.len == 0) return validationError(w, id, "path must be a non-empty string");
+    // Same gate main.zig's parseArgs applies to CLI path operands (unity_path.isUnityPath):
+    // reject anything that isn't a Unity YAML asset before it ever reaches git/the CLI argv.
+    if (!unity_path.isUnityPath(path.?)) return validationError(w, id, "path must end in a Unity YAML extension");
     const before = (getString(args, "before") catch return validationError(w, id, "before must be a string")) orelse "HEAD";
     const after = getString(args, "after") catch return validationError(w, id, "after must be a string");
     const project_root = getString(args, "projectRoot") catch return validationError(w, id, "projectRoot must be a non-empty string");
@@ -305,12 +309,13 @@ test "mcp: tools/call validation errors match the ts host contract" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // empty path / empty projectRoot / invalid format / missing arguments / unknown tool
+    // empty path / empty projectRoot / invalid format / missing arguments / unknown tool / non-Unity path extension
     const res = try roundtrip(arena, "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"\"}}}\n" ++
         "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"a.prefab\",\"projectRoot\":\"\"}}}\n" ++
         "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"a.prefab\",\"format\":\"xml\"}}}\n" ++
         "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\"}}\n" ++
-        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"nope\",\"arguments\":{}}}\n");
+        "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"nope\",\"arguments\":{}}}\n" ++
+        "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{\"name\":\"prefab_diff\",\"arguments\":{\"path\":\"Foo.txt\"}}}\n");
     var lines = std.mem.splitScalar(u8, std.mem.trimEnd(u8, res, "\n"), '\n');
     const l1 = lines.next().?;
     try testing.expectEqualStrings("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"Input validation error: path must be a non-empty string\"}],\"isError\":true}}", l1);
@@ -318,6 +323,10 @@ test "mcp: tools/call validation errors match the ts host contract" {
     try testing.expect(std.mem.indexOf(u8, lines.next().?, "format must be \\\"tree\\\" or \\\"json\\\"") != null);
     try testing.expect(std.mem.indexOf(u8, lines.next().?, "path must be a non-empty string") != null);
     try testing.expect(std.mem.indexOf(u8, lines.next().?, "-32602") != null);
+    // Foo.txt is well-formed but not a Unity YAML asset -- same response shape as the other
+    // validation errors above (validationError()'s envelope), not a git/CLI failure.
+    const l6 = lines.next().?;
+    try testing.expectEqualStrings("{\"jsonrpc\":\"2.0\",\"id\":6,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"Input validation error: path must end in a Unity YAML extension\"}],\"isError\":true}}", l6);
 }
 
 test "mcp: tools/call diffs a real git fixture with the ts host golden" {

--- a/cli/src/render_html.zig
+++ b/cli/src/render_html.zig
@@ -2,7 +2,19 @@ const std = @import("std");
 const core = @import("core");
 const testing = std.testing;
 
-test "html: self-contained document with escaped content" {
+// Renders `files` and returns the HTML for assertions.
+fn renderToString(
+    arena: std.mem.Allocator,
+    files: []const FileDiff,
+    resolved: ?*const core.json.Resolver,
+) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    try render(&aw.writer, files, resolved);
+    return aw.toArrayList().items;
+}
+
+test "html: self-contained page with pl-root and escaped content" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -29,16 +41,46 @@ test "html: self-contained document with escaped content" {
         \\  hp: 2
     ;
     const res = try core.diffBytes(arena, before, after);
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null);
-    const html = aw.toArrayList().items;
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, null);
     try testing.expect(std.mem.startsWith(u8, html, "<!DOCTYPE html>"));
     try testing.expect(std.mem.indexOf(u8, html, "<style>") != null);
     try testing.expect(std.mem.indexOf(u8, html, "</html>") != null);
+    // The stylesheet is embedded, not linked: no external requests ever.
+    try testing.expect(std.mem.indexOf(u8, html, "pl-root") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<link") == null);
+    try testing.expect(std.mem.indexOf(u8, html, "<script") == null);
     // HTML special chars escaped: "A<x>" -> "A&lt;x&gt;"
     try testing.expect(std.mem.indexOf(u8, html, "A&lt;x&gt;") != null);
     try testing.expect(std.mem.indexOf(u8, html, "Hp") != null);
+}
+
+test "html: modified component renders an extension-shaped card" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  hp: 1
+    ;
+    const after =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  hp: 2
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, null);
+    // Loose components sit in a components section, like the extension's
+    // diff.loose rendering.
+    try testing.expect(std.mem.indexOf(u8, html, "components (1)") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<details open class=\"pl-comp pl-modified\">") != null);
+    // Badge chip carries the ~ marker; the row itself is a native summary.
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"pl-badge\">~</span>") != null);
+    // Modified field: before -> arrow -> after, extension class names.
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"pl-path\">Hp</span>") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"pl-before\">1</span>") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"pl-arrow\">→</span>") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"pl-after\">2</span>") != null);
 }
 
 test "html: ref guid with markup is escaped" {
@@ -58,15 +100,12 @@ test "html: ref guid with markup is escaped" {
         \\  m_Target: {fileID: 3, guid: <img src=x onerror=alert(1)>, type: 3}
     ;
     const res = try core.diffBytes(arena, before, after);
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null);
-    const html = aw.toArrayList().items;
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, null);
     try testing.expect(std.mem.indexOf(u8, html, "<img") == null);
     try testing.expect(std.mem.indexOf(u8, html, "&lt;img") != null);
 }
 
-test "html: resolved script guid renders the resolved script name, not the raw type" {
+test "html: resolved script guid renders stem as name and full path as meta" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -85,17 +124,15 @@ test "html: resolved script guid renders the resolved script name, not the raw t
     const res = try core.diffBytes(arena, before, after);
     var resolver = core.json.Resolver.init(arena);
     try resolver.put("abc123", "Assets/Scripts/PlayerController.cs");
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, &resolver);
-    const html = aw.toArrayList().items;
-    // The resolved stem (extension-less basename) replaces the raw type name entirely.
-    try testing.expect(std.mem.indexOf(u8, html, "PlayerController") != null);
-    try testing.expect(std.mem.indexOf(u8, html, "PlayerController.cs") == null);
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, &resolver);
+    // Same display rule as the extension: stem replaces the type name, the
+    // full path rides in the pl-script meta span.
+    try testing.expect(std.mem.indexOf(u8, html, "PlayerController<") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "‹Script: Assets/Scripts/PlayerController.cs›") != null);
     try testing.expect(std.mem.indexOf(u8, html, "MonoBehaviour") == null);
 }
 
-test "html: nested child GameObject renders indented one level under its parent" {
+test "html: nested child GameObject nests inside the parent's pl-kids" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -140,41 +177,14 @@ test "html: nested child GameObject renders indented one level under its parent"
         \\  m_Father: {fileID: 4}
     ;
     const res = try core.diffBytes(arena, before, after);
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null);
-    const html = aw.toArrayList().items;
-    // Parent (depth 0, unchanged) has no leading pad before its span.
-    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"unchanged go\">  Parent</span>") != null);
-    // Child (depth 1, modified) is indented two spaces under it.
-    try testing.expect(std.mem.indexOf(u8, html, "  <span class=\"modified go\">~ ChildRenamed</span>") != null);
-}
-
-test "html: loose component renders without a GameObject wrapper" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    const before =
-        \\--- !u!114 &11400000
-        \\MonoBehaviour:
-        \\  m_Script: {fileID: 0, guid: def, type: 3}
-        \\  volume: 0.5
-    ;
-    const after =
-        \\--- !u!114 &11400000
-        \\MonoBehaviour:
-        \\  m_Script: {fileID: 0, guid: def, type: 3}
-        \\  volume: 0.8
-    ;
-    const res = try core.diffBytes(arena, before, after);
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null);
-    const html = aw.toArrayList().items;
-    try testing.expect(std.mem.indexOf(u8, html, "Volume") != null);
-    // Loose components render at depth 0 with a plain (non-"go") span class.
-    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"modified\">~ MonoBehaviour</span>") != null);
-    try testing.expect(std.mem.indexOf(u8, html, " go\">") == null);
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, null);
+    // Parent (unchanged) row exists, then a kids container, then the child.
+    const parent_at = std.mem.indexOf(u8, html, "Parent").?;
+    const kids_at = std.mem.indexOfPos(u8, html, parent_at, "<div class=\"pl-kids\">").?;
+    const child_at = std.mem.indexOfPos(u8, html, kids_at, "ChildRenamed").?;
+    try testing.expect(parent_at < kids_at and kids_at < child_at);
+    // The renamed child is a modified GameObject card.
+    try testing.expect(std.mem.indexOf(u8, html, "<details open class=\"pl-go pl-modified\">") != null);
 }
 
 test "html: added and removed fields render only their one side" {
@@ -194,157 +204,335 @@ test "html: added and removed fields render only their one side" {
         \\  m_NewField: 2
     ;
     const res = try core.diffBytes(arena, before, after);
-    var out: std.ArrayList(u8) = .empty;
-    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null);
-    const html = aw.toArrayList().items;
-    // Added field: only the "new" span, no paired "old" value.
-    try testing.expect(std.mem.indexOf(u8, html, "New Field") != null);
-    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"new\">2</span>") != null);
-    // Removed field: only the "old" span, no paired "new" value.
-    try testing.expect(std.mem.indexOf(u8, html, "Old Field") != null);
-    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"old\">1</span>") != null);
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, null);
+    // Added field: pl-after value only. Removed field: pl-before value only.
+    try testing.expect(std.mem.indexOf(u8, html, "<div class=\"pl-field pl-added\"><span class=\"pl-path\">New Field</span><span class=\"pl-after\">2</span></div>") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "<div class=\"pl-field pl-removed\"><span class=\"pl-path\">Old Field</span><span class=\"pl-before\">1</span></div>") != null);
+}
+
+test "html: file sections wrap per-path reports; empty diff notes no changes" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const changed = try core.diffBytes(arena, "--- !u!4 &4\nTransform:\n  x: 1", "--- !u!4 &4\nTransform:\n  x: 2");
+    const same = try core.diffBytes(arena, "--- !u!4 &4\nTransform:\n  x: 1", "--- !u!4 &4\nTransform:\n  x: 1");
+    const html = try renderToString(arena, &.{
+        .{ .path = "Assets/A & B.prefab", .res = changed },
+        .{ .path = "Assets/Same.prefab", .res = same },
+    }, null);
+    // Section summaries carry the escaped path (a non pl-* class so the
+    // parity tripwire stays clean).
+    try testing.expect(std.mem.indexOf(u8, html, "<details open class=\"file\">") != null);
+    try testing.expect(std.mem.indexOf(u8, html, "Assets/A &amp; B.prefab") != null);
+    // A semantically unchanged file is listed with the extension's note, not
+    // silently dropped.
+    try testing.expect(std.mem.indexOf(u8, html, "No semantic changes") != null);
+}
+
+test "html: unresolved guids surface the --project hint as a note" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 11500000, guid: abc123, type: 3}
+        \\  hp: 1
+    ;
+    const after =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  m_Script: {fileID: 11500000, guid: abc123, type: 3}
+        \\  hp: 2
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    const html = try renderToString(arena, &.{.{ .path = null, .res = res }}, null);
+    try testing.expect(std.mem.indexOf(u8, html, "--project") != null);
 }
 
 const model = core.model;
 const display = @import("display.zig");
 
-const head =
-    \\<!DOCTYPE html>
-    \\<html lang="en"><head><meta charset="utf-8">
-    \\<title>PrefabLens diff</title>
-    \\<style>
-    \\body{font:14px/1.5 ui-monospace,Menlo,Consolas,monospace;background:#0d1117;color:#c9d1d9;margin:1.5rem}
-    \\.tree{white-space:pre}
-    \\.added{color:#3fb950}.removed{color:#f85149}.modified{color:#d29922}.unchanged{color:#8b949e}
-    \\.go{font-weight:600}.field{color:#c9d1d9}
-    \\.old{color:#f85149}.new{color:#3fb950}
-    \\h1{font-size:1rem;color:#58a6ff}
-    \\</style></head><body>
-    \\<h1>PrefabLens — prefablens.diff.v2</h1>
-    \\<div class="tree">
+pub const FileDiff = struct {
+    /// null for a single unnamed report (plain two-file mode / single git target).
+    path: ?[]const u8,
+    res: model.DiffResult,
+};
+
+// Inline SVG markup for tree glyphs, byte-identical to
+// extension/src/renderer/icons.ts. Static strings only — never interpolate data.
+const chevron_svg =
+    \\<svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M6 4l4 4-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+;
+const cube_svg =
+    \\<svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8 1.5 14 5v6l-6 3.5L2 11V5l6-3.5Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/><path d="M2 5l6 3.5L14 5M8 8.5V14" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/></svg>
+;
+const gear_svg =
+    \\<svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.2"/><path d="M8 1.8v2M8 12.2v2M1.8 8h2M12.2 8h2M3.7 3.7l1.4 1.4M10.9 10.9l1.4 1.4M12.3 3.7l-1.4 1.4M5.1 10.9l-1.4 1.4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
+;
+const alert_svg =
+    \\<svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8 1.75a.9.9 0 0 1 .78.45l6.3 10.9a.9.9 0 0 1-.78 1.35H1.7a.9.9 0 0 1-.78-1.35l6.3-10.9A.9.9 0 0 1 8 1.75Z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/><path d="M8 6v3.2" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/><circle cx="8" cy="11.6" r=".8" fill="currentColor"/></svg>
+;
+const check_svg =
+    \\<svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M13.5 4.5 6.5 11.5 2.5 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
 ;
 
-const tail =
-    \\</div></body></html>
-;
+const page_head = "<!DOCTYPE html>\n<html lang=\"en\"><head><meta charset=\"utf-8\">\n" ++
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n" ++
+    "<title>PrefabLens diff</title>\n<style>\n" ++ @embedFile("semantic_view.css") ++
+    "</style></head><body><main>\n";
+const page_tail = "</main></body></html>\n";
 
 pub fn render(
     w: *std.Io.Writer,
-    res: model.DiffResult,
+    files: []const FileDiff,
     resolved: ?*const core.json.Resolver,
 ) !void {
-    try w.writeAll(head);
-    for (res.roots) |o| try renderObject(w, o, resolved, 0);
-    for (res.loose) |c| try renderComponent(w, c, resolved, 0);
-    try w.writeAll(tail);
+    try w.writeAll(page_head);
+    for (files) |f| {
+        if (f.path) |p| {
+            try w.writeAll("<details open class=\"file\"><summary>");
+            try writeEscaped(w, p);
+            try w.writeAll("</summary>");
+            try renderDiff(w, f.res, resolved);
+            try w.writeAll("</details>\n");
+        } else {
+            try renderDiff(w, f.res, resolved);
+        }
+    }
+    try w.writeAll(page_tail);
 }
 
-fn cls(s: model.Status) []const u8 {
+fn statusClass(s: model.Status) []const u8 {
     return switch (s) {
-        .added => "added",
-        .removed => "removed",
-        .modified => "modified",
-        .unchanged => "unchanged",
+        .added => " pl-added",
+        .removed => " pl-removed",
+        .modified => " pl-modified",
+        .unchanged => " pl-unchanged",
     };
 }
 
-fn sign(s: model.Status) []const u8 {
+// Same marks as the extension's BADGE map (removed is U+2212 minus).
+fn badge(s: model.Status) []const u8 {
     return switch (s) {
         .added => "+",
-        .removed => "-",
+        .removed => "−",
         .modified => "~",
-        .unchanged => " ",
+        .unchanged => "",
     };
 }
 
-fn pad(w: *std.Io.Writer, depth: usize) !void {
-    var i: usize = 0;
-    while (i < depth) : (i += 1) try w.writeAll("  ");
-}
-
-fn renderObject(w: *std.Io.Writer, o: model.ObjectDiff, resolved: ?*const core.json.Resolver, depth: usize) anyerror!void {
-    try pad(w, depth);
-    try w.print("<span class=\"{s} go\">{s} ", .{ cls(o.status), sign(o.status) });
-    try writeEscaped(w, display.objectName(o, resolved));
-    if (o.kind == .prefab_instance) try w.writeAll(" &lt;Prefab&gt;");
-    try w.writeAll("</span>\n");
-    // Display-dimension rule: components/overrides always sit under the components section.
-    // The label line has no sign+space prefix, so, as in render_tree.zig,
-    // use depth+2 to visually align with the child objects' name column.
-    if (o.overrides.len != 0 or o.components.len != 0) {
-        try pad(w, depth + 2);
-        try w.writeAll("<span class=\"unchanged\">components</span>\n");
-        try renderOverrides(w, o.overrides, depth + 3);
-        for (o.components) |c| try renderComponent(w, c, resolved, depth + 3);
+fn renderDiff(w: *std.Io.Writer, res: model.DiffResult, resolved: ?*const core.json.Resolver) !void {
+    try w.writeAll("<div class=\"pl-root\">");
+    for (res.roots) |o| try renderObject(w, o, resolved);
+    if (res.loose.len != 0) {
+        try openComponentsSection(w, res.loose.len);
+        for (res.loose) |c| try renderComponent(w, c, resolved);
+        try w.writeAll("</div></details>");
     }
-    for (o.children) |child| try renderObject(w, child, resolved, depth + 1);
+    if (res.roots.len == 0 and res.loose.len == 0) {
+        try w.writeAll("<div class=\"pl-note pl-empty\"><span class=\"pl-note-icon\">" ++ check_svg ++ "</span><span>No semantic changes</span></div>");
+    }
+    if (res.unresolved_guids.len != 0 and resolved == null) {
+        try w.writeAll("<div class=\"pl-note\"><span class=\"pl-note-icon\">" ++ alert_svg ++ "</span><span>");
+        try w.print("{d} unresolved guid reference(s); pass --project DIR to resolve", .{res.unresolved_guids.len});
+        try w.writeAll("</span></div>");
+    }
+    try w.writeAll("</div>");
 }
 
-fn renderOverrides(w: *std.Io.Writer, overrides: []const model.OverrideDiff, depth: usize) !void {
-    var current: []const u8 = "";
-    for (overrides) |ov| {
-        if (!std.mem.eql(u8, current, ov.group)) {
-            current = ov.group;
-            try pad(w, depth);
-            try w.print("<span class=\"{s}\">{s} ", .{ cls(ov.status), sign(ov.status) });
-            try writeEscaped(w, ov.group);
-            try w.writeAll("</span>\n");
+const Meta = union(enum) { none, prefab: ?[]const u8, script: ?[]const u8 };
+
+fn writeSummary(
+    w: *std.Io.Writer,
+    status: model.Status,
+    icon: []const u8,
+    icon_class: []const u8,
+    name: []const u8,
+    meta: Meta,
+    leaf: bool,
+) !void {
+    try w.writeAll("<summary class=\"pl-row");
+    if (leaf) try w.writeAll(" pl-leaf");
+    try w.writeAll("\"><span class=\"pl-chevron\">" ++ chevron_svg ++ "</span><span class=\"");
+    try w.writeAll(icon_class);
+    try w.writeAll("\">");
+    try w.writeAll(icon);
+    try w.writeAll("</span><span class=\"pl-name\">");
+    try writeEscaped(w, name);
+    switch (meta) {
+        .none => {},
+        .prefab => |p| {
+            try w.writeAll("<span class=\"pl-script\">‹Prefab");
+            if (p) |path| {
+                try w.writeAll(": ");
+                try writeEscaped(w, path);
+            }
+            try w.writeAll("›</span>");
+        },
+        .script => |p| {
+            try w.writeAll("<span class=\"pl-script\">‹Script");
+            if (p) |path| {
+                try w.writeAll(": ");
+                try writeEscaped(w, path);
+            }
+            try w.writeAll("›</span>");
+        },
+    }
+    try w.writeAll("</span>");
+    if (status != .unchanged) {
+        try w.writeAll("<span class=\"pl-badge\">");
+        try w.writeAll(badge(status));
+        try w.writeAll("</span>");
+    }
+    try w.writeAll("</summary>");
+}
+
+fn openComponentsSection(w: *std.Io.Writer, count: usize) !void {
+    try w.writeAll("<details open class=\"pl-components\"><summary class=\"pl-components-label\"><span class=\"pl-chevron\">" ++ chevron_svg ++ "</span><span>");
+    try w.print("components ({d})", .{count});
+    try w.writeAll("</span></summary><div class=\"pl-kids\">");
+}
+
+fn renderObject(w: *std.Io.Writer, o: model.ObjectDiff, resolved: ?*const core.json.Resolver) anyerror!void {
+    const is_prefab = o.kind == .prefab_instance;
+    const card_count = display.overrideGroupCount(o.overrides) + o.components.len;
+    const leaf = card_count == 0 and o.children.len == 0;
+    try w.writeAll(if (is_prefab) "<details open class=\"pl-pi" else "<details open class=\"pl-go");
+    try w.writeAll(statusClass(o.status));
+    try w.writeAll("\">");
+    var meta: Meta = .none;
+    if (is_prefab) {
+        const path: ?[]const u8 = if (o.source_guid) |g|
+            (if (resolved) |r| r.get(g) else null)
+        else
+            null;
+        meta = .{ .prefab = path };
+    }
+    try writeSummary(
+        w,
+        o.status,
+        cube_svg,
+        if (is_prefab) "pl-icon pl-icon-prefab" else "pl-icon",
+        display.objectName(o, resolved),
+        meta,
+        leaf,
+    );
+    if (!leaf) {
+        try w.writeAll("<div class=\"pl-kids\">");
+        if (card_count != 0) {
+            try openComponentsSection(w, card_count);
+            try renderOverrideGroups(w, o.overrides, resolved);
+            for (o.components) |c| try renderComponent(w, c, resolved);
+            try w.writeAll("</div></details>");
         }
-        try renderField(w, .{ .path = ov.label, .status = ov.status, .before = ov.before, .after = ov.after }, depth + 1);
+        for (o.children) |child| try renderObject(w, child, resolved);
+        try w.writeAll("</div>");
     }
+    try w.writeAll("</details>");
 }
 
-fn renderComponent(w: *std.Io.Writer, c: model.ComponentDiff, resolved: ?*const core.json.Resolver, depth: usize) !void {
-    try pad(w, depth);
-    try w.print("<span class=\"{s}\">{s} ", .{ cls(c.status), sign(c.status) });
-    try writeEscaped(w, display.componentName(c, resolved));
-    try w.writeAll("</span>\n");
-    for (c.fields) |f| try renderField(w, f, depth + 1);
-}
-
-fn renderField(w: *std.Io.Writer, f: model.FieldDiff, depth: usize) !void {
-    try pad(w, depth);
-    try w.print("<span class=\"{s} field\">{s} ", .{ cls(f.status), sign(f.status) });
-    try writeEscaped(w, f.path);
-    try w.writeAll(": ");
-    switch (f.status) {
-        .modified => {
-            try w.writeAll("<span class=\"old\">");
-            try writeValueEscaped(w, f.before);
-            try w.writeAll("</span> → <span class=\"new\">");
-            try writeValueEscaped(w, f.after);
-            try w.writeAll("</span>");
-        },
-        .added => {
-            try w.writeAll("<span class=\"new\">");
-            try writeValueEscaped(w, f.after);
-            try w.writeAll("</span>");
-        },
-        .removed => {
-            try w.writeAll("<span class=\"old\">");
-            try writeValueEscaped(w, f.before);
-            try w.writeAll("</span>");
-        },
-        .unchanged => {},
+fn renderOverrideGroups(w: *std.Io.Writer, overrides: []const model.OverrideDiff, resolved: ?*const core.json.Resolver) !void {
+    var current: []const u8 = "";
+    var i: usize = 0;
+    while (i < overrides.len) {
+        if (!std.mem.eql(u8, current, overrides[i].group)) {
+            if (current.len != 0) try w.writeAll("</div></details>");
+            current = overrides[i].group;
+            const hs = display.groupHeadingStatus(overrides, i);
+            try w.writeAll("<details open class=\"pl-comp");
+            try w.writeAll(statusClass(hs));
+            try w.writeAll("\">");
+            try writeSummary(w, hs, gear_svg, "pl-icon", current, .none, false);
+            try w.writeAll("<div class=\"pl-kids\">");
+        }
+        const ov = overrides[i];
+        try renderField(w, ov.label, ov.status, ov.before, ov.after, resolved);
+        i += 1;
     }
-    try w.writeAll("</span>\n");
+    if (current.len != 0) try w.writeAll("</div></details>");
 }
 
-fn writeValueEscaped(w: *std.Io.Writer, node: ?*const model.Node) !void {
+fn renderComponent(w: *std.Io.Writer, c: model.ComponentDiff, resolved: ?*const core.json.Resolver) !void {
+    const leaf = c.fields.len == 0;
+    try w.writeAll("<details open class=\"pl-comp");
+    try w.writeAll(statusClass(c.status));
+    try w.writeAll("\">");
+    // Mirror the extension: full source path as meta once the guid resolves.
+    var meta: Meta = .none;
+    if (c.script_guid) |g| {
+        meta = .{ .script = if (resolved) |r| r.get(g) else null };
+    }
+    try writeSummary(w, c.status, gear_svg, "pl-icon", display.componentName(c, resolved), meta, leaf);
+    if (!leaf) {
+        try w.writeAll("<div class=\"pl-kids\">");
+        for (c.fields) |f| try renderField(w, f.path, f.status, f.before, f.after, resolved);
+        try w.writeAll("</div>");
+    }
+    try w.writeAll("</details>");
+}
+
+fn renderField(
+    w: *std.Io.Writer,
+    label: []const u8,
+    status: model.Status,
+    before: ?*const model.Node,
+    after: ?*const model.Node,
+    resolved: ?*const core.json.Resolver,
+) !void {
+    try w.writeAll("<div class=\"pl-field");
+    try w.writeAll(statusClass(status));
+    try w.writeAll("\"><span class=\"pl-path\">");
+    try writeEscaped(w, label);
+    try w.writeAll("</span>");
+    // A structural summary row (before=after=null) has the count in its
+    // label and no value — same as the extension's fieldRow.
+    if (before != null or after != null) {
+        switch (status) {
+            .modified => {
+                try w.writeAll("<span class=\"pl-before\">");
+                try writeValue(w, before, resolved);
+                try w.writeAll("</span><span class=\"pl-arrow\">→</span><span class=\"pl-after\">");
+                try writeValue(w, after, resolved);
+                try w.writeAll("</span>");
+            },
+            .added => {
+                try w.writeAll("<span class=\"pl-after\">");
+                try writeValue(w, after, resolved);
+                try w.writeAll("</span>");
+            },
+            .removed => {
+                try w.writeAll("<span class=\"pl-before\">");
+                try writeValue(w, before, resolved);
+                try w.writeAll("</span>");
+            },
+            .unchanged => {},
+        }
+    }
+    try w.writeAll("</div>");
+}
+
+// Extension formatValue parity: — for null, #fileID for local refs, resolved
+// path (or raw guid:) for external refs.
+fn writeValue(w: *std.Io.Writer, node: ?*const model.Node, resolved: ?*const core.json.Resolver) !void {
     const n = node orelse {
-        try w.writeAll("∅");
+        try w.writeAll("—");
         return;
     };
     switch (n.*) {
         .scalar => |s| try writeEscaped(w, s),
         .ref => |r| {
             if (r.guid) |g| {
-                try w.writeAll("{guid:");
+                if (resolved) |rr| {
+                    if (rr.get(g)) |p| {
+                        try writeEscaped(w, p);
+                        return;
+                    }
+                }
+                try w.writeAll("guid:");
                 try writeEscaped(w, g);
-                try w.print(", fileID:{d}}}", .{r.file_id});
             } else {
-                try w.print("{{fileID:{d}}}", .{r.file_id});
+                try w.print("#{d}", .{r.file_id});
             }
         },
         .map => try w.writeAll("{...}"),

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const core = @import("core");
 const testing = std.testing;
 
-test "render: modified field shown old -> new without color" {
+test "render: modified loose component under a counted components group" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -21,18 +21,18 @@ test "render: modified field shown old -> new without color" {
     const res = try core.diffBytes(arena, before, after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null, false);
+    try render(arena, &aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    try testing.expect(std.mem.indexOf(u8, text, "MonoBehaviour") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "Volume") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "0.5") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "0.8") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "->") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "components (1)\n") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "└─ ~ MonoBehaviour") != null);
+    // Field status equals the card status, so the per-field sign is omitted.
+    try testing.expect(std.mem.indexOf(u8, text, "Volume: 0.5 → 0.8") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "~ Volume") == null);
     // No ANSI escape when color is disabled.
     try testing.expect(std.mem.indexOf(u8, text, "\x1b[") == null);
 }
 
-test "render: prefab instance shows name, components label and grouped overrides" {
+test "render: prefab instance shows cube glyph, meta marker and overrides" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -53,15 +53,16 @@ test "render: prefab instance shows name, components label and grouped overrides
     const res = try core.diffBytes(arena, "", after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null, false);
+    try render(arena, &aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    try testing.expect(std.mem.indexOf(u8, text, "+ Cylinder Variant  <Prefab>") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "components") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "◆ + Cylinder Variant ‹Prefab›") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "components (") != null);
     try testing.expect(std.mem.indexOf(u8, text, "+ Transform") != null);
+    // Row status (added) matches the group heading, so no per-row sign.
     try testing.expect(std.mem.indexOf(u8, text, "Scale.y: 2") != null);
 }
 
-test "render: components label separates object and component dimensions" {
+test "render: spine glyphs connect object, components node and cards" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -90,11 +91,65 @@ test "render: components label separates object and component dimensions" {
     const res = try core.diffBytes(arena, before, after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null, false);
+    try render(arena, &aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    // The depths become "  Player" -> "    components" -> "      ~ MonoBehaviour".
-    try testing.expect(std.mem.indexOf(u8, text, "\n    components\n") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "\n      ~ MonoBehaviour\n") != null);
+    // Player has no children, so components is its last (only) spine node,
+    // and the single card closes the inner spine.
+    try testing.expect(std.mem.indexOf(u8, text, "◆ Player\n└─ components (1)\n   └─ ~ MonoBehaviour\n") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "Hp: 100 → 250") != null);
+}
+
+test "render: child object hangs off the parent spine after components" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Child
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+    ;
+    const after =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: ChildRenamed
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+    ;
+    const res = try core.diffBytes(arena, before, after);
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    try render(arena, &aw.writer, res, null, false);
+    const text = aw.toArrayList().items;
+    // The child is the parent's last spine node.
+    try testing.expect(std.mem.indexOf(u8, text, "└─ ◆ ~ ChildRenamed") != null);
 }
 
 test "render: component shows editor class name when script is unresolved" {
@@ -118,14 +173,15 @@ test "render: component shows editor class name when script is unresolved" {
     const res = try core.diffBytes(arena, before, after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    // No resolver -> the guid can't be resolved, but the class name is more specific than MonoBehaviour.
-    try render(&aw.writer, res, null, false);
+    // No resolver -> the guid can't be resolved, but the class name is more
+    // specific than MonoBehaviour. The unresolved script keeps a bare marker.
+    try render(arena, &aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    try testing.expect(std.mem.indexOf(u8, text, "~ Cylinder1\n") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "~ Cylinder1 ‹Script›") != null);
     try testing.expect(std.mem.indexOf(u8, text, "MonoBehaviour") == null);
 }
 
-test "render: mixed-status override group gets a modified heading" {
+test "render: mixed-status override group keeps signs only where they differ" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -139,8 +195,6 @@ test "render: mixed-status override group gets a modified heading" {
         \\      value: 0
         \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
     ;
-    // Order it so the added mod comes first, to check the heading isn't
-    // dragged by the first line's status.
     const after =
         \\--- !u!1001 &1001
         \\PrefabInstance:
@@ -157,12 +211,15 @@ test "render: mixed-status override group gets a modified heading" {
     const res = try core.diffBytes(arena, before, after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null, false);
+    try render(arena, &aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    try testing.expect(std.mem.indexOf(u8, text, "~ Transform\n") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "+ Transform\n") == null);
+    // Mixed group -> modified heading; the added row differs so it keeps +,
+    // the modified row matches so its sign is dropped.
+    try testing.expect(std.mem.indexOf(u8, text, "~ Transform") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "+ Transform") == null);
     try testing.expect(std.mem.indexOf(u8, text, "+ Scale.y: 2") != null);
-    try testing.expect(std.mem.indexOf(u8, text, "~ Position.x: 0 -> 1") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "Position.x: 0 → 1") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "~ Position.x") == null);
 }
 
 test "render: structural summary row shows label only, no dangling value" {
@@ -195,22 +252,24 @@ test "render: structural summary row shows label only, no dangling value" {
     const res = try core.diffBytes(arena, before, after);
     var out: std.ArrayList(u8) = .empty;
     var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
-    try render(&aw.writer, res, null, false);
+    try render(arena, &aw.writer, res, null, false);
     const text = aw.toArrayList().items;
-    // The count is included in the label, so a value-less row ends with just the label.
-    try testing.expect(std.mem.indexOf(u8, text, "+ Added Components (1)\n") != null);
+    // The count is included in the label, so a value-less row ends with just
+    // the label.
+    try testing.expect(std.mem.indexOf(u8, text, "Added Components (1)\n") != null);
     try testing.expect(std.mem.indexOf(u8, text, "∅") == null);
 }
 
 const model = core.model;
 const display = @import("display.zig");
 
-const Color = struct {
-    const reset = "\x1b[0m";
-    const green = "\x1b[32m";
-    const red = "\x1b[31m";
-    const yellow = "\x1b[33m";
-    const dim = "\x1b[2m";
+pub const Color = struct {
+    pub const reset = "\x1b[0m";
+    pub const green = "\x1b[32m";
+    pub const red = "\x1b[31m";
+    pub const yellow = "\x1b[33m";
+    pub const dim = "\x1b[2m";
+    pub const bold = "\x1b[1m";
 };
 
 fn statusColor(s: model.Status) []const u8 {
@@ -227,26 +286,30 @@ fn statusSign(s: model.Status) []const u8 {
         .added => "+",
         .removed => "-",
         .modified => "~",
-        .unchanged => " ",
+        .unchanged => "",
     };
 }
 
 pub fn render(
+    arena: std.mem.Allocator,
     w: *std.Io.Writer,
     res: model.DiffResult,
     resolved: ?*const core.json.Resolver,
     color: bool,
 ) !void {
-    for (res.roots) |o| try renderObject(w, o, resolved, color, 0);
-    for (res.loose) |c| try renderComponent(w, c, resolved, color, 0);
+    var prefix: std.ArrayList(u8) = .empty;
+    for (res.roots) |o| try renderObject(arena, w, o, resolved, color, &prefix, "");
+    if (res.loose.len != 0) {
+        // Loose components form a root-level components group, mirroring the
+        // extension's diff.loose section.
+        try paintLabel(w, color, res.loose.len);
+        for (res.loose, 0..) |c, i| {
+            try renderCard(arena, w, .{ .component = c }, resolved, color, &prefix, i + 1 == res.loose.len);
+        }
+    }
     if (res.unresolved_guids.len != 0 and resolved == null) {
         try w.print("\n({d} unresolved guid reference(s); pass --project DIR to resolve)\n", .{res.unresolved_guids.len});
     }
-}
-
-fn indent(w: *std.Io.Writer, depth: usize) !void {
-    var i: usize = 0;
-    while (i < depth) : (i += 1) try w.writeAll("  ");
 }
 
 fn paint(w: *std.Io.Writer, color: bool, code: []const u8, text: []const u8) !void {
@@ -255,88 +318,169 @@ fn paint(w: *std.Io.Writer, color: bool, code: []const u8, text: []const u8) !vo
     if (color) try w.writeAll(Color.reset);
 }
 
+fn paintLabel(w: *std.Io.Writer, color: bool, count: usize) !void {
+    if (color) try w.writeAll(Color.dim);
+    try w.print("components ({d})", .{count});
+    if (color) try w.writeAll(Color.reset);
+    try w.writeByte('\n');
+}
+
+fn signed(w: *std.Io.Writer, color: bool, status: model.Status) !void {
+    if (status == .unchanged) return;
+    try paint(w, color, statusColor(status), statusSign(status));
+    try w.writeByte(' ');
+}
+
 fn renderObject(
+    arena: std.mem.Allocator,
     w: *std.Io.Writer,
     o: model.ObjectDiff,
     resolved: ?*const core.json.Resolver,
     color: bool,
-    depth: usize,
+    prefix: *std.ArrayList(u8),
+    branch: []const u8,
 ) anyerror!void {
-    try indent(w, depth);
-    try paint(w, color, statusColor(o.status), statusSign(o.status));
-    try w.print(" {s}", .{display.objectName(o, resolved)});
-    if (o.kind == .prefab_instance) try w.writeAll("  <Prefab>");
+    try w.writeAll(prefix.items);
+    try w.writeAll(branch);
+    try w.writeAll("◆ ");
+    try signed(w, color, o.status);
+    try w.writeAll(display.objectName(o, resolved));
+    if (o.kind == .prefab_instance) {
+        if (color) try w.writeAll(Color.dim);
+        try w.writeAll(" ‹Prefab");
+        if (o.source_guid) |g| if (resolved) |r| if (r.get(g)) |p| try w.print(": {s}", .{p});
+        try w.writeAll("›");
+        if (color) try w.writeAll(Color.reset);
+    }
     try w.writeByte('\n');
-    // Display-dimension rule: components/overrides always sit under the components section.
-    // The label line has no 2-char sign+space prefix, so use depth+2 to visually align with
-    // the child objects' name column (depth+1 indent + sign+space).
-    if (o.overrides.len != 0 or o.components.len != 0) {
-        try indent(w, depth + 2);
-        try paint(w, color, Color.dim, "components");
-        try w.writeByte('\n');
-        try renderOverrides(w, o.overrides, color, depth + 3);
-        for (o.components) |c| try renderComponent(w, c, resolved, color, depth + 3);
-    }
-    for (o.children) |child| try renderObject(w, child, resolved, color, depth + 1);
-}
 
-fn renderOverrides(w: *std.Io.Writer, overrides: []const model.OverrideDiff, color: bool, depth: usize) !void {
-    var current: []const u8 = "";
-    for (overrides, 0..) |ov, i| {
-        if (!std.mem.eql(u8, current, ov.group)) {
-            current = ov.group;
-            const hs = display.groupHeadingStatus(overrides, i);
-            try indent(w, depth);
-            try paint(w, color, statusColor(hs), statusSign(hs));
-            try w.print(" {s}\n", .{ov.group});
+    // Below this row the spine continues for our own kids: components group
+    // first (if any), then child objects.
+    const mark = prefix.items.len;
+    try prefix.appendSlice(arena, continuation(branch));
+    defer prefix.shrinkRetainingCapacity(mark);
+
+    const card_count = display.overrideGroupCount(o.overrides) + o.components.len;
+    if (card_count != 0) {
+        const label_last = o.children.len == 0;
+        try w.writeAll(prefix.items);
+        try w.writeAll(if (label_last) "└─ " else "├─ ");
+        try paintLabel(w, color, card_count);
+
+        const inner_mark = prefix.items.len;
+        try prefix.appendSlice(arena, if (label_last) "   " else "│  ");
+        defer prefix.shrinkRetainingCapacity(inner_mark);
+
+        var idx: usize = 0;
+        var current: []const u8 = "";
+        var i: usize = 0;
+        while (i < o.overrides.len) : (i += 1) {
+            if (!std.mem.eql(u8, current, o.overrides[i].group)) {
+                current = o.overrides[i].group;
+                idx += 1;
+                try renderCard(arena, w, .{ .group = .{ .overrides = o.overrides, .start = i } }, resolved, color, prefix, idx == card_count);
+            }
         }
-        try indent(w, depth + 1);
-        try paint(w, color, statusColor(ov.status), statusSign(ov.status));
-        // A structural summary row (before=after=null) has the count in the label and no value.
-        if (ov.before == null and ov.after == null) {
-            try w.print(" {s}\n", .{ov.label});
-            continue;
+        for (o.components) |c| {
+            idx += 1;
+            try renderCard(arena, w, .{ .component = c }, resolved, color, prefix, idx == card_count);
         }
-        try w.print(" {s}: ", .{ov.label});
-        switch (ov.status) {
-            .modified => {
-                try writeValueText(w, ov.before);
-                try w.writeAll(" -> ");
-                try writeValueText(w, ov.after);
-            },
-            .added => try writeValueText(w, ov.after),
-            .removed => try writeValueText(w, ov.before),
-            .unchanged => {},
-        }
-        try w.writeByte('\n');
+    }
+    for (o.children, 0..) |child, i| {
+        try renderObject(arena, w, child, resolved, color, prefix, if (i + 1 == o.children.len) "└─ " else "├─ ");
     }
 }
 
-fn renderComponent(
+fn continuation(branch: []const u8) []const u8 {
+    if (branch.len == 0) return "";
+    if (std.mem.eql(u8, branch, "├─ ")) return "│  ";
+    return "   ";
+}
+
+const Card = union(enum) {
+    component: model.ComponentDiff,
+    group: struct { overrides: []const model.OverrideDiff, start: usize },
+};
+
+fn renderCard(
+    arena: std.mem.Allocator,
     w: *std.Io.Writer,
-    c: model.ComponentDiff,
+    card: Card,
     resolved: ?*const core.json.Resolver,
     color: bool,
-    depth: usize,
+    prefix: *std.ArrayList(u8),
+    last: bool,
 ) !void {
-    try indent(w, depth);
-    try paint(w, color, statusColor(c.status), statusSign(c.status));
-    try w.print(" {s}\n", .{display.componentName(c, resolved)});
-    for (c.fields) |f| try renderField(w, f, color, depth + 1);
+    try w.writeAll(prefix.items);
+    try w.writeAll(if (last) "└─ " else "├─ ");
+    const status: model.Status = switch (card) {
+        .component => |c| c.status,
+        .group => |g| display.groupHeadingStatus(g.overrides, g.start),
+    };
+    try signed(w, color, status);
+    switch (card) {
+        .component => |c| {
+            try w.writeAll(display.componentName(c, resolved));
+            if (c.script_guid) |g| {
+                if (color) try w.writeAll(Color.dim);
+                try w.writeAll(" ‹Script");
+                if (resolved) |r| if (r.get(g)) |p| try w.print(": {s}", .{p});
+                try w.writeAll("›");
+                if (color) try w.writeAll(Color.reset);
+            }
+        },
+        .group => |g| try w.writeAll(g.overrides[g.start].group),
+    }
+    try w.writeByte('\n');
+
+    // Field rows sit under the card without glyphs of their own.
+    const mark = prefix.items.len;
+    try prefix.appendSlice(arena, if (last) "     " else "│    ");
+    defer prefix.shrinkRetainingCapacity(mark);
+
+    switch (card) {
+        .component => |c| for (c.fields) |f| {
+            try renderFieldRow(w, f.path, f.status, status, f.before, f.after, color, prefix);
+        },
+        .group => |g| {
+            const group_name = g.overrides[g.start].group;
+            for (g.overrides[g.start..]) |ov| {
+                if (!std.mem.eql(u8, ov.group, group_name)) break;
+                try renderFieldRow(w, ov.label, ov.status, status, ov.before, ov.after, color, prefix);
+            }
+        },
+    }
 }
 
-fn renderField(w: *std.Io.Writer, f: model.FieldDiff, color: bool, depth: usize) !void {
-    try indent(w, depth);
-    try paint(w, color, statusColor(f.status), statusSign(f.status));
-    try w.print(" {s}: ", .{f.path});
-    switch (f.status) {
+fn renderFieldRow(
+    w: *std.Io.Writer,
+    label: []const u8,
+    status: model.Status,
+    parent: model.Status,
+    before: ?*const model.Node,
+    after: ?*const model.Node,
+    color: bool,
+    prefix: *std.ArrayList(u8),
+) !void {
+    try w.writeAll(prefix.items);
+    // The sign repeats only when it adds information over the card's status.
+    if (status != parent) try signed(w, color, status);
+    try w.writeAll(label);
+    // A structural summary row (before=after=null) has the count in the
+    // label and no value.
+    if (before == null and after == null) {
+        try w.writeByte('\n');
+        return;
+    }
+    try w.writeAll(": ");
+    switch (status) {
         .modified => {
-            try writeValueText(w, f.before);
-            try w.writeAll(" -> ");
-            try writeValueText(w, f.after);
+            try writeValueText(w, before);
+            try w.writeAll(" → ");
+            try writeValueText(w, after);
         },
-        .added => try writeValueText(w, f.after),
-        .removed => try writeValueText(w, f.before),
+        .added => try writeValueText(w, after),
+        .removed => try writeValueText(w, before),
         .unchanged => {},
     }
     try w.writeByte('\n');
@@ -344,7 +488,7 @@ fn renderField(w: *std.Io.Writer, f: model.FieldDiff, color: bool, depth: usize)
 
 fn writeValueText(w: *std.Io.Writer, node: ?*const model.Node) !void {
     const n = node orelse {
-        try w.writeAll("∅");
+        try w.writeAll("—");
         return;
     };
     switch (n.*) {

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -280,22 +280,12 @@ fn renderObject(
     for (o.children) |child| try renderObject(w, child, resolved, color, depth + 1);
 }
 
-/// Heading status: that status if uniform within the group, modified if mixed.
-fn groupHeadingStatus(overrides: []const model.OverrideDiff, start: usize) model.Status {
-    const first = overrides[start];
-    for (overrides[start + 1 ..]) |ov| {
-        if (!std.mem.eql(u8, ov.group, first.group)) break;
-        if (ov.status != first.status) return .modified;
-    }
-    return first.status;
-}
-
 fn renderOverrides(w: *std.Io.Writer, overrides: []const model.OverrideDiff, color: bool, depth: usize) !void {
     var current: []const u8 = "";
     for (overrides, 0..) |ov, i| {
         if (!std.mem.eql(u8, current, ov.group)) {
             current = ov.group;
-            const hs = groupHeadingStatus(overrides, i);
+            const hs = display.groupHeadingStatus(overrides, i);
             try indent(w, depth);
             try paint(w, color, statusColor(hs), statusSign(hs));
             try w.print(" {s}\n", .{ov.group});

--- a/cli/src/semantic_view.css
+++ b/cli/src/semantic_view.css
@@ -1,0 +1,145 @@
+/* Ported from extension/src/renderer/styles.ts. The pl-* class set must stay
+ * identical to the extension's (guarded by
+ * extension/src/renderer/styles.parity.test.ts). Documented deltas:
+ *   1. `:host { all: initial }` dropped — standalone page, no shadow root.
+ *   2. `.pl-root.pl-dark { ... }` became the prefers-color-scheme media query
+ *      below — there is no script to stamp a theme class.
+ *   3. The "standalone-page additions" block at the end is new — the
+ *      extension inherits GitHub's page chrome, this page provides its own.
+ */
+.pl-root {
+  --pl-fg: var(--fgColor-default, #1f2328);
+  --pl-muted: var(--fgColor-muted, #59636e);
+  --pl-accent: var(--fgColor-accent, #0969da);
+  --pl-hairline: var(--borderColor-muted, #d8dee4);
+  --pl-hover: var(--bgColor-muted, #f6f8fa);
+  --pl-skeleton: var(--bgColor-neutral-muted, rgba(129, 139, 152, 0.18));
+  --pl-added: var(--fgColor-success, #1a7f37);
+  --pl-removed: var(--fgColor-danger, #cf222e);
+  --pl-modified: var(--fgColor-attention, #9a6700);
+  --pl-added-bg: var(--bgColor-success-muted, #dafbe1);
+  --pl-removed-bg: var(--bgColor-danger-muted, #ffebe9);
+  --pl-modified-bg: var(--bgColor-attention-muted, #fff8c5);
+  --pl-font: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  --pl-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font: 12px/1.5 var(--pl-font);
+  color: var(--pl-fg); padding: 8px 12px; display: block;
+}
+/* Delta 2: dark palette keyed off the OS theme instead of a .pl-dark class. */
+@media (prefers-color-scheme: dark) {
+  .pl-root {
+    --pl-fg: var(--fgColor-default, #f0f6fc);
+    --pl-muted: var(--fgColor-muted, #9198a1);
+    --pl-accent: var(--fgColor-accent, #4493f8);
+    --pl-hairline: var(--borderColor-muted, #3d444d);
+    --pl-hover: var(--bgColor-muted, #151b23);
+    --pl-skeleton: var(--bgColor-neutral-muted, rgba(101, 108, 118, 0.25));
+    --pl-added: var(--fgColor-success, #3fb950);
+    --pl-removed: var(--fgColor-danger, #f85149);
+    --pl-modified: var(--fgColor-attention, #d29922);
+    --pl-added-bg: var(--bgColor-success-muted, rgba(46, 160, 67, 0.15));
+    --pl-removed-bg: var(--bgColor-danger-muted, rgba(248, 81, 73, 0.15));
+    --pl-modified-bg: var(--bgColor-attention-muted, rgba(187, 128, 9, 0.15));
+  }
+}
+details { margin: 0; }
+summary { list-style: none; }
+summary::-webkit-details-marker { display: none; }
+.pl-row {
+  display: grid;
+  grid-template-columns: 16px 18px 1fr auto;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 4px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+}
+.pl-row:hover { background: var(--pl-hover); }
+.pl-chevron {
+  display: inline-flex; justify-content: center; align-items: center;
+  color: var(--pl-muted); transition: transform 120ms ease;
+}
+details[open] > summary .pl-chevron { transform: rotate(90deg); }
+summary.pl-leaf { cursor: default; }
+summary.pl-leaf .pl-chevron { visibility: hidden; }
+.pl-icon { display: inline-flex; align-items: center; color: var(--pl-muted); }
+.pl-icon-prefab { color: var(--pl-accent); }
+.pl-name { min-width: 0; overflow-wrap: anywhere; }
+.pl-script { color: var(--pl-muted); margin-left: 6px; }
+.pl-badge {
+  font: 600 11px/16px var(--pl-mono);
+  min-width: 16px; text-align: center;
+  border-radius: 4px; padding: 0 3px; margin-left: 8px;
+}
+details.pl-added > summary > .pl-badge { color: var(--pl-added); background: var(--pl-added-bg); }
+details.pl-removed > summary > .pl-badge { color: var(--pl-removed); background: var(--pl-removed-bg); }
+details.pl-modified > summary > .pl-badge { color: var(--pl-modified); background: var(--pl-modified-bg); }
+.pl-kids { margin-left: 11px; border-left: 1px solid var(--pl-hairline); padding-left: 8px; }
+.pl-components-label {
+  display: grid; grid-template-columns: 16px 1fr; align-items: center;
+  min-height: 22px; padding: 0 4px; border-radius: 4px;
+  cursor: pointer; user-select: none;
+  color: var(--pl-muted); font-size: 10px; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.6px;
+}
+.pl-components-label:hover { background: var(--pl-hover); }
+.pl-field {
+  display: flex; align-items: center; flex-wrap: wrap; column-gap: 6px;
+  min-height: 22px; padding: 0 4px 0 38px; border-radius: 4px;
+  font-family: var(--pl-mono);
+}
+.pl-field:hover { background: var(--pl-hover); }
+.pl-path { color: var(--pl-muted); }
+.pl-before { color: var(--pl-removed); }
+.pl-after { color: var(--pl-added); }
+.pl-arrow { color: var(--pl-muted); }
+.pl-note { display: flex; align-items: center; gap: 6px; min-height: 24px; color: var(--pl-muted); }
+.pl-note-icon { display: inline-flex; align-items: center; }
+.pl-error { color: var(--pl-removed); }
+.pl-spinner {
+  width: 12px; height: 12px; flex: none; border-radius: 50%;
+  border: 2px solid var(--pl-hairline); border-top-color: var(--pl-muted);
+  animation: pl-spin 1s linear infinite;
+}
+.pl-render {
+  font: 500 12px/1 var(--pl-font);
+  margin-top: 4px; padding: 5px 12px;
+  border: 1px solid var(--pl-hairline); border-radius: 6px;
+  background: transparent; color: var(--pl-fg); cursor: pointer;
+}
+.pl-render:hover { background: var(--pl-hover); }
+.pl-signin { flex-wrap: wrap; }
+.pl-signin a.pl-render { text-decoration: none; color: inherit; }
+.pl-user-code { font-weight: 600; user-select: all; }
+.pl-skel-row {
+  display: flex; align-items: center; gap: 6px;
+  min-height: 24px; padding-left: calc(var(--pl-indent) * 16px + 4px);
+}
+.pl-skel-icon { width: 14px; height: 14px; border-radius: 3px; flex: none; }
+.pl-skel-bar { height: 8px; border-radius: 4px; width: var(--pl-w); }
+.pl-skel-icon, .pl-skel-bar {
+  background: linear-gradient(90deg, var(--pl-skeleton) 25%, var(--pl-hover) 45%, var(--pl-skeleton) 65%) 0 0 / 200% 100%;
+  animation: pl-shimmer 1.4s linear infinite;
+}
+@keyframes pl-shimmer { to { background-position: -200% 0; } }
+@keyframes pl-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .pl-chevron { transition: none; }
+  .pl-skel-icon, .pl-skel-bar, .pl-spinner { animation: none; }
+}
+/* --- Delta 3: standalone-page additions (not in styles.ts) --- */
+body { margin: 0; background: #ffffff; }
+main { max-width: 960px; margin: 0 auto; padding: 16px; }
+.file { margin-bottom: 8px; }
+.file > summary {
+  font: 600 12px/2 ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  padding: 2px 10px; border: 1px solid #d8dee4; border-radius: 6px;
+  cursor: pointer; user-select: none;
+}
+details.file:not([open]) > summary::before { content: "\25B8  "; }
+details.file[open] > summary::before { content: "\25BE  "; }
+@media (prefers-color-scheme: dark) {
+  body { background: #0d1117; color: #f0f6fc; }
+  .file > summary { border-color: #3d444d; }
+}

--- a/cli/src/unity_path.zig
+++ b/cli/src/unity_path.zig
@@ -1,0 +1,54 @@
+//! Suffix gate for Unity text-serialized assets (UnityYAML).
+//! Mirrors extension/src/unity.ts UNITY_PATH — keep both lists in sync.
+const std = @import("std");
+const testing = std.testing;
+
+test "isUnityPath accepts every supported extension, case-insensitively" {
+    // One spelling per extension, plus a case-mangled sample: the git side of
+    // the CLI must classify operands exactly like the extension classifies
+    // PR file paths, or the two products would disagree on what is diffable.
+    const yes = [_][]const u8{
+        "a.prefab",             "Assets/Scenes/Main.unity", "x.asset",
+        "m.mat",                "run.anim",                 "ac.controller",
+        "o.overrideController", "p.physicMaterial",         "p2.physicsMaterial2D",
+        "t.playable",           "am.mask",                  "b.brush",
+        "f.flare",              "fs.fontsettings",          "g.guiskin",
+        "gi.giparams",          "rt.renderTexture",         "sa.spriteatlas",
+        "sa2.spriteatlasv2",    "tl.terrainlayer",          "mx.mixer",
+        "sv.shadervariants",    "pr.preset",                "sg.signal",
+        "l.lighting",           "st.scenetemplate",         "UPPER.PREFAB",
+        "Mixed.Mat",
+    };
+    for (yes) |p| try testing.expect(isUnityPath(p));
+}
+
+test "isUnityPath rejects git refs, .meta and unknown extensions" {
+    const no = [_][]const u8{
+        "main",       "HEAD~1",   "feat/mutate-fixtures",
+        "v0.4.0",     "Foo.meta", "Foo.prefab.meta",
+        "Foo.asmdef", "Foo.txt",  "Foo",
+        "prefab", // no dot: a ref named "prefab" must stay a ref
+    };
+    for (no) |p| try testing.expect(!isUnityPath(p));
+}
+
+// Same set as unityyamlmerge targets. Excludes .meta (not !u! document
+// format) and JSON like .asmdef.
+const extensions = [_][]const u8{
+    ".prefab",             ".unity",          ".asset",
+    ".mat",                ".anim",           ".controller",
+    ".overrideController", ".physicMaterial", ".physicsMaterial2D",
+    ".playable",           ".mask",           ".brush",
+    ".flare",              ".fontsettings",   ".guiskin",
+    ".giparams",           ".renderTexture",  ".spriteatlas",
+    ".spriteatlasv2",      ".terrainlayer",   ".mixer",
+    ".shadervariants",     ".preset",         ".signal",
+    ".lighting",           ".scenetemplate",
+};
+
+pub fn isUnityPath(path: []const u8) bool {
+    for (extensions) |ext| {
+        if (std.ascii.endsWithIgnoreCase(path, ext)) return true;
+    }
+    return false;
+}

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -33,7 +33,7 @@ namespace PrefabLens
         public static string DownloadUrl(string version, string assetName) =>
             $"https://github.com/hashiiiii/PrefabLens/releases/download/v{version}/{assetName}";
 
-        public static string[] BuildArgs(string assetPath) => new[] { "--git", "HEAD", assetPath, "--json" };
+        public static string[] BuildArgs(string assetPath) => new[] { "HEAD", assetPath, "--json" };
 
         /// Minimal quoting for ProcessStartInfo.Arguments (handles asset paths with spaces).
         public static string QuoteArgs(string[] args)
@@ -106,7 +106,7 @@ namespace PrefabLens
             public bool TimedOut;
         }
 
-        /// Run the CLI with the project root as cwd (--git looks at the repository in cwd).
+        /// Run the CLI with the project root as cwd (git refs are resolved against the repository in cwd).
         public static Result Run(string cliPath, string assetPath)
         {
             return RunProcess(cliPath, QuoteArgs(BuildArgs(assetPath)), Directory.GetCurrentDirectory(), RunTimeoutMs);

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -39,17 +39,14 @@ namespace PrefabLens.Tests
         [Test]
         public void BuildArgsDiffsHeadAgainstTheWorktreeAsJson()
         {
-            Assert.AreEqual(
-                new[] { "--git", "HEAD", "Assets/Foo.prefab", "--json" },
-                Cli.BuildArgs("Assets/Foo.prefab")
-            );
+            Assert.AreEqual(new[] { "HEAD", "Assets/Foo.prefab", "--json" }, Cli.BuildArgs("Assets/Foo.prefab"));
         }
 
         [Test]
         public void QuoteArgsSurvivesSpacesAndQuotes()
         {
             Assert.AreEqual(
-                "\"--git\" \"HEAD\" \"Assets/My Prefab.prefab\" \"--json\"",
+                "\"HEAD\" \"Assets/My Prefab.prefab\" \"--json\"",
                 Cli.QuoteArgs(Cli.BuildArgs("Assets/My Prefab.prefab"))
             );
             Assert.AreEqual("\"a\\\"b\"", Cli.QuoteArgs(new[] { "a\"b" }));

--- a/extension/src/renderer/styles.parity.test.ts
+++ b/extension/src/renderer/styles.parity.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+import { STYLES } from "./styles";
+
+// pl-dark is the extension-only theme marker: the CLI stylesheet replaces the
+// .pl-root.pl-dark block with a prefers-color-scheme media query (documented
+// delta 2 in cli/src/semantic_view.css), so it is excluded from the set.
+const THEME_MARKERS = new Set(["pl-dark", "pl-light"]);
+
+function plClasses(css: string): Set<string> {
+  const found = new Set<string>();
+  for (const m of css.matchAll(/pl-[a-z0-9-]+/g)) found.add(m[0]);
+  for (const marker of THEME_MARKERS) found.delete(marker);
+  return found;
+}
+
+it("CLI stylesheet keeps the same pl-* class set as the extension renderer", () => {
+  const cssPath = fileURLToPath(new URL("../../../cli/src/semantic_view.css", import.meta.url));
+  const cliCss = readFileSync(cssPath, "utf8");
+  expect(plClasses(cliCss)).toEqual(plClasses(STYLES));
+});


### PR DESCRIPTION
## Summary

Rework the CLI's output and argument UX so it matches the browser extension: `--html` now emits the extension-identical semantic view as fully static HTML (zero JavaScript), the terminal draws a box-drawing spine, and a new ref/path grammar plus bulk mode and `--open` remove the workflow friction of the old `--git` form.

## Motivation

The CLI's tree output and span-based HTML looked nothing like the extension's semantic view, and the most common invocation (`--git HEAD <path>`) was the most verbose. Since the extension's richness comes from `<details>`/CSS rather than JavaScript, the CLI can replicate it exactly by emitting the same `pl-*` DOM server-side — no JS embedded in the binary, no build artifacts committed.

## Changes

- `--html` rewritten: emits the extension renderer's DOM (`pl-*` classes, native `<details open>` tree, CSS ported from `styles.ts` with 3 documented deltas, byte-identical SVG icons); guid resolution is baked in server-side
- New grammar: operands ending in a supported Unity extension are paths, everything else is a git ref (`prefablens`, `prefablens main`, `prefablens HEAD~1 HEAD Foo.prefab`, two-file plain compare); `--git` removed (0.x breaking change; MCP argv and Unity Editor `Cli.cs` updated)
- Bulk mode: no path operand diffs every changed supported file into one report (per-file sections in HTML, bold headers in tree, `{path, diff}` array for `--json`)
- `--open`: writes the report to `$TMPDIR` and launches the browser; conflicts with `--json` (exit 2)
- `--help`/`-h`; terminal tree redrawn as a spine with counted `components (n)` groups and sign-omission for fields matching their card's status
- Hardening found in review: NUL-separated `git diff` output so non-ASCII paths survive quotepath; trailing `--` so a file-named ref operand fails loudly instead of silently succeeding; `isUnityPath` validation at the MCP boundary; empty `TMPDIR` fallback
- Drift guard: vitest tripwire asserting the `pl-*` class set of `cli/src/semantic_view.css` matches `extension/src/renderer/styles.ts`

## Testing

- `zig build test`: 163/163 pass (new: unity_path gate, changedPaths incl. 素材.prefab quotepath regression, pl-* DOM assertions incl. the guid XSS case, spine layout, grammar table, bulk modes, --open conflict/report-file)
- `cd extension && pnpm test && pnpm typecheck && pnpm lint`: 170/170 pass incl. the parity tripwire (proven to trip on a class rename in both directions), typecheck/lint clean for branch files
- `dotnet csharpier check` clean for the editor change
- Real-fixture smoke on unity-yaml-playground: `prefablens --project . main` renders 19 file sections; `prefablens --open --project . main` writes the temp report and opens the browser; per-file and two-file forms verified against `main..feat/mutate-fixtures`