### PR TITLE
feat: add tree icons and components group

### DIFF
--- a/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
@@ -54,6 +54,9 @@ namespace UnityEngine.UIElements
     public interface IStyle
     {
         StyleEnum<FlexDirection> flexDirection { get; set; }
+        StyleLength width { get; set; }
+        StyleLength height { get; set; }
+        StyleFloat flexShrink { get; set; }
         StyleLength marginTop { get; set; }
         StyleLength marginBottom { get; set; }
         StyleLength marginLeft { get; set; }
@@ -71,6 +74,9 @@ namespace UnityEngine.UIElements
     sealed class Style : IStyle
     {
         public StyleEnum<FlexDirection> flexDirection { get; set; }
+        public StyleLength width { get; set; }
+        public StyleLength height { get; set; }
+        public StyleFloat flexShrink { get; set; }
         public StyleLength marginTop { get; set; }
         public StyleLength marginBottom { get; set; }
         public StyleLength marginLeft { get; set; }
@@ -92,6 +98,11 @@ namespace UnityEngine.UIElements
         public void Add(VisualElement child) { }
 
         public void Clear() { }
+    }
+
+    public class Image : VisualElement
+    {
+        public Texture image { get; set; }
     }
 
     public class Label : VisualElement

--- a/editor/DotNetTests~/Package/Stubs/UnityEditorStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UnityEditorStubs.cs
@@ -36,6 +36,8 @@ namespace UnityEditor
         public static string GetAssetPath(UnityEngine.Object assetObject) => "";
 
         public static string GUIDToAssetPath(string guid) => "";
+
+        public static UnityEngine.Texture GetCachedIcon(string path) => null;
     }
 
     public static class Selection
@@ -46,5 +48,7 @@ namespace UnityEditor
     public static class EditorGUIUtility
     {
         public static bool isProSkin => false;
+
+        public static UnityEngine.Texture2D FindTexture(string name) => null;
     }
 }

--- a/editor/DotNetTests~/Package/Stubs/UnityEngineStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UnityEngineStubs.cs
@@ -7,6 +7,10 @@ namespace UnityEngine
 {
     public class Object { }
 
+    public class Texture : Object { }
+
+    public class Texture2D : Texture { }
+
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class SerializeField : Attribute { }
 

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -209,13 +209,17 @@ namespace PrefabLens
             );
         }
 
