### PR TITLE
docs: note extension is github.com only

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ treated as paths; everything else is a git ref.
 
 Shows semantic diffs for UnityYAML files on the GitHub pull request Files changed tab. Sign in with GitHub from the first diff panel (or the extension options page); authorization uses the GitHub device flow, so no token setup is needed.
 
+> [!NOTE]
+> The extension is currently available on github.com only.
+
 ### Unity Editor
 
 Open `Window > PrefabLens`. The window lists every changed UnityYAML asset vs HEAD and shows the selected asset's semantic diff. The CLI binary is downloaded automatically from GitHub Releases.


### PR DESCRIPTION
## Summary

Add a GitHub alert (`> [!NOTE]`) to the README stating that the Chrome extension is currently available on github.com only.

## Motivation

The README did not state which GitHub hosts the extension supports. Readers on GitHub Enterprise Server could assume it works there; this makes the current scope explicit.

## Changes

- Add a `> [!NOTE]` alert under Usage > Chrome extension in `README.md`

## Testing

- Docs-only change; verified the alert renders as a GitHub NOTE block in the PR diff preview