### PR TITLE
docs: add chrome web store badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Homebrew](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2Fhashiiiii%2Fhomebrew-tap%2Fmain%2FFormula%2Fprefablens.rb&search=version%20%22(%5B%5Cd.%5D%2B)%22&replace=%241&label=homebrew)](https://github.com/hashiiiii/homebrew-tap/blob/main/Formula/prefablens.rb)
 [![Scoop](https://img.shields.io/scoop/v/prefablens?bucket=https%3A%2F%2Fgithub.com%2Fhashiiiii%2Fscoop-bucket&label=scoop)](https://github.com/hashiiiii/scoop-bucket/blob/main/bucket/prefablens.json)
 [![OpenUPM](https://img.shields.io/npm/v/com.hashiiiii.prefablens?registry_uri=https%3A%2F%2Fpackage.openupm.com&label=openupm)](https://openupm.com/packages/com.hashiiiii.prefablens/)
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/dlhnalbfkikchkfedfneiimadommcnip?label=chrome%20web%20store)](https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip)
 
 Semantic diff tools for UnityYAML assets. Instead of raw text diffs, PrefabLens shows changes at the GameObject, component, and field level.
 


### PR DESCRIPTION
## Summary

Add the Chrome Web Store version badge to the distribution badge row in the README, completing the follow-up recorded in #127.

## Motivation

#127 deferred this badge because the listing page served no data at the time, which was read as an Unlisted limitation. It turned out to be first-publish propagation lag: once the storefront caught up, the shields badge renders fine while the listing is still Unlisted, so there is no reason to wait for the Public switch.

## Changes

- Append the Chrome Web Store badge (`img.shields.io/chrome-web-store/v/dlhnalbfkikchkfedfneiimadommcnip`) to the badge row, linking to the store listing

## Testing

- `curl` of the literal badge URL renders the current store version in the SVG title:
  `<title>chrome web store: v0.6.1</title>`
- Listing page confirmed live: `<title>PrefabLens - Chrome Web Store</title>`