-        static Row EntryRow(BulkEntry entry) => Badge(BulkModel.AggregateStatus(entry.Diff)).Add(entry.Path);
+        static Row EntryRow(BulkEntry entry) =>
+            Badge(BulkModel.AggregateStatus(entry.Diff))
+                .WithIcon(AssetDatabase.GetCachedIcon(entry.Path))
+                .Add(entry.Path);
 
         static void RenderRow(VisualElement e, Row row)
         {
             e.Clear();
-            foreach (var span in row.Spans)
+            for (var i = 0; i < row.Spans.Count; i++)
             {
+                var span = row.Spans[i];
                 var l = new Label(span.Text)
                 {
                     style =
@@ -229,7 +233,37 @@ namespace PrefabLens
                 if (span.Tint is Color tint)
                     l.style.color = tint;
                 e.Add(l);
+                // The icon sits between the badge (always the first span) and the name.
+                if (i == 0 && row.Icon != null)
+                    e.Add(
+                        new Image
+                        {
+                            image = row.Icon,
+                            style =
+                            {
+                                width = 16,
+                                height = 16,
+                                marginRight = 2,
+                                flexShrink = 0,
+                            },
+                        }
+                    );
             }
+        }
+
+        /// Unity built-in icon lookup. Pro skin ships d_-prefixed variants, so probe those
+        /// first; FindTexture returns null silently for unknown names.
+        static Texture2D FindIcon(string name)
+        {
+            var dark = EditorGUIUtility.isProSkin ? EditorGUIUtility.FindTexture("d_" + name) : null;
+            return dark != null ? dark : EditorGUIUtility.FindTexture(name);
+        }
+
+        static Texture2D ComponentIcon(ComponentDiff c)
+        {
+            // Built-in components have "<TypeName> Icon" textures; script components use the script icon.
+            var builtin = c.ClassName == null && c.ScriptGuid == null ? FindIcon(c.TypeName + " Icon") : null;
+            return builtin != null ? builtin : FindIcon("cs Script Icon");
         }
 
         // ---- Tree rendering (same color tone and notation as the Chrome renderer) ----
@@ -260,12 +294,19 @@ namespace PrefabLens
 
         sealed class Row
         {
+            public Texture Icon;
             public readonly List<Span> Spans = new();
 
             public Row Add(string text, Color? tint = null)
             {
                 if (!string.IsNullOrEmpty(text))
                     Spans.Add(new Span(text, tint));
+                return this;
+            }
+
+            public Row WithIcon(Texture icon)
+            {
+                Icon = icon;
                 return this;
             }
         }
@@ -295,12 +336,20 @@ namespace PrefabLens
             if (pi != null)
                 foreach (var ov in pi.Overrides)
                     children.Add(new TreeViewItemData<Row>(id++, OverrideRow(ov, m)));
-            foreach (var c in n.Components)
-                children.Add(ComponentItem(c, m, ref id));
+            if (n.Components.Count > 0)
+            {
+                // Components fold as their own group one level below the object row (extension parity).
+                var comps = new List<TreeViewItemData<Row>>();
+                foreach (var c in n.Components)
+                    comps.Add(ComponentItem(c, m, ref id));
+                children.Add(
+                    new TreeViewItemData<Row>(id++, Badge(DiffStatus.Unchanged).Add("Components", Palette.Muted), comps)
+                );
+            }
             foreach (var ch in n.Children)
                 children.Add(NodeItem(ch, m, ref id));
 
-            var row = Badge(n.Status).Add(n.Name);
+            var row = Badge(n.Status).WithIcon(FindIcon(pi != null ? "Prefab Icon" : "GameObject Icon")).Add(n.Name);
             if (pi?.SourceGuid != null)
                 row.Add(
                     " ‹Prefab: " + (m.Resolved.TryGetValue(pi.SourceGuid, out var src) ? src : pi.SourceGuid) + "›",
@@ -315,7 +364,7 @@ namespace PrefabLens
             foreach (var f in c.Fields)
                 children.Add(new TreeViewItemData<Row>(id++, FieldRow(f.Path, f.Status, f.Before, f.After, m)));
 
-            var row = Badge(c.Status);
+            var row = Badge(c.Status).WithIcon(ComponentIcon(c));
             if (!string.IsNullOrEmpty(c.ClassName))
                 row.Add(c.ClassName).Add(" ‹Script›", Palette.Muted);
             else if (c.ScriptGuid != null && m.Resolved.TryGetValue(c.ScriptGuid, out var p))


### PR DESCRIPTION
## Summary

Follow-up to #126/#129: make GameObject and component rows visually distinct in the diff tree, matching the extension's visual language (cube/gear icons + a "Components" fold) with real Unity built-in icons.

## Motivation

GameObject and component rows rendered as identical plain text, unlike the extension where the distinction is immediate (user feedback from the live smoke test). Inside the editor we can go one better than the extension and use Unity's own icons.

## Changes

- `editor/Editor/PrefabLensWindow.cs`:
  - Tree rows get Unity built-in icons via `EditorGUIUtility.FindTexture` — `GameObject Icon` / `Prefab Icon` for nodes, `<TypeName> Icon` with a `cs Script Icon` fallback for components (script components go straight to the script icon), probing `d_`-prefixed variants first on Pro skin; `FindTexture` returns null silently for unknown names so the fallback chain is safe
  - Components fold under a muted "Components" group node per GameObject (extension parity with PR #80)
  - Left-pane list rows show `AssetDatabase.GetCachedIcon(path)`
  - `Row` carries an optional icon rendered as a 16×16 `Image` between the badge and the name
- `editor/DotNetTests~` stubs: `Texture`/`Texture2D`, `EditorGUIUtility.FindTexture`, `AssetDatabase.GetCachedIcon`, UIElements `Image`, and `width`/`height`/`flexShrink` style properties

## Testing

```
$ cd editor && dotnet csharpier check . --no-msbuild-check && dotnet test 'DotNetTests~/Tests'
Passed!  - Failed:     0, Passed:    22, Skipped:     0, Total:    22
```

A Unity 2022.3.62f3 batchmode EditMode run (fresh throwaway project — the smoke project is locked by an open editor) is validating the new stub signatures against the real API; result will be posted here before merge. Icon appearance itself is being verified live in the user's open editor.