### PR TITLE
feat: respect Retry-After and back off on rate limits

### DIFF
--- a/extension/src/background/queue.test.ts
+++ b/extension/src/background/queue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { RateLimitError } from "../github/client";
 import { createQueue } from "./queue";
 
 // Line up manually-resolvable deferreds to observe execution order and concurrency
@@ -91,5 +92,126 @@ describe("createQueue", () => {
     await first;
     await expect(bad).rejects.toThrow("boom");
     await expect(good).resolves.toBe("ok");
+  });
+});
+
+// Hand-controlled sleep: records requested waits, resumes only when the test says so
+function manualSleep() {
+  const waits: Array<{ ms: number; resolve: () => void }> = [];
+  const sleep = (ms: number) =>
+    new Promise<void>((resolve) => {
+      waits.push({ ms, resolve });
+    });
+  return { sleep, waits };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("createQueue rate limit backoff", () => {
+  it("retries a rate-limited task after the advised wait", async () => {
+    const { sleep, waits } = manualSleep();
+    const queue = createQueue(1, sleep);
+    let attempts = 0;
+    const task = queue(async () => {
+      attempts++;
+      if (attempts === 1) throw new RateLimitError("limited", 5_000);
+      return "ok";
+    });
+    await flush();
+    expect(waits.map((w) => w.ms)).toEqual([5_000]); // paused for exactly the advice
+    expect(attempts).toBe(1); // nothing reruns while paused
+    waits[0]!.resolve();
+    await expect(task).resolves.toBe("ok");
+    expect(attempts).toBe(2);
+  });
+
+  it("caps the advised wait and falls back when no advice is given", async () => {
+    const { sleep, waits } = manualSleep();
+    const queue = createQueue(1, sleep);
+    // A 10-minute primary-limit advice is capped: better to fail into the manual message than hang until the reset
+    const capped = queue(async () => {
+      throw new RateLimitError("limited", 600_000);
+    });
+    const cappedRejects = expect(capped).rejects.toBeInstanceOf(RateLimitError);
+    await flush();
+    waits[0]!.resolve();
+    await flush();
+    waits[1]!.resolve();
+    await cappedRejects;
+    // A secondary limit without headers gets the fallback wait
+    const noAdvice = queue(async () => {
+      throw new RateLimitError("limited");
+    });
+    const noAdviceRejects = expect(noAdvice).rejects.toBeInstanceOf(RateLimitError);
+    await flush();
+    waits[2]!.resolve();
+    await flush();
+    waits[3]!.resolve();
+    await noAdviceRejects;
+    expect(waits.map((w) => w.ms)).toEqual([60_000, 60_000, 30_000, 30_000]);
+  });
+
+  it("gives up after two retries and surfaces the original error", async () => {
+    const { sleep, waits } = manualSleep();
+    const queue = createQueue(1, sleep);
+    let attempts = 0;
+    const task = queue(async () => {
+      attempts++;
+      throw new RateLimitError("limited", 1_000);
+    });
+    const taskRejects = expect(task).rejects.toBeInstanceOf(RateLimitError);
+    await flush();
+    waits[0]!.resolve(); // resume → retry 1 fails
+    await flush();
+    waits[1]!.resolve(); // resume → retry 2 fails → reject
+    await taskRejects;
+    expect(attempts).toBe(3); // initial + 2 retries, then the manual-retry UI takes over
+    expect(waits).toHaveLength(2);
+  });
+
+  it("pauses queued work during backoff instead of failing it", async () => {
+    const { sleep, waits } = manualSleep();
+    const queue = createQueue(1, sleep);
+    let attempts = 0;
+    const limited = queue(async () => {
+      attempts++;
+      if (attempts === 1) throw new RateLimitError("limited", 1_000);
+      return "retried";
+    });
+    await flush();
+    let ran = false;
+    const queued = queue(async () => {
+      ran = true;
+      return "later";
+    });
+    await flush();
+    expect(ran).toBe(false); // held back while the queue is paused, not rejected
+    waits[0]!.resolve();
+    await expect(limited).resolves.toBe("retried");
+    await expect(queued).resolves.toBe("later");
+  });
+
+  it("runs user tasks before a retried prefetch task after backoff", async () => {
+    const { sleep, waits } = manualSleep();
+    const queue = createQueue(1, sleep);
+    const order: string[] = [];
+    let attempts = 0;
+    const prefetchTask = queue(async () => {
+      attempts++;
+      if (attempts === 1) throw new RateLimitError("limited", 1_000);
+      order.push("prefetch-retry");
+    });
+    await flush();
+    // The user clicks while the queue is backing off: their request must not starve
+    const user = queue(
+      async () => {
+        order.push("user");
+      },
+      { front: true },
+    );
+    await flush();
+    waits[0]!.resolve();
+    await Promise.all([prefetchTask, user]);
+    expect(order).toEqual(["user", "prefetch-retry"]);
   });
 });

--- a/extension/src/background/queue.ts
+++ b/extension/src/background/queue.ts
@@ -1,30 +1,79 @@
-type Job = { run: () => Promise<unknown>; resolve: (v: unknown) => void; reject: (e: unknown) => void };
+import { RateLimitError } from "../github/client";
+
+type Job = {
+  run: () => Promise<unknown>;
+  resolve: (v: unknown) => void;
+  reject: (e: unknown) => void;
+  front: boolean;
+  retries: number;
+};
 
 export type Queue = <T>(task: () => Promise<T>, opts?: { front?: boolean }) => Promise<T>;
 
+const MAX_RATE_LIMIT_RETRIES = 2; // per job, on top of the initial attempt
+const BACKOFF_CAP_MS = 60_000; // a primary-limit reset can be an hour away: fail into the manual message instead
+const BACKOFF_FALLBACK_MS = 30_000; // secondary limits sometimes advise nothing; they clear within a minute
+
 /** Throttles REST concurrency (GitHub secondary rate limits trigger on bursts).
- *  front is for user-action interrupts: it jumps the prefetch queue. */
-export function createQueue(limit: number): Queue {
+ *  front is for user-action interrupts: it jumps the prefetch queue.
+ *  A RateLimitError pauses the whole queue for the advised (capped) duration and re-enqueues
+ *  the failed job by lane — front jobs re-enter at the front so prefetch never starves them. */
+export function createQueue(
+  limit: number,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
+): Queue {
   const pending: Job[] = [];
   let active = 0;
+  let paused = false;
+
+  const pauseFor = (ms: number): void => {
+    if (paused) return; // concurrent failures share the first backoff; later ones just requeue
+    paused = true;
+    void sleep(ms).then(() => {
+      paused = false;
+      pump();
+    });
+  };
+
   const pump = (): void => {
-    while (active < limit && pending.length) {
+    while (!paused && active < limit && pending.length) {
       const job = pending.shift()!;
       active++;
       // Normalize even a synchronous throw into a rejection: a leak here leaves active undecremented and jams the queue forever
       Promise.resolve()
         .then(job.run)
-        .then(job.resolve, job.reject)
-        .finally(() => {
-          active--;
-          pump();
-        });
+        .then(
+          (v) => {
+            active--;
+            job.resolve(v);
+            pump();
+          },
+          (e: unknown) => {
+            active--;
+            if (e instanceof RateLimitError && job.retries < MAX_RATE_LIMIT_RETRIES) {
+              job.retries++;
+              if (job.front) pending.unshift(job);
+              else pending.push(job);
+              pauseFor(Math.min(e.retryAfterMs ?? BACKOFF_FALLBACK_MS, BACKOFF_CAP_MS));
+            } else {
+              job.reject(e);
+            }
+            pump();
+          },
+        );
     }
   };
+
   return <T>(task: () => Promise<T>, opts?: { front?: boolean }) =>
     new Promise<T>((resolve, reject) => {
-      const job: Job = { run: task, resolve: resolve as (v: unknown) => void, reject };
-      if (opts?.front) pending.unshift(job);
+      const job: Job = {
+        run: task,
+        resolve: resolve as (v: unknown) => void,
+        reject,
+        front: opts?.front === true,
+        retries: 0,
+      };
+      if (job.front) pending.unshift(job);
       else pending.push(job);
       pump();
     });

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -182,6 +182,58 @@ describe("GithubClient", () => {
       ).getPrRefs("o", "r", 1),
     ).rejects.toBeInstanceOf(AuthError);
   });
+
+  it("carries retry-after advice on a secondary rate limit", async () => {
+    const { fn } = fakeFetch({
+      "/pulls/7": () => new Response("slow down", { status: 403, headers: { "retry-after": "12" } }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const err = await client.getPrRefs("o", "r", 7).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RateLimitError);
+    // retry-after is seconds; the queue consumes milliseconds
+    expect((err as RateLimitError).retryAfterMs).toBe(12_000);
+  });
+
+  it("derives advice from x-ratelimit-reset when retry-after is absent", async () => {
+    const reset = Math.floor(Date.now() / 1000) + 30;
+    const { fn } = fakeFetch({
+      "/pulls/7": () =>
+        new Response("", {
+          status: 403,
+          headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(reset) },
+        }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const err = (await client.getPrRefs("o", "r", 7).catch((e: unknown) => e)) as RateLimitError;
+    // reset is an absolute epoch: allow scheduling slack around the 30s target
+    expect(err.retryAfterMs).toBeGreaterThan(25_000);
+    expect(err.retryAfterMs).toBeLessThanOrEqual(30_000);
+  });
+
+  it("leaves retryAfterMs undefined when no header advises a wait", async () => {
+    const { fn } = fakeFetch({
+      "/pulls/7": () => new Response('{"message":"You have exceeded a secondary rate limit."}', { status: 403 }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const err = (await client.getPrRefs("o", "r", 7).catch((e: unknown) => e)) as RateLimitError;
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.retryAfterMs).toBeUndefined();
+  });
+
+  it("attaches advice to graphql RATE_LIMITED errors", async () => {
+    const reset = Math.floor(Date.now() / 1000) + 30;
+    const { fn } = fakeFetch({
+      "/graphql": () =>
+        new Response(JSON.stringify({ errors: [{ type: "RATE_LIMITED" }] }), {
+          status: 200,
+          headers: { "content-type": "application/json", "x-ratelimit-reset": String(reset) },
+        }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const err = (await client.batchBlobTexts("o", "r", ["oid1"]).catch((e: unknown) => e)) as RateLimitError;
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.retryAfterMs).toBeGreaterThan(0);
+  });
 });
 
 describe("graphqlUrl", () => {

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -1,5 +1,23 @@
 export class AuthError extends Error {}
-export class RateLimitError extends Error {}
+export class RateLimitError extends Error {
+  /** Backoff advice from response headers; undefined when GitHub gave none. */
+  constructor(
+    message: string,
+    readonly retryAfterMs?: number,
+  ) {
+    super(message);
+  }
+}
+
+/** retry-after (seconds) wins; else x-ratelimit-reset (epoch seconds) relative to now.
+ *  Number(null) is 0 and Number("") is NaN, so absent headers fail the > 0 guards. */
+function adviceMs(headers: Headers): number | undefined {
+  const retryAfter = Number(headers.get("retry-after"));
+  if (retryAfter > 0) return retryAfter * 1000;
+  const reset = Number(headers.get("x-ratelimit-reset"));
+  if (reset > 0) return Math.max(0, reset * 1000 - Date.now());
+  return undefined;
+}
 export class ApiError extends Error {
   constructor(readonly status: number) {
     super(`GitHub API error (HTTP ${status})`); // does not carry the raw body (leak prevention)
@@ -38,7 +56,7 @@ export class GithubClient {
         res.headers.has("retry-after") ||
         res.headers.get("x-ratelimit-remaining") === "0" ||
         /rate limit|abuse/i.test(body);
-      if (rateLimited) throw new RateLimitError("GitHub rate limit exceeded");
+      if (rateLimited) throw new RateLimitError("GitHub rate limit exceeded", adviceMs(res.headers));
       throw new AuthError("GitHub authentication failed");
     }
     if (res.status === 401) throw new AuthError("GitHub authentication failed");
@@ -172,7 +190,8 @@ export class GithubClient {
       errors?: Array<{ type?: string }>;
     };
     // GraphQL returns errors while still HTTP 200: RATE_LIMITED is caught here
-    if (body.errors?.some((e) => e.type === "RATE_LIMITED")) throw new RateLimitError("GitHub rate limit exceeded");
+    if (body.errors?.some((e) => e.type === "RATE_LIMITED"))
+      throw new RateLimitError("GitHub rate limit exceeded", adviceMs(res.headers));
     const blobs = body.data?.repository;
     if (!blobs) throw new ApiError(res.status);
     return Object.fromEntries(oids.map((oid, i) => [oid, blobs[`b${i}`]?.text ?? null]));


### PR DESCRIPTION
## Summary

The extension's request queue now honors GitHub's backoff advice (`Retry-After` / `x-ratelimit-reset`): on a rate limit it pauses all queued work for the advised (capped) duration and retries the failed request automatically instead of failing straight into the manual "wait and toggle again" message.

## Motivation

The GitHub client already classified every rate-limit shape (primary 403, secondary 403 + retry-after, 429, GraphQL `RATE_LIMITED` over HTTP 200) but stopped there: the error surfaced to the UI and asked the user to retry by hand, and queued work failed alongside.

Closes #163

## Changes

- `RateLimitError` now carries `retryAfterMs`, computed in the client from `retry-after` (seconds) or, failing that, `x-ratelimit-reset` (epoch) — for both REST and GraphQL responses.
- `createQueue` catches `RateLimitError`, pauses the whole queue for `min(advice, 60s)` (30s fallback when GitHub gives no advice), re-enqueues the failed job by lane, and retries up to 2 times before surfacing the original error.
- Requeued user-lane (`front`) jobs re-enter at the front, so prefetch work never starves a user click during backoff.
- The existing "GitHub rate limit exceeded. Wait a while and toggle again." panel is unchanged and remains the final fallback once retries are exhausted.
- The backoff timer is an injected `sleep` parameter (defaulted to `setTimeout`), so `background/index.ts` is untouched and tests drive the clock by hand.

## Testing

```
$ pnpm test
 Test Files  17 passed (17)
      Tests  209 passed (209)

$ pnpm typecheck   # tsc --noEmit: clean
$ pnpm lint        # biome ci: OK
```

New tests: header→`retryAfterMs` derivation (REST retry-after / x-ratelimit-reset / headerless secondary / GraphQL RATE_LIMITED) in `client.test.ts`, and backoff behavior (advised wait, cap + fallback, bounded retries, queued-work pause, user-before-prefetch resume order) in `queue.test.ts` with a hand-controlled `sleep`.