### PR TITLE
feat: support github's react-based diff ui

### DIFF
--- a/extension/e2e/fixtures/pr-files-react.html
+++ b/extension/e2e/fixtures/pr-files-react.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html data-color-mode="light">
+  <head>
+    <meta charset="utf-8" /><title>PR fixture (react diff ui)</title>
+  </head>
+  <body>
+    <div data-testid="diff-content">
+      <div data-hpc="true" data-testid="progressive-diffs-list" class="d-flex flex-column gap-3">
+        <div class="PullRequestDiffsList-module__diffEntry__djnVa">
+          <div role="region" id="diff-aaa111" aria-labelledby="h0" class="Diff-module__diffTargetable Diff-module__diff">
+            <div class="Diff-module__diffHeaderWrapper">
+              <div class="DiffFileHeader-module__diff-file-header">
+                <h3 id="h0" class="DiffFileHeader-module__file-name">
+                  <a class="Link--primary" href="#diff-aaa111"><code>&#x200e;Assets/Foo.prefab&#x200e;</code></a>
+                </h3>
+                <button type="button" aria-expanded="true" aria-label="Collapse file">
+                  <svg class="octicon octicon-chevron-down"></svg>
+                </button>
+              </div>
+            </div>
+            <div class="Diff-module__diffContent">raw github diff table</div>
+          </div>
+        </div>
+        <div class="PullRequestDiffsList-module__diffEntry__djnVa">
+          <div role="region" id="diff-bbb222" aria-labelledby="h1" class="Diff-module__diffTargetable Diff-module__diff">
+            <div class="Diff-module__diffHeaderWrapper">
+              <div class="DiffFileHeader-module__diff-file-header">
+                <h3 id="h1" class="DiffFileHeader-module__file-name">
+                  <a class="Link--primary" href="#diff-bbb222"><code>&#x200e;Assets/Big.unity&#x200e;</code></a>
+                </h3>
+                <button type="button" aria-expanded="true" aria-label="Collapse file">
+                  <svg class="octicon octicon-chevron-down"></svg>
+                </button>
+              </div>
+            </div>
+            <div class="Diff-module__diffContent">raw github diff table</div>
+          </div>
+        </div>
+        <div class="PullRequestDiffsList-module__diffEntry__djnVa">
+          <div role="region" id="diff-ccc333" aria-labelledby="h2" class="Diff-module__diffTargetable Diff-module__diff">
+            <div class="Diff-module__diffHeaderWrapper">
+              <div class="DiffFileHeader-module__diff-file-header">
+                <h3 id="h2" class="DiffFileHeader-module__file-name">
+                  <a class="Link--primary" href="#diff-ccc333"><code>&#x200e;README.md&#x200e;</code></a>
+                </h3>
+                <button type="button" aria-expanded="true" aria-label="Collapse file">
+                  <svg class="octicon octicon-chevron-down"></svg>
+                </button>
+              </div>
+            </div>
+            <div class="Diff-module__diffContent">raw github diff table</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/extension/e2e/react.spec.ts
+++ b/extension/e2e/react.spec.ts
@@ -1,0 +1,144 @@
+/// <reference types="node" />
+
+import { readFileSync } from "node:fs";
+import { expect, type Page, test } from "@playwright/test";
+
+const fixture = readFileSync(new URL("./fixtures/pr-files-react.html", import.meta.url), "utf8");
+
+// Same chrome stub as smoke.spec.ts: storage is mandatory for init, semanticDiff is canned.
+function stubChrome(page: Page, res: unknown, viewMode?: string) {
+  return page.addInitScript(
+    ({ res, viewMode }) => {
+      (window as unknown as Record<string, unknown>).chrome = {
+        runtime: {
+          sendMessage: (msg: { type?: string }) =>
+            msg?.type === "semanticDiff" ? Promise.resolve(res) : Promise.resolve(),
+          onMessage: { addListener: () => {} },
+        },
+        storage: {
+          local: {
+            get: () => Promise.resolve(viewMode ? { viewMode } : {}),
+            set: () => Promise.resolve(),
+          },
+          onChanged: { addListener: () => {} },
+        },
+      };
+    },
+    { res, viewMode },
+  );
+}
+
+const cannedResponse = {
+  ok: true,
+  json: {
+    schema: "prefablens.diff.v2",
+    unresolvedGuids: [],
+    resolved: {},
+    roots: [],
+    loose: [
+      {
+        kind: "component",
+        fileId: "11400000",
+        classId: 114,
+        typeName: "MonoBehaviour",
+        scriptGuid: null,
+        className: null,
+        status: "modified",
+        fields: [{ path: "volume", status: "modified", before: "0.5", after: "0.8" }],
+      },
+    ],
+  },
+};
+
+// The react ui serves the files tab at /changes, so every test drives that URL.
+async function open(page: Page) {
+  await page.route("**/pull/1/changes", (route) => route.fulfill({ body: fixture, contentType: "text/html" }));
+  await page.goto("https://prefablens.test/owner/repo/pull/1/changes");
+  await page.addScriptTag({ path: "dist/content.js" });
+}
+
+const fooHeader = (page: Page) => page.locator('#diff-aaa111 [class*="diff-file-header"]');
+
+test("detects unity files on the react layout and renders the semantic view", async ({ page }) => {
+  await stubChrome(page, cannedResponse);
+  await open(page);
+
+  // Toggle appears only on unity file headers (path comes from header text, not data-path)
+  await expect(fooHeader(page).getByRole("button", { name: "Semantic" })).toBeVisible();
+  await expect(page.locator("#diff-ccc333 [data-prefablens-toggle]")).toHaveCount(0);
+
+  await fooHeader(page).getByRole("button", { name: "Semantic" }).click();
+  const view = page.locator("#diff-aaa111 [data-prefablens-view]");
+  await expect(view).toContainText("MonoBehaviour");
+  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeHidden();
+
+  // Back to raw restores github's body and hides ours
+  await fooHeader(page).getByRole("button", { name: "Raw" }).click();
+  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeVisible();
+  await expect(view).toBeHidden();
+});
+
+test("global toggle mounts before the virtualized list, not inside a recycled item", async ({ page }) => {
+  await stubChrome(page, cannedResponse);
+  await open(page);
+
+  await expect(page.locator("[data-prefablens-global]")).toHaveCount(1);
+  await expect(page.locator('[data-prefablens-global] + [data-testid="progressive-diffs-list"]')).toHaveCount(1);
+
+  // Global semantic switches both unity files, readme untouched
+  await page.locator("[data-prefablens-global]").getByRole("button", { name: "Semantic" }).click();
+  await expect(page.locator("[data-prefablens-view]")).toHaveCount(2);
+});
+
+test("github's collapse chevron hides the semantic view and re-hides a remounted body", async ({ page }) => {
+  await stubChrome(page, cannedResponse);
+  await open(page);
+
+  await fooHeader(page).getByRole("button", { name: "Semantic" }).click();
+  const view = page.locator("#diff-aaa111 [data-prefablens-view]");
+  await expect(view).toContainText("MonoBehaviour");
+
+  // Collapse: react swaps the chevron icon and unmounts the body node
+  await page.evaluate(() => {
+    const region = document.querySelector("#diff-aaa111")!;
+    region.querySelector(".octicon-chevron-down")!.setAttribute("class", "octicon octicon-chevron-right");
+    region.querySelector(".Diff-module__diffContent")!.remove();
+  });
+  await expect(view).toBeHidden();
+
+  // Expand: react remounts a FRESH body node (no inline style) and swaps the icon back.
+  // The per-scan sync must re-hide the new body and re-show our view.
+  await page.evaluate(() => {
+    const region = document.querySelector("#diff-aaa111")!;
+    region.querySelector(".octicon-chevron-right")!.setAttribute("class", "octicon octicon-chevron-down");
+    const body = document.createElement("div");
+    body.className = "Diff-module__diffContent";
+    body.textContent = "raw github diff table";
+    region.append(body);
+  });
+  await expect(view).toBeVisible();
+  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeHidden();
+});
+
+test("virtualization: a fully remounted file re-attaches and inherits the semantic default", async ({ page }) => {
+  await stubChrome(page, cannedResponse, "semantic");
+  await open(page);
+
+  // Both unity files start semantic from the persisted default
+  await expect(page.locator("[data-prefablens-view]")).toHaveCount(2);
+
+  // Scroll-out + scroll-in: react discards the whole list item and recreates it fresh,
+  // without any of our nodes, marker attributes, or inline styles.
+  await page.evaluate(() => {
+    const entry = document.querySelector("#diff-aaa111")!.parentElement!;
+    const clone = entry.cloneNode(true) as HTMLElement;
+    clone.querySelector("[data-prefablens-view]")?.remove();
+    clone.querySelector("[data-prefablens-toggle]")?.remove();
+    clone.querySelector("[data-prefablens]")?.removeAttribute("data-prefablens");
+    for (const el of clone.querySelectorAll<HTMLElement>("[style]")) el.style.display = "";
+    entry.replaceWith(clone);
+  });
+
+  await expect(page.locator("#diff-aaa111 [data-prefablens-view]")).toBeVisible();
+  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeHidden();
+});

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -31,6 +31,19 @@ describe("parsePrUrl", () => {
     expect(parsePrUrl("/owner/repo/pull/42")).toBeNull();
     expect(parsePrUrl("/owner/repo/blob/main/a.prefab")).toBeNull();
   });
