### PR TITLE
refactor: type-check site demo against viewer api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,11 @@ jobs:
         run: |
           zig build
           zig build wasm
-      - name: Build viewer artifact
+      - name: Build demo bundle
         working-directory: extension
         run: |
           pnpm install --frozen-lockfile
-          pnpm run viewer
+          pnpm run demo
       - name: Site checks
         working-directory: site
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,11 +27,11 @@ jobs:
         run: |
           zig build
           zig build wasm
-      - name: Build viewer artifact
+      - name: Build demo bundle
         working-directory: extension
         run: |
           pnpm install --frozen-lockfile
-          pnpm run viewer
+          pnpm run demo
       - name: Build site
         working-directory: site
         run: node build.mjs

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -5,14 +5,14 @@ mkdirSync("dist", { recursive: true });
 
 const e2e = process.argv.includes("--e2e");
 
-// --viewer: build only the embeddable viewer artifact (see src/viewer.ts).
-// Kept out of the default build so the extension's shipped dist stays lean.
-if (process.argv.includes("--viewer")) {
+// --demo: build only the site demo bundle (src/demo.ts, viewer surface
+// inlined). Kept out of the default build so the extension's shipped dist
+// stays lean.
+if (process.argv.includes("--demo")) {
   await build({
-    entryPoints: { viewer: "src/viewer.ts" },
+    entryPoints: { demo: "src/demo.ts" },
     bundle: true,
     format: "iife",
-    globalName: "PrefabLensViewer",
     target: "chrome120",
     minify: true,
     outdir: "dist",

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@11.10.0",
   "scripts": {
     "build": "node build.mjs",
-    "viewer": "node build.mjs --viewer",
+    "demo": "node build.mjs --demo",
     "typecheck": "tsc --noEmit",
     "lint": "biome ci .",
     "fmt": "biome check --write .",

--- a/extension/src/demo.ts
+++ b/extension/src/demo.ts
@@ -1,14 +1,26 @@
-// Live demo for extension.html: the mock PR page runs the extension's real
-// renderer, toggle, and WASM diff engine via the viewer artifact (viewer.js,
-// global PrefabLensViewer — built by `pnpm run viewer` in extension/), wired
-// the same way as the extension's content script minus the GitHub API and
-// auth layers. Diff inputs are fixture files served next to the page;
-// build.mjs marks each Unity file header with data-before/data-after URLs
-// (empty on the added/removed side, matching the CLI's empty-side semantics).
-const { applyResolved, createDiffer, createToggle, createViewState, injectPageStyles, render, renderError, renderLoading } =
-  PrefabLensViewer;
+// Live demo for the site's extension.html: the mock PR page runs the
+// extension's real renderer, toggle, and WASM diff engine, wired the same way
+// as the content script minus the GitHub API and auth layers. Importing the
+// viewer surface (./viewer) keeps the demo type-checked against the declared
+// API; `node build.mjs --demo` bundles it as dist/demo.js for site/build.mjs.
+// Diff inputs are fixture files served next to the page; site/build.mjs marks
+// each Unity file header with data-before/data-after URLs (empty on the
+// added/removed side, matching the CLI's empty-side semantics).
+import {
+  applyResolved,
+  createDiffer,
+  createToggle,
+  createViewState,
+  type Differ,
+  type DiffV2,
+  injectPageStyles,
+  render,
+  renderError,
+  renderLoading,
+  type View,
+} from "./viewer";
 
-async function fetchBytes(url) {
+async function fetchBytes(url: string | undefined): Promise<Uint8Array<ArrayBuffer>> {
   if (!url) return new Uint8Array();
   const res = await fetch(url);
   if (!res.ok) throw new Error(`${url}: HTTP ${res.status}`);
@@ -19,9 +31,14 @@ async function fetchBytes(url) {
  *  applyResolved attaches paths from the index, and the mergeSources loop
  *  fetches the source prefab of added/removed instances by resolved path and
  *  re-diffs with assets — here from fixture URLs instead of the GitHub API. */
-async function diffResolved(differ, index, before, after) {
+async function diffResolved(
+  differ: Differ,
+  index: Map<string, string>,
+  before: Uint8Array,
+  after: Uint8Array,
+): Promise<DiffV2> {
   let diff = applyResolved(differ.diff(before, after), index);
-  const assets = new Map();
+  const assets = new Map<string, Uint8Array>();
   for (let round = 0; round < 3; round++) {
     const needed = (diff.neededSources ?? []).filter((s) => !assets.has(s.guid));
     if (!needed.length) break;
@@ -41,43 +58,50 @@ async function diffResolved(differ, index, before, after) {
   return diff;
 }
 
-function attachFile(header, differ, index, initial) {
-  const content = header.parentElement.querySelector(".js-file-content");
-  let host;
+function attachFile(
+  header: HTMLElement,
+  differ: Differ,
+  index: Map<string, string>,
+  initial: View,
+): (view: View) => void {
+  // Non-null: site/build.mjs always nests the header in a .file with a .js-file-content sibling.
+  const content = header.parentElement!.querySelector<HTMLElement>(".js-file-content")!;
+  let host: HTMLDivElement | undefined;
+  let root: ShadowRoot | undefined;
   let rendered = false;
 
-  const show = (view) => {
+  const show = (view: View): void => {
     if (view === "raw") {
       content.style.display = "";
       if (host) host.style.display = "none";
       return;
     }
     content.style.display = "none";
-    if (!host) {
+    if (!host || !root) {
       host = document.createElement("div");
       host.setAttribute("data-prefablens-view", "");
       // Same Primer class as .js-file-content: the collapse chevron toggles
       // Details--on on .file, and the host must opt into that CSS itself.
       host.classList.add("Details-content--hidden");
-      host.attachShadow({ mode: "open" });
+      root = host.attachShadow({ mode: "open" });
       content.after(host);
     }
     host.style.display = "";
     if (rendered) return; // fixtures are static: render each file once
     rendered = true;
-    const root = host.shadowRoot;
-    renderLoading(root);
+    const target = root;
+    renderLoading(target);
     Promise.all([fetchBytes(header.dataset.before), fetchBytes(header.dataset.after)])
       .then(([before, after]) => diffResolved(differ, index, before, after))
-      .then((diff) => render(root, diff))
-      .catch((err) => renderError(root, String(err)));
+      .then((diff) => render(target, diff))
+      .catch((err) => renderError(target, String(err)));
   };
 
   show(initial);
   return show;
 }
 
-async function main() {
+async function main(): Promise<void> {
   injectPageStyles();
 
   // The collapse chevrons work on every file, Unity or not (GitHub behavior).
@@ -88,23 +112,23 @@ async function main() {
     });
   }
 
-  const headers = [...document.querySelectorAll(".file-header[data-before]")];
+  const headers = [...document.querySelectorAll<HTMLElement>(".file-header[data-before]")];
   if (!headers.length) return;
 
   const differ = await createDiffer(await fetchBytes("prefablens.wasm"));
   // guid → asset path, generated by build.mjs from the fixture .meta files —
   // the demo's stand-in for the extension's GitHub-backed repo index.
-  const index = new Map(Object.entries(await (await fetch("fixtures/guids.json")).json()));
+  const index = new Map<string, string>(Object.entries(await (await fetch("fixtures/guids.json")).json()));
   // Semantic by default, like the extension once the user has picked it; the
   // demo has no chrome.storage, so persistence is a no-op.
   const state = createViewState("semantic", () => {});
-  const appliers = [];
+  const appliers: Array<(view: View) => void> = [];
   state.onDefaultChange((view) => {
     for (const apply of appliers) apply(view);
   });
 
   // Global bar above the first Unity file, same anchor rule as the content script.
-  const firstFile = headers[0].closest(".file");
+  const firstFile = headers[0].closest(".file")!;
   const bar = document.createElement("div");
   bar.setAttribute("data-prefablens-global", "");
   const label = document.createElement("span");
@@ -116,7 +140,7 @@ async function main() {
   state.onDefaultChange((view) => globalToggle.set(view));
 
   for (const header of headers) {
-    const path = header.dataset.path;
+    const path = header.dataset.path ?? "";
     const show = attachFile(header, differ, index, state.effective(path));
     const toggle = createToggle((view) => {
       state.setOverride(path, view); // a click overrides just this file
@@ -130,4 +154,4 @@ async function main() {
   }
 }
 
-main();
+void main();

--- a/extension/src/github/resolved.ts
+++ b/extension/src/github/resolved.ts
@@ -1,8 +1,9 @@
 import type { DiffV2 } from "../types";
 
 /** Host-side resolution seam. Attaches with the same scoping rule as core's "resolved".
- *  Lives apart from guids.ts so the viewer artifact can export it without pulling
- *  the GitHub client (whose module init needs the build-time __API_BASE__ define). */
+ *  Lives apart from guids.ts so the viewer surface (src/viewer.ts) can export it
+ *  without pulling the GitHub client (whose module init needs the build-time
+ *  __API_BASE__ define). */
 export function applyResolved(diff: DiffV2, index: Map<string, string>): DiffV2 {
   const resolved: Record<string, string> = {};
   for (const g of diff.unresolvedGuids) {

--- a/extension/src/viewer.ts
+++ b/extension/src/viewer.ts
@@ -1,9 +1,10 @@
-// Public surface of the embeddable semantic-diff viewer. `pnpm run viewer`
-// builds this entry standalone (dist/viewer.js, global PrefabLensViewer) so
-// external consumers like site/ depend on a built artifact with a declared
-// API instead of reaching into extension sources.
+// Curated public surface of the embeddable semantic-diff viewer. Consumers
+// outside the extension's own entry points (today: the site demo, src/demo.ts,
+// bundled by `pnpm run demo`) import from this module only, so API drift is a
+// type error instead of a broken page.
 export { createToggle, injectPageStyles, type View } from "./content/toggle";
 export { createViewState } from "./content/viewstate";
 export { applyResolved } from "./github/resolved";
 export { render, renderError, renderLoading } from "./renderer/render";
-export { createDiffer } from "./wasm/differ";
+export type { DiffV2 } from "./types";
+export { createDiffer, type Differ } from "./wasm/differ";

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -1,8 +1,8 @@
 // Demo-site build. Everything visitors see is produced by the real product
 // code, and the site consumes only built artifacts: the CLI binary renders the
-// report and terminal tree, the extension's viewer artifact powers the mock PR
+// report and terminal tree, the extension's demo bundle powers the mock PR
 // page, and git provides the raw diffs. Run `zig build && zig build wasm` and
-// `pnpm run viewer` (in extension/) first. The site itself needs no toolchain.
+// `pnpm run demo` (in extension/) first. The site itself needs no toolchain.
 import { execFileSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -14,7 +14,7 @@ const SITE = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SITE, "..");
 const BIN = join(ROOT, "zig-out", "bin", process.platform === "win32" ? "prefablens.exe" : "prefablens");
 const WASM = join(ROOT, "zig-out", "bin", "prefablens.wasm");
-const VIEWER = join(ROOT, "extension", "dist", "viewer.js");
+const DEMO = join(ROOT, "extension", "dist", "demo.js");
 const FIXTURES = join(SITE, "fixtures");
 const DIST = join(SITE, "dist");
 
@@ -181,7 +181,7 @@ function guidIndex(side) {
 
 assertBuilt(BIN, "zig build");
 assertBuilt(WASM, "zig build wasm");
-assertBuilt(VIEWER, "pnpm run viewer (in extension/)");
+assertBuilt(DEMO, "pnpm run demo (in extension/)");
 rmSync(DIST, { recursive: true, force: true });
 mkdirSync(DIST, { recursive: true });
 
@@ -242,7 +242,7 @@ cpSync(join(FIXTURES, "after"), join(DIST, "fixtures", "after"), { recursive: tr
 // through this index, standing in for the extension's GitHub-backed one.
 writeFileSync(join(DIST, "fixtures", "guids.json"), JSON.stringify(guidIndex("after"), null, 2));
 cpSync(WASM, join(DIST, "prefablens.wasm"));
-cpSync(VIEWER, join(DIST, "viewer.js"));
-for (const file of ["site.css", "favicon.svg", "demo.js"]) cpSync(join(SITE, "static", file), join(DIST, file));
+cpSync(DEMO, join(DIST, "demo.js"));
+for (const file of ["site.css", "favicon.svg"]) cpSync(join(SITE, "static", file), join(DIST, file));
 
 console.log(`site built at ${DIST}`);

--- a/site/static/extension.html
+++ b/site/static/extension.html
@@ -6,7 +6,6 @@
     <title>PrefabLens extension demo — simulated GitHub pull request</title>
     <link rel="icon" href="favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="site.css" />
-    <script src="viewer.js" defer></script>
     <script src="demo.js" defer></script>
   </head>
   <body>


### PR DESCRIPTION
## Summary

Port the site demo script to TypeScript inside the extension toolchain and ship it as a single typed `demo.js` bundle, replacing the untyped `viewer.js` + `site/static/demo.js` pair.

## Motivation

`site/static/demo.js` destructured the viewer's exports from an untyped global. CI built the site but never executed the script, so renaming or removing a viewer export kept CI green while the deployed demo page threw at load — it was the only hand-written script in the repo that no compiler, linter, or test saw. Closes #121.

## Changes

- Add `extension/src/demo.ts`, a typed port of the demo wiring that imports the curated viewer surface (`src/viewer.ts`), so `tsc --noEmit` catches API drift
- Export `Differ` and `DiffV2` from the viewer surface (types its API already implies)
- Replace `node build.mjs --viewer` with `--demo`: bundles `dist/demo.js` with the viewer inlined, dropping the `PrefabLensViewer` global (site was the standalone artifact's only consumer)
- `site/build.mjs` consumes `extension/dist/demo.js`; `extension.html` loads one script instead of two; delete `site/static/demo.js`
- Update `ci.yml` and `pages.yml` to build the demo bundle via `pnpm run demo`

## Testing

- `pnpm run typecheck && pnpm run lint && pnpm run demo && pnpm test` in `extension/` — pass (184 tests)
- Negative check: temporarily renaming `render` in `src/viewer.ts` fails typecheck with `error TS2305: Module '"./viewer"' has no exported member 'render'`, then restored
- `node --test src/*.test.mjs && node build.mjs` in `site/` — pass; `dist/` contains `demo.js` and no `viewer.js`
- Served `site/dist` locally and loaded `extension.html` via Playwright: 0 console errors; all four files render semantic views with guid resolution (`FixtureBehaviour‹Script: …›`), source-prefab merge (`RobotVariant‹Prefab: Robot.prefab›`), and built-in names (`Plane (built-in)`); global and per-file Raw/Semantic toggles present