### PR TITLE
perf: fetch pr blobs by blob sha

### DIFF
--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -17,6 +17,8 @@ const DIFF: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: ["g1"], ro
 function makeDeps(overrides?: {
   files?: PrFile[];
   contents?: Record<string, string>; // `${path}@${ref}` → text
+  blobs?: Record<string, string>; // blob sha → text (getBlobRaw; absent sha = 404 → null)
+  baseShas?: Record<string, string>; // path → blob sha at the merge base (listBlobShas)
   diff?: Differ["diff"];
   diffWithAssets?: Differ["diffWithAssets"];
   pat?: string | undefined;
@@ -33,6 +35,14 @@ function makeDeps(overrides?: {
     getPrRefs: vi.fn(async () => ({ baseSha: "base-sha", headSha: "head-sha" })),
     listPrFiles: vi.fn(async () => files),
     getFileAtRef,
+    getBlobRaw: vi.fn(async (_o: string, _r: string, sha: string) => {
+      const text = overrides?.blobs?.[sha];
+      return text === undefined ? null : new TextEncoder().encode(text);
+    }),
+    listBlobShas: vi.fn(async () => ({
+      truncated: false,
+      byPath: new Map(Object.entries(overrides?.baseShas ?? {})),
+    })),
     searchMetaByGuid: vi.fn(async (_o: string, _r: string, guid: string) => overrides?.search?.[guid] ?? null),
     listMetaTree: vi.fn(
       async (): Promise<{ truncated: boolean; metas: Array<{ path: string; sha: string }> }> => ({
@@ -390,6 +400,114 @@ describe("createHandler", () => {
     const limited = makeDeps();
     limited.client.getPrRefs.mockRejectedValue(new RateLimitError("x"));
     expect(await resolveFully(createHandler(limited.deps), REQ)).toEqual({ ok: false, error: "rate-limited" });
+  });
+
+  describe("blob-sha fetching", () => {
+    // contents-by-path has erratic multi-second TTFB (#110): whenever the blob sha is known
+    // (files API for head, merge-base tree for base), fetch by sha and leave path+ref as the fallback.
+    it("fetches base and head by blob sha without touching the contents api", async () => {
+      const { deps, client } = makeDeps({
+        files: [
+          { path: "Assets/Foo.prefab", status: "modified", sha: "foo-head" },
+          { path: "Assets/S.cs.meta", status: "modified", sha: "meta-head" },
+        ],
+        blobs: { "foo-head": "a", "foo-base": "b", "meta-head": "guid: g1\n" },
+        baseShas: { "Assets/Foo.prefab": "foo-base" },
+        contents: {},
+      });
+      const res = await resolveFully(createHandler(deps), REQ);
+      // the guid index also reads the changed .meta by its files-api sha
+      expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/S.cs" } } });
+      expect(client.getBlobRaw).toHaveBeenCalledWith("o", "r", "foo-base");
+      expect(client.getBlobRaw).toHaveBeenCalledWith("o", "r", "foo-head");
+      expect(client.getFileAtRef).not.toHaveBeenCalled();
+    });
+
+    it("uses the files-api sha for the base side of removed files", async () => {
+      const diff = vi.fn<Differ["diff"]>(() => DIFF);
+      const { deps, client } = makeDeps({
+        files: [{ path: "Assets/Foo.prefab", status: "removed", sha: "foo-base" }],
+        blobs: { "foo-base": "b" },
+        contents: {},
+        diff,
+      });
+      const res = await resolveFully(createHandler(deps), REQ);
+      expect(res.ok).toBe(true);
+      expect(client.getBlobRaw).toHaveBeenCalledWith("o", "r", "foo-base");
+      expect(client.getFileAtRef).not.toHaveBeenCalled();
+      expect(diff.mock.calls[0]?.[1]).toHaveLength(0); // after stays empty
+    });
+
+    it("looks up renamed base blobs under previousPath in the base tree", async () => {
+      const { deps, client } = makeDeps({
+        files: [{ path: "Assets/Foo.prefab", status: "renamed", previousPath: "Assets/Old.prefab", sha: "foo-head" }],
+        blobs: { "foo-head": "a", "old-base": "b" },
+        baseShas: { "Assets/Old.prefab": "old-base" },
+        contents: {},
+      });
+      const res = await resolveFully(createHandler(deps), REQ);
+      expect(res.ok).toBe(true);
+      expect(client.getBlobRaw).toHaveBeenCalledWith("o", "r", "old-base");
+      expect(client.getFileAtRef).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the contents api for the base side when the tree is truncated", async () => {
+      const { deps, client } = makeDeps({
+        files: [{ path: "Assets/Foo.prefab", status: "modified", sha: "foo-head" }],
+        blobs: { "foo-head": "a" },
+        contents: { "Assets/Foo.prefab@base-sha": "b" },
+      });
+      client.listBlobShas.mockResolvedValue({ truncated: true, byPath: new Map() });
+      const res = await resolveFully(createHandler(deps), REQ);
+      expect(res.ok).toBe(true);
+      expect(client.getBlobRaw).toHaveBeenCalledWith("o", "r", "foo-head");
+      expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "base-sha");
+    });
+
+    it("falls back to the contents api when the blob fetch 404s", async () => {
+      // a force push between the files listing and the blob fetch can strand the sha
+      const { deps, client } = makeDeps({
+        files: [{ path: "Assets/Foo.prefab", status: "modified", sha: "foo-head" }],
+        blobs: {}, // getBlobRaw misses → null
+        contents: { "Assets/Foo.prefab@base-sha": "b", "Assets/Foo.prefab@head-sha": "a" },
+      });
+      const res = await resolveFully(createHandler(deps), REQ);
+      expect(res.ok).toBe(true);
+      expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "head-sha");
+    });
+
+    it("degrades to the contents api when the base tree fetch fails", async () => {
+      const { deps, client } = makeDeps({
+        files: [{ path: "Assets/Foo.prefab", status: "modified", sha: "foo-head" }],
+        blobs: { "foo-head": "a" },
+        contents: { "Assets/Foo.prefab@base-sha": "b" },
+      });
+      client.listBlobShas.mockRejectedValue(new Error("socket"));
+      const res = await resolveFully(createHandler(deps), REQ);
+      expect(res.ok).toBe(true);
+      expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Foo.prefab", "base-sha");
+    });
+
+    it("propagates a rate-limited base tree fetch like the guid index does", async () => {
+      const { deps, client } = makeDeps();
+      client.listBlobShas.mockRejectedValue(new RateLimitError("x"));
+      expect(await resolveFully(createHandler(deps), REQ)).toEqual({ ok: false, error: "rate-limited" });
+    });
+
+    it("reads removed .meta files via their files-api sha (base-side blob)", async () => {
+      const { deps, client } = makeDeps({
+        files: [
+          { path: "Assets/Foo.prefab", status: "modified", sha: "foo-head" },
+          { path: "Assets/S.cs.meta", status: "removed", sha: "meta-base" },
+        ],
+        blobs: { "foo-head": "a", "foo-base": "b", "meta-base": "guid: g1\n" },
+        baseShas: { "Assets/Foo.prefab": "foo-base" },
+        contents: {},
+      });
+      const res = await resolveFully(createHandler(deps), REQ);
+      expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/S.cs" } } });
+      expect(client.getFileAtRef).not.toHaveBeenCalled();
+    });
   });
 
   describe("source prefab merging", () => {

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -7,7 +7,14 @@ import { DiffError, type Differ } from "../wasm/differ";
 
 type ClientLike = Pick<
   GithubClient,
-  "getPrRefs" | "listPrFiles" | "getFileAtRef" | "searchMetaByGuid" | "listMetaTree" | "batchBlobTexts"
+  | "getPrRefs"
+  | "listPrFiles"
+  | "getFileAtRef"
+  | "getBlobRaw"
+  | "listBlobShas"
+  | "searchMetaByGuid"
+  | "listMetaTree"
+  | "batchBlobTexts"
 >;
 
 export type Deps = {
@@ -24,7 +31,13 @@ export type Handler = {
   prefetch(req: PrefetchRequest): Promise<void>;
 };
 
-type PrContext = { refs: PrRefs; files: PrFile[]; guidIndex: Map<string, string> };
+// baseShas: path → blob sha at the merge base. null = tree unavailable (truncated/failed) → contents-api fallback
+type PrContext = {
+  refs: PrRefs;
+  files: PrFile[];
+  guidIndex: Map<string, string>;
+  baseShas: Map<string, string> | null;
+};
 
 const EMPTY = new Uint8Array(0);
 const MAX_SEARCHES = 10; // Code Search is authenticated 10 req/min — don't burn it all in one response
@@ -132,17 +145,22 @@ export function createHandler(deps: Deps): Handler {
     return p;
   }
 
+  /** blobSha rides along when known (files API / merge-base tree): blob-by-sha latency is flat where
+   *  contents-by-path stalls for seconds (#110). A 404 on the sha (force push) falls back to path+ref. */
   async function fetchBlob(
     client: ClientLike,
     owner: string,
     repo: string,
     path: string,
     sha: string,
+    blobSha?: string,
   ): Promise<Uint8Array | null> {
-    const key = `${sha}:${path}`;
+    const key = blobSha ?? `${sha}:${path}`; // a blob sha never collides with the `${sha}:${path}` form
     const hit = blobs.get(key); // the stored value is Promise<Uint8Array | null>, so undefined = not cached
     if (hit !== undefined) return hit;
-    const p = client.getFileAtRef(owner, repo, path, sha);
+    const p = blobSha
+      ? client.getBlobRaw(owner, repo, blobSha).then((bytes) => bytes ?? client.getFileAtRef(owner, repo, path, sha))
+      : client.getFileAtRef(owner, repo, path, sha);
     p.catch(() => blobs.delete(key)); // don't keep failures: the next call can re-fetch
     blobs.set(key, p);
     if (blobs.size > BLOB_CACHE_MAX) blobs.delete(blobs.keys().next().value!);
@@ -160,11 +178,14 @@ export function createHandler(deps: Deps): Handler {
     const file = ctx.files.find((f) => f.path === path);
     const status = file?.status ?? "modified";
     const beforePath = file?.previousPath ?? path;
-    const fetchSide = (p: string, sha: string): Promise<Uint8Array> =>
-      fetchBlob(client, owner, repo, p, sha).then((bytes) => bytes ?? EMPTY);
+    // files API sha is the head blob, except for removed files where it is the base blob
+    const beforeBlob = status === "removed" ? file?.sha : ctx.baseShas?.get(beforePath);
+    const afterBlob = status === "removed" ? undefined : file?.sha;
+    const fetchSide = (p: string, sha: string, blobSha?: string): Promise<Uint8Array> =>
+      fetchBlob(client, owner, repo, p, sha, blobSha).then((bytes) => bytes ?? EMPTY);
     return Promise.all([
-      status === "added" ? Promise.resolve(EMPTY) : fetchSide(beforePath, ctx.refs.baseSha),
-      status === "removed" ? Promise.resolve(EMPTY) : fetchSide(path, ctx.refs.headSha),
+      status === "added" ? Promise.resolve(EMPTY) : fetchSide(beforePath, ctx.refs.baseSha, beforeBlob),
+      status === "removed" ? Promise.resolve(EMPTY) : fetchSide(path, ctx.refs.headSha, afterBlob),
     ]);
   }
 
@@ -193,9 +214,11 @@ export function createHandler(deps: Deps): Handler {
         const path = current.resolved?.[s.guid];
         if (path === undefined) continue;
         const sha = s.side === "before" ? ctx.refs.baseSha : ctx.refs.headSha;
+        // sources aren't PR files, so only the base tree can supply a sha; the head side keeps the path fallback
+        const blobSha = s.side === "before" ? ctx.baseShas?.get(path) : undefined;
         let bytes: Uint8Array | null = null;
         try {
-          bytes = await fetchBlob(client, owner, repo, path, sha);
+          bytes = await fetchBlob(client, owner, repo, path, sha, blobSha);
         } catch {
           return current; // rate limit etc.: degrade to the first-pass diff
         }
@@ -225,11 +248,30 @@ export function createHandler(deps: Deps): Handler {
         client.getPrRefs(owner, repo, prNumber),
         client.listPrFiles(owner, repo, prNumber),
       ]);
-      const guidIndex = await buildGuidIndex(files, async (path, side) => {
-        const bytes = await fetchBlob(client, owner, repo, path, side === "base" ? refs.baseSha : refs.headSha);
-        return bytes ? new TextDecoder().decode(bytes) : null;
-      });
-      return { refs, files, guidIndex };
+      const bySha = new Map(files.map((f) => [f.path, f.sha]));
+      const [guidIndex, baseShas] = await Promise.all([
+        buildGuidIndex(files, async (path, side) => {
+          // the files API sha matches the side buildGuidIndex reads: head, or base exactly for removed metas
+          const bytes = await fetchBlob(
+            client,
+            owner,
+            repo,
+            path,
+            side === "base" ? refs.baseSha : refs.headSha,
+            bySha.get(path),
+          );
+          return bytes ? new TextDecoder().decode(bytes) : null;
+        }),
+        // like buildGuidIndex, only rate limits propagate; anything else degrades to the contents-api fallback
+        client.listBlobShas(owner, repo, refs.baseSha).then(
+          (tree) => (tree.truncated ? null : tree.byPath),
+          (err: unknown) => {
+            if (err instanceof RateLimitError) throw err;
+            return null;
+          },
+        ),
+      ]);
+      return { refs, files, guidIndex, baseShas };
     })();
     contexts.set(key, { at: Date.now(), ctx });
     ctx.catch(() => contexts.delete(key)); // don't cache failures

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -53,7 +53,9 @@ describe("GithubClient", () => {
 
   it("listPrFiles paginates past 100 entries", async () => {
     const page1 = Array.from({ length: 100 }, (_, i) => ({ filename: `f${i}.cs`, status: "modified" }));
-    const page2 = [{ filename: "Assets/Foo.prefab", status: "renamed", previous_filename: "Assets/Old.prefab" }];
+    const page2 = [
+      { filename: "Assets/Foo.prefab", status: "renamed", previous_filename: "Assets/Old.prefab", sha: "blob-head" },
+    ];
     const { fn } = fakeFetch({
       "&page=1": () => json(page1),
       "&page=2": () => json(page2),
@@ -61,7 +63,28 @@ describe("GithubClient", () => {
     const client = new GithubClient("https://api.github.com", "tok", fn);
     const files = await client.listPrFiles("o", "r", 1);
     expect(files).toHaveLength(101);
-    expect(files[100]).toEqual({ path: "Assets/Foo.prefab", status: "renamed", previousPath: "Assets/Old.prefab" });
+    // sha is the head-side blob (base-side for removed files) — fetchPair fetches by it instead of path+ref
+    expect(files[100]).toEqual({
+      path: "Assets/Foo.prefab",
+      status: "renamed",
+      previousPath: "Assets/Old.prefab",
+      sha: "blob-head",
+    });
+  });
+
+  it("getBlobRaw requests raw bytes by blob sha", async () => {
+    const { fn, calls } = fakeFetch({ "/git/blobs/": () => new Response(new Uint8Array([1, 2, 3])) });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const bytes = await client.getBlobRaw("o", "r", "blob1");
+    expect([...bytes!]).toEqual([1, 2, 3]);
+    expect(calls[0]?.url).toBe("https://api.github.com/repos/o/r/git/blobs/blob1");
+    expect(calls[0]?.headers.accept).toBe("application/vnd.github.raw+json");
+  });
+
+  it("getBlobRaw returns null on 404 (sha gone after a force push)", async () => {
+    const { fn } = fakeFetch({});
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    expect(await client.getBlobRaw("o", "r", "gone")).toBeNull();
   });
 
   it("getFileAtRef requests raw content with URL-encoded path segments", async () => {
@@ -194,6 +217,32 @@ describe("listMetaTree", () => {
         { path: "Assets/Dir.meta", sha: "sha3" },
       ],
     });
+  });
+});
+
+describe("listBlobShas", () => {
+  it("maps every blob path to its sha with the truncated flag", async () => {
+    const fetchFn = vi.fn(
+      async (..._args: Parameters<typeof fetch>) =>
+        new Response(
+          JSON.stringify({
+            truncated: false,
+            tree: [
+              { path: "Assets/Foo.prefab", type: "blob", sha: "sha1" },
+              { path: "Assets/S.cs.meta", type: "blob", sha: "sha2" },
+              { path: "Assets", type: "tree", sha: "sha3" }, // tree nodes are excluded
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    const client = new GithubClient("https://api.github.com", "tok", fetchFn);
+    const res = await client.listBlobShas("o", "r", "merge-base");
+    expect(fetchFn.mock.calls[0]?.[0]).toBe("https://api.github.com/repos/o/r/git/trees/merge-base?recursive=1");
+    expect(res.truncated).toBe(false);
+    expect(res.byPath.get("Assets/Foo.prefab")).toBe("sha1");
+    expect(res.byPath.get("Assets/S.cs.meta")).toBe("sha2");
+    expect(res.byPath.has("Assets")).toBe(false);
   });
 });
 

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -6,7 +6,8 @@ export class ApiError extends Error {
   }
 }
 
-export type PrFile = { path: string; status: string; previousPath?: string };
+// sha is the blob at head (at base for removed files) — the files API provides it for every status.
+export type PrFile = { path: string; status: string; previousPath?: string; sha?: string };
 export type PrRefs = { baseSha: string; headSha: string };
 
 // The REST base is fixed at build time (see build.mjs's esbuild define).
@@ -74,10 +75,11 @@ export class GithubClient {
   async listPrFiles(owner: string, repo: string, prNumber: number): Promise<PrFile[]> {
     const out: PrFile[] = [];
     for (let page = 1; ; page++) {
-      const batch = await this.json<Array<{ filename: string; status: string; previous_filename?: string }>>(
-        `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`,
-      );
-      for (const f of batch) out.push({ path: f.filename, status: f.status, previousPath: f.previous_filename });
+      const batch = await this.json<
+        Array<{ filename: string; status: string; previous_filename?: string; sha?: string }>
+      >(`/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`);
+      for (const f of batch)
+        out.push({ path: f.filename, status: f.status, previousPath: f.previous_filename, sha: f.sha });
       if (batch.length < 100) return out;
     }
   }
@@ -93,7 +95,9 @@ export class GithubClient {
     return path?.endsWith(".meta") ? path.slice(0, -".meta".length) : null;
   }
 
-  /** Raw bytes at ref. null if the file is absent on that side. */
+  /** Raw bytes at ref. null if the file is absent on that side.
+   *  Path resolution at an arbitrary ref has erratic multi-second TTFB on GitHub's side (#110):
+   *  prefer getBlobRaw whenever the blob SHA is known. */
   async getFileAtRef(owner: string, repo: string, path: string, ref: string): Promise<Uint8Array | null> {
     const encoded = path.split("/").map(encodeURIComponent).join("/");
     const res = await this.request(
@@ -105,19 +109,46 @@ export class GithubClient {
     return new Uint8Array(await res.arrayBuffer());
   }
 
+  /** Raw blob bytes by SHA — content-addressed, so latency stays flat where contents-by-path stalls.
+   *  null on 404 (the SHA can vanish after a force push + gc). */
+  async getBlobRaw(owner: string, repo: string, sha: string): Promise<Uint8Array | null> {
+    const res = await this.request(`/repos/${owner}/${repo}/git/blobs/${sha}`, "application/vnd.github.raw+json");
+    if (res.status === 404) return null;
+    if (!res.ok) throw new ApiError(res.status);
+    return new Uint8Array(await res.arrayBuffer());
+  }
+
+  private async tree(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<{ truncated: boolean; tree: Array<{ path: string; type: string; sha: string }> }> {
+    return this.json(`/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`);
+  }
+
   /** path + blob SHA of every .meta at ref (a commit SHA is allowed). truncated means the listing was cut off past 100k entries. */
   async listMetaTree(
     owner: string,
     repo: string,
     ref: string,
   ): Promise<{ truncated: boolean; metas: Array<{ path: string; sha: string }> }> {
-    const body = await this.json<{ truncated: boolean; tree: Array<{ path: string; type: string; sha: string }> }>(
-      `/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`,
-    );
+    const body = await this.tree(owner, repo, ref);
     const metas = body.tree
       .filter((e) => e.type === "blob" && e.path.endsWith(".meta"))
       .map((e) => ({ path: e.path, sha: e.sha }));
     return { truncated: body.truncated, metas };
+  }
+
+  /** path → blob SHA of every blob at ref. Feeds base-side getBlobRaw lookups; same truncation rule as listMetaTree. */
+  async listBlobShas(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<{ truncated: boolean; byPath: Map<string, string> }> {
+    const body = await this.tree(owner, repo, ref);
+    const byPath = new Map<string, string>();
+    for (const e of body.tree) if (e.type === "blob") byPath.set(e.path, e.sha);
+    return { truncated: body.truncated, byPath };
   }
 
   /** Batch-fetches blob text via GraphQL (chunking is the caller's job). GraphQL has an independent 5,000 pt/h budget. */


### PR DESCRIPTION
## Summary

Fetches PR file contents by blob SHA (`git/blobs/{sha}`) instead of path+ref (`contents/{path}?ref=`), eliminating the erratic multi-second server-side stalls of the contents API that pushed semantic-diff first paint to ~10s on PR files pages.

## Motivation

Closes #110. Measured against the same endpoints: contents-by-path TTFB ranges 0.25–8.0s independent of file size (five of six identical requests at 0.25–0.6s, one at 4.9s), while blobs-by-SHA stays at 0.27–0.46s across all runs. With ~36 contents calls behind a 6-slot queue, a handful of stalled calls gated every file's render.

## Changes

- `PrFile` now carries the blob `sha` from the files API (head side; base side for removed files)
- `GithubClient.getBlobRaw` fetches raw bytes by blob SHA; `listBlobShas` maps path → blob SHA from one recursive tree call
- `loadContext` resolves base-side SHAs via a single `git/trees/{mergeBase}?recursive=1` call, in parallel with the guid index; rate limits propagate, other failures degrade to the contents fallback
- `fetchBlob` accepts an optional blob SHA (cache key folds with prefetch); a 404 on the SHA falls back to path+ref
- `fetchPair`, `buildGuidIndex`, and base-side `mergeSources` fetches all ride the SHA path; head-side source prefabs (not PR files) keep the contents fallback
- Note: the base tree map is held per PR context (60s TTL); on a 100k-file repo that is one transient Map in SW memory

## Testing

- `pnpm test` — 184 passed (12 new: blob-SHA pair/meta fetching, renamed/removed sides, truncated-tree and 404 fallbacks, rate-limit propagation)
- `pnpm typecheck`, `pnpm lint`, `pnpm build` — clean
- `pnpm e2e` — 10 passed (extension loaded in Chromium)
- New tests were written first and observed failing (`getBlobRaw is not a function`, contents API still touched) before implementation