### PR TITLE
docs: replace stale PAT note with GitHub sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ treated as paths; everything else is a git ref.
 
 ### Chrome extension
 
-Shows semantic diffs for UnityYAML files on the GitHub pull request Files changed tab. Requires a GitHub Personal Access Token (configure on the extension options page).
+Shows semantic diffs for UnityYAML files on the GitHub pull request Files changed tab. Sign in with GitHub via the OAuth device flow — directly from the PR page prompt or the extension options page. No Personal Access Token is required.
 
 ### Unity Editor
 


### PR DESCRIPTION
## Summary

The Chrome extension section of the README still said a GitHub Personal Access Token was required and had to be configured on the extension options page. Since #77 and #79, the extension authenticates via GitHub sign-in using the OAuth device flow — available directly from the PR page prompt or the options page — and no PAT is needed.

- Replace the stale PAT sentence with a description of the current sign-in flow.

Verified the rest of the README against the current code (mise toolchain versions, CLI flags, dev commands, install channels) — no other stale claims found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UX5c1mQRhj5JX673hiZyDF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UX5c1mQRhj5JX673hiZyDF)_