### PR TITLE
feat: redesign editor window as changed-asset list

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Shows semantic diffs for UnityYAML files on the GitHub pull request Files change
 
 ### Unity Editor
 
-Open `Window > PrefabLens`, or right-click a supported asset and choose `PrefabLens: Diff vs HEAD`. The CLI binary is downloaded automatically from GitHub Releases.
+Open `Window > PrefabLens`, or right-click a supported asset and choose `PrefabLens: Diff vs HEAD`. The window automatically lists every changed UnityYAML asset vs HEAD and shows the selected asset's semantic diff. The CLI binary is downloaded automatically from GitHub Releases.
 
 ## Supported files
 

--- a/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
@@ -1,6 +1,8 @@
 // Minimal Unity API stand-ins so editor/Editor compiles on the plain dotnet SDK.
 // Signatures mirror Unity 2022.3; bodies are inert.
+#pragma warning disable 67 // stub events are never raised
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace UnityEngine.UIElements
@@ -127,5 +129,34 @@ namespace UnityEngine.UIElements
         public T GetItemDataForIndex<T>(int index) => default;
 
         public void ExpandAll() { }
+    }
+
+    public enum TwoPaneSplitViewOrientation
+    {
+        Horizontal,
+        Vertical,
+    }
+
+    public class TwoPaneSplitView : VisualElement
+    {
+        public TwoPaneSplitView(
+            int fixedPaneIndex,
+            float fixedPaneStartDimension,
+            TwoPaneSplitViewOrientation orientation
+        ) { }
+    }
+
+    public class ListView : VisualElement
+    {
+        public float fixedItemHeight { get; set; }
+        public Func<VisualElement> makeItem { get; set; }
+        public Action<VisualElement, int> bindItem { get; set; }
+        public IList itemsSource { get; set; }
+
+        public event Action<IEnumerable<object>> selectionChanged;
+
+        public void SetSelection(int index) { }
+
+        public void RefreshItems() { }
     }
 }

--- a/editor/Editor/BulkModel.cs
+++ b/editor/Editor/BulkModel.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using PrefabLens.MiniJson;
+
+namespace PrefabLens
+{
+    public sealed class BulkEntry
+    {
+        public string Path;
+        public DiffModel Diff;
+    }
+
+    /// Reader-side model for the CLI's bulk mode (`prefablens --json` with no operands):
+    /// a top-level array of {path, diff} for every changed UnityYAML file vs HEAD.
+    /// Entries missing either key are skipped rather than failing (same tolerance as DiffModel).
+    public sealed class BulkModel
+    {
+        public List<BulkEntry> Entries = new();
+
+        public static BulkModel Parse(string json)
+        {
+            if (Json.Deserialize(json) is not List<object> arr)
+                throw new FormatException("bulk json root is not an array");
+            var m = new BulkModel();
+            foreach (var item in arr)
+            {
+                if (item is not Dictionary<string, object> o)
+                    continue;
+                if (
+                    o.TryGetValue("path", out var p)
+                    && p is string path
+                    && o.TryGetValue("diff", out var d)
+                    && d is Dictionary<string, object> diff
+                )
+                    m.Entries.Add(new BulkEntry { Path = path, Diff = DiffModel.FromDict(diff) });
+            }
+            return m;
+        }
+
+        /// The list badge for an entry: a wholly added / wholly removed asset keeps its
+        /// status, anything else (including an empty semantic diff) reads as modified.
+        public static DiffStatus AggregateStatus(DiffModel diff)
+        {
+            var any = false;
+            var allAdded = true;
+            var allRemoved = true;
+            foreach (var n in diff.Roots)
+            {
+                any = true;
+                allAdded &= n.Status == DiffStatus.Added;
+                allRemoved &= n.Status == DiffStatus.Removed;
+            }
+            foreach (var c in diff.Loose)
+            {
+                any = true;
+                allAdded &= c.Status == DiffStatus.Added;
+                allRemoved &= c.Status == DiffStatus.Removed;
+            }
+            if (!any)
+                return DiffStatus.Modified;
+            if (allAdded)
+                return DiffStatus.Added;
+            if (allRemoved)
+                return DiffStatus.Removed;
+            return DiffStatus.Modified;
+        }
+    }
+}

