### PR TITLE
ci: add site label to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,11 @@ extension:
       - any-glob-to-any-file:
           - "extension/**"
 
+site:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "site/**"
+
 ci:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary

Add a `site` rule to the Pull Request Labeler config so PRs touching the demo site package are labeled automatically.

## Motivation

The `site/` package (GitHub Pages demo site, introduced in #96) had no matching labeler rule, so PRs changing it only received generic labels like `documentation`. Every other package (`core`, `cli`, `editor`, `extension`) already has one.

## Changes

- Add `site: site/**` to `.github/labeler.yml`
- Create the `site` label on GitHub (`Demo site (GitHub Pages)`, `#006b75`)

## Testing

```
$ ruby -ryaml -e "puts YAML.load_file('.github/labeler.yml').keys.inspect"
["core", "cli", "editor", "extension", "site", "ci", "documentation"]

$ gh label list --repo hashiiiii/PrefabLens --search site
site  Demo site (GitHub Pages)  #006b75
```