### PR TITLE
docs: refresh readme to current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ mise use -g github:hashiiiii/PrefabLens
 
 Download the zip for your platform from [GitHub Releases](https://github.com/hashiiiii/PrefabLens/releases).
 
+### Chrome extension (Chrome Web Store)
+
+Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip).
+
 ### Unity Editor package (OpenUPM)
 
 ```bash
@@ -80,7 +84,7 @@ treated as paths; everything else is a git ref.
 
 ### Chrome extension
 
-Shows semantic diffs for UnityYAML files on the GitHub pull request Files changed tab. Requires a GitHub Personal Access Token (configure on the extension options page).
+Shows semantic diffs for UnityYAML files on the GitHub pull request Files changed tab. Sign in with GitHub from the first diff panel (or the extension options page); authorization uses the GitHub device flow, so no token setup is needed.
 
 ### Unity Editor
 
@@ -92,7 +96,7 @@ Text-serialized Unity assets such as `.prefab`, `.unity`, `.asset`, `.mat`, `.an
 
 ## Development
 
-Toolchain is managed with [mise](https://mise.jdx.dev/) (Zig 0.16, Node 24, .NET 10).
+Toolchain is managed with [mise](https://mise.jdx.dev/) (Zig 0.16, Node 24, pnpm 11, .NET 10).
 
 ```bash
 mise install
@@ -106,6 +110,9 @@ zig build wasm
 
 # Extension
 cd extension && pnpm install && pnpm run build && pnpm test
+
+# Editor (EditMode tests run on .NET, no Unity required)
+cd editor && dotnet test DotNetTests~/Tests
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Update the README to match the current state of the project: the Chrome extension no longer requires a Personal Access Token and is now installable from the Chrome Web Store.

## Motivation

The Chrome extension usage section still said a GitHub Personal Access Token was required, but the PAT field was removed when GitHub device-flow sign-in landed (#76, #79). The Chrome Web Store listing is also live now, yet the README offered no install path for the extension.

## Changes

- Installation: add a Chrome extension section linking to the Chrome Web Store listing
- Usage: replace the PAT requirement with Sign in with GitHub via the device flow
- Development: list pnpm 11 in the mise toolchain and add the editor .NET test command

## Testing

- Docs-only change; verified each statement against the current sources: `extension/src/options/options.ts` (no PAT field, device-flow sign-in), `extension/src/content/signin.ts` (in-page sign-in), `.github/workflows/ci.yml` (`dotnet test DotNetTests~/Tests`), `mise.toml` (pnpm 11)