### PR TITLE
refactor: curate core public api at module root

### DIFF
--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -824,17 +824,6 @@ fn diffOne(
     return res;
 }
 
-fn writeJsonString(w: *std.Io.Writer, s: []const u8) !void {
-    try w.writeByte('"');
-    for (s) |c| switch (c) {
-        '"' => try w.writeAll("\\\""),
-        '\\' => try w.writeAll("\\\\"),
-        0x00...0x1f => try w.print("\\u{x:0>4}", .{c}),
-        else => try w.writeByte(c),
-    };
-    try w.writeByte('"');
-}
-
 /// Looks up an environment variable, treating a set-but-empty value the same as unset.
 /// Some shells/CI configs export TMPDIR="" rather than leaving it undefined, and an empty
 /// directory string would otherwise win the `orelse` fallback chain below with a bogus path.
@@ -993,7 +982,7 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                 for (diffs.items, 0..) |d, i| {
                     if (i != 0) try stdout.writeByte(',');
                     try stdout.writeAll("{\"path\":");
-                    try writeJsonString(stdout, d.path.?);
+                    try core.json.writeJsonString(stdout, d.path.?);
                     try stdout.writeAll(",\"diff\":");
                     try stdout.writeAll(try core.json.serialize(arena, d.res, resolver_ptr));
                     try stdout.writeByte('}');

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -1,13 +1,14 @@
 const std = @import("std");
 pub const model = @import("model.zig");
-pub const classid = @import("classid.zig");
-pub const parser = @import("parser.zig");
-pub const diff = @import("diff.zig");
-pub const tree = @import("tree.zig");
 pub const json = @import("json.zig");
-pub const inspector = @import("inspector.zig");
-pub const perf = @import("perf.zig");
-pub const instantiate = @import("instantiate.zig");
+
+const classid = @import("classid.zig");
+const parser = @import("parser.zig");
+const diff = @import("diff.zig");
+const tree = @import("tree.zig");
+const inspector = @import("inspector.zig");
+const perf = @import("perf.zig");
+const instantiate = @import("instantiate.zig");
 
 pub const Assets = instantiate.Assets;
 const no_assets: Assets = .empty;
@@ -36,5 +37,14 @@ pub fn diffToJsonWithAssets(arena: std.mem.Allocator, before_src: []const u8, af
 
 test {
     std.testing.refAllDecls(@This());
+    // refAllDecls only references pub decls; reference the internal modules
+    // explicitly so their tests are still discovered.
+    _ = classid;
+    _ = parser;
+    _ = diff;
+    _ = tree;
+    _ = inspector;
+    _ = perf;
+    _ = instantiate;
     _ = @import("fixture_test.zig");
 }


### PR DESCRIPTION
## Summary

Curate the core module's public surface at `root.zig`, following the Zig std / zig-clap convention: only the API actually consumed by the CLI and wasm builds stays `pub`; internal pipeline stages become unreachable from outside the module.

## Motivation

`root.zig` re-exported every submodule wholesale, so internal plumbing such as `core.diff.compute` and `core.tree.build` was indistinguishable from the intended API. Zig's only real visibility boundary is the module root namespace, so curation there is the idiomatic fix (std.zig and zig-clap both do exactly this). With the boundary in place, a consumer referencing an internal stage now fails to compile.

## Changes

- `core/src/root.zig`: keep `model`, `json`, `Assets`, and the four `diffBytes`/`diffToJson` functions public; demote `parser`, `diff`, `tree`, `instantiate`, `classid`, `inspector`, `perf` to non-pub imports
- `core/src/root.zig`: reference the demoted modules explicitly in the `test` block, since `refAllDecls` only sees pub decls and their 90+ inline tests would otherwise silently stop running
- `cli/src/main.zig`: drop the duplicate `writeJsonString` and call `core.json.writeJsonString` instead

## Testing

- `zig build test --summary all`: 161/161 tests passed (91 core + 70 CLI), identical count to main, confirming no test was silently dropped from discovery
- `zig build wasm`: passes
- Negative check: appending `comptime { _ = core.parser; }` to the CLI fails with `error: 'parser' is not marked 'pub'`, proving the boundary is enforced by the compiler