+  it("matches the react ui changes tab (rolled out since december 2025)", () => {
+    expect(parsePrUrl("/owner/repo/pull/42/changes")).toEqual({ owner: "owner", repo: "repo", prNumber: 42 });
+    // "Between commit A and B" range view, same shape github-url-detection accepts
+    expect(parsePrUrl("/owner/repo/pull/42/changes/1e27d799..e1aba6f")).toEqual({
+      owner: "owner",
+      repo: "repo",
+      prNumber: 42,
+    });
+  });
+  it("rejects the single-commit changes view (commit pages are a separate issue)", () => {
+    expect(parsePrUrl("/owner/repo/pull/42/changes/1e27d7998afdd3608d9fc3bf95ccf27fa5010641")).toBeNull();
+    expect(parsePrUrl("/owner/repo/pull/42/changes/1e27d79")).toBeNull();
+  });
 });
 
 describe("parsePrPage", () => {

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -70,7 +70,21 @@ describe("scanUnityFiles", () => {
       "Assets/Scenes/Main.unity",
       "Assets/Data/Config.asset",
     ]);
-    expect(entries[0]?.content.classList.contains("js-file-content")).toBe(true);
+    // Behavior replaces the old `content` field: hiding acts on the .js-file-content element
+    const content = document.querySelector<HTMLElement>(".file .js-file-content")!;
+    entries[0]!.setRawHidden(true);
+    expect(content.style.display).toBe("none");
+    entries[0]!.setRawHidden(false);
+    expect(content.style.display).toBe("");
+    // Classic collapse is handled by Primer's Details CSS, not by us
+    expect(entries[0]!.collapsed()).toBe(false);
+    // The global bar anchors on the .file container
+    expect(entries[0]!.globalAnchor()).toBe(document.querySelector(".file"));
+    // The host lands right after the content and opts into the Details collapse CSS
+    const host = document.createElement("div");
+    entries[0]!.attachHost(host);
+    expect(content.nextElementSibling).toBe(host);
+    expect(host.classList.contains("Details-content--hidden")).toBe(true);
   });
 
   it("finds every UnityYAML asset extension beyond the original trio", () => {
@@ -128,6 +142,108 @@ describe("scanUnityFiles", () => {
 
   it("is harmless when the expected structure is missing (defensive selectors)", () => {
     document.body.innerHTML = "<div>totally different markup</div>";
+    expect(scanUnityFiles(document)).toEqual([]);
+  });
+});
+
+// Captured shape of GitHub's react diff UI (login-gated rollout): hashed CSS-module classes,
+// path only as LRM-wrapped header text, no data-path attribute anywhere.
+const REACT_FIXTURE = `
+  <div data-testid="diff-content">
+    <div data-testid="progressive-diffs-list">
+      <div class="PullRequestDiffsList-module__diffEntry__djnVa">
+        <div role="region" id="diff-aaa111" class="Diff-module__diffTargetable Diff-module__diff">
+          <div class="Diff-module__diffHeaderWrapper">
+            <div class="DiffFileHeader-module__diff-file-header">
+              <h3 class="DiffFileHeader-module__file-name"><a href="#diff-aaa111"><code>‎Assets/Foo.prefab‎</code></a></h3>
+              <button type="button" aria-expanded="true"><svg class="octicon octicon-chevron-down"></svg></button>
+            </div>
+          </div>
+          <div class="Diff-module__diffContent">raw diff</div>
+        </div>
+      </div>
+      <div class="PullRequestDiffsList-module__diffEntry__djnVa">
+        <div role="region" id="diff-bbb222" class="Diff-module__diffTargetable Diff-module__diff">
+          <div class="Diff-module__diffHeaderWrapper">
+            <div class="DiffFileHeader-module__diff-file-header">
+              <h3 class="DiffFileHeader-module__file-name"><a href="#diff-bbb222"><code>‎README.md‎</code></a></h3>
+              <button type="button" aria-expanded="true"><svg class="octicon octicon-chevron-down"></svg></button>
+            </div>
+          </div>
+          <div class="Diff-module__diffContent">raw diff</div>
+        </div>
+      </div>
+    </div>
+  </div>
+`;
+
+describe("scanUnityFiles (react ui)", () => {
+  it("finds unity files by header text and strips bidi marks", () => {
+    document.body.innerHTML = REACT_FIXTURE;
+    const entries = scanUnityFiles(document);
+    expect(entries.map((e) => e.path)).toEqual(["Assets/Foo.prefab"]);
+  });
+
+  it("reads the renamed-to path from the visually hidden span", () => {
+    // Renames concatenate visible text and sr-only "OLD renamed to NEW" in textContent,
+    // so the sr-only form must win when present.
+    document.body.innerHTML = REACT_FIXTURE.replace(
+      "<code>‎Assets/Foo.prefab‎</code>",
+      '<code>‎Assets/{Old.prefab → New.prefab}‎<span class="sr-only">Assets/Old.prefab renamed to Assets/New.prefab</span></code>',
+    );
+    expect(scanUnityFiles(document).map((e) => e.path)).toEqual(["Assets/New.prefab"]);
+  });
+
+  it("hides every region child except the header block and our host", () => {
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    const host = document.createElement("div");
+    host.setAttribute("data-prefablens-view", "");
+    entry.attachHost(host);
+    // Host goes right after the header wrapper, inside the region
+    const region = document.querySelector("#diff-aaa111")!;
+    expect(region.children[1]).toBe(host);
+    entry.setRawHidden(true);
+    const body = region.querySelector<HTMLElement>(".Diff-module__diffContent")!;
+    expect(body.style.display).toBe("none");
+    expect(host.style.display).not.toBe("none");
+    expect(region.querySelector<HTMLElement>(".Diff-module__diffHeaderWrapper")!.style.display).not.toBe("none");
+    entry.setRawHidden(false);
+    expect(body.style.display).toBe("");
+  });
+
+  it("re-resolves body nodes on every call because react recreates them", () => {
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    entry.setRawHidden(true);
+    // Simulate a react remount: fresh body node without our inline style
+    const region = document.querySelector("#diff-aaa111")!;
+    region.querySelector(".Diff-module__diffContent")!.remove();
+    const fresh = document.createElement("div");
+    fresh.className = "Diff-module__diffContent";
+    region.append(fresh);
+    entry.setRawHidden(true);
+    expect(fresh.style.display).toBe("none");
+  });
+
+  it("reports the chevron collapse state", () => {
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    expect(entry.collapsed()).toBe(false);
+    // React swaps the chevron icon when the file is collapsed
+    const icon = document.querySelector("#diff-aaa111 .octicon-chevron-down")!;
+    icon.setAttribute("class", "octicon octicon-chevron-right");
+    expect(entry.collapsed()).toBe(true);
+  });
+
+  it("anchors the global bar on the virtualized list root", () => {
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    expect(entry.globalAnchor()).toBe(document.querySelector('[data-testid="progressive-diffs-list"]'));
+  });
+
+  it("is harmless when the react structure is missing pieces", () => {
+    document.body.innerHTML = '<div role="region" id="diff-x"><div>no header</div></div>';
     expect(scanUnityFiles(document)).toEqual([]);
   });
 });

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -236,6 +236,15 @@ describe("scanUnityFiles (react ui)", () => {
     expect(entry.collapsed()).toBe(true);
   });
 
+  it("also reads collapse from the header's collapsed module class", () => {
+    // Second signal, independent of the icon: github stamps this class on the header row
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    const header = document.querySelector("#diff-aaa111 .DiffFileHeader-module__diff-file-header")!;
+    header.classList.add("DiffFileHeader-module__collapsed__aB3cD");
+    expect(entry.collapsed()).toBe(true);
+  });
+
   it("anchors the global bar on the virtualized list root", () => {
     document.body.innerHTML = REACT_FIXTURE;
     const entry = scanUnityFiles(document)[0]!;

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -90,8 +90,11 @@ function scanReact(root: ParentNode): FileEntry[] {
           (child as HTMLElement).style.display = hidden ? "none" : "";
         }
       },
-      // React swaps the chevron octicon per state; a collapsed file shows chevron-right
-      collapsed: () => headerBlock().querySelector(".octicon-chevron-right") !== null,
+      // Two independent collapse signals: github swaps the chevron octicon per state and
+      // stamps a DiffFileHeader-module__collapsed class on the header row
+      collapsed: () =>
+        headerBlock().querySelector(".octicon-chevron-right") !== null ||
+        headerBlock().querySelector('[class*="DiffFileHeader-module__collapsed"]') !== null,
       globalAnchor: () => region.closest('[data-testid="progressive-diffs-list"]') ?? region.parentElement,
     });
   }

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -3,7 +3,11 @@ import { isUnityPath } from "../unity";
 export type FileEntry = { path: string; header: HTMLElement; content: HTMLElement };
 
 export function parsePrUrl(pathname: string): { owner: string; repo: string; prNumber: number } | null {
-  const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/files(\/|$)/.exec(pathname);
+  // files: any suffix (ranges render inline). changes (react ui): bare tab or A..B range only —
+  // a single sha under /changes/ is the commit view, which this extension does not handle yet.
+  const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/(?:files(?:\/|$)|changes(?:\/[\da-f]{7,40}\.\.[\da-f]{7,40})?\/?$)/.exec(
+    pathname,
+  );
   return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
 }
 

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -1,6 +1,13 @@
 import { isUnityPath } from "../unity";
 
