### PR TITLE
docs: note all unityyaml assets in site hero

### DIFF
--- a/site/static/index.html
+++ b/site/static/index.html
@@ -22,7 +22,9 @@
         <h1>Review prefabs, not YAML noise.</h1>
         <p>
           PrefabLens shows Unity asset changes as a GameObject / component / field tree —
-          on GitHub pull requests and in your terminal.
+          on GitHub pull requests and in your terminal. Not just prefabs: it reads every
+          UnityYAML asset — scenes (<code>.unity</code>), ScriptableObjects
+          (<code>.asset</code>), materials, animators, and more.
         </p>
         <div class="hero-actions">
           <a class="button ext" href="extension.html">Try the extension demo</a>


### PR DESCRIPTION
## Summary

State on the site hero that PrefabLens handles every UnityYAML asset, not just prefabs.

## Motivation

The hero copy only said "Unity asset changes", while the product name suggests prefabs only. Visitors should immediately see that scenes (`.unity`), ScriptableObjects (`.asset`), materials, animators, and every other UnityYAML format are supported. The README already covers this in its intro and the "Supported files" section, so only the site needed the clarification.

## Changes

- Append a sentence to the hero paragraph in `site/static/index.html` listing representative UnityYAML formats

## Testing

- `node site/build.mjs` — succeeded, and `site/dist/index.html` contains the new sentence