### PR TITLE
feat: distribute editor package via openupm

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ mise use -g github:hashiiiii/PrefabLens
 
 Download the zip for your platform from [GitHub Releases](https://github.com/hashiiiii/PrefabLens/releases).
 
+### Unity Editor package (OpenUPM)
+
+```bash
+openupm add com.hashiiiii.prefablens
+```
+
+Without the [openupm-cli](https://github.com/openupm/openupm-cli), add the scoped registry as described on the [package page](https://openupm.com/packages/com.hashiiiii.prefablens/), or install via the Package Manager git URL: `https://github.com/hashiiiii/PrefabLens.git?path=editor`.
+
 ## Usage
 
 ### CLI

--- a/editor/package.json
+++ b/editor/package.json
@@ -4,5 +4,15 @@
   "displayName": "PrefabLens",
   "description": "Semantic diff viewer for UnityYAML assets in the Editor.",
   "unity": "2022.3",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "author": {
+    "name": "hashiiiii",
+    "url": "https://github.com/hashiiiii"
+  },
+  "keywords": [
+    "unity",
+    "prefab",
+    "diff",
+    "yaml"
+  ]
 }


### PR DESCRIPTION
## Summary

Document the OpenUPM install path for the Unity Editor package and enrich `editor/package.json` with optional UPM metadata. Companion submission: openupm/openupm PR adding `com.hashiiiii.prefablens` (created separately).

## Motivation

OpenUPM is the natural distribution channel for the `editor/` package — it reaches Unity developers directly and tracks our existing `vX.Y.Z` tags with zero per-release maintenance. Everything OpenUPM requires already holds: subfolder `package.json` (monorepo support), `.meta` files, per-tag version stamping via `.bumpversion.toml`. Spec: `docs/superpowers/specs/2026-07-14-openupm-distribution-design.md` (local).

## Changes

- `README.md` — add "Unity Editor package (OpenUPM)" install subsection: `openupm add` as the primary path, package-page scoped registry and Package Manager git URL (`?path=editor`) as alternatives
- `editor/package.json` — add `author` and `keywords`; surfaces in OpenUPM search and on the package page from the next tagged release

## Testing

- `jq . editor/package.json` — valid JSON; the `"version"` line targeted by `.bumpversion.toml` is untouched
- No code changes; editor CI (`dotnet test`) is unaffected