### PR TITLE
feat: distribute CLI via Homebrew and Scoop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,10 @@ jobs:
         run: |
           dotnet tool restore
           dotnet csharpier check . --no-msbuild-check
+
+  packaging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Render test
+        run: packaging/render_test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,51 @@ jobs:
           # Publish as the App so the release isn't attributed to github-actions[bot].
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh release create "v$VERSION" dist/*.zip --generate-notes
+
+  # Regenerates the Homebrew formula and Scoop manifest from the published
+  # release and pushes them to the manifest repos. Idempotent: safe to re-run
+  # without re-tagging.
+  publish-manifests:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: hashiiiii
+          repositories: PrefabLens,homebrew-tap,scoop-bucket
+      - uses: actions/checkout@v7
+      - name: Render manifests from the published release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh release download "v$VERSION" --dir dist
+          packaging/render.sh "$VERSION" dist out
+      - name: Push manifests
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          # publish <repo> <src> <dest>: commit the rendered manifest to the
+          # manifest repo, skipping the push when nothing changed (re-runs).
+          publish() {
+            git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/hashiiiii/$1.git" "repos/$1"
+            mkdir -p "repos/$1/$(dirname "$3")"
+            cp "$2" "repos/$1/$3"
+            git -C "repos/$1" config user.name "${APP_SLUG}[bot]"
+            git -C "repos/$1" config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+            git -C "repos/$1" add "$3"
+            git -C "repos/$1" diff --cached --quiet || {
+              git -C "repos/$1" commit -m "chore: prefablens v$VERSION"
+              git -C "repos/$1" push
+            }
+          }
+          publish homebrew-tap out/prefablens.rb Formula/prefablens.rb
+          publish scoop-bucket out/prefablens.json bucket/prefablens.json

--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@ Semantic diff tools for UnityYAML assets. Instead of raw text diffs, PrefabLens 
 | `extension/` | Chrome extension for semantic diffs on GitHub pull requests |
 | `editor/` | Unity Editor package for semantic UnityYAML diffs |
 
+## Installation
+
+### Homebrew (macOS / Linux)
+
+```bash
+brew install hashiiiii/tap/prefablens
+```
+
+### Scoop (Windows)
+
+```bash
+scoop bucket add hashiiiii https://github.com/hashiiiii/scoop-bucket
+scoop install prefablens
+```
+
+### mise
+
+```bash
+mise use -g github:hashiiiii/PrefabLens
+```
+
+### Manual
+
+Download the zip for your platform from [GitHub Releases](https://github.com/hashiiiii/PrefabLens/releases).
+
 ## Usage
 
 ### CLI

--- a/packaging/prefablens.json.tmpl
+++ b/packaging/prefablens.json.tmpl
@@ -1,0 +1,13 @@
+{
+    "version": "{{VERSION}}",
+    "description": "Semantic diff for UnityYAML assets",
+    "homepage": "https://github.com/hashiiiii/PrefabLens",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hashiiiii/PrefabLens/releases/download/v{{VERSION}}/prefablens-windows-x64.zip",
+            "hash": "{{SHA256_WINDOWS_X64}}"
+        }
+    },
+    "bin": "prefablens.exe"
+}

--- a/packaging/prefablens.rb.tmpl
+++ b/packaging/prefablens.rb.tmpl
@@ -1,0 +1,31 @@
+class Prefablens < Formula
+  desc "Semantic diff for UnityYAML assets"
+  homepage "https://github.com/hashiiiii/PrefabLens"
+  version "{{VERSION}}"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/hashiiiii/PrefabLens/releases/download/v#{version}/prefablens-macos-arm64.zip"
+      sha256 "{{SHA256_MACOS_ARM64}}"
+    end
+    on_intel do
+      url "https://github.com/hashiiiii/PrefabLens/releases/download/v#{version}/prefablens-macos-x64.zip"
+      sha256 "{{SHA256_MACOS_X64}}"
+    end
+  end
+  on_linux do
+    on_intel do
+      url "https://github.com/hashiiiii/PrefabLens/releases/download/v#{version}/prefablens-linux-x64.zip"
+      sha256 "{{SHA256_LINUX_X64}}"
+    end
+  end
+
+  def install
+    bin.install "prefablens"
+  end
+
+  test do
+    assert_match "usage: prefablens", shell_output("#{bin}/prefablens --help")
+  end
+end

--- a/packaging/render.sh
+++ b/packaging/render.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Render the Homebrew formula and Scoop manifest from the packaging
+# templates. The release workflow and the initial bootstrap both call this.
+#
+# Usage: render.sh <version> <dist-dir> <out-dir>
+#   <dist-dir> holds the release zips (prefablens-<target>.zip).
+#   <out-dir> receives prefablens.rb and prefablens.json.
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+version=$1 dist=$2 out=$3
+mkdir -p "$out"
+
+sha() { shasum -a 256 "$dist/prefablens-$1.zip" | cut -d' ' -f1; }
+
+render() {
+  sed -e "s/{{VERSION}}/$version/g" \
+      -e "s/{{SHA256_MACOS_ARM64}}/$(sha macos-arm64)/g" \
+      -e "s/{{SHA256_MACOS_X64}}/$(sha macos-x64)/g" \
+      -e "s/{{SHA256_LINUX_X64}}/$(sha linux-x64)/g" \
+      -e "s/{{SHA256_WINDOWS_X64}}/$(sha windows-x64)/g" \
+      "$script_dir/$1"
+}
+
+render prefablens.rb.tmpl > "$out/prefablens.rb"
+render prefablens.json.tmpl > "$out/prefablens.json"
+
+# A leftover placeholder means a template and this script drifted apart.
+if grep -q '{{' "$out/prefablens.rb" "$out/prefablens.json"; then
+  echo "error: unrendered placeholder remains" >&2
+  exit 1
+fi

--- a/packaging/render_test.sh
+++ b/packaging/render_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Tests for render.sh: it renders the Homebrew formula and Scoop manifest
+# from the packaging templates, substituting the version and the per-target
+# SHA256 hashes of the release zips.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# Fixture release assets with distinct known content; render.sh only hashes
+# the zips, so plain files are enough.
+mkdir -p "$tmp/dist"
+for target in macos-arm64 macos-x64 linux-x64 windows-x64; do
+  printf '%s' "$target" > "$tmp/dist/prefablens-$target.zip"
+done
+
+./render.sh 1.2.3 "$tmp/dist" "$tmp/out"
+
+fail() { echo "FAIL: $1"; exit 1; }
+sha() { shasum -a 256 "$tmp/dist/prefablens-$1.zip" | cut -d' ' -f1; }
+
+# The version reaches both manifests.
+grep -q 'version "1.2.3"' "$tmp/out/prefablens.rb" || fail "formula version"
+grep -q '"version": "1.2.3"' "$tmp/out/prefablens.json" || fail "manifest version"
+
+# Each manifest embeds the hash of its own target's asset.
+grep -q "$(sha macos-arm64)" "$tmp/out/prefablens.rb" || fail "formula macos-arm64 hash"
+grep -q "$(sha macos-x64)" "$tmp/out/prefablens.rb" || fail "formula macos-x64 hash"
+grep -q "$(sha linux-x64)" "$tmp/out/prefablens.rb" || fail "formula linux-x64 hash"
+grep -q "$(sha windows-x64)" "$tmp/out/prefablens.json" || fail "manifest windows-x64 hash"
+
+# No placeholder survives rendering.
+if grep -q '{{' "$tmp/out/prefablens.rb" "$tmp/out/prefablens.json"; then
+  fail "unrendered placeholder"
+fi
+
+echo "PASS"


### PR DESCRIPTION
## Summary

Make the `prefablens` CLI installable via Homebrew (macOS / Linux) and Scoop (Windows). Manifests are rendered from templates in `packaging/` and pushed to [hashiiiii/homebrew-tap](https://github.com/hashiiiii/homebrew-tap) and [hashiiiii/scoop-bucket](https://github.com/hashiiiii/scoop-bucket) automatically on every release.

## Motivation

Until now the CLI was only available as manual zip downloads from GitHub Releases. Package manager installs lower the entry barrier on every desktop platform and keep upgrades one command away. Design doc: `docs/superpowers/specs/2026-07-12-package-manager-distribution-design.md` (local, not committed).

## Changes

- `packaging/`: Homebrew formula and Scoop manifest templates, `render.sh` (substitutes version + per-target SHA256), and `render_test.sh`.
- `.github/workflows/ci.yml`: new `packaging` job running the render test.
- `.github/workflows/release.yml`: new idempotent `publish-manifests` job that downloads the published release assets, renders both manifests, and pushes them to the two manifest repos with a cross-repo App token.
- `README.md`: new Installation section (Homebrew / Scoop / `mise use -g github:hashiiiii/PrefabLens` / manual zip).

Bootstrap note: both manifest repos are already live with v0.4.0. Since v0.4.0 predates `--help`, the bootstrapped formula's `test do` block asserts the no-operand usage output instead; the next release overwrites it with the template version.

## Testing

- `packaging/render_test.sh` — PASS (also wired into CI).
- `brew install hashiiiii/tap/prefablens` from the live GitHub tap — installs v0.4.0, binary runs, `brew test prefablens` exits 0, `brew style hashiiiii/tap` reports no offenses.
- `mise x github:hashiiiii/PrefabLens@latest -- prefablens` — asset auto-selection, checksum, and SLSA verification pass; binary prints usage.
- Scoop manifest validated for shape (`version` / `architecture.64bit` / `bin`, 64-char hash); no Windows machine available for a real `scoop install`.
- `zig build test` — pass (baseline, unaffected).