--- a/editor/Editor/BulkModel.cs.meta
+++ b/editor/Editor/BulkModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5cc551da6e254edf858f74c2875db22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -35,8 +35,6 @@ namespace PrefabLens
         public static string DownloadUrl(string version, string assetName) =>
             $"https://github.com/hashiiiii/PrefabLens/releases/download/v{version}/{assetName}";
 
-        public static string[] BuildArgs(string assetPath) => new[] { "HEAD", assetPath, "--json" };
-
         /// Bare invocation = bulk mode: HEAD vs working tree, all changed Unity files,
         /// as a [{path, diff}] JSON array.
         public static string[] BuildBulkArgs() => new[] { "--json" };
@@ -143,12 +141,6 @@ namespace PrefabLens
             public string Stdout;
             public string Stderr;
             public bool TimedOut;
-        }
-
-        /// Run the CLI with the project root as cwd (git refs are resolved against the repository in cwd).
-        public static Result Run(string cliPath, string assetPath)
-        {
-            return RunProcess(cliPath, QuoteArgs(BuildArgs(assetPath)), Directory.GetCurrentDirectory(), RunTimeoutMs);
         }
 
         public static Result RunProcess(string file, string arguments, string workDir, int timeoutMs)

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEditor;
 
 namespace PrefabLens
@@ -34,6 +36,43 @@ namespace PrefabLens
             $"https://github.com/hashiiiii/PrefabLens/releases/download/v{version}/{assetName}";
 
         public static string[] BuildArgs(string assetPath) => new[] { "HEAD", assetPath, "--json" };
+
+        /// Bare invocation = bulk mode: HEAD vs working tree, all changed Unity files,
+        /// as a [{path, diff}] JSON array.
+        public static string[] BuildBulkArgs() => new[] { "--json" };
+
+        /// Run bulk mode off the main thread. The callback is posted back through the
+        /// caller's SynchronizationContext (Unity's main thread when called from the window).
+        public static void RunBulkAsync(string cliPath, Action<Result> onDone) =>
+            RunAsync(cliPath, QuoteArgs(BuildBulkArgs()), onDone, SynchronizationContext.Current);
+
+        public static void RunAsync(string file, string arguments, Action<Result> onDone, SynchronizationContext ctx)
+        {
+            var workDir = Directory.GetCurrentDirectory();
+            Task.Run(() =>
+            {
+                Result res;
+                try
+                {
+                    res = RunProcess(file, arguments, workDir, RunTimeoutMs);
+                }
+                catch (Exception e)
+                {
+                    // Process.Start failures (missing binary, permissions) become a Result
+                    // so every failure reaches the window through one path.
+                    res = new Result
+                    {
+                        ExitCode = -1,
+                        Stdout = "",
+                        Stderr = e.Message,
+                    };
+                }
+                if (ctx != null)
+                    ctx.Post(_ => onDone(res), null);
+                else
+                    onDone(res);
+            });
+        }
 
         /// Minimal quoting for ProcessStartInfo.Arguments (handles asset paths with spaces).
         public static string QuoteArgs(string[] args)

--- a/editor/Editor/DiffModel.cs
+++ b/editor/Editor/DiffModel.cs
@@ -87,6 +87,11 @@ namespace PrefabLens
             // so the Window's "Could not parse CLI output" branch (which catches the Exception) works.
             if (Json.Deserialize(json) is not Dictionary<string, object> o)
                 throw new FormatException("diff json root is not an object");
