### PR TITLE
ci: gate prs on approved linked issues

### DIFF
--- a/.github/workflows/pr-issue-gate.yml
+++ b/.github/workflows/pr-issue-gate.yml
@@ -1,0 +1,110 @@
+name: PR issue gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, edited]
+  # Manual entry point for E2E tests: OWNER PRs are exempt below, so a
+  # scratch PR can only be exercised by dispatching with its number.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to check
+        required: true
+
+permissions: {}
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    # The owner, Renovate, and the bot itself are exempt from the gate.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.author_association != 'OWNER' &&
+       github.event.pull_request.user.login != 'renovate[bot]' &&
+       github.event.pull_request.user.login != 'unidog-bot[bot]')
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Enforce issue-first flow
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          owner=${REPO%/*} name=${REPO#*/}
+
+          # One query answers everything: the PR's own labels (maintainer
+          # escape hatch for trivial fixes), the labels of every issue the
+          # body closes, and the draft state the enforcement step needs.
+          data=$(gh api graphql -F owner="$owner" -F name="$name" \
+            -F number="$PR_NUMBER" -f query='
+            query($owner: String!, $name: String!, $number: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  id
+                  isDraft
+                  labels(first: 50) { nodes { name } }
+                  closingIssuesReferences(first: 20) {
+                    nodes { labels(first: 50) { nodes { name } } }
+                  }
+                }
+              }
+            }')
+
+          approved=$(jq -r '
+            .data.repository.pullRequest
+            | [.labels.nodes[].name]
+              + [.closingIssuesReferences.nodes[].labels.nodes[].name]
+            | any(. == "approved")' <<<"$data")
+          if [ "$approved" = "true" ]; then
+            echo "gate passed: approved issue linked or PR labeled"
+            exit 0
+          fi
+
+          body=$(cat <<'EOF'
+          <!-- pr-issue-gate -->
+          Thanks for the pull request!
+
+          PrefabLens is pre-1.0 and follows an **issue-first** flow (see [CONTRIBUTING.md](https://github.com/hashiiiii/PrefabLens/blob/main/CONTRIBUTING.md)): breaking changes and large refactors are in flight, and a PR without prior discussion is likely to conflict with them or wait unreviewed.
+
+          To get this PR reviewed:
+
+          1. Open an issue describing the change (or pick an existing one) and discuss the approach.
+          2. Wait for a maintainer to add the `approved` label to that issue.
+          3. Link the issue from this PR's body with `Closes #NNN`, then mark the PR **Ready for review**.
+
+          Until then this PR stays in draft.
+          EOF
+          )
+          # The marker is the comment's first line; reusing it avoids a
+          # second copy that could drift.
+          marker=$(head -1 <<<"$body")
+
+          # .[] streams across the concatenated arrays --paginate emits,
+          # so this stays correct past 100 comments.
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate |
+            jq -r --arg marker "$marker" \
+              '.[] | select(.body | startswith($marker)) | .id' | head -1)
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
+              -f body="$body" --silent
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body="$body" --silent
+          fi
+
+          if [ "$(jq -r '.data.repository.pullRequest.isDraft' <<<"$data")" = "false" ]; then
+            gh api graphql \
+              -F id="$(jq -r '.data.repository.pullRequest.id' <<<"$data")" \
+              -f query='
+              mutation($id: ID!) {
+                convertPullRequestToDraft(input: { pullRequestId: $id }) {
+                  pullRequest { isDraft }
+                }
+              }'
+          fi
+          echo "gate failed: commented and ensured draft state"

--- a/.github/workflows/pr-issue-gate.yml
+++ b/.github/workflows/pr-issue-gate.yml
@@ -11,6 +11,12 @@ on:
         description: PR number to check
         required: true
 
+# One run per PR at a time; a newer trigger supersedes an in-flight run
+# so the sticky comment is never double-posted by a race.
+concurrency:
+  group: pr-issue-gate-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/pr-issue-gate.yml
+++ b/.github/workflows/pr-issue-gate.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, reopened, ready_for_review, edited]
   # Manual entry point for E2E tests: OWNER PRs are exempt below, so a
   # scratch PR can only be exercised by dispatching with its number.
+  # Dispatch runs skip the exemptions entirely — never point one at a
+  # Renovate PR (drafting it stalls automerge).
   workflow_dispatch:
     inputs:
       pr_number:
@@ -55,16 +57,23 @@ jobs:
                   isDraft
                   labels(first: 50) { nodes { name } }
                   closingIssuesReferences(first: 20) {
-                    nodes { labels(first: 50) { nodes { name } } }
+                    nodes {
+                      repository { nameWithOwner }
+                      labels(first: 50) { nodes { name } }
+                    }
                   }
                 }
               }
             }')
 
