### PR TITLE
docs: remove install section from editor page

### DIFF
--- a/site/static/editor.html
+++ b/site/static/editor.html
@@ -57,16 +57,6 @@
           and <code>.controller</code>.
         </p>
       </section>
-
-      <section class="install page-section">
-        <h2>Install</h2>
-        <dl>
-          <dt>OpenUPM</dt>
-          <dd><pre><code>openupm add com.hashiiiii.prefablens</code></pre></dd>
-          <dt>Package Manager git URL</dt>
-          <dd><pre><code>https://github.com/hashiiiii/PrefabLens.git?path=editor</code></pre></dd>
-        </dl>
-      </section>
     </main>
     <footer class="site-footer">
       Requires Unity 2022.3 or newer. Source on


### PR DESCRIPTION
## Summary

Removes the Install section from the site's Unity Editor page so install guidance lives only in the landing page's "Get PrefabLens" section.

## Motivation

editor.html was the only individual page with its own Install section (added in #134), duplicating the landing entries; the extension and CLI demo pages have none. Consolidating on the landing page makes all three individual pages consistent.

Closes #145

## Changes

- Delete the `<section class="install page-section">` block (OpenUPM + Package Manager git URL) from `site/static/editor.html`.
- No landing, CSS, or build changes: `.install` styles are still used by `index.html`.

## Testing

```
$ cd site && node --test src/*.test.mjs && node build.mjs
ℹ tests 4
ℹ pass 4
ℹ fail 0
site built at .../site/dist

$ grep -ci "install" site/dist/editor.html || echo "editor: no install"
0
editor: no install
$ grep -c "Get PrefabLens" site/dist/index.html
1
```