+            return FromDict(o);
+        }
+
+        internal static DiffModel FromDict(Dictionary<string, object> o)
+        {
             var m = new DiffModel();
             foreach (var g in Items(o, "unresolvedGuids"))
                 if (g is string s)

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -105,7 +105,7 @@ namespace PrefabLens
             var menuInvoked = pendingSelectPath != null;
             pendingSelectPath = null;
             if (content == null)
-                return; // OnFocus can trigger a refresh before CreateGUI; nothing to render into yet
+                return; // unreachable given Refresh's own guard; kept as cheap defense
             content.Clear();
             if (res.ExitCode != 0)
             {
@@ -183,6 +183,7 @@ namespace PrefabLens
             list.itemsSource = bulk.Entries;
             list.RefreshItems();
             status.text = "";
+            // pendingSelectPath intentionally survives this path so DownloadThenRefresh carries the menu intent through.
             content.Clear();
             Note($"prefablens CLI not found (v{Cli.Version}).");
             content.Add(

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -99,8 +99,13 @@ namespace PrefabLens
         void OnBulkDone(Cli.Result res)
         {
             refreshing = false;
+            // Consume the menu's pending selection on every completion path, success or not,
+            // so a failed run cannot leak it into a later unrelated refresh.
+            var wanted = pendingSelectPath ?? selectedPath;
+            var menuInvoked = pendingSelectPath != null;
+            pendingSelectPath = null;
             if (content == null)
-                return; // window was closed while the CLI ran
+                return; // OnFocus can trigger a refresh before CreateGUI; nothing to render into yet
             content.Clear();
             if (res.ExitCode != 0)
             {
@@ -124,10 +129,7 @@ namespace PrefabLens
             list.RefreshItems();
             status.text = bulk.Entries.Count == 0 ? "No changes vs HEAD" : $"{bulk.Entries.Count} changed vs HEAD";
 
-            var wanted = pendingSelectPath ?? selectedPath;
-            var missingWanted = pendingSelectPath != null && IndexOfPath(pendingSelectPath) < 0;
-            pendingSelectPath = null;
-            if (missingWanted)
+            if (menuInvoked && IndexOfPath(wanted) < 0)
             {
                 Note($"No semantic changes for {wanted}");
                 return;
@@ -135,7 +137,12 @@ namespace PrefabLens
             if (bulk.Entries.Count == 0)
                 return;
             var idx = IndexOfPath(wanted);
-            list.SetSelection(idx < 0 ? 0 : idx);
+            if (idx < 0)
+                idx = 0;
+            list.SetSelection(idx);
+            // Render directly instead of relying on SetSelection to re-fire selectionChanged
+            // when the index is unchanged (undocumented ListView behavior).
+            ShowEntry(bulk.Entries[idx]);
         }
 
         int IndexOfPath(string path)
@@ -154,15 +161,20 @@ namespace PrefabLens
             {
                 if (item is not BulkEntry entry)
                     return;
-                selectedPath = entry.Path;
-                content.Clear();
-                entry.Diff.ResolveWith(AssetDatabase.GUIDToAssetPath);
-                if (entry.Diff.IsEmpty)
-                    Note("No semantic changes");
-                else
-                    content.Add(BuildTree(entry.Diff));
+                ShowEntry(entry);
                 return;
             }
+        }
+
+        void ShowEntry(BulkEntry entry)
+        {
+            selectedPath = entry.Path;
+            content.Clear();
+            entry.Diff.ResolveWith(AssetDatabase.GUIDToAssetPath);
+            if (entry.Diff.IsEmpty)
+                Note("No semantic changes");
+            else
+                content.Add(BuildTree(entry.Diff));
         }
 
         void ShowMissingCli()

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -7,14 +7,17 @@ using UnityEngine.UIElements;
 
 namespace PrefabLens
 {
-    /// Displays the "HEAD vs working tree" semantic diff of the selected asset.
+    /// Master-detail view: UnityYAML assets that differ from HEAD on the left,
+    /// the selected asset's semantic diff on the right.
     public sealed class PrefabLensWindow : EditorWindow
     {
-        [SerializeField]
-        string assetPath = "";
-
         Label status;
+        ListView list;
         VisualElement content;
+        BulkModel bulk = new();
+        string selectedPath;
+        string pendingSelectPath;
+        bool refreshing;
 
         [MenuItem("Window/PrefabLens")]
         public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
@@ -23,7 +26,7 @@ namespace PrefabLens
         static void DiffSelected()
         {
             var w = GetWindow<PrefabLensWindow>("PrefabLens");
-            w.assetPath = AssetDatabase.GetAssetPath(Selection.activeObject);
+            w.pendingSelectPath = AssetDatabase.GetAssetPath(Selection.activeObject);
             w.Refresh();
         }
 
@@ -58,64 +61,126 @@ namespace PrefabLens
             toolbar.Add(new Button(Refresh) { text = "Refresh" });
             rootVisualElement.Add(toolbar);
 
+            var split = new TwoPaneSplitView(0, 240, TwoPaneSplitViewOrientation.Horizontal);
+            list = new ListView { fixedItemHeight = 20 };
+            list.makeItem = () =>
+                new VisualElement { style = { flexDirection = FlexDirection.Row, alignItems = Align.Center } };
+            list.bindItem = (e, i) => RenderRow(e, EntryRow(bulk.Entries[i]));
+            list.selectionChanged += OnSelectionChanged;
+            split.Add(list);
             content = new VisualElement { style = { flexGrow = 1 } };
-            rootVisualElement.Add(content);
+            split.Add(content);
+            rootVisualElement.Add(split);
             Refresh();
+        }
+
+        /// Unity calls this whenever the window gains focus; before CreateGUI on first open.
+        void OnFocus()
+        {
+            if (content != null)
+                Refresh();
         }
 
         void Refresh()
         {
-            content.Clear();
-            if (string.IsNullOrEmpty(assetPath))
-            {
-                status.text =
-                    "Select a UnityYAML asset (.prefab / .unity / .asset / .mat / .anim / …) and run Assets → PrefabLens: Diff vs HEAD";
+            if (content == null || refreshing)
                 return;
-            }
-            status.text = assetPath;
-
             var cli = Cli.Find();
             if (cli == null)
             {
-                Note($"prefablens CLI not found (v{Cli.Version}).");
-                content.Add(
-                    new Button(DownloadThenRefresh)
-                    {
-                        text = "Download from GitHub Releases",
-                        style = { alignSelf = Align.FlexStart, marginLeft = 6 },
-                    }
-                );
-                Note($"Or set a manual path via EditorPrefs key '{Cli.CliPathPref}'.");
+                ShowMissingCli();
                 return;
             }
+            refreshing = true;
+            status.text = "Refreshing…";
+            Cli.RunBulkAsync(cli, OnBulkDone);
+        }
 
-            var res = Cli.Run(cli, assetPath);
+        void OnBulkDone(Cli.Result res)
+        {
+            refreshing = false;
+            if (content == null)
+                return; // window was closed while the CLI ran
+            content.Clear();
             if (res.ExitCode != 0)
             {
-                // The CLI's stderr is the primary source (non-git repository, invalid ref, etc.)
+                // The CLI's stderr is the primary source (non-git repository, timeout, etc.)
+                status.text = "";
                 Note(string.IsNullOrEmpty(res.Stderr) ? $"prefablens exited with {res.ExitCode}" : res.Stderr.Trim());
                 return;
             }
-
-            DiffModel model;
             try
             {
-                model = DiffModel.Parse(res.Stdout);
+                bulk = BulkModel.Parse(res.Stdout);
             }
             catch (Exception)
             {
+                status.text = "";
                 Note("Could not parse CLI output (CLI version mismatch?):");
                 Note(res.Stdout.Length > 200 ? res.Stdout.Substring(0, 200) + "…" : res.Stdout);
                 return;
             }
+            list.itemsSource = bulk.Entries;
+            list.RefreshItems();
+            status.text = bulk.Entries.Count == 0 ? "No changes vs HEAD" : $"{bulk.Entries.Count} changed vs HEAD";
 
-            model.ResolveWith(AssetDatabase.GUIDToAssetPath);
-            if (model.IsEmpty)
+            var wanted = pendingSelectPath ?? selectedPath;
+            var missingWanted = pendingSelectPath != null && IndexOfPath(pendingSelectPath) < 0;
+            pendingSelectPath = null;
+            if (missingWanted)
             {
-                Note("No semantic changes");
+                Note($"No semantic changes for {wanted}");
                 return;
             }
-            content.Add(BuildTree(model));
+            if (bulk.Entries.Count == 0)
+                return;
+            var idx = IndexOfPath(wanted);
+            list.SetSelection(idx < 0 ? 0 : idx);
+        }
+
+        int IndexOfPath(string path)
+        {
+            if (path == null)
+                return -1;
+            for (var i = 0; i < bulk.Entries.Count; i++)
+                if (bulk.Entries[i].Path == path)
+                    return i;
+            return -1;
+        }
+
+        void OnSelectionChanged(IEnumerable<object> items)
+        {
+            foreach (var item in items)
+            {
+                if (item is not BulkEntry entry)
+                    return;
+                selectedPath = entry.Path;
+                content.Clear();
+                entry.Diff.ResolveWith(AssetDatabase.GUIDToAssetPath);
+                if (entry.Diff.IsEmpty)
+                    Note("No semantic changes");
+                else
+                    content.Add(BuildTree(entry.Diff));
+                return;
+            }
+        }
+
+        void ShowMissingCli()
+        {
+            bulk = new BulkModel();
+            list.itemsSource = bulk.Entries;
+            list.RefreshItems();
+            status.text = "";
+            content.Clear();
+            Note($"prefablens CLI not found (v{Cli.Version}).");
+            content.Add(
+                new Button(DownloadThenRefresh)
+                {
+                    text = "Download from GitHub Releases",
+                    style = { alignSelf = Align.FlexStart, marginLeft = 6 },
+                }
+            );
+            Note($"Or set a manual path via EditorPrefs key '{Cli.CliPathPref}'.");
         }
 
         void DownloadThenRefresh()
@@ -147,6 +212,29 @@ namespace PrefabLens
                     },
                 }
             );
+        }
+
+        static Row EntryRow(BulkEntry entry) => Badge(BulkModel.AggregateStatus(entry.Diff)).Add(entry.Path);
+
+        static void RenderRow(VisualElement e, Row row)
+        {
+            e.Clear();
+            foreach (var span in row.Spans)
+            {
+                var l = new Label(span.Text)
+                {
+                    style =
+                    {
+                        marginLeft = 0,
+                        marginRight = 0,
+                        paddingLeft = 0,
+                        paddingRight = 0,
+                    },
+                };
+                if (span.Tint is Color tint)
+                    l.style.color = tint;
+                e.Add(l);
+            }
         }
 
         // ---- Tree rendering (same color tone and notation as the Chrome renderer) ----
@@ -200,26 +288,7 @@ namespace PrefabLens
             tree.SetRootItems(items);
             tree.makeItem = () =>
                 new VisualElement { style = { flexDirection = FlexDirection.Row, alignItems = Align.Center } };
-            tree.bindItem = (e, i) =>
-            {
-                e.Clear();
-                foreach (var span in tree.GetItemDataForIndex<Row>(i).Spans)
-                {
-                    var l = new Label(span.Text)
-                    {
-                        style =
-                        {
-                            marginLeft = 0,
-                            marginRight = 0,
-                            paddingLeft = 0,
-                            paddingRight = 0,
-                        },
-                    };
-                    if (span.Tint is Color tint)
-                        l.style.color = tint;
-                    e.Add(l);
-                }
-            };
+            tree.bindItem = (e, i) => RenderRow(e, tree.GetItemDataForIndex<Row>(i));
             tree.ExpandAll();
             return tree;
         }

