### PR TITLE
fix: keep tree fold state on unchanged refresh

### DIFF
--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -16,6 +16,7 @@ namespace PrefabLens
         VisualElement content;
         BulkModel bulk = new();
         string selectedPath;
+        string lastStdout;
         bool refreshing;
 
         [MenuItem("Window/PrefabLens")]
@@ -94,10 +95,18 @@ namespace PrefabLens
             refreshing = false;
             if (content == null)
                 return; // unreachable given Refresh's own guard; kept as cheap defense
+            // Unchanged output — the common focus-triggered refresh. Leave the whole UI
+            // alone so the user's tree fold state survives; only restore the status line.
+            if (res.ExitCode == 0 && res.Stdout == lastStdout)
+            {
+                status.text = CountText();
+                return;
+            }
             content.Clear();
             if (res.ExitCode != 0)
             {
                 // The CLI's stderr is the primary source (non-git repository, timeout, etc.)
+                lastStdout = null;
                 status.text = "";
                 Note(string.IsNullOrEmpty(res.Stderr) ? $"prefablens exited with {res.ExitCode}" : res.Stderr.Trim());
                 return;
@@ -108,14 +117,16 @@ namespace PrefabLens
             }
             catch (Exception)
             {
+                lastStdout = null;
                 status.text = "";
                 Note("Could not parse CLI output (CLI version mismatch?):");
                 Note(res.Stdout.Length > 200 ? res.Stdout.Substring(0, 200) + "…" : res.Stdout);
                 return;
             }
+            lastStdout = res.Stdout;
             list.itemsSource = bulk.Entries;
             list.RefreshItems();
-            status.text = bulk.Entries.Count == 0 ? "No changes vs HEAD" : $"{bulk.Entries.Count} changed vs HEAD";
+            status.text = CountText();
 
             if (bulk.Entries.Count == 0)
                 return;
@@ -127,6 +138,8 @@ namespace PrefabLens
             // when the index is unchanged (undocumented ListView behavior).
             ShowEntry(bulk.Entries[idx]);
         }
+
+        string CountText() => bulk.Entries.Count == 0 ? "No changes vs HEAD" : $"{bulk.Entries.Count} changed vs HEAD";
 
         int IndexOfPath(string path)
         {


### PR DESCRIPTION
## Summary

Stop the focus-triggered refresh from discarding the user's tree fold state when nothing changed.

## Motivation

Every refresh rebuilt the selected asset's `TreeView` and called `ExpandAll`, so merely focusing away and back re-expanded everything the user had collapsed (user feedback from live use). The focus refresh almost never carries new data, making the rebuild pure churn.

## Changes

- `editor/Editor/PrefabLensWindow.cs`: `OnBulkDone` remembers the last successful CLI stdout; when a new run returns byte-identical output it leaves the list and tree untouched and only restores the status line. Error paths reset the marker so recovery rebuilds. When output genuinely changed, the rebuild (and re-expand) is intentional — it shows what moved.

## Testing

```
$ cd editor && dotnet csharpier check . --no-msbuild-check && dotnet test 'DotNetTests~/Tests'
Checked 13 files in 121ms.
Passed!  - Failed:     0, Passed:    22, Skipped:     0, Total:    22
```

No new Unity API surface (pure C# state logic), so no EditMode re-run is needed beyond the standing 2022.3.62f3 validation; fold-state behavior is being confirmed live in the open editor.