### PR TITLE
fix: wrap long field values in semantic views

### DIFF
--- a/cli/src/semantic_view.css
+++ b/cli/src/semantic_view.css
@@ -93,6 +93,7 @@ details.pl-modified > summary > .pl-badge { color: var(--pl-modified); backgroun
 .pl-path { color: var(--pl-muted); }
 .pl-before { color: var(--pl-removed); }
 .pl-after { color: var(--pl-added); }
+.pl-path, .pl-before, .pl-after { min-width: 0; overflow-wrap: anywhere; }
 .pl-arrow { color: var(--pl-muted); }
 .pl-note { display: flex; align-items: center; gap: 6px; min-height: 24px; color: var(--pl-muted); }
 .pl-note-icon { display: inline-flex; align-items: center; }

--- a/extension/src/renderer/styles.ts
+++ b/extension/src/renderer/styles.ts
@@ -86,6 +86,7 @@ export const STYLES = `
   .pl-path { color: var(--pl-muted); }
   .pl-before { color: var(--pl-removed); }
   .pl-after { color: var(--pl-added); }
+  .pl-path, .pl-before, .pl-after { min-width: 0; overflow-wrap: anywhere; }
   .pl-arrow { color: var(--pl-muted); }
   .pl-note { display: flex; align-items: center; gap: 6px; min-height: 24px; color: var(--pl-muted); }
   .pl-note-icon { display: inline-flex; align-items: center; }

--- a/site/static/site.css
+++ b/site/static/site.css
@@ -133,7 +133,7 @@ main { max-width: 1024px; margin: 0 auto; padding: 24px 32px 96px; }
  * semantic view, side by side. */
 .compare {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(380px, 100%), 1fr));
   gap: 24px;
   margin: 56px 0 0;
 }


### PR DESCRIPTION
## Summary

Long unbreakable field values — the `guid:<32-hex>` form that Unity built-in resource references keep after guid resolution — no longer overflow the semantic tree on narrow screens, and the landing page no longer scrolls sideways on phones.

## Motivation

On a phone (390px viewport), the extension demo's MeshFilter `Mesh` and MeshRenderer `Materials[0]` rows bled out of the frame: their values are Unity built-in engine references (`guid:0000...e000...` / `...f000...`), which have no asset path to resolve to (project guids are resolved since #102), and the 37-char token has no break opportunity. `.pl-field` is a flex row, so the value span's min-content width won the layout. Separately, `section.compare` on index.html used `minmax(380px, 1fr)`, whose hard 380px floor forced horizontal page scroll below ~412px viewports.

## Changes

- `extension/src/renderer/styles.ts`: `.pl-path`, `.pl-before`, `.pl-after` get `min-width: 0; overflow-wrap: anywhere;`, mirroring the existing `.pl-name` rule
- `cli/src/semantic_view.css`: the same rule, keeping the documented parity with the extension stylesheet
- `site/static/site.css`: `.compare` grid uses `minmax(min(380px, 100%), 1fr)` so the column can shrink below 380px

## Testing

- `cd extension && pnpm test` — 170/170 pass (includes the styles parity test)
- `zig build test` — pass
- `cd site && node --test src/*.test.mjs && node build.mjs` — pass
- Playwright at 390×844 against the rebuilt `site/dist`: the guid rows wrap inside the frame, and an overflow scan (scrollWidth > clientWidth on every element, shadow DOM and iframes included, ellipsis/scroll containers excluded) reports zero hits on index.html, extension.html, and cli.html; at 1280px the compare section still renders two 468px columns