--- a/editor/Tests/Editor/BulkModelTests.cs
+++ b/editor/Tests/Editor/BulkModelTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+
+namespace PrefabLens.Tests
+{
+    public class BulkModelTests
+    {
+        // Shape emitted by `prefablens --json` (bulk mode, v0.6.1), verified against the
+        // released binary: a top-level array of {path, diff} objects.
+        const string Bulk =
+            "[{\"path\":\"Assets/Smoke.prefab\",\"diff\":{\"schema\":\"prefablens.diff.v2\",\"unresolvedGuids\":[],\"roots\":[{\"kind\":\"gameObject\",\"fileId\":\"1\",\"name\":\"Smoke\",\"status\":\"unchanged\",\"components\":[{\"kind\":\"component\",\"fileId\":\"4\",\"classId\":4,\"typeName\":\"Transform\",\"scriptGuid\":null,\"className\":null,\"status\":\"modified\",\"fields\":[{\"path\":\"Position.x\",\"status\":\"modified\",\"before\":\"0\",\"after\":\"1\"}]}],\"children\":[]}],\"loose\":[]}},"
+            + "{\"path\":\"ProjectSettings/ProjectSettings.asset\",\"diff\":{\"schema\":\"prefablens.diff.v2\",\"unresolvedGuids\":[],\"roots\":[],\"loose\":[{\"kind\":\"component\",\"fileId\":\"1\",\"classId\":129,\"typeName\":\"PlayerSettings\",\"scriptGuid\":null,\"className\":null,\"status\":\"modified\",\"fields\":[]}]}}]";
+
+        [Test]
+        public void ParsesEntriesInOrder()
+        {
+            var m = BulkModel.Parse(Bulk);
+            Assert.AreEqual(2, m.Entries.Count);
+            Assert.AreEqual("Assets/Smoke.prefab", m.Entries[0].Path);
+            Assert.AreEqual("Smoke", m.Entries[0].Diff.Roots[0].Name);
+            Assert.AreEqual("ProjectSettings/ProjectSettings.asset", m.Entries[1].Path);
+            Assert.AreEqual("PlayerSettings", m.Entries[1].Diff.Loose[0].TypeName);
+        }
+
+        [Test]
+        public void EmptyArrayYieldsNoEntries()
+        {
+            Assert.AreEqual(0, BulkModel.Parse("[]").Entries.Count);
+        }
+
+        [Test]
+        public void ThrowsOnMalformedOrNonArrayJson()
+        {
+            // Same contract as DiffModel.Parse: the window converts the throw into
+            // the "Could not parse CLI output" display.
+            Assert.That(() => BulkModel.Parse("not json"), Throws.Exception);
+            Assert.That(() => BulkModel.Parse(""), Throws.Exception);
+            Assert.That(() => BulkModel.Parse("{}"), Throws.Exception); // root is not an array
+        }
+
+        [Test]
+        public void SkipsEntriesMissingPathOrDiff()
+        {
+            var m = BulkModel.Parse(
+                "[{\"path\":\"Assets/A.prefab\"},{\"diff\":{\"roots\":[],\"loose\":[]}},{\"path\":\"Assets/B.prefab\",\"diff\":{\"roots\":[],\"loose\":[]}}]"
+            );
+            Assert.AreEqual(1, m.Entries.Count);
+            Assert.AreEqual("Assets/B.prefab", m.Entries[0].Path);
+        }
+
+        [Test]
+        public void AggregateStatusDerivesTheListBadge()
+        {
+            // All top-level statuses added -> Added (new asset), all removed -> Removed
+            // (deleted asset), anything else -> Modified. Empty diff -> Modified
+            // (the file changed in git even if the semantic diff is empty).
+            var added = DiffModel.Parse(
+                "{\"roots\":[{\"kind\":\"gameObject\",\"status\":\"added\"}],\"loose\":[{\"kind\":\"component\",\"status\":\"added\"}]}"
+            );
+            var removed = DiffModel.Parse(
+                "{\"roots\":[{\"kind\":\"gameObject\",\"status\":\"removed\"}],\"loose\":[]}"
+            );
+            var mixed = DiffModel.Parse(
+                "{\"roots\":[{\"kind\":\"gameObject\",\"status\":\"unchanged\"}],\"loose\":[]}"
+            );
+            var empty = DiffModel.Parse("{\"roots\":[],\"loose\":[]}");
+            Assert.AreEqual(DiffStatus.Added, BulkModel.AggregateStatus(added));
+            Assert.AreEqual(DiffStatus.Removed, BulkModel.AggregateStatus(removed));
+            Assert.AreEqual(DiffStatus.Modified, BulkModel.AggregateStatus(mixed));
+            Assert.AreEqual(DiffStatus.Modified, BulkModel.AggregateStatus(empty));
+        }
+    }
+}

