### PR TITLE
feat: detect unityyaml by content

### DIFF
--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -215,6 +215,28 @@ test "run: bulk mode reports when every candidate fails the content sniff" {
     try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "no Unity YAML changes") != null);
 }
 
+test "run: bulk json keeps the array contract when the sniff empties the list" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Fake.asset", .data = "\x00\x01binary-v1" });
+    try gitInit(arena, dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Fake.asset", .data = "\x00\x01binary-v2" });
+
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    // A json consumer must always get an array on exit 0, never prose.
+    const code = try run(testing.io, arena, &.{ "--project", dir, "--json" }, &aw.writer, &aw_err.writer, false, null);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expectEqualStrings("[]\n", aw.toArrayList().items);
+}
+
 test "run: bulk json emits an array of path/diff objects" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -965,10 +987,6 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                 for (all) |p| if (unity_path.isUnityPath(p)) try path_list.append(arena, p);
             }
             const paths = path_list.items;
-            if (paths.len == 0) {
-                try stdout.writeAll("no Unity YAML changes\n");
-                return 0;
-            }
             for (paths) |p| {
                 const before = input.showAtRef(io, arena, repo_dir, g.before_ref, p, input.default_git_timeout) catch |err| {
                     if (err == error.GitTimeout)
@@ -1000,14 +1018,14 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                 // Single explicit path keeps the headerless single-file output.
                 try diffs.append(arena, .{ .path = if (g.path != null) null else p, .before = before, .after = after, .res = res });
             }
+            // No candidates listed, or every one sniffed away (binary .asset):
+            // one exit for both, honoring --json's array contract. Explicit
+            // paths and .files always append, so only bulk mode gets here.
+            if (diffs.items.len == 0) {
+                if (opt.format == .json) try stdout.writeAll("[]\n") else try stdout.writeAll("no Unity YAML changes\n");
+                return 0;
+            }
         },
-    }
-
-    // Every bulk candidate can be sniffed away (binary .asset only): same
-    // outcome as having no candidates, so reuse that message and exit code.
-    if (diffs.items.len == 0) {
-        try stdout.writeAll("no Unity YAML changes\n");
-        return 0;
     }
 
     // Default guid resolution: with no --project and no --no-project, git mode

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -165,6 +165,56 @@ test "run: bulk mode with no matching files reports and exits 0" {
     try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "no Unity YAML changes") != null);
 }
 
+test "run: bulk mode skips files whose content is not UnityYAML" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    // Fake.asset passes the extension gate but is binary on both sides, like a
+    // LightingDataAsset: the content sniff must drop it, not render an empty diff.
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "--- !u!114 &1\nMonoBehaviour:\n  hp: 1\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Fake.asset", .data = "\x00\x01binary-v1" });
+    try gitInit(arena, dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Foo.prefab", .data = "--- !u!114 &1\nMonoBehaviour:\n  hp: 2\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Fake.asset", .data = "\x00\x01binary-v2" });
+
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false, null);
+    try testing.expectEqual(@as(u8, 0), code);
+    const text = aw.toArrayList().items;
+    try testing.expect(std.mem.indexOf(u8, text, "Foo.prefab") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "Fake.asset") == null);
+}
+
+test "run: bulk mode reports when every candidate fails the content sniff" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Fake.asset", .data = "\x00\x01binary-v1" });
+    try gitInit(arena, dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Fake.asset", .data = "\x00\x01binary-v2" });
+
+    var out: std.ArrayList(u8) = .empty;
+    var aw = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err_out: std.ArrayList(u8) = .empty;
+    var aw_err = std.Io.Writer.Allocating.fromArrayList(arena, &err_out);
+    const code = try run(testing.io, arena, &.{ "--project", dir }, &aw.writer, &aw_err.writer, false, null);
+    try testing.expectEqual(@as(u8, 0), code);
+    // Same wording as the "no candidates at all" early exit: to the user both
+    // cases mean the same thing.
+    try testing.expect(std.mem.indexOf(u8, aw.toArrayList().items, "no Unity YAML changes") != null);
+}
+
 test "run: bulk json emits an array of path/diff objects" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -942,11 +992,22 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
                             try stderr.print("error: git show failed for '{s}:{s}'\n", .{ g.after_ref, p });
                         return 1;
                     };
