### PR TITLE
fix: match tree order to unity hierarchy

### DIFF
--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -58,24 +58,30 @@ fn sourcePrefabGuid(doc: *const model.Document) ?[]const u8 {
     };
 }
 
-// Pick up the m_Name override as the instance name (from the after-preferred structural doc).
-fn instanceName(idx: *Index, pi_id: i64) []const u8 {
-    const doc = idx.structuralDoc(pi_id) orelse return "";
-    const m = model.findValue(doc.body.map, "m_Modification") orelse return "";
-    if (m.* != .map) return "";
-    const list = model.findValue(m.map, "m_Modifications") orelse return "";
-    if (list.* != .seq) return "";
+// Read one m_Modifications override value of a PrefabInstance by propertyPath
+// (from the after-preferred structural doc).
+fn modificationValue(idx: *Index, pi_id: i64, property_path: []const u8) ?[]const u8 {
+    const doc = idx.structuralDoc(pi_id) orelse return null;
+    const m = model.findValue(doc.body.map, "m_Modification") orelse return null;
+    if (m.* != .map) return null;
+    const list = model.findValue(m.map, "m_Modifications") orelse return null;
+    if (list.* != .seq) return null;
     for (list.seq) |item| {
         if (item.* != .map) continue;
         const pp = model.findValue(item.map, "propertyPath") orelse continue;
-        if (pp.* != .scalar or !std.mem.eql(u8, pp.scalar, "m_Name")) continue;
+        if (pp.* != .scalar or !std.mem.eql(u8, pp.scalar, property_path)) continue;
         const v = model.findValue(item.map, "value") orelse continue;
         return switch (v.*) {
             .scalar => |s| s,
-            else => "",
+            else => null,
         };
     }
-    return "";
+    return null;
+}
+
+// Pick up the m_Name override as the instance name.
+fn instanceName(idx: *Index, pi_id: i64) []const u8 {
+    return modificationValue(idx, pi_id, "m_Name") orelse "";
 }
 
 // Hop limit for walking the nesting chain. Stops even if stripped PrefabInstances
@@ -142,6 +148,92 @@ fn makeComponent(dd: diffmod.DocDiff) ComponentDiff {
         .status = dd.status,
         .fields = dd.fields,
     };
+}
+
+// Unity 2022.2+ scenes list root transforms in Hierarchy order in a SceneRoots document.
+const scene_roots_class_id = 1660057539;
+
+fn sceneRootsDoc(fd: diffmod.FlatDiff) ?*model.Document {
+    // After side preferred: it reflects the current Hierarchy.
+    for (fd.after) |*d| if (d.class_id == scene_roots_class_id) return d;
+    for (fd.before) |*d| if (d.class_id == scene_roots_class_id) return d;
+    return null;
+}
+
+// Stable reorder of node ids against a list of transform refs (m_Children / m_Roots):
+// ids matching a ref (in ref order) first, the rest in insertion order after them
+// (removed objects have no position in the after-side Hierarchy anymore).
+fn orderByTransformRefs(arena: std.mem.Allocator, idx: *Index, refs: []*model.Node, list: *std.ArrayList(i64)) !void {
+    var members = std.AutoHashMap(i64, void).init(arena);
+    for (list.items) |id| try members.put(id, {});
+    var picked = std.AutoHashMap(i64, void).init(arena);
+    var out: std.ArrayList(i64) = .empty;
+    try out.ensureTotalCapacity(arena, list.items.len);
+    for (refs) |r| {
+        const tid = refFileId(r) orelse continue;
+        const owner = ownerNodeIdOfTransform(idx, tid) orelse continue;
+        if (!members.contains(owner) or picked.contains(owner)) continue;
+        try picked.put(owner, {});
+        out.appendAssumeCapacity(owner);
+    }
+    for (list.items) |id| {
+        if (!picked.contains(id)) out.appendAssumeCapacity(id);
+    }
+    list.* = out;
+}
+
+// Reorder a sibling list to the parent Transform's m_Children order. A PrefabInstance
+// parent keeps insertion order: its inner transforms live in the source prefab, so the
+// outer document carries no sibling order for them.
+fn orderChildren(arena: std.mem.Allocator, idx: *Index, parent_id: i64, list: *std.ArrayList(i64)) !void {
+    const parent = idx.structuralDoc(parent_id) orelse return;
+    if (parent.class_id != 1) return;
+    const tr = transformOf(idx, parent_id) orelse return;
+    const kids = model.findValue(tr.body.map, "m_Children") orelse return;
+    if (kids.* != .seq) return;
+    try orderByTransformRefs(arena, idx, kids.seq, list);
+}
+
+fn rootOrderOf(idx: *Index, id: i64) ?i64 {
+    const doc = idx.structuralDoc(id) orelse return null;
+    if (doc.class_id == 1001) {
+        const s = modificationValue(idx, id, "m_RootOrder") orelse return null;
+        return std.fmt.parseInt(i64, s, 10) catch null;
+    }
+    const tr = transformOf(idx, id) orelse return null;
+    const v = model.findValue(tr.body.map, "m_RootOrder") orelse return null;
+    return switch (v.*) {
+        .scalar => |s| std.fmt.parseInt(i64, s, 10) catch null,
+        else => null,
+    };
+}
+
+// Scene root order: SceneRoots.m_Roots when present, else the per-transform
+// m_RootOrder of older scene formats. Prefabs and .asset files carry neither,
+// so they fall through untouched.
+fn orderRoots(arena: std.mem.Allocator, idx: *Index, fd: diffmod.FlatDiff, roots_ids: *std.ArrayList(i64)) !void {
+    if (sceneRootsDoc(fd)) |doc| {
+        const roots = model.findValue(doc.body.map, "m_Roots") orelse return;
+        if (roots.* != .seq) return;
+        try orderByTransformRefs(arena, idx, roots.seq, roots_ids);
+        return;
+    }
+    const Keyed = struct { key: i64, pos: usize, id: i64 };
+    const keyed = try arena.alloc(Keyed, roots_ids.items.len);
+    var any_key = false;
+    for (roots_ids.items, 0..) |id, i| {
+        const key = rootOrderOf(idx, id);
+        if (key != null) any_key = true;
+        keyed[i] = .{ .key = key orelse std.math.maxInt(i64), .pos = i, .id = id };
+    }
+    if (!any_key) return;
+    std.mem.sort(Keyed, keyed, {}, struct {
+        fn lessThan(_: void, a: Keyed, b: Keyed) bool {
+            if (a.key != b.key) return a.key < b.key;
+            return a.pos < b.pos;
+        }
+    }.lessThan);
+    for (keyed, 0..) |k, i| roots_ids.items[i] = k.id;
 }
 
 pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