--- a/editor/Tests/Editor/BulkModelTests.cs.meta
+++ b/editor/Tests/Editor/BulkModelTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 78ff1d03655d44ed28561be576848208
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -38,17 +38,11 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void BuildArgsDiffsHeadAgainstTheWorktreeAsJson()
-        {
-            Assert.AreEqual(new[] { "HEAD", "Assets/Foo.prefab", "--json" }, Cli.BuildArgs("Assets/Foo.prefab"));
-        }
-
-        [Test]
         public void QuoteArgsSurvivesSpacesAndQuotes()
         {
             Assert.AreEqual(
                 "\"HEAD\" \"Assets/My Prefab.prefab\" \"--json\"",
-                Cli.QuoteArgs(Cli.BuildArgs("Assets/My Prefab.prefab"))
+                Cli.QuoteArgs(new[] { "HEAD", "Assets/My Prefab.prefab", "--json" })
             );
             Assert.AreEqual("\"a\\\"b\"", Cli.QuoteArgs(new[] { "a\"b" }));
         }

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 using NUnit.Framework;
 
 namespace PrefabLens.Tests
@@ -111,6 +112,60 @@ namespace PrefabLens.Tests
             // 4000 lines × 41 bytes ≈ 160KB. Reliably exceeds the buffer while also detecting dropped output.
             Assert.Greater(res.Stdout.Length, 100_000);
             Assert.Greater(res.Stderr.Length, 100_000);