+                // Bulk mode trusts content over extension: some .asset files
+                // are binary regardless of Force Text and would render as an
+                // empty diff. An explicit path operand is never second-guessed.
+                if (g.path == null and !core.isUnityYaml(before) and !core.isUnityYaml(after)) continue;
                 const res = diffOne(io, arena, before, after, resolver_ptr, &assets, repo_dir) catch |err| return diffError(stderr, err);
                 // Single explicit path keeps the headerless single-file output.
                 try diffs.append(arena, .{ .path = if (g.path != null) null else p, .before = before, .after = after, .res = res });
             }
         },
+    }
+
+    // Every bulk candidate can be sniffed away (binary .asset only): same
+    // outcome as having no candidates, so reuse that message and exit code.
+    if (diffs.items.len == 0) {
+        try stdout.writeAll("no Unity YAML changes\n");
+        return 0;
     }
 
     // Default guid resolution: with no --project and no --no-project, git mode

--- a/cli/src/unity_path.zig
+++ b/cli/src/unity_path.zig
@@ -32,8 +32,10 @@ test "isUnityPath rejects git refs, .meta and unknown extensions" {
     for (no) |p| try testing.expect(!isUnityPath(p));
 }
 
-// Same set as unityyamlmerge targets. Excludes .meta (not !u! document
-// format) and JSON like .asmdef.
+// Same set as unityyamlmerge targets, i.e. the community Unity.gitattributes:
+// https://github.com/gitattributes/gitattributes/blob/master/Unity.gitattributes
+// Excludes .meta (not !u! document format) and JSON like .asmdef. This is a
+// prefilter; content is the ground truth (core isUnityYaml).
 const extensions = [_][]const u8{
     ".prefab",             ".unity",          ".asset",
     ".mat",                ".anim",           ".controller",

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -687,3 +687,37 @@ const TopLevelIter = struct {
 fn splitTopLevel(s: []const u8) TopLevelIter {
     return .{ .s = s };
 }
+
+/// Content sniff for UnityYAML. The extension allowlists in the products are
+/// prefilters only; some .asset files are binary regardless of Force Text
+/// (LightingDataAsset etc.), so the leading bytes are the ground truth.
+/// Directives (%...) may precede the first document; anything else decides.
+pub fn isUnityYaml(src: []const u8) bool {
+    const head = src[0..@min(src.len, 512)];
+    var lines = std.mem.splitScalar(u8, head, '\n');
+    while (lines.next()) |line| {
+        if (std.mem.startsWith(u8, line, "%TAG !u!")) return true;
+        if (std.mem.startsWith(u8, line, "--- !u!")) return true;
+        if (line.len == 0 or line[0] == '%') continue;
+        return false;
+    }
+    return false;
+}
+
+test "isUnityYaml: accepts UnityYAML heads, rejects other content" {
+    // Full Unity-written header: %YAML directive first, %TAG !u! second.
+    try testing.expect(isUnityYaml("%YAML 1.1\n%TAG !u! tag:unity3d.com,2011:\n--- !u!1 &1\nGameObject:\n"));
+    // Fixture-style head without directives: the document marker alone decides.
+    try testing.expect(isUnityYaml("--- !u!114 &1\nMonoBehaviour:\n  hp: 1\n"));
+    // CRLF must not defeat the prefix checks.
+    try testing.expect(isUnityYaml("%YAML 1.1\r\n%TAG !u! tag:unity3d.com,2011:\r\n--- !u!1 &1\r\n"));
+
+    // .meta files are YAML but not !u! documents.
+    try testing.expect(!isUnityYaml("fileFormatVersion: 2\nguid: 0123456789abcdef0123456789abcdef\n"));
+    // Plain YAML with a bare document marker is not UnityYAML.
+    try testing.expect(!isUnityYaml("---\nfoo: 1\n"));
+    // Binary content (e.g. a binary-serialized .asset) has no UnityYAML head.
+    try testing.expect(!isUnityYaml("\x00\x01\x02binary"));
+    // Empty input: an absent side is "missing", never "UnityYAML".
+    try testing.expect(!isUnityYaml(""));
+}

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -693,9 +693,13 @@ fn splitTopLevel(s: []const u8) TopLevelIter {
 /// (LightingDataAsset etc.), so the leading bytes are the ground truth.
 /// Directives (%...) may precede the first document; anything else decides.
 pub fn isUnityYaml(src: []const u8) bool {
-    const head = src[0..@min(src.len, 512)];
+    var head = src[0..@min(src.len, 512)];
+    // Unity writes no BOM, but external tools may prepend one; parse() still
+    // finds the documents, so the sniff must not disagree with it.
+    if (std.mem.startsWith(u8, head, "\xEF\xBB\xBF")) head = head[3..];
     var lines = std.mem.splitScalar(u8, head, '\n');
-    while (lines.next()) |line| {
+    while (lines.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
         if (std.mem.startsWith(u8, line, "%TAG !u!")) return true;
         if (std.mem.startsWith(u8, line, "--- !u!")) return true;
         if (line.len == 0 or line[0] == '%') continue;
@@ -711,6 +715,11 @@ test "isUnityYaml: accepts UnityYAML heads, rejects other content" {
     try testing.expect(isUnityYaml("--- !u!114 &1\nMonoBehaviour:\n  hp: 1\n"));
     // CRLF must not defeat the prefix checks.
     try testing.expect(isUnityYaml("%YAML 1.1\r\n%TAG !u! tag:unity3d.com,2011:\r\n--- !u!1 &1\r\n"));
+    // A UTF-8 BOM prepended by an external tool must not defeat the sniff:
+    // parse() finds the documents regardless, so the sniff must agree.
+    try testing.expect(isUnityYaml("\xEF\xBB\xBF%YAML 1.1\n%TAG !u! tag:unity3d.com,2011:\n--- !u!1 &1\n"));
+    // A blank CRLF line before the first document is as skippable as its LF twin.
+    try testing.expect(isUnityYaml("%YAML 1.1\r\n\r\n--- !u!1 &1\r\n"));
 
     // .meta files are YAML but not !u! documents.
     try testing.expect(!isUnityYaml("fileFormatVersion: 2\nguid: 0123456789abcdef0123456789abcdef\n"));

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -11,6 +11,7 @@ const perf = @import("perf.zig");
 const instantiate = @import("instantiate.zig");
 
 pub const Assets = instantiate.Assets;
+pub const isUnityYaml = parser.isUnityYaml;
 const no_assets: Assets = .empty;
 
 pub fn diffBytes(arena: std.mem.Allocator, before_src: []const u8, after_src: []const u8) !model.DiffResult {

--- a/core/src/wasm.zig
+++ b/core/src/wasm.zig
@@ -39,6 +39,10 @@ export fn diff_with_assets(
     return run(slice(before_ptr, before_len), slice(after_ptr, after_len), slice(assets_ptr, assets_len));
 }
 
+export fn is_unity_yaml(ptr: ?[*]const u8, len: usize) i32 {
+    return @intFromBool(core.isUnityYaml(slice(ptr, len)));
+}
+
 fn slice(ptr: ?[*]const u8, len: usize) []const u8 {
     return if (ptr) |p| p[0..len] else "";
 }

--- a/extension/e2e/fixtures/pr-files.html
+++ b/extension/e2e/fixtures/pr-files.html
@@ -22,6 +22,12 @@
       <div class="js-file-content Details-content--hidden">raw github diff table</div>
     </div>
     <div class="file js-details-container Details Details--on open">
+      <div class="file-header" data-path="Assets/Baked.asset">
+        <span class="file-info">Assets/Baked.asset</span>
+      </div>
+      <div class="js-file-content Details-content--hidden">raw github diff table</div>
+    </div>
+    <div class="file js-details-container Details Details--on open">
       <div class="file-header" data-path="README.md">
         <span class="file-info">README.md</span>
       </div>

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -40,6 +40,7 @@ function startServer(): Promise<Server> {
         return json([
           { filename: "Assets/Foo.prefab", status: "modified" },
           { filename: "Assets/Big.unity", status: "modified" },
+          { filename: "Assets/Baked.asset", status: "modified" },
         ]);
       case "/repos/o/r/pulls/1":
         return json({ base: { sha: "B" }, head: { sha: "H" } });
@@ -51,6 +52,10 @@ function startServer(): Promise<Server> {
         return send(url.searchParams.get("ref") === "MB" ? BEFORE : AFTER, "application/vnd.github.raw+json");
       case "/repos/o/r/contents/Assets/Big.unity":
         return send(BIG, "application/vnd.github.raw+json");
+      // A binary-serialized .asset (LightingDataAsset etc.): passes the path
+      // prefilter, must be rejected by the real wasm content sniff.
+      case "/repos/o/r/contents/Assets/Baked.asset":
+        return send("\x00\x01PK-binary-payload", "application/vnd.github.raw+json");
       case "/search/code":
         return json({ items: [{ path: "Assets/Scripts/Sound.cs.meta" }] });
       case "/graphql":
@@ -103,6 +108,18 @@ test("renders a real wasm diff with code-search guid resolution", async () => {
   await expect(view).toContainText("Volume");
   await expect(view).toContainText("0.5");
   await expect(view).toContainText("0.8");
+  await page.close();
+});
+
+test("rejects a binary .asset through the real wasm sniff", async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/1/files`);
+
+  const header = page.locator('.file-header[data-path="Assets/Baked.asset"]');
+  await header.getByRole("button", { name: "Semantic" }).click();
+
+  const view = page.locator("[data-prefablens-view]");
+  await expect(view).toContainText("not a text-serialized Unity asset", { timeout: 30_000 });
   await page.close();
 });
 

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -21,8 +21,9 @@ MonoBehaviour:
   volume: 0.5
 `;
 const AFTER = BEFORE.replace("0.5", "0.8");
-// 26MB with no documents trips the 25MB guard; after force it finishes cheaply with an empty diff
-const BIG = "x".repeat(26 * 1024 * 1024);
+// 26MB with a UnityYAML head but no documents trips the 25MB guard; after
+// force, the content sniff passes and it finishes cheaply with an empty diff
+const BIG = `%YAML 1.1\n%TAG !u! tag:unity3d.com,2011:\n${"x".repeat(26 * 1024 * 1024)}`;
 
 function startServer(): Promise<Server> {
   const server = createServer((req, res) => {

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -202,8 +202,8 @@ test("applies the persisted semantic default to every unity file and late additi
   await page.goto("https://prefablens.test/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
-  // Both Unity files render as semantic without a click
-  await expect(page.locator("[data-prefablens-view]")).toHaveCount(2);
+  // All three Unity files render as semantic without a click
+  await expect(page.locator("[data-prefablens-view]")).toHaveCount(3);
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Foo.prefab"]) .js-file-content')).toBeHidden();
 
   // The global toggle also reflects the default and appears in the Semantic pressed state
@@ -218,7 +218,7 @@ test("applies the persisted semantic default to every unity file and late additi
       '<div class="file-header" data-path="Assets/Late.prefab"></div><div class="js-file-content">raw diff</div>';
     document.body.append(file);
   });
-  await expect(page.locator("[data-prefablens-view]")).toHaveCount(3);
+  await expect(page.locator("[data-prefablens-view]")).toHaveCount(4);
   await expect(page.locator('.file:has(.file-header[data-path="Assets/Late.prefab"]) .js-file-content')).toBeHidden();
 });
 
@@ -240,7 +240,7 @@ test("global toggle switches all files and resets per-file overrides", async ({ 
 
   // Global Semantic → all Unity files switch (README is excluded)
   await global.getByRole("button", { name: "Semantic" }).click();
-  await expect(page.locator("[data-prefablens-view]")).toHaveCount(2);
+  await expect(page.locator("[data-prefablens-view]")).toHaveCount(3);
 
   // Per-file override to Raw → only that file reverts to raw
   const fooHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -189,6 +189,19 @@ describe("createHandler", () => {
     expect(diff).not.toHaveBeenCalled();
   });
 
+  it("caches the not-unity-yaml outcome for the sha pair", async () => {
+    // Unlike too-large there is no force escape hatch: the verdict is
+    // deterministic for a given blob pair, so a second toggle must serve the
+    // cached outcome instead of re-fetching and re-sniffing.
+    const isUnityYaml = vi.fn<Differ["isUnityYaml"]>(() => false);
+    const { deps } = makeDeps({ isUnityYaml });
+    const handler = createHandler(deps);
+    expect(await handler.semanticDiff(REQ, () => {})).toEqual({ ok: false, error: "not-unity-yaml" });
+    const sniffs = isUnityYaml.mock.calls.length;
+    expect(await handler.semanticDiff(REQ, () => {})).toEqual({ ok: false, error: "not-unity-yaml" });
+    expect(isUnityYaml.mock.calls.length).toBe(sniffs);
+  });
+
   it("diffs a file missing from the PR list as modified (files API caps at 3000)", async () => {
     // In a PR with over 3000 files, the listing API is truncated, so a file present in the UI may be absent from the listing
     const { deps, client } = makeDeps({ files: [{ path: "Assets/Other.prefab", status: "modified" }] });

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -21,6 +21,7 @@ function makeDeps(overrides?: {
   baseShas?: Record<string, string>; // path → blob sha at the merge base (listBlobShas)
   diff?: Differ["diff"];
   diffWithAssets?: Differ["diffWithAssets"];
+  isUnityYaml?: Differ["isUnityYaml"];
   pat?: string | undefined;
   search?: Record<string, string | null>; // guid → asset path (null = no hit)
   cached?: Record<string, string>; // initial contents of guidCache
@@ -55,6 +56,8 @@ function makeDeps(overrides?: {
   const differ: Differ = {
     diff: overrides?.diff ?? vi.fn(() => DIFF),
     diffWithAssets: overrides?.diffWithAssets ?? vi.fn(() => DIFF),
+    // Fixture contents are shorthand strings, not real UnityYAML: accept by default.
+    isUnityYaml: overrides?.isUnityYaml ?? (() => true),
   };
   const cacheData: Record<string, Record<string, string>> = {};
   if (overrides?.cached) cacheData["https://api.github.com/o/r"] = { ...overrides.cached };

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -174,6 +174,21 @@ describe("createHandler", () => {
     expect(diff.mock.calls[0]?.[1]).toHaveLength(0); // after is empty
   });
 
+  it("rejects a file whose content is not UnityYAML on either side", async () => {
+    // Real sniff behavior lives in differ.test.ts; here the fake reproduces its
+    // contract so the outcome plumbing (computeDiff -> response) is what's tested.
+    const diff = vi.fn<Differ["diff"]>(() => DIFF);
+    const { deps } = makeDeps({
+      contents: { "Assets/Foo.prefab@base-sha": "\x00binary", "Assets/Foo.prefab@head-sha": "\x00binary2" },
+      diff,
+      isUnityYaml: () => false,
+    });
+    const res = await resolveFully(createHandler(deps), REQ);
+    expect(res).toEqual({ ok: false, error: "not-unity-yaml" });
+    // The differ must not even run on rejected content.
+    expect(diff).not.toHaveBeenCalled();
+  });
+
   it("diffs a file missing from the PR list as modified (files API caps at 3000)", async () => {
     // In a PR with over 3000 files, the listing API is truncated, so a file present in the UI may be absent from the listing
     const { deps, client } = makeDeps({ files: [{ path: "Assets/Other.prefab", status: "modified" }] });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -226,6 +226,9 @@ export function createHandler(deps: Deps): Handler {
           return current; // rate limit etc.: degrade to the first-pass diff
         }
         if (!bytes) continue;
+        // Sources resolved by guid can be binary-serialized too: merging
+        // them is a no-op re-diff, so don't count it as progress.
+        if (!differ.isUnityYaml(bytes)) continue;
         assets.set(s.guid, bytes);
         progressed = true;
       }
@@ -327,7 +330,9 @@ export function createHandler(deps: Deps): Handler {
     diffs.set(key, p);
     p.then(
       (o) => {
-        if (!o.ok) diffs.delete(key); // too-large allows a force recomputation
+        // too-large allows a force recomputation; not-unity-yaml is
+        // deterministic for the sha pair, so keep it cached in memory
+        if (!o.ok && o.error === "too-large") diffs.delete(key);
       },
       () => diffs.delete(key),
     );

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -48,7 +48,10 @@ const TOO_LARGE_BYTES = 25 * 1024 * 1024; // over 25MB renders on click
 const PREFETCH_MAX = 100; // prefetch cap per PR (bounds API usage)
 const PREFETCH_CONCURRENCY = 4;
 
-type DiffOutcome = { ok: true; json: DiffV2 } | { ok: false; error: "too-large"; bytes: number };
+type DiffOutcome =
+  | { ok: true; json: DiffV2 }
+  | { ok: false; error: "too-large"; bytes: number }
+  | { ok: false; error: "not-unity-yaml" };
 
 export function createHandler(deps: Deps): Handler {
   // Per-PR context cache. The SW may be killed at any time; then we just re-fetch.
@@ -294,6 +297,11 @@ export function createHandler(deps: Deps): Handler {
       return { ok: false, error: "too-large", bytes: before.length + after.length };
     }
     const differ = await deps.getDiffer();
+    // Path passed the extension prefilter, but some .asset files are binary
+    // regardless of Force Text: content is the ground truth.
+    if (!differ.isUnityYaml(before) && !differ.isUnityYaml(after)) {
+      return { ok: false, error: "not-unity-yaml" };
+    }
     return { ok: true, json: differ.diff(before, after) };
   }
 

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -27,6 +27,7 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
   "rate-limited": "GitHub rate limit exceeded. Wait a while and toggle again.",
   "fetch-failed": "Could not fetch file contents from GitHub.",
   "diff-failed": "Could not compute a semantic diff for this file.",
+  "not-unity-yaml": "This file is not a text-serialized Unity asset.",
 };
 
 // path → render target. When a push (guidResolved) arrives, merge resolved and re-render

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -75,7 +75,13 @@ export type SemanticDiffRequest = {
 export type PrefetchRequest = { type: "prefetch"; owner: string; repo: string; prNumber: number };
 export type BackgroundRequest = SemanticDiffRequest | PrefetchRequest;
 
-export type BackgroundError = "pat-missing" | "auth-failed" | "rate-limited" | "fetch-failed" | "diff-failed";
+export type BackgroundError =
+  | "pat-missing"
+  | "auth-failed"
+  | "rate-limited"
+  | "fetch-failed"
+  | "diff-failed"
+  | "not-unity-yaml";
 
 export type SemanticDiffResponse =
   | { ok: true; json: DiffV2; pending?: boolean }

--- a/extension/src/unity.ts
+++ b/extension/src/unity.ts
@@ -1,5 +1,8 @@
-// Extensions that Unity text-serializes (UnityYAML). Same set as unityyamlmerge targets.
-// Excludes .meta (not !u! document format) and JSON like .asmdef.
+// Extensions that Unity text-serializes (UnityYAML). Same set as unityyamlmerge
+// targets, i.e. the community Unity.gitattributes:
+// https://github.com/gitattributes/gitattributes/blob/master/Unity.gitattributes
+// Excludes .meta (not !u! document format) and JSON like .asmdef. This is a
+// prefilter; content is the ground truth (core isUnityYaml via the wasm bridge).
 const UNITY_PATH =
   /\.(prefab|unity|asset|mat|anim|controller|overrideController|physicMaterial|physicsMaterial2D|playable|mask|brush|flare|fontsettings|guiskin|giparams|renderTexture|spriteatlas|spriteatlasv2|terrainlayer|mixer|shadervariants|preset|signal|lighting|scenetemplate)$/i;
 

--- a/extension/src/wasm/differ.test.ts
+++ b/extension/src/wasm/differ.test.ts
@@ -39,6 +39,16 @@ describe("createDiffer", () => {
     expect(() => differ.diff(hostile, hostile)).toThrowError(DiffError);
   });
 
+  it("isUnityYaml sniffs content, not paths", () => {
+    // The BEFORE fixture is a bare "--- !u!" document head.
+    expect(differ.isUnityYaml(BEFORE)).toBe(true);
+    // .meta-style plain YAML and binary bytes are both rejected.
+    expect(differ.isUnityYaml(enc.encode("fileFormatVersion: 2\nguid: abc\n"))).toBe(false);
+    expect(differ.isUnityYaml(new Uint8Array([0, 1, 2, 255]))).toBe(false);
+    // An absent side (added/removed file) is empty bytes: never UnityYAML.
+    expect(differ.isUnityYaml(new Uint8Array(0))).toBe(false);
+  });
+
   it("is re-entrant across many calls", () => {
     for (let i = 0; i < 50; i++) expect(differ.diff(BEFORE, AFTER).schema).toBe("prefablens.diff.v2");
   });

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -5,6 +5,7 @@ export class DiffError extends Error {}
 export type Differ = {
   diff(before: Uint8Array, after: Uint8Array): DiffV2;
   diffWithAssets(before: Uint8Array, after: Uint8Array, assets: Map<string, Uint8Array>): DiffV2;
+  isUnityYaml(bytes: Uint8Array): boolean;
 };
 
 type Exports = {
@@ -13,6 +14,7 @@ type Exports = {
   free(ptr: number, len: number): void;
   diff(bp: number, bl: number, ap: number, al: number): number;
   diff_with_assets(bp: number, bl: number, ap: number, al: number, tp: number, tl: number): number;
+  is_unity_yaml(p: number, l: number): number;
 };
 
 /** assets TLV (LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }.
@@ -71,8 +73,20 @@ export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
     }
   }
 
+  function isUnityYaml(bytes: Uint8Array): boolean {
+    if (!bytes.length) return false;
+    const ptr = exp.alloc(bytes.length);
+    new Uint8Array(exp.memory.buffer, ptr, bytes.length).set(bytes);
+    try {
+      return exp.is_unity_yaml(ptr, bytes.length) !== 0;
+    } finally {
+      exp.free(ptr, bytes.length);
+    }
+  }
+
   return {
     diff: (before, after) => call(before, after),
     diffWithAssets: (before, after, assets) => call(before, after, encodeAssets(assets)),
+    isUnityYaml,
   };
 }

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -74,13 +74,15 @@ export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
   }
 
   function isUnityYaml(bytes: Uint8Array): boolean {
-    if (!bytes.length) return false;
-    const ptr = exp.alloc(bytes.length);
-    new Uint8Array(exp.memory.buffer, ptr, bytes.length).set(bytes);
+    // The Zig sniff reads at most 512 bytes: never marshal a whole blob
+    // (wasm memory only grows) just to inspect its head.
+    const head = bytes.subarray(0, 512);
+    const ptr = head.length ? exp.alloc(head.length) : 0;
+    new Uint8Array(exp.memory.buffer, ptr, head.length).set(head);
     try {
-      return exp.is_unity_yaml(ptr, bytes.length) !== 0;
+      return exp.is_unity_yaml(ptr, head.length) !== 0;
     } finally {
-      exp.free(ptr, bytes.length);
+      if (head.length) exp.free(ptr, head.length);
     }
   }
 


### PR DESCRIPTION
## Summary

Add a content-based UnityYAML predicate to core (`isUnityYaml`, first-512-bytes sniff for the `%TAG !u!` directive or a `--- !u!` document header) and apply it in the CLI bulk mode and the extension diff pipeline, so binary-serialized `.asset` files (LightingDataAsset etc.) no longer render as bogus empty diffs.

## Motivation

The 26-extension allowlist is a path-only prefilter and its failure mode was a correctness bug: some `.asset` files are binary regardless of Force Text, pass the gate, and `core.parse` silently returns an empty document list — the user sees "0 objects changed" instead of a clear signal. With the sniff, an allowlist omission is only a coverage miss, while false positives are structurally impossible.

Closes #168

## Changes

- core: `pub fn isUnityYaml` in `parser.zig` (BOM- and CRLF-tolerant, O(1) on binary blobs), re-exported from `root.zig` and as `is_unity_yaml` in `wasm.zig`
- CLI: bulk mode skips files whose both sides fail the sniff; explicit operands are never second-guessed; the all-skipped/no-candidate exit is now a single site honoring the `--json` array contract (`[]` instead of prose)
- extension: `computeDiff` rejects blobs failing the sniff with a new `not-unity-yaml` error and dedicated copy; the verdict stays cached per sha pair (only `too-large` is evicted for force); `mergeSources` skips binary source prefabs; `Differ.isUnityYaml` marshals at most 512 bytes into wasm
- e2e: new test drives a binary `.asset` through the real wasm sniff; the oversized fixture now carries a UnityYAML head (real oversized scenes do); provenance URL comments added next to both allowlists

Known bounded limitation: empty-diff results persisted by the previous version in `chrome.storage.session` shadow the new verdict for the same sha pair until the browser session ends (session-scoped storage, self-healing).

## Testing

- `zig build test` — all pass (new: predicate unit tests incl. BOM/CRLF/binary/empty, 3 bulk-mode CLI tests)
- extension: `pnpm typecheck` / `pnpm vitest run` 190 passed / `biome ci` clean (68 pre-existing warnings, ±0) / `pnpm build` / wasm gzip 45.4 KB (limit 150 KB)
- `pnpm run e2e` — 11 passed, including the new binary-`.asset` rejection through the real extension + wasm in Chrome
- Manual CLI drive on a temp repo (old binary vs this branch): bulk output drops the binary `.asset` and keeps the real prefab diff; `--json` with only a binary change now emits `[]` where the old build emitted a bogus `[{"path":"Fake.asset","diff":{...empty...}}]`; explicit-path behavior unchanged