### PR TITLE
feat: auto-download cli binary in editor window

### DIFF
--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -99,6 +99,7 @@ namespace PrefabLens
         }
 
         /// Fetch from GitHub Releases and extract under Library. Returns the executable path on success, throws on failure.
+        /// Synchronous and free of Unity API calls so it can run on a worker thread (see DownloadAsync).
         public static string Download()
         {
             var asset = ReleaseAssetName(
@@ -110,29 +111,63 @@ namespace PrefabLens
             var dir = Path.GetDirectoryName(DefaultPath);
             Directory.CreateDirectory(dir);
 
-            try
-            {
-                EditorUtility.DisplayProgressBar("PrefabLens", $"Downloading {asset}…", 0.3f);
-                using var http = new HttpClient();
-                var bytes = http.GetByteArrayAsync(url).Result;
-                using var zip = new ZipArchive(new MemoryStream(bytes));
-                foreach (var entry in zip.Entries)
-                {
-                    // ZipFileExtensions (ExtractToFile) isn't referenceable under netstandard, so copy manually
-                    var dest = Path.Combine(dir, entry.Name);
-                    using var src = entry.Open();
-                    using var dst = File.Create(dest);
-                    src.CopyTo(dst);
-                }
-            }
-            finally
-            {
-                EditorUtility.ClearProgressBar();
-            }
+            using var http = new HttpClient();
+            // GetAwaiter().GetResult() unwraps AggregateException so onDone sees the HttpRequestException message.
+            var bytes = http.GetByteArrayAsync(url).GetAwaiter().GetResult();
+            ExtractTo(bytes, dir);
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 RunProcess("chmod", "+x \"" + DefaultPath + "\"", ".", RunTimeoutMs);
+            DeleteStaleVersions(Path.GetDirectoryName(dir), Version);
             return DefaultPath;
+        }
+
+        /// Run Download() off the main thread. The outcome is posted back through the caller's
+        /// SynchronizationContext (Unity's main thread when called from the window).
+        /// Exactly one of (path, error) is non-null.
+        public static void DownloadAsync(Action<string, string> onDone)
+        {
+            var ctx = SynchronizationContext.Current;
+            Task.Run(() =>
+            {
+                string path = null;
+                string error = null;
+                try
+                {
+                    path = Download();
+                }
+                catch (Exception e)
+                {
+                    error = e.Message;
+                }
+                if (ctx != null)
+                    ctx.Post(_ => onDone(path, error), null);
+                else
+                    onDone(path, error);
+            });
+        }
+
+        public static void ExtractTo(byte[] zipBytes, string dir)
+        {
+            using var zip = new ZipArchive(new MemoryStream(zipBytes));
+            foreach (var entry in zip.Entries)
+            {
+                // ZipFileExtensions (ExtractToFile) isn't referenceable under netstandard, so copy manually
+                var dest = Path.Combine(dir, entry.Name);
+                using var src = entry.Open();
+                using var dst = File.Create(dest);
+                src.CopyTo(dst);
+            }
+        }
+
+        /// Drop cached binaries of other versions once the pinned one is in place.
+        public static void DeleteStaleVersions(string root, string keep)
+        {
+            if (!Directory.Exists(root))
+                return;
+            foreach (var dir in Directory.GetDirectories(root))
+                if (Path.GetFileName(dir) != keep)
+                    Directory.Delete(dir, recursive: true);
         }
 
         public struct Result

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -161,13 +161,23 @@ namespace PrefabLens
         }
 
         /// Drop cached binaries of other versions once the pinned one is in place.