+        }
+
+        [Test]
+        public void BuildBulkArgsRequestsAllChangedFilesAsJson()
+        {
+            // Bare `prefablens --json` is bulk mode: HEAD vs working tree, all changed Unity files.
+            Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs());
+        }
+
+        [Test]
+        public void RunAsyncInvokesTheCallbackOffTheBlockedCaller()
+        {
+            // ctx: null exercises the no-SynchronizationContext fallback; with a captured
+            // context the callback would deadlock here because this test blocks the caller.
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c echo hello" : "-c \"echo hello\"";
+            Cli.Result? got = null;
+            using var done = new ManualResetEventSlim();
+            Cli.RunAsync(
+                file,
+                args,
+                r =>
+                {
+                    got = r;
+                    done.Set();
+                },
+                ctx: null
+            );
+            Assert.IsTrue(done.Wait(30_000), "callback never fired");
+            Assert.AreEqual(0, got.Value.ExitCode);
+            StringAssert.Contains("hello", got.Value.Stdout);
+        }
+
+        [Test]
+        public void RunAsyncReportsAStartupFailureInsteadOfThrowing()
+        {
+            // Process.Start throws when the binary is missing; the async path must fold
+            // that into a Result so the window's error display keeps working.
+            Cli.Result? got = null;
+            using var done = new ManualResetEventSlim();
+            Cli.RunAsync(
+                "/nonexistent/prefablens-binary",
+                "\"--json\"",
+                r =>
+                {
+                    got = r;
+                    done.Set();
+                },
+                ctx: null
+            );
+            Assert.IsTrue(done.Wait(30_000), "callback never fired");
+            Assert.AreNotEqual(0, got.Value.ExitCode);
+            Assert.IsNotEmpty(got.Value.Stderr);
         }
     }
 }

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -118,8 +118,8 @@ namespace PrefabLens.Tests
         [Test]
         public void RunAsyncInvokesTheCallbackOffTheBlockedCaller()
         {
-            // ctx: null exercises the no-SynchronizationContext fallback; with a captured
-            // context the callback would deadlock here because this test blocks the caller.
+            // ctx: null exercises the no-SynchronizationContext fallback; a posted callback
+            // could not run while this test blocks the caller, failing the wait below.
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var file = isWindows ? "cmd.exe" : "/bin/sh";
             var args = isWindows ? "/c echo hello" : "-c \"echo hello\"";


### PR DESCRIPTION
## Summary

Redesign `PrefabLensWindow` from a manual per-asset diff viewer into a master-detail panel: the left pane lists every UnityYAML asset that differs from HEAD, the right pane shows the selected asset's semantic diff. Keep the window open and it refreshes on focus, without blocking the Unity main thread.

## Motivation

The window required selecting an asset and invoking a menu item per file, and it ran the CLI synchronously on the main thread (worst case 90 s freeze). The CLI's bulk mode (`prefablens --json`, shipped in v0.6.1) already returns every changed Unity file with its diff in one call, so the editor can present a live "what changed" panel with no CLI changes at all.

Design: `docs/superpowers/specs/2026-07-14-editor-changed-list-window-design.md` (local, uncommitted per repo policy).

## Changes

- `editor/Editor/BulkModel.cs`: parse the bulk `[{path, diff}]` array (tolerant per-entry, throw on wrong root — same contracts as `DiffModel`), plus `AggregateStatus` deriving the list badge (`+`/`−`/`~`)
- `editor/Editor/DiffModel.cs`: split object-level parsing into `FromDict` so `BulkModel` reuses it
- `editor/Editor/Cli.cs`: `RunBulkAsync`/`RunAsync` run the CLI on a worker thread and post the callback back through the captured `SynchronizationContext`; `Process.Start` failures fold into `Result`; the single-asset `Run`/`BuildArgs` API is removed (0.x)
- `editor/Editor/PrefabLensWindow.cs`: `TwoPaneSplitView` + `ListView` master-detail UI; refresh on focus + button with re-entry guard; selection preserved by path across refreshes; menu item now opens the window and selects the asset in the list ("No semantic changes for <path>" when absent); guid resolution per displayed entry
- `editor/DotNetTests~`: compile-only stubs for `ListView`/`TwoPaneSplitView` (signatures verified against Unity 2022.3 docs and a real 2022.3.62f3 compile)
- `README.md`: one sentence on the new window behavior
- New `.cs.meta` files tracked — without them, immutable installs (OpenUPM / git URL) silently drop the new sources and the package fails to compile for consumers

## Testing

```
$ cd editor && dotnet csharpier check . --no-msbuild-check && dotnet test 'DotNetTests~/Tests'
Checked 15 files in 109ms.
Passed!  - Failed:     0, Passed:    25, Skipped:     0, Total:    25

$ Unity 2022.3.62f3 -batchmode -runTests -testPlatform EditMode  (package via file: reference + testables)
exit=0, testcasecount="25", passed="25", failed="0", zero `error CS` in the log
```

Multi-agent review (per-task + whole-branch) passed; findings fixed in-branch (`pendingSelectPath` leak on failed refresh, `SetSelection` notification dependence, untracked meta files). Remaining: a manual GUI smoke test in Unity (window open, list contents, refresh-on-focus, menu selection) is pending and will be reported on this PR before merge.