-export type FileEntry = { path: string; header: HTMLElement; content: HTMLElement };
+export type FileEntry = {
+  path: string;
+  header: HTMLElement; // toggle mount point + data-prefablens marker
+  attachHost(host: HTMLElement): void; // insert the semantic-view host at the layout's spot
+  setRawHidden(hidden: boolean): void; // idempotent, re-resolves live DOM every call
+  collapsed(): boolean; // github-level file collapse state (react ui chevron)
+  globalAnchor(): Element | null; // element the global bar is inserted before
+};
 
 export function parsePrUrl(pathname: string): { owner: string; repo: string; prNumber: number } | null {
   // files: any suffix (ranges render inline). changes (react ui): bare tab or A..B range only —
@@ -18,7 +25,7 @@ export function parsePrPage(pathname: string): { owner: string; repo: string; pr
 }
 
 // Defensively searches GitHub's Files changed (classic DOM). If it doesn't match, ends harmlessly with an empty array.
-export function scanUnityFiles(root: ParentNode): FileEntry[] {
+function scanClassic(root: ParentNode): FileEntry[] {
   const out: FileEntry[] = [];
   for (const header of root.querySelectorAll<HTMLElement>(".file-header[data-path]")) {
     const path = header.dataset.path;
@@ -26,7 +33,73 @@ export function scanUnityFiles(root: ParentNode): FileEntry[] {
     const container = header.closest(".file");
     const content = container?.querySelector<HTMLElement>(".js-file-content") ?? null;
     if (!content) continue;
-    out.push({ path, header, content });
+    out.push({
+      path,
+      header,
+      attachHost(host) {
+        // Same Primer class github puts on .js-file-content: the chevron / Viewed collapse
+        // only toggles Details--on on .file, so the host must opt into that CSS itself
+        host.classList.add("Details-content--hidden");
+        content.after(host);
+      },
+      setRawHidden(hidden) {
+        content.style.display = hidden ? "none" : "";
+      },
+      collapsed: () => false, // the Details--on CSS contract hides collapsed content without our help
+      globalAnchor: () => container,
+    });
   }
   return out;
+}
+
+const BIDI_MARKS = /[‎‏]/g;
+
+/** The react ui has no path attribute: the path only exists as header text wrapped in
+ *  LRM marks, and renames add a visually hidden "OLD renamed to NEW" span. */
+function reactPath(header: HTMLElement): string | null {
+  const code = header.querySelector('[class*="file-name"] code');
+  if (!code) return null;
+  const renamed = code.querySelector("span.sr-only")?.textContent?.split(" renamed to ", 2)[1];
+  const text = (renamed ?? code.textContent ?? "").replace(BIDI_MARKS, "").trim();
+  return text || null;
+}
+
+// GitHub's react diff UI (login-gated rollout). Class names are hashed CSS modules, so
+// anchors are role/id plus class-prefix matches; the body is "any region child that isn't
+// the header block", because its class is unstable and react recreates it constantly.
+function scanReact(root: ParentNode): FileEntry[] {
+  const out: FileEntry[] = [];
+  for (const region of root.querySelectorAll<HTMLElement>('div[role="region"][id^="diff-"]')) {
+    const header = region.querySelector<HTMLElement>('[class*="diff-file-header"]');
+    if (!header) continue;
+    const path = reactPath(header);
+    if (!path || !isUnityPath(path)) continue;
+    // The region child containing the header (normally the diffHeaderWrapper)
+    const headerBlock = (): Element => {
+      let el: Element = header;
+      while (el.parentElement && el.parentElement !== region) el = el.parentElement;
+      return el;
+    };
+    out.push({
+      path,
+      header,
+      attachHost: (host) => headerBlock().after(host),
+      setRawHidden(hidden) {
+        for (const child of region.children) {
+          if (child === headerBlock() || child.hasAttribute("data-prefablens-view")) continue;
+          (child as HTMLElement).style.display = hidden ? "none" : "";
+        }
+      },
+      // React swaps the chevron octicon per state; a collapsed file shows chevron-right
+      collapsed: () => headerBlock().querySelector(".octicon-chevron-right") !== null,
+      globalAnchor: () => region.closest('[data-testid="progressive-diffs-list"]') ?? region.parentElement,
+    });
+  }
+  return out;
+}
+
+// Both scanners always run: on any given page one matches and the other yields [] harmlessly,
+// so no layout probe is needed (and a mid-rollout A/B flip can't strand us).
+export function scanUnityFiles(root: ParentNode): FileEntry[] {
+  return [...scanClassic(root), ...scanReact(root)];
 }

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -37,7 +37,7 @@ function countUnresolved(json: DiffV2): number {
 }
 
 // Targets of the global switch: drives the toggle + display of already-attached files from outside
-type Applier = { header: HTMLElement; apply(view: View): void };
+type Applier = { header: HTMLElement; apply(view: View): void; sync(): void };
 const appliers = new Set<Applier>();
 let globalToggle: Toggle | undefined;
 let currentPr = ""; // overrides are valid only while on the PR: discard when the PR changes
@@ -86,21 +86,26 @@ function attach(state: ViewState): void {
   if (key !== currentPr) {
     currentPr = key;
     state.clearOverrides();
-    // Crossing PRs also drops references to dead DOM (prevents a soft leak)
-    for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
     for (const [k, v] of views) if (!v.root.host.isConnected) views.delete(k); // not only ignore late pushes to views killed by navigation, but also cut the reference
   }
+  // The react ui virtualizes the list and discards off-screen DOM continuously, so prune
+  // dead appliers every scan, not just on PR change (also plugs the classic soft leak).
+  for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
   const entries = scanUnityFiles(document);
   if (entries.length) ensureGlobalToggle(state, entries[0]!);
   for (const entry of entries) attachToggle(state, pr, entry);
+  // Re-assert view state: react remounts diff bodies under still-marked headers, which
+  // silently undoes the inline hide. All sync operations are idempotent and fetch-free.
+  for (const a of appliers) a.sync();
 }
 
-/** Injects exactly one global toggle right before the first Unity file's .file container.
- *  The toolbar DOM changes heavily on GitHub's side, so anchor on the reliably-present .file. */
+/** Injects exactly one global toggle right before the first Unity file's layout anchor:
+ *  the .file container on classic, the virtualized list root on the react ui (a bar inside
+ *  a recycled list item would be discarded on scroll). */
 function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
   if (globalToggle?.element.closest("[data-prefablens-global]")?.isConnected) return;
-  const container = first.header.closest(".file");
-  if (!container?.parentElement) return;
+  const anchor = first.globalAnchor();
+  if (!anchor?.parentElement) return;
   const bar = document.createElement("div");
   bar.setAttribute("data-prefablens-global", "");
   const label = document.createElement("span");
@@ -108,7 +113,7 @@ function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
   label.textContent = "PrefabLens";
   const toggle = createToggle((view) => state.setDefault(view), state.defaultView());
   bar.append(label, toggle.element);
-  container.before(bar);
+  anchor.before(bar);
   globalToggle = toggle;
 }
 
@@ -120,23 +125,34 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
   let host: HTMLElement | undefined;
   let requested = false;
 
-  const show = (view: View): void => {
+  // Display-only re-assert, never fetches: safe to run on every scan even while a panel
+  // sits on an error (a fetching sync would silently hammer retries on rate limits).
+  const sync = (view: View): void => {
     if (view === "raw") {
-      entry.content.style.display = "";
+      entry.setRawHidden(false);
       if (host) host.style.display = "none";
       return;
     }
-    entry.content.style.display = "none";
+    if (!host) return; // semantic never rendered here: leave the raw diff alone
+    entry.setRawHidden(true);
+    if (!host.isConnected) entry.attachHost(host); // a react remount can drop the host together with the old body
+    // Follow github's own collapse (react ui): the classic layout handles this via the
+    // Details CSS class added in attachHost instead, where collapsed() is always false.
+    host.style.display = entry.collapsed() ? "none" : "";
+  };
+
+  const show = (view: View): void => {
+    if (view === "raw") {
+      sync(view);
+      return;
+    }
     if (!host) {
       host = document.createElement("div");
       host.setAttribute("data-prefablens-view", "");
-      // Same Primer class github puts on .js-file-content: the chevron / Viewed collapse
-      // only toggles Details--on on .file, so the host must opt into that CSS itself
-      host.classList.add("Details-content--hidden");
       host.attachShadow({ mode: "open" });
-      entry.content.after(host);
+      entry.attachHost(host);
     }
-    host.style.display = "";
+    sync(view);
     if (requested) return; // cache only successful results per file (re-toggle doesn't re-fetch)
     const root = host.shadowRoot!;
     const request = (force?: boolean): void => {
@@ -173,6 +189,7 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
       toggle.set(view);
       show(view);
     },
+    sync: () => sync(state.effective(entry.path)),
   });
 
   // If the default is semantic, start rendering at attach time: lazy-loaded files also pass through here, so


### PR DESCRIPTION
## Summary

Support GitHub's new React-based "Files changed" UI (login-gated rollout, `/pull/N/changes`) in the Chrome extension: Unity-file detection, the per-file toggle, semantic-view injection, and the global toggle bar now work on both the classic and the React layouts.

## Motivation

The extension only matched the classic DOM (`.file-header[data-path]`, `.js-file-content`); on the React UI those selectors match nothing and the extension silently does nothing. The React UI has been GitHub's default for logged-in users since late 2025, so the product's primary channel was at risk.

Closes #159

## Changes

- `parsePrUrl` accepts `/pull/N/changes` and `/pull/N/changes/<sha>..<sha>` (a single sha under `/changes/` is the commit view and stays out of scope), mirroring `github-url-detection`
- `detect.ts`: `FileEntry` is now a per-layout adapter (`attachHost` / `setRawHidden` / `collapsed` / `globalAnchor`); the classic and React scanners always both run, and the non-matching one yields `[]` harmlessly — no layout probe needed
- React scanner anchors on `div[role="region"][id^="diff-"]` plus hashed CSS-module class prefixes; the path is parsed from header text (LRM marks stripped, `sr-only` rename form preferred) because the React UI has no path attribute anywhere
- `content/index.ts`: mounting goes through the adapter; a display-only, fetch-free `sync()` re-asserts hide/show on every scan because the React UI virtualizes the file list (TanStack Virtual) and recreates DOM nodes continuously; disconnected appliers are pruned every scan instead of only on PR change
- Collapse is read from two independent signals: the chevron octicon swap and the `DiffFileHeader-module__collapsed` header class
- e2e: new fixture `pr-files-react.html` + `react.spec.ts` covering detection/render, global-bar placement outside the virtualized list, collapse chevron + body remount re-hide, and a full virtualization remount inheriting the semantic default

React-UI DOM structure was cross-checked against refined-github, TombWater/github-codeowners, sudo-vaibhav/pr-diff-plus, dkareh/bookmarklets, DIO0550/github-html-preview-ext, a live-captured fixture (elad12390/group-gh-pr-files), and GitHub's own shipped component chunk (confirms `role="region"`, `id="diff-${pathDigest}"`, header wrapper as first region child, and the CSS-module class map).

## Testing

- `pnpm test` — 197 passed (17 files)
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0
- `pnpm e2e` — 14 passed (10 existing classic specs unchanged + 4 new react specs)

### Live verification on the real React UI (performed 2026-07-16)

Verified on https://github.com/hashiiiii/unity-yaml-playground/pull/2/changes in a logged-in browser session, by injecting the built `dist/content.js` with the same `chrome.*` stub the e2e suite uses (canned semantic-diff response; the background fetch/wasm path is covered separately by the existing unit + classic e2e layers):

- Scanner matched all 21 file regions; toggles attached to exactly the 19 UnityYAML files (both `.meta` files correctly excluded, including a renamed one)
- Path extraction verified against the live DOM, including the rename case (`sr-only` "renamed to" form returns the new path)
- Global bar rendered once, immediately before `[data-testid="progressive-diffs-list"]`
- Semantic toggle: shadow-root view rendered, real React diff body hidden
- Real collapse round-trip: chevron click unmounts the body (region children 2 → 1) and the semantic host hides; re-expand remounts a fresh body node which the per-scan `sync()` re-hides while the semantic view returns
- Live DOM matched the fixture assumptions exactly (`Diff-module__diffHeaderWrapper` as first region child, chevron icon swap, `DiffFileHeader-module__collapsed` class stamped when collapsed)

### Manual verification (for reviewers)

1. Sign in to github.com with the new Files changed experience enabled (or click "Try the new experience" on a PR)
2. Open a PR with UnityYAML changes (e.g. hashiiiii/unity-yaml-playground#2) and go to the Files changed tab (`/changes`)
3. Confirm: the PrefabLens global bar sits above the diff list, each Unity file header has the Raw/Semantic toggle, Semantic replaces the raw diff, collapsing a file hides the semantic view, and scrolling far away and back preserves the chosen view