@@ -238,6 +330,12 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         try linkToParent(arena, &obj_by_id, &children_of, &roots_ids, parentGoId(&idx, go_id), go_id);
     for (pi_ids.items) |pi_id|
         try linkToParent(arena, &obj_by_id, &children_of, &roots_ids, instanceParentId(&idx, pi_id), pi_id);
+
+    // Reorder siblings and roots to Unity's Hierarchy order; document order in the
+    // file is unrelated to it (often exactly reversed).
+    var cit = children_of.iterator();
+    while (cit.next()) |e| try orderChildren(arena, &idx, e.key_ptr.*, e.value_ptr);
+    try orderRoots(arena, &idx, fd, &roots_ids);
 
     // Materialize recursively, pruning unchanged subtrees with no changed descendants.
     var roots: std.ArrayList(ObjectDiff) = .empty;
@@ -407,6 +505,357 @@ test "tree: child GameObject nests under parent via Transform m_Father" {
     const parent = findRoot(res, 1).?;
     try testing.expectEqual(@as(usize, 1), parent.children.len);
     try testing.expectEqual(@as(i64, 2), parent.children[0].file_id);
+}
+
+test "tree: siblings follow the parent transform's m_Children order, not document order" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // The file lists B before A, but the parent's m_Children puts A first (Unity Hierarchy order).
+    const before =
+        \\--- !u!1 &3
+        \\GameObject:
+        \\  m_Name: B
+        \\  m_Component:
+        \\  - component: {fileID: 6}
+        \\--- !u!4 &6
+        \\Transform:
+        \\  m_GameObject: {fileID: 3}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: A
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_Children:
+        \\  - {fileID: 5}
+        \\  - {fileID: 6}
+    ;
+    const after =
+        \\--- !u!1 &3
+        \\GameObject:
+        \\  m_Name: B2
+        \\  m_Component:
+        \\  - component: {fileID: 6}
+        \\--- !u!4 &6
+        \\Transform:
+        \\  m_GameObject: {fileID: 3}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: A2
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_Children:
+        \\  - {fileID: 5}
+        \\  - {fileID: 6}
+    ;
+    const res = try root.diffBytes(arena, before, after);
+    const parent = findRoot(res, 1).?;
+    try testing.expectEqual(@as(usize, 2), parent.children.len);
+    try testing.expectEqual(@as(i64, 2), parent.children[0].file_id);
+    try testing.expectEqual(@as(i64, 3), parent.children[1].file_id);
+}
+
+test "tree: scene roots follow SceneRoots m_Roots order" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // Document order is Floor, Crate, Sun; the Hierarchy order in SceneRoots is the reverse.
+    const before =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Floor
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Crate
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &3
+        \\GameObject:
+        \\  m_Name: Sun
+        \\  m_Component:
+        \\  - component: {fileID: 6}
+        \\--- !u!4 &6
+        \\Transform:
+        \\  m_GameObject: {fileID: 3}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1660057539 &9223372036854775807
+        \\SceneRoots:
+        \\  m_Roots:
+        \\  - {fileID: 6}
+        \\  - {fileID: 5}
+        \\  - {fileID: 4}
+    ;
+    const after =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Floor2
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Crate2
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1 &3
+        \\GameObject:
+        \\  m_Name: Sun2
+        \\  m_Component:
+        \\  - component: {fileID: 6}
+        \\--- !u!4 &6
+        \\Transform:
+        \\  m_GameObject: {fileID: 3}
+        \\  m_Father: {fileID: 0}
+        \\--- !u!1660057539 &9223372036854775807
+        \\SceneRoots:
+        \\  m_Roots:
+        \\  - {fileID: 6}
+        \\  - {fileID: 5}
+        \\  - {fileID: 4}
+    ;
+    const res = try root.diffBytes(arena, before, after);
+    try testing.expectEqual(@as(usize, 3), res.roots.len);
+    try testing.expectEqual(@as(i64, 3), res.roots[0].file_id);
+    try testing.expectEqual(@as(i64, 2), res.roots[1].file_id);
+    try testing.expectEqual(@as(i64, 1), res.roots[2].file_id);
+    // The unchanged SceneRoots document itself stays invisible.
+    try testing.expectEqual(@as(usize, 0), res.loose.len);
+}
+
+test "tree: roots follow m_RootOrder when SceneRoots is absent" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // Old scene format: no SceneRoots document, each root transform carries m_RootOrder.
+    const before =
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Y
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 0}
+        \\  m_RootOrder: 1
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: X
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_RootOrder: 0
+    ;
+    const after =
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Y2
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 0}
+        \\  m_RootOrder: 1
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: X2
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_RootOrder: 0
+    ;
+    const res = try root.diffBytes(arena, before, after);
+    try testing.expectEqual(@as(usize, 2), res.roots.len);
+    try testing.expectEqual(@as(i64, 1), res.roots[0].file_id);
+    try testing.expectEqual(@as(i64, 2), res.roots[1].file_id);
+}
+
+test "tree: prefab instance ranks among siblings via its stripped transform" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // m_Children lists the instance's stripped transform (42) before the plain child (5).
+    const after =
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: C
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_TransformParent: {fileID: 4}
+        \\    m_Modifications:
+        \\    - target: {fileID: 8, guid: aaa, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Inst
+        \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
+        \\--- !u!4 &42 stripped
+        \\Transform:
+        \\  m_PrefabInstance: {fileID: 1001}
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_Children:
+        \\  - {fileID: 42}
+        \\  - {fileID: 5}
+    ;
+    const res = try root.diffBytes(arena, "", after);
+    const parent = findRoot(res, 1).?;
+    try testing.expectEqual(@as(usize, 2), parent.children.len);
+    try testing.expectEqual(@as(i64, 1001), parent.children[0].file_id);
+    try testing.expectEqual(@as(i64, 2), parent.children[1].file_id);
+}
+
+test "tree: removed child sorts after siblings present in m_Children" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // R only exists on the before side; the after-side m_Children ranks A before B,
+    // and the deleted R has no Hierarchy position anymore so it goes last.
+    const before =
+        \\--- !u!1 &9
+        \\GameObject:
+        \\  m_Name: R
+        \\  m_Component:
+        \\  - component: {fileID: 7}
+        \\--- !u!4 &7
+        \\Transform:
+        \\  m_GameObject: {fileID: 9}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &3
+        \\GameObject:
+        \\  m_Name: B
+        \\  m_Component:
+        \\  - component: {fileID: 6}
+        \\--- !u!4 &6
+        \\Transform:
+        \\  m_GameObject: {fileID: 3}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: A
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_Children:
+        \\  - {fileID: 5}
+        \\  - {fileID: 7}
+        \\  - {fileID: 6}
+    ;
+    const after =
+        \\--- !u!1 &3
+        \\GameObject:
+        \\  m_Name: B2
+        \\  m_Component:
+        \\  - component: {fileID: 6}
+        \\--- !u!4 &6
+        \\Transform:
+        \\  m_GameObject: {fileID: 3}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: A2
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 4}
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Parent
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+        \\  m_Children:
+        \\  - {fileID: 5}
+        \\  - {fileID: 6}
+    ;
+    const res = try root.diffBytes(arena, before, after);
+    const parent = findRoot(res, 1).?;
+    try testing.expectEqual(@as(usize, 3), parent.children.len);
+    try testing.expectEqual(@as(i64, 2), parent.children[0].file_id);
+    try testing.expectEqual(@as(i64, 3), parent.children[1].file_id);
+    try testing.expectEqual(@as(i64, 9), parent.children[2].file_id);
+    try testing.expectEqual(model.Status.removed, parent.children[2].status);
 }
 
 test "tree: removed GameObject surfaces as a removed root with its name" {


### PR DESCRIPTION
## Summary

Order the diff tree the way Unity's Hierarchy window does: siblings follow the parent Transform's `m_Children` array, and scene roots follow `SceneRoots.m_Roots` (or `m_RootOrder` for old scene formats) instead of YAML document order.

## Motivation

Unity serializes YAML documents in an order unrelated (often exactly reversed) to the Hierarchy. `core/src/tree.zig` built the tree in document order, so the editor window, CLI, and extension all showed objects in the wrong order — e.g. the Playground scene fixture rendered Floor → Crate → Sun while the Hierarchy shows Sun → Crate → Floor. One fix in core corrects all three surfaces.

Closes #150

## Changes

- Reorder each sibling list to the parent Transform/RectTransform `m_Children` order; PrefabInstance children rank via their stripped root Transform (reusing `ownerNodeIdOfTransform`).
- Reorder roots by `SceneRoots.m_Roots` (class 1660057539, after side preferred) when present, else stable-sort by `m_RootOrder` (PrefabInstance roots read it from `m_Modifications`); prefabs and `.asset` files fall through untouched.
- Nodes absent from the after-side ordering data (removed objects) keep insertion order after the ranked ones.
- Extract `modificationValue` from `instanceName` for reuse.
- Add five ordering tests (m_Children siblings, SceneRoots roots, m_RootOrder fallback, instance-among-siblings, removed-child placement).

## Testing

- `zig build test --summary all` — 168/168 tests passed (the five new tests failed before the fix with reversed order, e.g. `expected 2, found 3`).
- `pnpm test` (extension) — 187/187 passed.
- `dotnet test` (editor DotNetTests~) — 34/34 passed.
- CLI on real fixtures:
  - `prefablens site/fixtures/{before,after}/Assets/Scenes/Playground.unity` now prints roots Sun → Crate → Floor, matching `SceneRoots.m_Roots` (previously Floor → Crate → Sun).
  - Empty-vs-`Robot.prefab` diff now prints Robot → Arm → Sensor, matching the root Transform's `m_Children` (document order is Sensor → Arm).