### PR TITLE
fix: correct license name in site footer

### DIFF
--- a/site/static/index.html
+++ b/site/static/index.html
@@ -102,7 +102,7 @@ scoop install prefablens</code></pre></dd>
       </section>
     </main>
     <footer class="site-footer">
-      MIT licensed. Source and issues on
+      Apache 2.0 licensed. Source and issues on
       <a href="https://github.com/hashiiiii/PrefabLens">github.com/hashiiiii/PrefabLens</a>.
     </footer>
   </body>


### PR DESCRIPTION
## Summary

Corrects the landing-page footer introduced in #99: the repository is Apache 2.0 licensed, not MIT.

## Motivation

The footer text said "MIT licensed", contradicting `LICENSE` (Apache License 2.0) and the README.

## Changes

- `site/static/index.html`: footer now reads "Apache 2.0 licensed".

## Testing

- `cd site && node build.mjs` — builds; `dist/index.html` contains "Apache 2.0 licensed".