### PR TITLE
docs: document site and contributing in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Try the [live demo](https://hashiiiii.github.io/PrefabLens/) — the extension's
 | `cli/` | `prefablens` command-line tool |
 | `extension/` | Chrome extension for semantic diffs on GitHub pull requests |
 | `editor/` | Unity Editor package for semantic UnityYAML diffs |
+| `site/` | Live demo site published to GitHub Pages, built from the CLI and extension artifacts |
 
 ## Installation
 
@@ -51,6 +52,8 @@ Download the zip for your platform from [GitHub Releases](https://github.com/has
 Install from the [Chrome Web Store](https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip).
 
 ### Unity Editor package (OpenUPM)
+
+Requires Unity 2022.3 or newer.
 
 ```bash
 openupm add com.hashiiiii.prefablens
@@ -111,7 +114,14 @@ cd extension && pnpm install && pnpm run build && pnpm test
 
 # Editor (EditMode tests run on .NET, no Unity required)
 cd editor && dotnet test DotNetTests~/Tests
+
+# Site (build the CLI, WASM, and extension demo bundle first: `pnpm run demo`)
+cd site && node --test src/*.test.mjs && node build.mjs
 ```
+
+## Contributing
+
+Contributions follow an issue-first flow: open an issue and wait for the `approved` label before sending a pull request. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## License
 


### PR DESCRIPTION
## Summary

Fill the README gaps found in a coverage review: the `site/` directory, a Contributing pointer, and the minimum Unity version for the editor package.

## Motivation

`site/` is a top-level directory with CI-enforced tests, but the README neither lists it in Components nor documents its build. CONTRIBUTING.md is unlinked, so contributors meet the pr-issue-gate draft conversion without warning. The OpenUPM section omits the Unity floor declared in `editor/package.json`.

Closes #141

## Changes

- Add a `site/` row to the Components table.
- Add the site test/build commands to the Development section, mirroring the `site` job in `ci.yml`.
- Add a Contributing section linking CONTRIBUTING.md and naming the issue-first flow.
- State "Requires Unity 2022.3 or newer" in the OpenUPM install section.

## Testing

Ran the exact commands now documented in the Development section (with `zig-out` binaries and `extension/dist/demo.js` already built):

```
$ cd site && node --test src/*.test.mjs && node build.mjs
ℹ tests 4
ℹ pass 4
ℹ fail 0
site built at .../site/dist
```