+        /// Best-effort: a locked directory (e.g. an old prefablens.exe still running
+        /// on Windows) must not fail the download that just succeeded.
         public static void DeleteStaleVersions(string root, string keep)
         {
             if (!Directory.Exists(root))
                 return;
             foreach (var dir in Directory.GetDirectories(root))
-                if (Path.GetFileName(dir) != keep)
+            {
+                if (Path.GetFileName(dir) == keep)
+                    continue;
+                try
+                {
                     Directory.Delete(dir, recursive: true);
+                }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
         }
 
         public struct Result

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -18,6 +18,8 @@ namespace PrefabLens
         string selectedPath;
         string lastStdout;
         bool refreshing;
+        bool downloadAttempted;
+        string downloadError;
 
         [MenuItem("Window/PrefabLens")]
         public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
@@ -82,7 +84,13 @@ namespace PrefabLens
             var cli = Cli.Find();
             if (cli == null)
             {
-                ShowMissingCli();
+                // Fetch the pinned binary automatically, once per session; after a
+                // failure, fall back to the manual screen instead of re-downloading
+                // on every focus.
+                if (downloadAttempted)
+                    ShowMissingCli();
+                else
+                    StartDownload();
                 return;
             }
             refreshing = true;
@@ -180,9 +188,11 @@ namespace PrefabLens
             list.RefreshItems();
             status.text = "";
             content.Clear();
+            if (downloadError != null)
+                Note($"Download failed: {downloadError}");
             Note($"prefablens CLI not found (v{Cli.Version}).");
             content.Add(
-                new Button(DownloadThenRefresh)
+                new Button(StartDownload)
                 {
                     text = "Download from GitHub Releases",
                     style = { alignSelf = Align.FlexStart, marginLeft = 6 },
@@ -191,17 +201,25 @@ namespace PrefabLens
             Note($"Or set a manual path via EditorPrefs key '{Cli.CliPathPref}'.");
         }
 
-        void DownloadThenRefresh()
+        /// Shared by the automatic trigger in Refresh and the manual retry button.
+        void StartDownload()
         {
-            try
+            downloadAttempted = true;
+            refreshing = true; // keeps focus-triggered Refresh calls out while the download runs
+            status.text = $"Downloading prefablens v{Cli.Version}…";
+            content.Clear();
+            Cli.DownloadAsync(OnDownloadDone);
+        }
+
+        void OnDownloadDone(string path, string error)
+        {
+            refreshing = false;
+            if (content == null)
+                return;
+            downloadError = error;
+            if (error != null)
             {
-                Cli.Download();
-            }
-            catch (Exception e)
-            {
-                content.Clear();
-                Note($"Download failed: {e.Message}");
-                Note($"You can place the binary manually and set EditorPrefs '{Cli.CliPathPref}'.");
+                ShowMissingCli();
                 return;
             }
             Refresh();

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -206,11 +206,16 @@ namespace PrefabLens
         {
             downloadAttempted = true;
             refreshing = true; // keeps focus-triggered Refresh calls out while the download runs
+            bulk = new BulkModel();
+            list.itemsSource = bulk.Entries;
+            list.RefreshItems();
             status.text = $"Downloading prefablens v{Cli.Version}…";
             content.Clear();
             Cli.DownloadAsync(OnDownloadDone);
         }
 
+        /// The success path re-resolves through Cli.Find instead of using the returned
+        /// path, so the manual EditorPrefs override keeps precedence.
         void OnDownloadDone(string path, string error)
         {
             refreshing = false;

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -186,6 +186,7 @@ namespace PrefabLens
             bulk = new BulkModel();
             list.itemsSource = bulk.Entries;
             list.RefreshItems();
+            lastStdout = null;
             status.text = "";
             content.Clear();
             if (downloadError != null)
@@ -209,6 +210,7 @@ namespace PrefabLens
             bulk = new BulkModel();
             list.itemsSource = bulk.Entries;
             list.RefreshItems();
+            lastStdout = null;
             status.text = $"Downloading prefablens v{Cli.Version}…";
             content.Clear();
             Cli.DownloadAsync(OnDownloadDone);

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Threading;
 using NUnit.Framework;
@@ -160,6 +162,62 @@ namespace PrefabLens.Tests
             Assert.IsTrue(done.Wait(30_000), "callback never fired");
             Assert.AreNotEqual(0, got.Value.ExitCode);
             Assert.IsNotEmpty(got.Value.Stderr);
+        }
+
+        [Test]
+        public void ExtractToWritesEveryZipEntry()
+        {
+            // Build a real zip in memory (no fixture files) and extract it into a temp dir.
+            var buffer = new MemoryStream();
+            using (var zip = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                using (var w = new StreamWriter(zip.CreateEntry("prefablens").Open()))
+                    w.Write("binary");
+                using (var w = new StreamWriter(zip.CreateEntry("LICENSE").Open()))
+                    w.Write("apache");
+            }
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            try
+            {
+                Cli.ExtractTo(buffer.ToArray(), dir);
+                Assert.AreEqual("binary", File.ReadAllText(Path.Combine(dir, "prefablens")));
+                Assert.AreEqual("apache", File.ReadAllText(Path.Combine(dir, "LICENSE")));
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Test]
+        public void DeleteStaleVersionsKeepsOnlyThePinnedVersion()
+        {
+            // Simulates Library/PrefabLens after a package upgrade: the old cache dir
+            // must be removed, the freshly downloaded pinned version must survive.
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(Path.Combine(root, "0.5.0"));
+            File.WriteAllText(Path.Combine(root, "0.5.0", "prefablens"), "old");
+            Directory.CreateDirectory(Path.Combine(root, "0.6.1"));
+            try
+            {
+                Cli.DeleteStaleVersions(root, keep: "0.6.1");
+                Assert.IsFalse(Directory.Exists(Path.Combine(root, "0.5.0")));
+                Assert.IsTrue(Directory.Exists(Path.Combine(root, "0.6.1")));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
+        public void DeleteStaleVersionsToleratesAMissingRoot()
+        {
+            // First-ever download: Library/PrefabLens does not exist yet.
+            // Cleanup must be a silent no-op, not a DirectoryNotFoundException.
+            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Assert.DoesNotThrow(() => Cli.DeleteStaleVersions(root, keep: "0.6.1"));
         }
     }
 }


### PR DESCRIPTION
## Summary

The Unity Editor window now downloads the pinned `prefablens` CLI binary automatically when it is missing, instead of showing a "Download from GitHub Releases" button on every package-version bump. The download runs off the main thread with progress in the status line, and stale `Library/PrefabLens/<old-version>/` caches are cleaned up best-effort after a successful download.

Closes #135

## Motivation

`Cli.Version` bumps with every package update, so each upgrade dropped users back to the not-found screen for a click that adds nothing: installing the package already expressed intent, the asset is version-pinned from the project's own releases, and the README/site copy has always described the download as automatic. The old code also blocked the Unity main thread behind a modal progress bar, which auto-triggering would have made unacceptable.

## Changes

- `Cli.Download()` no longer touches Unity APIs (modal progress bar removed) so it can run on a worker thread; `.GetAwaiter().GetResult()` unwraps `AggregateException` for clean error messages
- New `Cli.DownloadAsync(Action<string, string> onDone)` mirrors the existing `RunAsync` SynchronizationContext pattern; exactly one of (path, error) is non-null
- New pure helpers `Cli.ExtractTo` and `Cli.DeleteStaleVersions` (best-effort: a locked old-version directory on Windows cannot fail a successful download), both unit-tested
- `PrefabLensWindow.Refresh()` auto-starts the download once per session when `Cli.Find()` misses; status line shows `Downloading prefablens v{Version}…`; failure falls back to the manual screen with the error and a retry button sharing the same `StartDownload` path; `DownloadThenRefresh` deleted
- Both list-reset sites also null `lastStdout` so the post-download re-render cannot be skipped by `OnBulkDone`'s unchanged-output dedupe (this also fixes a pre-existing latent variant on the manual path)
- The `EditorPrefs` manual override (`PrefabLens.CliPath`) and version pinning are unchanged; no PATH search

## Testing

- `dotnet test DotNetTests~/Tests`: 25/25 passed (3 new tests: real in-memory zip extraction, stale-version cleanup, missing-root no-op)
- `dotnet csharpier check . --no-msbuild-check`: clean
- TDD: the new tests failed with CS0117 before the implementation existed, then passed
- Reviewed: per-task reviews plus a whole-branch review walked the download/refresh state machine (first open, focus during download, failure + refocus, manual retry, success, mid-session binary loss) — verdict "Ready to merge"

> [!NOTE]
> Post-merge manual task: real-Unity GUI smoke — with a fresh `Library/`, open `Window > PrefabLens` and confirm the automatic download then the changed list; offline, confirm the error + retry screen. The dotnet harness proves compile + pure logic only.