### PR TITLE
ci: publish extension to chrome web store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,3 +126,43 @@ jobs:
             }
           }
           publish homebrew-tap out/prefablens.rb Formula/prefablens.rb
+
+  # Uploads the extension zip from the published release to the Chrome Web
+  # Store and submits it for review; the store publishes it automatically on
+  # approval. Independent from the release: safe to re-run in isolation, but
+  # fails while a previous submission is still pending review.
+  publish-extension:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Download extension zip from the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release download "v$VERSION" --repo "$GITHUB_REPOSITORY" --pattern "prefablens-extension-*.zip" --dir dist
+      - name: Upload and submit for review
+        env:
+          CWS_EXTENSION_ID: ${{ secrets.CWS_EXTENSION_ID }}
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+        run: |
+          set -euo pipefail
+          access_token=$(curl -fsS https://oauth2.googleapis.com/token \
+            -d client_id="$CWS_CLIENT_ID" \
+            -d client_secret="$CWS_CLIENT_SECRET" \
+            -d refresh_token="$CWS_REFRESH_TOKEN" \
+            -d grant_type=refresh_token | jq -er .access_token)
+          upload=$(curl -fsS -X PUT "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CWS_EXTENSION_ID" \
+            -H "Authorization: Bearer $access_token" \
+            -H "x-goog-api-version: 2" \
+            -T "dist/prefablens-extension-$VERSION.zip")
+          echo "$upload"
+          jq -e '.uploadState == "SUCCESS"' <<<"$upload" >/dev/null
+          result=$(curl -fsS -X POST "https://www.googleapis.com/chromewebstore/v1.1/items/$CWS_EXTENSION_ID/publish" \
+            -H "Authorization: Bearer $access_token" \
+            -H "x-goog-api-version: 2" \
+            -H "Content-Length: 0")
+          echo "$result"
+          jq -e '.status == ["OK"]' <<<"$result" >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,20 +149,14 @@ jobs:
           CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
         run: |
           set -euo pipefail
-          access_token=$(curl -fsS https://oauth2.googleapis.com/token \
-            -d client_id="$CWS_CLIENT_ID" \
-            -d client_secret="$CWS_CLIENT_SECRET" \
-            -d refresh_token="$CWS_REFRESH_TOKEN" \
-            -d grant_type=refresh_token | jq -er .access_token)
-          upload=$(curl -fsS -X PUT "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CWS_EXTENSION_ID" \
-            -H "Authorization: Bearer $access_token" \
-            -H "x-goog-api-version: 2" \
-            -T "dist/prefablens-extension-$VERSION.zip")
-          echo "$upload"
-          jq -e '.uploadState == "SUCCESS"' <<<"$upload" >/dev/null
-          result=$(curl -fsS -X POST "https://www.googleapis.com/chromewebstore/v1.1/items/$CWS_EXTENSION_ID/publish" \
-            -H "Authorization: Bearer $access_token" \
-            -H "x-goog-api-version: 2" \
-            -H "Content-Length: 0")
-          echo "$result"
-          jq -e '.status == ["OK"]' <<<"$result" >/dev/null
+          token=$(curl -fsS https://oauth2.googleapis.com/token \
+            -d client_id="$CWS_CLIENT_ID" -d client_secret="$CWS_CLIENT_SECRET" \
+            -d refresh_token="$CWS_REFRESH_TOKEN" -d grant_type=refresh_token | jq -er .access_token)
+          # cws <curl args...>: call the API, log the response, and pass it to the jq assertion
+          cws() { curl -fsS -H "Authorization: Bearer $token" -H "x-goog-api-version: 2" "$@" | tee /dev/stderr; }
+          cws -X PUT -T "dist/prefablens-extension-$VERSION.zip" \
+            "https://www.googleapis.com/upload/chromewebstore/v1.1/items/$CWS_EXTENSION_ID" \
+            | jq -e '.uploadState == "SUCCESS"' >/dev/null
+          cws -X POST -H "Content-Length: 0" \
+            "https://www.googleapis.com/chromewebstore/v1.1/items/$CWS_EXTENSION_ID/publish" \
+            | jq -e '.status == ["OK"]' >/dev/null


### PR DESCRIPTION
## Summary

Adds a `publish-extension` job to the release workflow that uploads the extension zip from the published GitHub Release to the Chrome Web Store and submits it for review.

## Motivation

The Chrome Web Store requires a review for every version update, and submitting it is currently a manual dashboard step — the only distribution channel not automated by the release pipeline. Closes #112.

## Changes

- Add a `publish-extension` job to `.github/workflows/release.yml` (`needs: release`, mirroring the `publish-manifests` fan-out pattern)
- Download `prefablens-extension-<version>.zip` from the release, upload it via the Chrome Web Store Publish API with plain `curl`, and submit it for review (`publish`); API responses are echoed to the log and asserted with `jq`
- Credentials come from four new repository secrets: `CWS_EXTENSION_ID`, `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`

## Testing

- `actionlint .github/workflows/release.yml` — no findings in the new job; the two pre-existing reports about `create-github-app-token@v3`'s `client-id` input are false positives from actionlint's outdated built-in action schema (the v0.6.1 release ran this configuration successfully)
- Not exercised end-to-end: requires the CWS secrets and the initial store review to complete first (see the merge checklist below)

---

Draft until the one-time setup is done:

- [x] Initial Chrome Web Store review approved (API rejects uploads while a submission is pending)
- [x] GCP project with the Chrome Web Store API enabled, OAuth client created, consent screen set to "In production" (Testing-status refresh tokens expire after 7 days)
- [x] Refresh token generated with scope `https://www.googleapis.com/auth/chromewebstore`
- [x] Repository secrets registered: `CWS_EXTENSION_ID`, `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`