-          approved=$(jq -r '
+          # Cross-repo closing links don't count: a contributor could
+          # self-apply an approved label in a repo they own.
+          approved=$(jq -r --arg repo "$REPO" '
             .data.repository.pullRequest
             | [.labels.nodes[].name]
-              + [.closingIssuesReferences.nodes[].labels.nodes[].name]
+              + [.closingIssuesReferences.nodes[]
+                 | select(.repository.nameWithOwner == $repo)
+                 | .labels.nodes[].name]
             | any(. == "approved")' <<<"$data")
           if [ "$approved" = "true" ]; then
             echo "gate passed: approved issue linked or PR labeled"
@@ -91,10 +100,13 @@ jobs:
           marker=$(head -1 <<<"$body")
 
           # .[] streams across the concatenated arrays --paginate emits,
-          # so this stays correct past 100 comments.
+          # so this stays correct past 100 comments. Only the bot's own
+          # comment counts: a planted marker by someone else must not
+          # be PATCHed (it would 403 and abort before draft conversion).
           existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate |
             jq -r --arg marker "$marker" \
-              '.[] | select(.body | startswith($marker)) | .id' | head -1)
+              '.[] | select(.user.login == "unidog-bot[bot]")
+                   | select(.body | startswith($marker)) | .id' | head -1)
           if [ -n "$existing" ]; then
             gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
               -f body="$body" --silent


### PR DESCRIPTION
## Summary

Add a `pr-issue-gate` workflow: PRs without an `approved` linked issue get an issue-first guidance comment from unidog-bot and are converted to draft.

## Motivation

PrefabLens is pre-1.0; CONTRIBUTING (#54) states the issue-first policy, and this workflow enforces it reactively — PR creation itself cannot be blocked on GitHub. Gate passes when a `Closes #NNN`-linked issue in this repository (or the PR itself, as a maintainer escape hatch) carries the `approved` label. The owner, `renovate[bot]`, and `unidog-bot[bot]` are exempt.

**Merge after #54** — the bot comment links to `CONTRIBUTING.md` on `main`, which #54 introduces.

## Changes

- `.github/workflows/pr-issue-gate.yml`: `pull_request_target` (opened/reopened/ready_for_review/edited), no PR code checkout, unidog-bot App token for all API calls; sticky marker comment (bot-authored only) + `convertPullRequestToDraft`; per-PR `concurrency` group; cross-repo `Closes` links are ignored (a contributor could self-apply `approved` in a repo they own); `workflow_dispatch` entry for E2E testing (OWNER PRs are exempt from the real trigger).
- Created the `approved` label (repo settings, not in this diff).

## Testing

- `ruby -ryaml` parses the workflow; extracted `run` script passes `bash -n`.
- jq gate predicate verified against fixtures: same-repo `approved` issue → `true`; cross-repo `approved` issue → `false`; empty references → `false`.
- E2E after merge (workflow runs from the default branch): scratch PR without a linked issue → dispatch → expect bot comment + draft conversion; then `approved` on a linked scratch issue → dispatch → expect pass. Results will be posted in this PR.
- Known risk: `convertPullRequestToDraft` may fail for App tokens (actions/toolkit#1165 documents it for GITHUB_TOKEN). The E2E run settles it; fallback is a classic PAT for the draft call only.