### PR TITLE
test: run editor tests on dotnet in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
         run: |
           dotnet tool restore
           dotnet csharpier check . --no-msbuild-check
+      - name: Test
+        working-directory: editor
+        run: dotnet test DotNetTests~/Tests
 
   packaging:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ extension/node_modules/
 extension/dist/
 extension/test-results/
 site/dist/
+editor/**/bin/
+editor/**/obj/

--- a/editor/DotNetTests~/Package/PrefabLens.Editor.csproj
+++ b/editor/DotNetTests~/Package/PrefabLens.Editor.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Mirrors how Unity 2022.3 compiles the package: netstandard2.1 API surface + C# 9. -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <AssemblyName>PrefabLens.Editor</AssemblyName>
+    <RootNamespace>PrefabLens</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../Editor/*.cs" LinkBase="Editor" />
+  </ItemGroup>
+</Project>

--- a/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
@@ -1,0 +1,131 @@
+// Minimal Unity API stand-ins so editor/Editor compiles on the plain dotnet SDK.
+// Signatures mirror Unity 2022.3; bodies are inert.
+using System;
+using System.Collections.Generic;
+
+namespace UnityEngine.UIElements
+{
+    public enum FlexDirection
+    {
+        Column,
+        ColumnReverse,
+        Row,
+        RowReverse,
+    }
+
+    public enum Align
+    {
+        Auto,
+        FlexStart,
+        Center,
+        FlexEnd,
+        Stretch,
+    }
+
+    public enum WhiteSpace
+    {
+        Normal,
+        NoWrap,
+    }
+
+    public struct StyleFloat
+    {
+        public static implicit operator StyleFloat(float v) => default;
+    }
+
+    public struct StyleLength
+    {
+        public static implicit operator StyleLength(float v) => default;
+    }
+
+    public struct StyleColor
+    {
+        public static implicit operator StyleColor(Color v) => default;
+    }
+
+    public struct StyleEnum<T>
+        where T : struct, IConvertible
+    {
+        public static implicit operator StyleEnum<T>(T v) => default;
+    }
+
+    public interface IStyle
+    {
+        StyleEnum<FlexDirection> flexDirection { get; set; }
+        StyleLength marginTop { get; set; }
+        StyleLength marginBottom { get; set; }
+        StyleLength marginLeft { get; set; }
+        StyleLength marginRight { get; set; }
+        StyleLength paddingLeft { get; set; }
+        StyleLength paddingRight { get; set; }
+        StyleFloat flexGrow { get; set; }
+        StyleEnum<TextAnchor> unityTextAlign { get; set; }
+        StyleEnum<Align> alignSelf { get; set; }
+        StyleEnum<Align> alignItems { get; set; }
+        StyleEnum<WhiteSpace> whiteSpace { get; set; }
+        StyleColor color { get; set; }
+    }
+
+    sealed class Style : IStyle
+    {
+        public StyleEnum<FlexDirection> flexDirection { get; set; }
+        public StyleLength marginTop { get; set; }
+        public StyleLength marginBottom { get; set; }
+        public StyleLength marginLeft { get; set; }
+        public StyleLength marginRight { get; set; }
+        public StyleLength paddingLeft { get; set; }
+        public StyleLength paddingRight { get; set; }
+        public StyleFloat flexGrow { get; set; }
+        public StyleEnum<TextAnchor> unityTextAlign { get; set; }
+        public StyleEnum<Align> alignSelf { get; set; }
+        public StyleEnum<Align> alignItems { get; set; }
+        public StyleEnum<WhiteSpace> whiteSpace { get; set; }
+        public StyleColor color { get; set; }
+    }
+
+    public class VisualElement
+    {
+        public IStyle style { get; } = new Style();
+
+        public void Add(VisualElement child) { }
+
+        public void Clear() { }
+    }
+
+    public class Label : VisualElement
+    {
+        public Label() { }
+
+        public Label(string text)
+        {
+            this.text = text;
+        }
+
+        public string text { get; set; }
+    }
+
+    public class Button : VisualElement
+    {
+        public Button(Action clickEvent) { }
+
+        public string text { get; set; }
+    }
+
+    public struct TreeViewItemData<T>
+    {
+        public TreeViewItemData(int id, T data, List<TreeViewItemData<T>> children = null) { }
+    }
+
+    public class TreeView : VisualElement
+    {
+        public float fixedItemHeight { get; set; }
+        public Func<VisualElement> makeItem { get; set; }
+        public Action<VisualElement, int> bindItem { get; set; }
+
+        public void SetRootItems<T>(IList<TreeViewItemData<T>> rootItems) { }
+
+        public T GetItemDataForIndex<T>(int index) => default;
+
+        public void ExpandAll() { }
+    }
+}

--- a/editor/DotNetTests~/Package/Stubs/UnityEditorStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UnityEditorStubs.cs
@@ -1,0 +1,50 @@
+// Minimal Unity API stand-ins so editor/Editor compiles on the plain dotnet SDK.
+// Signatures mirror Unity 2022.3; bodies are inert.
+using System;
+using UnityEngine.UIElements;
+
+namespace UnityEditor
+{
+    public class EditorWindow
+    {
+        public VisualElement rootVisualElement { get; } = new VisualElement();
+
+        public static T GetWindow<T>(string title)
+            where T : EditorWindow => throw new NotSupportedException("compile-only stub");
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class MenuItem : Attribute
+    {
+        public MenuItem(string itemName, bool isValidateFunction = false) { }
+    }
+
+    public static class EditorPrefs
+    {
+        public static string GetString(string key, string defaultValue) => defaultValue;
+    }
+
+    public static class EditorUtility
+    {
+        public static void DisplayProgressBar(string title, string info, float progress) { }
+
+        public static void ClearProgressBar() { }
+    }
+
+    public static class AssetDatabase
+    {
+        public static string GetAssetPath(UnityEngine.Object assetObject) => "";
+
+        public static string GUIDToAssetPath(string guid) => "";
+    }
+
+    public static class Selection
+    {
+        public static UnityEngine.Object activeObject => null;
+    }
+
+    public static class EditorGUIUtility
+    {
+        public static bool isProSkin => false;
+    }
+}

--- a/editor/DotNetTests~/Package/Stubs/UnityEngineStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UnityEngineStubs.cs
@@ -1,0 +1,41 @@
+// Minimal Unity API stand-ins so editor/Editor compiles on the plain dotnet SDK.
+// Signatures mirror Unity 2022.3; bodies are inert. The tests only exercise
+// Unity-free code paths, so none of these members run during `dotnet test`.
+using System;
+
+namespace UnityEngine
+{
+    public class Object { }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public sealed class SerializeField : Attribute { }
+
+    public struct Color
+    {
+        public float r,
+            g,
+            b,
+            a;
+
+        public Color(float r, float g, float b, float a = 1f)
+        {
+            this.r = r;
+            this.g = g;
+            this.b = b;
+            this.a = a;
+        }
+    }
+
+    public enum TextAnchor
+    {
+        UpperLeft,
+        UpperCenter,
+        UpperRight,
+        MiddleLeft,
+        MiddleCenter,
+        MiddleRight,
+        LowerLeft,
+        LowerCenter,
+        LowerRight,
+    }
+}

--- a/editor/DotNetTests~/README.md
+++ b/editor/DotNetTests~/README.md
@@ -1,0 +1,18 @@
+# DotNetTests~
+
+Runs the Unity EditMode tests in `../Tests/Editor` on the plain dotnet SDK, without a Unity installation.
+
+- `Package/` compiles `../Editor/*.cs` as `netstandard2.1` + C# 9 — the same API surface and language version Unity 2022.3 uses — against minimal Unity API stubs (`Package/Stubs/`).
+- `Tests/` links `../Tests/Editor/*.cs` and runs them with NUnit via `dotnet test`.
+
+The trailing `~` hides this folder from the Unity asset importer, so the package stays clean when installed via UPM.
+
+Run from `editor/`:
+
+```sh
+dotnet test DotNetTests~/Tests
+```
+
+## Caveats
+
+The stubs only prove the code compiles against hand-written Unity signatures. Divergence from the real Unity API and the runtime behavior of `PrefabLensWindow` are not covered here — verify those by opening the package in a real Unity Editor (2022.3 LTS, the declared minimum) and running the EditMode tests plus a Window/PrefabLens smoke test.

--- a/editor/DotNetTests~/Tests/PrefabLens.Editor.Tests.csproj
+++ b/editor/DotNetTests~/Tests/PrefabLens.Editor.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- LangVersion stays at 9.0 so the tests keep compiling inside Unity 2022.3 (EditMode). -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <AssemblyName>PrefabLens.Editor.Tests</AssemblyName>
+    <RootNamespace>PrefabLens.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../Tests/Editor/*.cs" LinkBase="Tests" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Package/PrefabLens.Editor.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Run the `editor/` NUnit tests on the plain dotnet SDK in CI, without a Unity installation.

## Motivation

CI only format-checked `editor/` with CSharpier; the tests in `editor/Tests/Editor` never ran anywhere (Unity EditMode had never been executed for this package). Previous editor PRs were verified with a throwaway dotnet harness rebuilt in a scratchpad each time. This commits that harness so every PR gets the check automatically.

## Changes

- `editor/DotNetTests~/Package`: `netstandard2.1` + C# 9 classlib compiling `editor/Editor/*.cs` against minimal hand-written Unity API stubs — the same API surface and `LangVersion` Unity 2022.3 (the declared minimum) uses
- `editor/DotNetTests~/Tests`: `net10.0` NUnit project linking `editor/Tests/Editor/*.cs`, run via `dotnet test`
- The trailing `~` hides the folder from the Unity asset importer, so UPM installs stay clean
- `.github/workflows/ci.yml`: add a `Test` step to the `editor` job
- `.gitignore`: ignore `bin/` and `obj/` under `editor/`

## Testing

dotnet harness (what CI now runs):

```
$ cd editor && dotnet test DotNetTests~/Tests
Passed!  - Failed:     0, Passed:    18, Skipped:     0, Total:    18, Duration: 644 ms - PrefabLens.Editor.Tests.dll (net10.0)

$ dotnet csharpier check . --no-msbuild-check
Checked 13 files in 111ms.
```

Real Unity 2022.3 LTS (the declared minimum, `2022.3.62f3`), package installed via `file:` reference with `testables`, EditMode run in batchmode:

```
$ Unity -batchmode -projectPath <smoke project> -runTests -testPlatform EditMode
exit=0, testcasecount="18", passed="18", failed="0", zero `error CS` in the log
```

The Unity log contains no mention of `DotNetTests~`, confirming the importer ignores the hidden folder. The released v0.6.1 CLI was also run from the smoke project (`prefablens HEAD Assets/Smoke.prefab --json`) and returned the expected semantic diff (Transform Position.x/y/z modified), i.e. the exact command `PrefabLensWindow` executes works end to end. The only part not covered is the window UI rendering itself (manual GUI smoke test).