### PR TITLE
docs: add distribution version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![Release](https://img.shields.io/github/v/release/hashiiiii/PrefabLens)](https://github.com/hashiiiii/PrefabLens/releases)
 [![License](https://img.shields.io/github/license/hashiiiii/PrefabLens)](LICENSE)
 
+[![Homebrew](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fhashiiiii%2Fhomebrew-tap%2Fmain%2FFormula%2Fprefablens.rb&search=version%20%22(%5B%5Cd.%5D%2B)%22&replace=%241&label=homebrew)](https://github.com/hashiiiii/homebrew-tap/blob/main/Formula/prefablens.rb)
+[![Scoop](https://img.shields.io/scoop/v/prefablens?bucket=https%3A%2F%2Fgithub.com%2Fhashiiiii%2Fscoop-bucket&label=scoop)](https://github.com/hashiiiii/scoop-bucket/blob/main/bucket/prefablens.json)
+[![OpenUPM](https://img.shields.io/npm/v/com.hashiiiii.prefablens?registry_uri=https%3A%2F%2Fpackage.openupm.com&label=openupm)](https://openupm.com/packages/com.hashiiiii.prefablens/)
+
 Semantic diff tools for UnityYAML assets. Instead of raw text diffs, PrefabLens shows changes at the GameObject, component, and field level.
 
 Try the [live demo](https://hashiiiii.github.io/PrefabLens/) — the extension's GitHub view and the CLI's local output, running in your browser.


### PR DESCRIPTION
## Summary

Add a second badge row to the README showing the released version of each distribution channel (Homebrew tap, Scoop bucket, OpenUPM).

## Motivation

The release pipeline fans out to channels that update at different speeds (store review lag, failed publish jobs). A side-by-side badge row next to the Release badge makes per-channel lag visible at a glance.

## Changes

- Insert three shields.io badges directly after the License badge, each linking to its channel's distribution page:
  - Homebrew: dynamic regex badge over `Formula/prefablens.rb` in `hashiiiii/homebrew-tap`
  - Scoop: `scoop/v` badge with the custom bucket `hashiiiii/scoop-bucket`
  - OpenUPM: `npm/v` badge against the `package.openupm.com` registry
- The Chrome Web Store badge is deferred until the listing goes Public — shields scrapes the listing page, which serves no data while Unlisted (verified with the live extension ID `dlhnalbfkikchkfedfneiimadommcnip`).
- [x] Follow-up (done in #128): add the Chrome Web Store badge once the listing is Public

## Testing

`curl` of each literal badge URL (byte-identical to the URLs in the README) renders the current release version in the SVG title:

```console
$ check() { curl -fsS "$1" | grep -o '<title>[^<]*</title>'; }
$ check 'https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fhashiiiii%2Fhomebrew-tap%2Fmain%2FFormula%2Fprefablens.rb&search=version%20%22(%5B%5Cd.%5D%2B)%22&replace=%241&label=homebrew'
<title>homebrew: 0.6.1</title>
$ check 'https://img.shields.io/scoop/v/prefablens?bucket=https%3A%2F%2Fgithub.com%2Fhashiiiii%2Fscoop-bucket&label=scoop'
<title>scoop: v0.6.1</title>
$ check 'https://img.shields.io/npm/v/com.hashiiiii.prefablens?registry_uri=https%3A%2F%2Fpackage.openupm.com&label=openupm'
<title>openupm: v0.6.1</title>
```

All three match the current latest release `v0.6.1` (`gh release view --json tagName`).
