### PR TITLE
feat: support commit and compare pages in the extension

### DIFF
--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -33,6 +33,8 @@ function startServer(): Promise<Server> {
       res.end(body);
     };
     const json = (body: unknown): void => send(JSON.stringify(body), "application/json");
+    // Every ref pair shares one empty tree: blob fetches then fall back to the contents API below
+    if (url.pathname.startsWith("/repos/o/r/git/trees/")) return json({ truncated: false, tree: [] });
     switch (url.pathname) {
       case "/o/r/pull/1/files":
         return send(fixture, "text/html");
@@ -46,10 +48,30 @@ function startServer(): Promise<Server> {
         return json({ base: { sha: "B" }, head: { sha: "H" } });
       case "/repos/o/r/compare/B...H":
         return json({ merge_base_commit: { sha: "MB" } });
-      case "/repos/o/r/git/trees/H":
-        return json({ truncated: false, tree: [] });
-      case "/repos/o/r/contents/Assets/Foo.prefab":
-        return send(url.searchParams.get("ref") === "MB" ? BEFORE : AFTER, "application/vnd.github.raw+json");
+      // Commit page: same classic DOM, but discovery goes through the commit API (base = first parent)
+      case "/o/r/commit/abcdef0":
+        return send(fixture, "text/html");
+      case "/repos/o/r/commits/abcdef0":
+        return json({
+          sha: "HC",
+          parents: [{ sha: "PC" }],
+          files: [{ filename: "Assets/Foo.prefab", status: "modified" }],
+        });
+      // Compare page: merge base from the compare API, head resolved via the sha media type
+      case "/o/r/compare/main...topic":
+        return send(fixture, "text/html");
+      case "/repos/o/r/compare/main...topic":
+        return json({
+          merge_base_commit: { sha: "MC" },
+          files: [{ filename: "Assets/Foo.prefab", status: "modified" }],
+        });
+      case "/repos/o/r/commits/topic":
+        return send("HT\n", "application/vnd.github.sha");
+      case "/repos/o/r/contents/Assets/Foo.prefab": {
+        // MB/PC/MC are the base side of the pull/commit/compare flows respectively
+        const ref = url.searchParams.get("ref") ?? "";
+        return send(["MB", "PC", "MC"].includes(ref) ? BEFORE : AFTER, "application/vnd.github.raw+json");
+      }
       case "/repos/o/r/contents/Assets/Big.unity":
         return send(BIG, "application/vnd.github.raw+json");
       // A binary-serialized .asset (LightingDataAsset etc.): passes the path
@@ -106,6 +128,33 @@ test("renders a real wasm diff with code-search guid resolution", async () => {
   // Via Code Search, guid def resolves to Sound.cs, so the script name shows instead of the type name
   await expect(view).toContainText("Sound");
   await expect(view).toContainText("Volume");
+  await expect(view).toContainText("0.5");
+  await expect(view).toContainText("0.8");
+  await page.close();
+});
+
+test("serves a commit page against the commit API", async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/commit/abcdef0`);
+
+  const header = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await header.getByRole("button", { name: "Semantic" }).click();
+
+  const view = page.locator("[data-prefablens-view]");
+  // BEFORE at the first parent, AFTER at the commit itself: the same real-wasm diff as the PR flow
+  await expect(view).toContainText("0.5");
+  await expect(view).toContainText("0.8");
+  await page.close();
+});
+
+test("serves a compare page from the merge base", async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/compare/main...topic`);
+
+  const header = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await header.getByRole("button", { name: "Semantic" }).click();
+
+  const view = page.locator("[data-prefablens-view]");
   await expect(view).toContainText("0.5");
   await expect(view).toContainText("0.8");
   await page.close();

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { AuthError, type PrFile, RateLimitError } from "../github/client";
+import { AuthError, type ChangedFile, RateLimitError } from "../github/client";
 import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../types";
 import { DiffError, type Differ } from "../wasm/differ";
 import { createHandler, type Deps, type Handler } from "./handler";
@@ -15,7 +15,7 @@ const REQ: SemanticDiffRequest = {
 const DIFF: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: ["g1"], roots: [], loose: [] };
 
 function makeDeps(overrides?: {
-  files?: PrFile[];
+  files?: ChangedFile[];
   contents?: Record<string, string>; // `${path}@${ref}` → text
   blobs?: Record<string, string>; // blob sha → text (getBlobRaw; absent sha = 404 → null)
   baseShas?: Record<string, string>; // path → blob sha at the merge base (listBlobShas)
@@ -708,7 +708,7 @@ describe("prefetch", () => {
   });
 
   it("prefetches only unity files and caps at 100", async () => {
-    const files: PrFile[] = Array.from({ length: 120 }, (_, i) => ({
+    const files: ChangedFile[] = Array.from({ length: 120 }, (_, i) => ({
       path: `Assets/F${i}.prefab`,
       status: "modified",
     }));

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -8,7 +8,7 @@ const REQ: SemanticDiffRequest = {
   type: "semanticDiff",
   owner: "o",
   repo: "r",
-  prNumber: 1,
+  target: { kind: "pull", prNumber: 1 },
   path: "Assets/Foo.prefab",
 };
 
@@ -35,6 +35,10 @@ function makeDeps(overrides?: {
   const client = {
     getPrRefs: vi.fn(async () => ({ baseSha: "base-sha", headSha: "head-sha" })),
     listPrFiles: vi.fn(async () => files),
+    // Commit/compare fakes mirror the PR refs so the same contents table serves every target kind
+    getCommit: vi.fn(async () => ({ sha: "head-sha", parentSha: "base-sha" as string | null, files })),
+    compareRefs: vi.fn(async () => ({ mergeBaseSha: "base-sha", files })),
+    resolveRefSha: vi.fn(async () => "head-sha"),
     getFileAtRef,
     getBlobRaw: vi.fn(async (_o: string, _r: string, sha: string) => {
       const text = overrides?.blobs?.[sha];
@@ -150,6 +154,35 @@ describe("createHandler", () => {
     });
     const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: { g1: "Assets/S.cs" } } });
+  });
+
+  it("serves a commit target from the commit API with the first parent as base", async () => {
+    const { deps, client } = makeDeps();
+    const res = await resolveFully(createHandler(deps), { ...REQ, target: { kind: "commit", sha: "head-sha" } });
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: {} } });
+    expect(client.getCommit).toHaveBeenCalledWith("o", "r", "head-sha");
+    expect(client.getPrRefs).not.toHaveBeenCalled(); // commit pages never touch the PR API
+  });
+
+  it("serves a root commit (no parent) as an all-added diff", async () => {
+    const files = [{ path: "Assets/Foo.prefab", status: "added", sha: "blob-head" }];
+    const { deps, client } = makeDeps({ files, blobs: { "blob-head": "a" } });
+    client.getCommit.mockResolvedValue({ sha: "head-sha", parentSha: null, files });
+    const res = await resolveFully(createHandler(deps), { ...REQ, target: { kind: "commit", sha: "head-sha" } });
+    // The before side is never fetched for added files, so a missing parent is harmless
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: {} } });
+  });
+
+  it("serves a compare target from the merge base and resolves the head ref", async () => {
+    const { deps, client } = makeDeps();
+    const res = await resolveFully(createHandler(deps), {
+      ...REQ,
+      target: { kind: "compare", base: "main", head: "feature" },
+    });
+    expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: {} } });
+    expect(client.compareRefs).toHaveBeenCalledWith("o", "r", "main", "feature");
+    // Cache keys need an immutable sha, not a branch name that a push would silently move
+    expect(client.resolveRefSha).toHaveBeenCalledWith("o", "r", "feature");
   });
 
   it("uses an empty before for added files without fetching the base side", async () => {

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -1,7 +1,15 @@
 import { API_BASE, AuthError, type GithubClient, type PrFile, type PrRefs, RateLimitError } from "../github/client";
 import { applyResolved, buildGuidIndex, type GuidCache } from "../github/guids";
 import { type RepoIndexStore, syncRepoIndex } from "../github/repoIndex";
-import type { DiffV2, GuidResolvedPush, PrefetchRequest, SemanticDiffRequest, SemanticDiffResponse } from "../types";
+import {
+  type DiffTarget,
+  type DiffV2,
+  type GuidResolvedPush,
+  type PrefetchRequest,
+  type SemanticDiffRequest,
+  type SemanticDiffResponse,
+  targetKey,
+} from "../types";
 import { isUnityPath } from "../unity";
 import { DiffError, type Differ } from "../wasm/differ";
 
@@ -9,6 +17,9 @@ type ClientLike = Pick<
   GithubClient,
   | "getPrRefs"
   | "listPrFiles"
+  | "getCommit"
+  | "compareRefs"
+  | "resolveRefSha"
   | "getFileAtRef"
   | "getBlobRaw"
   | "listBlobShas"
@@ -31,13 +42,40 @@ export type Handler = {
   prefetch(req: PrefetchRequest): Promise<void>;
 };
 
-// baseShas: path → blob sha at the merge base. null = tree unavailable (truncated/failed) → contents-api fallback
-type PrContext = {
+// baseShas: path → blob sha at the base ref. null = tree unavailable (truncated/failed) → contents-api fallback
+type DiffContext = {
   refs: PrRefs;
   files: PrFile[];
   guidIndex: Map<string, string>;
   baseShas: Map<string, string> | null;
 };
+
+/** The only per-kind logic: refs + changed-file discovery. Everything downstream is target-agnostic. */
+async function loadRefsAndFiles(
+  client: ClientLike,
+  owner: string,
+  repo: string,
+  target: DiffTarget,
+): Promise<{ refs: PrRefs; files: PrFile[] }> {
+  if (target.kind === "pull") {
+    const [refs, files] = await Promise.all([
+      client.getPrRefs(owner, repo, target.prNumber),
+      client.listPrFiles(owner, repo, target.prNumber),
+    ]);
+    return { refs, files };
+  }
+  if (target.kind === "commit") {
+    const commit = await client.getCommit(owner, repo, target.sha);
+    // Root commit: every file is added, so the before side is never fetched; using the commit's
+    // own sha as baseSha keeps downstream tree lookups harmless.
+    return { refs: { baseSha: commit.parentSha ?? commit.sha, headSha: commit.sha }, files: commit.files };
+  }
+  const [cmp, headSha] = await Promise.all([
+    client.compareRefs(owner, repo, target.base, target.head),
+    client.resolveRefSha(owner, repo, target.head), // cache keys need an immutable sha, not a branch name
+  ]);
+  return { refs: { baseSha: cmp.mergeBaseSha, headSha }, files: cmp.files };
+}
 
 const EMPTY = new Uint8Array(0);
 const MAX_SEARCHES = 10; // Code Search is authenticated 10 req/min — don't burn it all in one response
@@ -55,7 +93,7 @@ type DiffOutcome =
 
 export function createHandler(deps: Deps): Handler {
   // Per-PR context cache. The SW may be killed at any time; then we just re-fetch.
-  const contexts = new Map<string, { at: number; ctx: Promise<PrContext> }>();
+  const contexts = new Map<string, { at: number; ctx: Promise<DiffContext> }>();
   // sha+path → bytes Promise. Storing a Promise folds concurrent prefetch and manual-toggle requests into one fetch.
   const blobs = new Map<string, Promise<Uint8Array | null>>();
   // guids that missed in Code Search. Indexing lag means we don't persist these — SW lifetime only
@@ -173,7 +211,7 @@ export function createHandler(deps: Deps): Handler {
   /** Retrieves the before/after blobs (status/previousPath rules follow the files API). */
   async function fetchPair(
     client: ClientLike,
-    ctx: PrContext,
+    ctx: DiffContext,
     owner: string,
     repo: string,
     path: string,
@@ -201,7 +239,7 @@ export function createHandler(deps: Deps): Handler {
     differ: Differ,
     before: Uint8Array,
     after: Uint8Array,
-    ctx: PrContext,
+    ctx: DiffContext,
     client: ClientLike,
     owner: string,
     repo: string,
@@ -245,15 +283,12 @@ export function createHandler(deps: Deps): Handler {
     return current;
   }
 
-  function loadContext(client: ClientLike, owner: string, repo: string, prNumber: number): Promise<PrContext> {
-    const key = `${owner}/${repo}#${prNumber}`;
+  function loadContext(client: ClientLike, owner: string, repo: string, target: DiffTarget): Promise<DiffContext> {
+    const key = targetKey(owner, repo, target);
     const entry = contexts.get(key);
     if (entry && Date.now() - entry.at < CONTEXT_TTL_MS) return entry.ctx;
     const ctx = (async () => {
-      const [refs, files] = await Promise.all([
-        client.getPrRefs(owner, repo, prNumber),
-        client.listPrFiles(owner, repo, prNumber),
-      ]);
+      const { refs, files } = await loadRefsAndFiles(client, owner, repo, target);
       const bySha = new Map(files.map((f) => [f.path, f.sha]));
       const [guidIndex, baseShas] = await Promise.all([
         buildGuidIndex(files, async (path, side) => {
@@ -288,7 +323,7 @@ export function createHandler(deps: Deps): Handler {
    *  (resolved improves later via Code Search, so the raw diff determined by sha alone is the cache unit). */
   async function computeDiff(
     client: ClientLike,
-    ctx: PrContext,
+    ctx: DiffContext,
     owner: string,
     repo: string,
     path: string,
@@ -311,7 +346,7 @@ export function createHandler(deps: Deps): Handler {
   /** sha-keyed, so a push naturally produces a different key (no invalidation needed). */
   function getDiff(
     client: ClientLike,
-    ctx: PrContext,
+    ctx: DiffContext,
     owner: string,
     repo: string,
     path: string,
@@ -347,11 +382,11 @@ export function createHandler(deps: Deps): Handler {
     client: ClientLike,
     req: SemanticDiffRequest,
     base: string,
-    ctx: PrContext,
+    ctx: DiffContext,
     push: (msg: GuidResolvedPush) => void,
   ): Promise<void> {
     const repoKey = `${base}/${req.owner}/${req.repo}`;
-    const at = { owner: req.owner, repo: req.repo, prNumber: req.prNumber, path: req.path };
+    const at = { owner: req.owner, repo: req.repo, target: req.target, path: req.path };
     try {
       // If remaining is empty (source re-merge only), don't wait on the index: the first index build can take tens of seconds and doesn't help resolution
       const index = remaining.length
@@ -396,7 +431,7 @@ export function createHandler(deps: Deps): Handler {
       if (!settings.pat) return { ok: false, error: "pat-missing" };
       const base = API_BASE;
       const client = deps.makeClient(base, settings.pat, "user");
-      const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
+      const ctx = await loadContext(client, req.owner, req.repo, req.target);
       const outcome = await getDiff(client, ctx, req.owner, req.repo, req.path, req.force === true);
       if (!outcome.ok) return outcome;
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
@@ -422,7 +457,7 @@ export function createHandler(deps: Deps): Handler {
       if (!settings.pat) return;
       const base = API_BASE;
       const client = deps.makeClient(base, settings.pat, "prefetch");
-      const ctx = await loadContext(client, req.owner, req.repo, req.prNumber);
+      const ctx = await loadContext(client, req.owner, req.repo, { kind: "pull", prNumber: req.prNumber });
       // Run independently of raw-diff prefetch (index sync speeds up the 3-stage resolution at serve time)
       void getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
       const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -79,7 +79,9 @@ async function loadRefsAndFiles(
   }
   const [cmp, headSha] = await Promise.all([
     client.compareRefs(owner, repo, target.base, target.head),
-    client.resolveRefSha(owner, repo, target.head), // cache keys need an immutable sha, not a branch name
+    // Cache keys need an immutable sha, not a branch name. The compare body can't supply it:
+    // its commits array truncates at 250, so the last entry isn't always the head.
+    client.resolveRefSha(owner, repo, target.head),
   ]);
   return { refs: { baseSha: cmp.mergeBaseSha, headSha }, files: cmp.files };
 }

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -1,4 +1,11 @@
-import { API_BASE, AuthError, type GithubClient, type PrFile, type PrRefs, RateLimitError } from "../github/client";
+import {
+  API_BASE,
+  AuthError,
+  type ChangedFile,
+  type GithubClient,
+  RateLimitError,
+  type RefPair,
+} from "../github/client";
 import { applyResolved, buildGuidIndex, type GuidCache } from "../github/guids";
 import { type RepoIndexStore, syncRepoIndex } from "../github/repoIndex";
 import {
@@ -44,8 +51,8 @@ export type Handler = {
 
 // baseShas: path → blob sha at the base ref. null = tree unavailable (truncated/failed) → contents-api fallback
 type DiffContext = {
-  refs: PrRefs;
-  files: PrFile[];
+  refs: RefPair;
+  files: ChangedFile[];
   guidIndex: Map<string, string>;
   baseShas: Map<string, string> | null;
 };
@@ -56,7 +63,7 @@ async function loadRefsAndFiles(
   owner: string,
   repo: string,
   target: DiffTarget,
-): Promise<{ refs: PrRefs; files: PrFile[] }> {
+): Promise<{ refs: RefPair; files: ChangedFile[] }> {
   if (target.kind === "pull") {
     const [refs, files] = await Promise.all([
       client.getPrRefs(owner, repo, target.prNumber),

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { parsePrPage, parsePrUrl, scanUnityFiles } from "./detect";
+import { parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 
 const FIXTURE = `
   <div class="file">
@@ -22,27 +22,67 @@ const FIXTURE = `
   <div class="file-header" data-path="Assets/Orphan.prefab"></div>
 `;
 
-describe("parsePrUrl", () => {
+describe("parseDiffUrl", () => {
   it("matches the PR files tab", () => {
-    expect(parsePrUrl("/owner/repo/pull/42/files")).toEqual({ owner: "owner", repo: "repo", prNumber: 42 });
-    expect(parsePrUrl("/owner/repo/pull/42/files/abc123")).toEqual({ owner: "owner", repo: "repo", prNumber: 42 });
-  });
-  it("rejects other pages", () => {
-    expect(parsePrUrl("/owner/repo/pull/42")).toBeNull();
-    expect(parsePrUrl("/owner/repo/blob/main/a.prefab")).toBeNull();
-  });
-  it("matches the react ui changes tab (rolled out since december 2025)", () => {
-    expect(parsePrUrl("/owner/repo/pull/42/changes")).toEqual({ owner: "owner", repo: "repo", prNumber: 42 });
-    // "Between commit A and B" range view, same shape github-url-detection accepts
-    expect(parsePrUrl("/owner/repo/pull/42/changes/1e27d799..e1aba6f")).toEqual({
+    expect(parseDiffUrl("/owner/repo/pull/42/files")).toEqual({
       owner: "owner",
       repo: "repo",
+      target: { kind: "pull", prNumber: 42 },
+    });
+    expect(parseDiffUrl("/owner/repo/pull/42/files/abc123")?.target).toEqual({ kind: "pull", prNumber: 42 });
+  });
+  it("matches the react ui changes tab and its commit range view", () => {
+    expect(parseDiffUrl("/owner/repo/pull/42/changes")?.target).toEqual({ kind: "pull", prNumber: 42 });
+    // "Between commit A and B" range view, same shape github-url-detection accepts
+    expect(parseDiffUrl("/owner/repo/pull/42/changes/1e27d799..e1aba6f")?.target).toEqual({
+      kind: "pull",
       prNumber: 42,
     });
   });
-  it("rejects the single-commit changes view (commit pages are a separate issue)", () => {
-    expect(parsePrUrl("/owner/repo/pull/42/changes/1e27d7998afdd3608d9fc3bf95ccf27fa5010641")).toBeNull();
-    expect(parsePrUrl("/owner/repo/pull/42/changes/1e27d79")).toBeNull();
+  it("maps single-commit views inside a PR to a commit target", () => {
+    // react ui: /changes/SHA, classic: /commits/SHA — both show one commit against its parent
+    expect(parseDiffUrl("/owner/repo/pull/42/changes/1e27d7998afdd3608d9fc3bf95ccf27fa5010641")?.target).toEqual({
+      kind: "commit",
+      sha: "1e27d7998afdd3608d9fc3bf95ccf27fa5010641",
+    });
+    expect(parseDiffUrl("/owner/repo/pull/42/commits/1e27d79")?.target).toEqual({ kind: "commit", sha: "1e27d79" });
+  });
+  it("matches commit pages", () => {
+    expect(parseDiffUrl("/owner/repo/commit/1e27d7998afdd3608d9fc3bf95ccf27fa5010641")).toEqual({
+      owner: "owner",
+      repo: "repo",
+      target: { kind: "commit", sha: "1e27d7998afdd3608d9fc3bf95ccf27fa5010641" },
+    });
+    expect(parseDiffUrl("/owner/repo/commit/1e27d79/")?.target).toEqual({ kind: "commit", sha: "1e27d79" });
+    expect(parseDiffUrl("/owner/repo/commit/not-a-sha")).toBeNull();
+  });
+  it("matches same-repo three-dot compare pages", () => {
+    expect(parseDiffUrl("/owner/repo/compare/main...feature")).toEqual({
+      owner: "owner",
+      repo: "repo",
+      target: { kind: "compare", base: "main", head: "feature" },
+    });
+    // branch names keep their slashes; encoded characters are decoded per side
+    expect(parseDiffUrl("/owner/repo/compare/feat/a...feat/b")?.target).toEqual({
+      kind: "compare",
+      base: "feat/a",
+      head: "feat/b",
+    });
+    expect(parseDiffUrl("/owner/repo/compare/v1%2E0...main")?.target).toEqual({
+      kind: "compare",
+      base: "v1.0",
+      head: "main",
+    });
+  });
+  it("rejects compare pages this extension cannot serve", () => {
+    expect(parseDiffUrl("/owner/repo/compare/main...other:branch")).toBeNull(); // cross-fork
+    expect(parseDiffUrl("/owner/repo/compare/main")).toBeNull(); // single ref
+    expect(parseDiffUrl("/owner/repo/compare")).toBeNull(); // picker page
+  });
+  it("rejects other pages", () => {
+    expect(parseDiffUrl("/owner/repo/pull/42")).toBeNull();
+    expect(parseDiffUrl("/owner/repo/pull/42/commits")).toBeNull(); // commit list, no diff
+    expect(parseDiffUrl("/owner/repo/blob/main/a.prefab")).toBeNull();
   });
 });
 

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -73,6 +73,22 @@ describe("parseDiffUrl", () => {
       base: "v1.0",
       head: "main",
     });
+    // A manually typed trailing slash must not leak into the head ref (git refs can't end with /)
+    expect(parseDiffUrl("/owner/repo/compare/main...topic/")?.target).toEqual({
+      kind: "compare",
+      base: "main",
+      head: "topic",
+    });
+  });
+
+  it("survives malformed percent escapes instead of throwing", () => {
+    // Browsers pass invalid %-sequences through pathname verbatim; decodeURIComponent would
+    // throw URIError and attach() runs this unguarded before the MutationObserver is installed
+    expect(parseDiffUrl("/owner/repo/compare/50%discount...main")?.target).toEqual({
+      kind: "compare",
+      base: "50%discount",
+      head: "main",
+    });
   });
   it("rejects compare pages this extension cannot serve", () => {
     expect(parseDiffUrl("/owner/repo/compare/main...other:branch")).toBeNull(); // cross-fork

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -1,3 +1,4 @@
+import type { DiffTarget } from "../types";
 import { isUnityPath } from "../unity";
 
 export type FileEntry = {
@@ -9,16 +10,34 @@ export type FileEntry = {
   globalAnchor(): Element | null; // element the global bar is inserted before
 };
 
-export function parsePrUrl(pathname: string): { owner: string; repo: string; prNumber: number } | null {
-  // files: any suffix (ranges render inline). changes (react ui): bare tab or A..B range only —
-  // a single sha under /changes/ is the commit view, which this extension does not handle yet.
-  const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/(?:files(?:\/|$)|changes(?:\/[\da-f]{7,40}\.\.[\da-f]{7,40})?\/?$)/.exec(
-    pathname,
-  );
-  return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
+export type DiffPage = { owner: string; repo: string; target: DiffTarget };
+
+/** Recognizes every diff page the pipeline can serve. Compare is same-repo three-dot only:
+ *  fork syntax (owner:branch) would need a second repo's blobs, and GitHub's compare page
+ *  itself is three-dot (merge base), which is exactly what the compare API returns. */
+export function parseDiffUrl(pathname: string): DiffPage | null {
+  // files: any suffix (ranges render inline). changes (react ui): bare tab or A..B range only.
+  const pr =
+    /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/(?:files(?:\/|$)|changes(?:\/[\da-f]{7,40}\.\.[\da-f]{7,40})?\/?$)/.exec(
+      pathname,
+    );
+  if (pr) return { owner: pr[1]!, repo: pr[2]!, target: { kind: "pull", prNumber: Number(pr[3]!) } };
+  // Single-commit views inside a PR (classic /commits/SHA, react /changes/SHA) share the commit pipeline
+  const prCommit = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/(?:commits|changes)\/([\da-f]{7,40})\/?$/.exec(pathname);
+  if (prCommit) return { owner: prCommit[1]!, repo: prCommit[2]!, target: { kind: "commit", sha: prCommit[3]! } };
+  const commit = /^\/([^/]+)\/([^/]+)\/commit\/([\da-f]{7,40})\/?$/.exec(pathname);
+  if (commit) return { owner: commit[1]!, repo: commit[2]!, target: { kind: "commit", sha: commit[3]! } };
+  const compare = /^\/([^/]+)\/([^/]+)\/compare\/(.+?)\.\.\.(.+)$/.exec(pathname);
+  if (compare) {
+    const base = decodeURIComponent(compare[3]!);
+    const head = decodeURIComponent(compare[4]!);
+    if (base.includes(":") || head.includes(":")) return null;
+    return { owner: compare[1]!, repo: compare[2]!, target: { kind: "compare", base, head } };
+  }
+  return null;
 }
 
-/** Matches any PR tab (the prefetch trigger). Different role from the files-only parsePrUrl. */
+/** Matches any PR tab (the prefetch trigger). Different role from the diff-page-only parseDiffUrl. */
 export function parsePrPage(pathname: string): { owner: string; repo: string; prNumber: number } | null {
   const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(\/|$)/.exec(pathname);
   return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -12,6 +12,17 @@ export type FileEntry = {
 
 export type DiffPage = { owner: string; repo: string; target: DiffTarget };
 
+/** decodeURIComponent that tolerates malformed escapes: a pathname can carry a bare %
+ *  (browsers pass invalid sequences through verbatim), and parseDiffUrl runs unguarded
+ *  in attach() — throwing here would kill the whole page scan. */
+function decodeRef(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
 /** Recognizes every diff page the pipeline can serve. Compare is same-repo three-dot only:
  *  fork syntax (owner:branch) would need a second repo's blobs, and GitHub's compare page
  *  itself is three-dot (merge base), which is exactly what the compare API returns. */
@@ -22,15 +33,14 @@ export function parseDiffUrl(pathname: string): DiffPage | null {
       pathname,
     );
   if (pr) return { owner: pr[1]!, repo: pr[2]!, target: { kind: "pull", prNumber: Number(pr[3]!) } };
-  // Single-commit views inside a PR (classic /commits/SHA, react /changes/SHA) share the commit pipeline
-  const prCommit = /^\/([^/]+)\/([^/]+)\/pull\/\d+\/(?:commits|changes)\/([\da-f]{7,40})\/?$/.exec(pathname);
-  if (prCommit) return { owner: prCommit[1]!, repo: prCommit[2]!, target: { kind: "commit", sha: prCommit[3]! } };
-  const commit = /^\/([^/]+)\/([^/]+)\/commit\/([\da-f]{7,40})\/?$/.exec(pathname);
+  // Single-commit views: standalone /commit/SHA, plus the in-PR classic /commits/SHA and
+  // react /changes/SHA — all show one commit against its parent
+  const commit = /^\/([^/]+)\/([^/]+)\/(?:pull\/\d+\/(?:commits|changes)|commit)\/([\da-f]{7,40})\/?$/.exec(pathname);
   if (commit) return { owner: commit[1]!, repo: commit[2]!, target: { kind: "commit", sha: commit[3]! } };
-  const compare = /^\/([^/]+)\/([^/]+)\/compare\/(.+?)\.\.\.(.+)$/.exec(pathname);
+  const compare = /^\/([^/]+)\/([^/]+)\/compare\/(.+?)\.\.\.(.+?)\/?$/.exec(pathname);
   if (compare) {
-    const base = decodeURIComponent(compare[3]!);
-    const head = decodeURIComponent(compare[4]!);
+    const base = decodeRef(compare[3]!);
+    const head = decodeRef(compare[4]!);
     if (base.includes(":") || head.includes(":")) return null;
     return { owner: compare[1]!, repo: compare[2]!, target: { kind: "compare", base, head } };
   }

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -74,7 +74,7 @@ function signInPanel(root: ShadowRoot, message: string): void {
 function attach(state: ViewState): void {
   const prPage = parsePrPage(location.pathname);
   if (prPage) {
-    const prKey = `${prPage.owner}/${prPage.repo}#${prPage.prNumber}`;
+    const prKey = targetKey(prPage.owner, prPage.repo, { kind: "pull", prNumber: prPage.prNumber });
     if (prKey !== prefetchedPr) {
       prefetchedPr = prKey;
       // fire-and-forget: don't wait on the response, ignore failures (the manual-toggle path is separately alive)

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -7,15 +7,16 @@ import {
   renderSignInPending,
   renderTooLarge,
 } from "../renderer/render";
-import type {
-  BackgroundError,
-  DiffV2,
-  GuidResolvedPush,
-  PrefetchRequest,
-  SemanticDiffRequest,
-  SemanticDiffResponse,
+import {
+  type BackgroundError,
+  type DiffV2,
+  type GuidResolvedPush,
+  type PrefetchRequest,
+  type SemanticDiffRequest,
+  type SemanticDiffResponse,
+  targetKey,
 } from "../types";
-import { type FileEntry, parsePrPage, parsePrUrl, scanUnityFiles } from "./detect";
+import { type DiffPage, type FileEntry, parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 import { fillDeviceCode } from "./devicePage";
 import { createSignIn, type PendingSignIn } from "./signin";
 import { createToggle, type Toggle, type View } from "./toggle";
@@ -41,7 +42,7 @@ function countUnresolved(json: DiffV2): number {
 type Applier = { header: HTMLElement; apply(view: View): void; sync(): void };
 const appliers = new Set<Applier>();
 let globalToggle: Toggle | undefined;
-let currentPr = ""; // overrides are valid only while on the PR: discard when the PR changes
+let currentPage = ""; // overrides are valid only while on the diff page: discard when it changes
 let prefetchedPr = ""; // send prefetch just once across all PR tabs, including the conversation tab
 
 // Files whose panels are stuck on an auth error: all retried once a token lands in storage.
@@ -71,21 +72,22 @@ function signInPanel(root: ShadowRoot, message: string): void {
 }
 
 function attach(state: ViewState): void {
-  const page = parsePrPage(location.pathname);
-  if (!page) return;
-  const pageKey = `${page.owner}/${page.repo}#${page.prNumber}`;
-  if (pageKey !== prefetchedPr) {
-    prefetchedPr = pageKey;
-    // fire-and-forget: don't wait on the response, ignore failures (the manual-toggle path is separately alive)
-    void (
-      chrome.runtime.sendMessage({ type: "prefetch", ...page } satisfies PrefetchRequest) as Promise<unknown>
-    ).catch(() => {});
+  const prPage = parsePrPage(location.pathname);
+  if (prPage) {
+    const prKey = `${prPage.owner}/${prPage.repo}#${prPage.prNumber}`;
+    if (prKey !== prefetchedPr) {
+      prefetchedPr = prKey;
+      // fire-and-forget: don't wait on the response, ignore failures (the manual-toggle path is separately alive)
+      void (
+        chrome.runtime.sendMessage({ type: "prefetch", ...prPage } satisfies PrefetchRequest) as Promise<unknown>
+      ).catch(() => {});
+    }
   }
-  const pr = parsePrUrl(location.pathname);
-  if (!pr) return;
-  const key = `${pr.owner}/${pr.repo}#${pr.prNumber}`;
-  if (key !== currentPr) {
-    currentPr = key;
+  const page = parseDiffUrl(location.pathname);
+  if (!page) return;
+  const key = targetKey(page.owner, page.repo, page.target);
+  if (key !== currentPage) {
+    currentPage = key;
     state.clearOverrides();
     for (const [k, v] of views) if (!v.root.host.isConnected) views.delete(k); // not only ignore late pushes to views killed by navigation, but also cut the reference
   }
@@ -94,7 +96,7 @@ function attach(state: ViewState): void {
   for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
   const entries = scanUnityFiles(document);
   if (entries.length) ensureGlobalToggle(state, entries[0]!);
-  for (const entry of entries) attachToggle(state, pr, entry);
+  for (const entry of entries) attachToggle(state, page, entry);
   // Re-assert view state: react remounts diff bodies under still-marked headers, which
   // silently undoes the inline hide. All sync operations are idempotent and fetch-free.
   for (const a of appliers) a.sync();
@@ -118,10 +120,10 @@ function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
   globalToggle = toggle;
 }
 
-function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNumber: number }, entry: FileEntry): void {
+function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void {
   if (entry.header.hasAttribute("data-prefablens")) return;
   entry.header.setAttribute("data-prefablens", "");
-  const viewKey = `${pr.owner}/${pr.repo}#${pr.prNumber}:${entry.path}`;
+  const viewKey = `${targetKey(page.owner, page.repo, page.target)}:${entry.path}`;
 
   let host: HTMLElement | undefined;
   let requested = false;
@@ -159,7 +161,14 @@ function attachToggle(state: ViewState, pr: { owner: string; repo: string; prNum
     const request = (force?: boolean): void => {
       requested = true;
       renderLoading(root);
-      void requestDiff({ type: "semanticDiff", ...pr, path: entry.path, force }).then((res) => {
+      void requestDiff({
+        type: "semanticDiff",
+        owner: page.owner,
+        repo: page.repo,
+        target: page.target,
+        path: entry.path,
+        force,
+      }).then((res) => {
         if (res.ok) {
           views.set(viewKey, { root, json: res.json });
           // Always show it while pending: even if all names are resolved, source merging may remain
@@ -243,8 +252,8 @@ async function init(): Promise<void> {
   // guid resolution push from background (the second stage of the two-stage response): re-render if the matching view exists
   chrome.runtime.onMessage.addListener((msg: GuidResolvedPush) => {
     if (msg?.type !== "guidResolved") return;
-    const view = views.get(`${msg.owner}/${msg.repo}#${msg.prNumber}:${msg.path}`);
-    if (!view) return; // already navigated to a different PR, etc.: drop silently
+    const view = views.get(`${targetKey(msg.owner, msg.repo, msg.target)}:${msg.path}`);
+    if (!view) return; // already navigated to a different diff page, etc.: drop silently
     // The final push replaces json (mergeSources may change the structure), an intermediate push merges resolved
     view.json = msg.json ?? { ...view.json, resolved: { ...view.json.resolved, ...msg.resolved } };
     render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(countUnresolved(view.json), 1) });

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -182,6 +182,63 @@ describe("GithubClient", () => {
       ).getPrRefs("o", "r", 1),
     ).rejects.toBeInstanceOf(AuthError);
   });
+
+  it("getCommit returns the first parent as base and maps files", async () => {
+    const { fn } = fakeFetch({
+      "/commits/abc1234?": () =>
+        json({
+          sha: "abc1234full",
+          parents: [{ sha: "parent-sha" }, { sha: "merge-second-parent" }],
+          files: [{ filename: "Assets/Foo.prefab", status: "modified", sha: "blob-head" }],
+        }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const commit = await client.getCommit("o", "r", "abc1234");
+    // GitHub's commit page diffs against the first parent; so do we
+    expect(commit).toEqual({
+      sha: "abc1234full",
+      parentSha: "parent-sha",
+      files: [{ path: "Assets/Foo.prefab", status: "modified", previousPath: undefined, sha: "blob-head" }],
+    });
+  });
+
+  it("getCommit paginates past 300 files and flags a root commit", async () => {
+    // The commit API pages files 300 at a time (3,000-file cap on GitHub's side)
+    const page1 = Array.from({ length: 300 }, (_, i) => ({ filename: `f${i}.cs`, status: "added" }));
+    const { fn } = fakeFetch({
+      "&page=1": () => json({ sha: "root-sha", parents: [], files: page1 }),
+      "&page=2": () => json({ sha: "root-sha", parents: [], files: [{ filename: "last.cs", status: "added" }] }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const commit = await client.getCommit("o", "r", "root-sha");
+    expect(commit.parentSha).toBeNull(); // root commit: every file is added, no base side exists
+    expect(commit.files).toHaveLength(301);
+  });
+
+  it("compareRefs returns the merge base and maps files", async () => {
+    const { fn, calls } = fakeFetch({
+      "/compare/feat%2Fx...main": () =>
+        json({
+          merge_base_commit: { sha: "merge-base" },
+          files: [{ filename: "Assets/Foo.prefab", status: "removed", sha: "blob-base" }],
+        }),
+    });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const cmp = await client.compareRefs("o", "r", "feat/x", "main");
+    expect(cmp).toEqual({
+      mergeBaseSha: "merge-base",
+      files: [{ path: "Assets/Foo.prefab", status: "removed", previousPath: undefined, sha: "blob-base" }],
+    });
+    // refs are encoded per side so branch slashes can't be misread as path segments
+    expect(calls[0]?.url).toContain("/compare/feat%2Fx...main");
+  });
+
+  it("resolveRefSha asks for the sha media type and trims the text body", async () => {
+    const { fn, calls } = fakeFetch({ "/commits/main": () => new Response("full-head-sha\n") });
+    const client = new GithubClient("https://api.github.com", "tok", fn);
+    await expect(client.resolveRefSha("o", "r", "main")).resolves.toBe("full-head-sha");
+    expect(calls[0]?.headers.accept).toBe("application/vnd.github.sha");
+  });
 });
 
 describe("graphqlUrl", () => {

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -7,12 +7,12 @@ export class ApiError extends Error {
 }
 
 // sha is the blob at head (at base for removed files) — the files API provides it for every status.
-export type PrFile = { path: string; status: string; previousPath?: string; sha?: string };
-export type PrRefs = { baseSha: string; headSha: string };
+export type ChangedFile = { path: string; status: string; previousPath?: string; sha?: string };
+export type RefPair = { baseSha: string; headSha: string };
 
 // GitHub's shared "diff entry" schema: PR files, commit files, and compare files all use it.
 type DiffEntry = { filename: string; status: string; previous_filename?: string; sha?: string };
-const toPrFile = (f: DiffEntry): PrFile => ({
+const toChangedFile = (f: DiffEntry): ChangedFile => ({
   path: f.filename,
   status: f.status,
   previousPath: f.previous_filename,
@@ -71,7 +71,7 @@ export class GithubClient {
   }
 
   // The before side is the merge-base: GitHub's PR diff compares against the merge-base, not the base branch tip.
-  async getPrRefs(owner: string, repo: string, prNumber: number): Promise<PrRefs> {
+  async getPrRefs(owner: string, repo: string, prNumber: number): Promise<RefPair> {
     const pr = await this.json<{ base: { sha: string }; head: { sha: string } }>(
       `/repos/${owner}/${repo}/pulls/${prNumber}`,
     );
@@ -81,13 +81,13 @@ export class GithubClient {
     return { baseSha: cmp.merge_base_commit.sha, headSha: pr.head.sha };
   }
 
-  async listPrFiles(owner: string, repo: string, prNumber: number): Promise<PrFile[]> {
-    const out: PrFile[] = [];
+  async listPrFiles(owner: string, repo: string, prNumber: number): Promise<ChangedFile[]> {
+    const out: ChangedFile[] = [];
     for (let page = 1; ; page++) {
       const batch = await this.json<DiffEntry[]>(
         `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`,
       );
-      for (const f of batch) out.push(toPrFile(f));
+      for (const f of batch) out.push(toChangedFile(f));
       if (batch.length < 100) return out;
     }
   }
@@ -99,8 +99,8 @@ export class GithubClient {
     owner: string,
     repo: string,
     ref: string,
-  ): Promise<{ sha: string; parentSha: string | null; files: PrFile[] }> {
-    const files: PrFile[] = [];
+  ): Promise<{ sha: string; parentSha: string | null; files: ChangedFile[] }> {
+    const files: ChangedFile[] = [];
     let sha = "";
     let parentSha: string | null = null;
     for (let page = 1; ; page++) {
@@ -112,7 +112,7 @@ export class GithubClient {
         parentSha = body.parents[0]?.sha ?? null;
       }
       const batch = body.files ?? [];
-      for (const f of batch) files.push(toPrFile(f));
+      for (const f of batch) files.push(toChangedFile(f));
       if (batch.length < 300) return { sha, parentSha, files };
     }
   }
@@ -126,12 +126,12 @@ export class GithubClient {
     repo: string,
     base: string,
     head: string,
-  ): Promise<{ mergeBaseSha: string; files: PrFile[] }> {
+  ): Promise<{ mergeBaseSha: string; files: ChangedFile[] }> {
     const basehead = `${encodeURIComponent(base)}...${encodeURIComponent(head)}`;
     const body = await this.json<{ merge_base_commit: { sha: string }; files?: DiffEntry[] }>(
       `/repos/${owner}/${repo}/compare/${basehead}`,
     );
-    return { mergeBaseSha: body.merge_base_commit.sha, files: (body.files ?? []).map(toPrFile) };
+    return { mergeBaseSha: body.merge_base_commit.sha, files: (body.files ?? []).map(toChangedFile) };
   }
 
   /** Resolves a ref (branch, tag, abbreviated sha) to the full commit sha via the sha media type. */

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -75,10 +75,8 @@ export class GithubClient {
     const pr = await this.json<{ base: { sha: string }; head: { sha: string } }>(
       `/repos/${owner}/${repo}/pulls/${prNumber}`,
     );
-    const cmp = await this.json<{ merge_base_commit: { sha: string } }>(
-      `/repos/${owner}/${repo}/compare/${pr.base.sha}...${pr.head.sha}`,
-    );
-    return { baseSha: cmp.merge_base_commit.sha, headSha: pr.head.sha };
+    const cmp = await this.compareRefs(owner, repo, pr.base.sha, pr.head.sha);
+    return { baseSha: cmp.mergeBaseSha, headSha: pr.head.sha };
   }
 
   async listPrFiles(owner: string, repo: string, prNumber: number): Promise<ChangedFile[]> {
@@ -103,7 +101,9 @@ export class GithubClient {
     const files: ChangedFile[] = [];
     let sha = "";
     let parentSha: string | null = null;
-    for (let page = 1; ; page++) {
+    // GitHub documents a 3,000-file cap for this endpoint: 10 pages of 300 bounds the loop
+    // even if the API ever stops honoring the paging params.
+    for (let page = 1; page <= 10; page++) {
       const body = await this.json<{ sha: string; parents: Array<{ sha: string }>; files?: DiffEntry[] }>(
         `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}?per_page=300&page=${page}`,
       );
@@ -113,8 +113,9 @@ export class GithubClient {
       }
       const batch = body.files ?? [];
       for (const f of batch) files.push(toChangedFile(f));
-      if (batch.length < 300) return { sha, parentSha, files };
+      if (batch.length < 300) break;
     }
+    return { sha, parentSha, files };
   }
 
   /** Three-dot comparison (what GitHub's compare page shows): merge base + changed files.

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -10,6 +10,15 @@ export class ApiError extends Error {
 export type PrFile = { path: string; status: string; previousPath?: string; sha?: string };
 export type PrRefs = { baseSha: string; headSha: string };
 
+// GitHub's shared "diff entry" schema: PR files, commit files, and compare files all use it.
+type DiffEntry = { filename: string; status: string; previous_filename?: string; sha?: string };
+const toPrFile = (f: DiffEntry): PrFile => ({
+  path: f.filename,
+  status: f.status,
+  previousPath: f.previous_filename,
+  sha: f.sha,
+});
+
 // The REST base is fixed at build time (see build.mjs's esbuild define).
 export const API_BASE = __API_BASE__;
 
@@ -75,13 +84,64 @@ export class GithubClient {
   async listPrFiles(owner: string, repo: string, prNumber: number): Promise<PrFile[]> {
     const out: PrFile[] = [];
     for (let page = 1; ; page++) {
-      const batch = await this.json<
-        Array<{ filename: string; status: string; previous_filename?: string; sha?: string }>
-      >(`/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`);
-      for (const f of batch)
-        out.push({ path: f.filename, status: f.status, previousPath: f.previous_filename, sha: f.sha });
+      const batch = await this.json<DiffEntry[]>(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`,
+      );
+      for (const f of batch) out.push(toPrFile(f));
       if (batch.length < 100) return out;
     }
+  }
+
+  /** Commit metadata + changed files vs the first parent (what GitHub's commit page shows).
+   *  Files paginate 300 per page up to GitHub's 3,000-file cap; sha in the response is
+   *  full-length even when the request ref is abbreviated. */
+  async getCommit(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): Promise<{ sha: string; parentSha: string | null; files: PrFile[] }> {
+    const files: PrFile[] = [];
+    let sha = "";
+    let parentSha: string | null = null;
+    for (let page = 1; ; page++) {
+      const body = await this.json<{ sha: string; parents: Array<{ sha: string }>; files?: DiffEntry[] }>(
+        `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}?per_page=300&page=${page}`,
+      );
+      if (page === 1) {
+        sha = body.sha;
+        parentSha = body.parents[0]?.sha ?? null;
+      }
+      const batch = body.files ?? [];
+      for (const f of batch) files.push(toPrFile(f));
+      if (batch.length < 300) return { sha, parentSha, files };
+    }
+  }
+
+  /** Three-dot comparison (what GitHub's compare page shows): merge base + changed files.
+   *  GitHub returns compare files only on the first page, capped at 300 for the whole
+   *  comparison — like the PR 3,000-file cap, unlisted files degrade to the handler's
+   *  treat-as-modified / 404→EMPTY path. */
+  async compareRefs(
+    owner: string,
+    repo: string,
+    base: string,
+    head: string,
+  ): Promise<{ mergeBaseSha: string; files: PrFile[] }> {
+    const basehead = `${encodeURIComponent(base)}...${encodeURIComponent(head)}`;
+    const body = await this.json<{ merge_base_commit: { sha: string }; files?: DiffEntry[] }>(
+      `/repos/${owner}/${repo}/compare/${basehead}`,
+    );
+    return { mergeBaseSha: body.merge_base_commit.sha, files: (body.files ?? []).map(toPrFile) };
+  }
+
+  /** Resolves a ref (branch, tag, abbreviated sha) to the full commit sha via the sha media type. */
+  async resolveRefSha(owner: string, repo: string, ref: string): Promise<string> {
+    const res = await this.request(
+      `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
+      "application/vnd.github.sha",
+    );
+    if (!res.ok) throw new ApiError(res.status);
+    return (await res.text()).trim();
   }
 
   /** Looks up guid → asset path (with .meta stripped) via Code Search. No hit / not indexed (422) → null.

--- a/extension/src/github/guids.ts
+++ b/extension/src/github/guids.ts
@@ -1,4 +1,4 @@
-import { type PrFile, RateLimitError } from "./client";
+import { type ChangedFile, RateLimitError } from "./client";
 
 /** Same rule as parseGuid in cli/src/resolve.zig: picks up "guid:" at the start of a line (after trim). */
 export function parseGuidFromMeta(meta: string): string | undefined {
@@ -22,11 +22,11 @@ const MAX_CONCURRENT_META_FETCHES = 8;
 
 /** Builds a guid → asset path index only from .meta files changed in the PR. removed ones are read from the base side.
  *  Caps concurrent fetches at 8 (avoids GitHub secondary rate limits on large .meta changes). */
-export async function buildGuidIndex(files: PrFile[], fetchMeta: MetaFetcher): Promise<Map<string, string>> {
+export async function buildGuidIndex(files: ChangedFile[], fetchMeta: MetaFetcher): Promise<Map<string, string>> {
   const index = new Map<string, string>();
   const metas = files.filter((f) => f.path.endsWith(".meta"));
 
-  const indexOne = async (f: PrFile): Promise<void> => {
+  const indexOne = async (f: ChangedFile): Promise<void> => {
     const side = f.status === "removed" ? "base" : "head";
     // Only rate limits propagate: swallowing them would cache a degraded index for the SW's lifetime
     const text = await fetchMeta(f.path, side).catch((err) => {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -85,7 +85,7 @@ export type SemanticDiffRequest = {
   type: "semanticDiff";
   owner: string;
   repo: string;
-  prNumber: number;
+  target: DiffTarget;
   path: string;
   force?: boolean; // render past the 25MB guard ("Render anyway" click)
 };
@@ -111,7 +111,7 @@ export type GuidResolvedPush = {
   type: "guidResolved";
   owner: string;
   repo: string;
-  prNumber: number;
+  target: DiffTarget;
   path: string;
   resolved: Record<string, string>;
   json?: DiffV2; // carried on the final push when mergeSources updated the structure (content replaces the view)

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -62,6 +62,24 @@ export type DiffV2 = {
 
 export type DiffErrorV1 = { schema: "prefablens.error.v1"; error: string };
 
+// Which diff page a request is for. Every kind shares the blob/diff pipeline; only
+// the refs + changed-file discovery differs (PR API / commit API / compare API).
+export type DiffTarget =
+  | { kind: "pull"; prNumber: number }
+  | { kind: "commit"; sha: string }
+  | { kind: "compare"; base: string; head: string };
+
+/** Stable identity of a target within a repo — context caches and view keys derive from it. */
+export function targetKey(owner: string, repo: string, target: DiffTarget): string {
+  const suffix =
+    target.kind === "pull"
+      ? `#${target.prNumber}`
+      : target.kind === "commit"
+        ? `@${target.sha}`
+        : `@${target.base}...${target.head}`;
+  return `${owner}/${repo}${suffix}`;
+}
+
 // content ↔ background messages (chrome.runtime only serializes JSON)
 export type SemanticDiffRequest = {
   type: "semanticDiff";


### PR DESCRIPTION
## Summary

The semantic toggle now works on commit pages (`/commit/SHA`, plus the single-commit views inside a PR: classic `/pull/N/commits/SHA` and react `/pull/N/changes/SHA`) and same-repo compare pages (`/compare/A...B`). PR page behavior is unchanged.

## Motivation

Unity YAML diffs are just as unreadable on commit and compare pages as on PR pages, but detection only matched `/pull/N/files` (and `/changes` since #167). The diff pipeline itself was already source-agnostic.

Closes #160

## Changes

- URL parsing generalizes to a `DiffTarget` discriminated union (`pull` / `commit` / `compare`) carried through `SemanticDiffRequest` and `GuidResolvedPush`; `targetKey` derives every context/view cache key (including the prefetch dedupe key).
- Only refs + changed-file discovery is per-kind (`loadRefsAndFiles`): commit pages use the commit API (first parent = base, files paginated 300/page, bounded at GitHub's documented 3,000-file cap), compare pages use the compare API (merge base = base) plus a `application/vnd.github.sha` lookup so cache keys get an immutable head sha instead of a branch name (the compare body's commits array truncates at 250, so it can't supply the head).
- The blob-SHA cache, `baseSha:headSha:path` diff cache, guid resolution, and both DOM scanners are reused untouched. The react `/changes/SHA` view that #167 deliberately rejected now maps to a commit target. `getPrRefs` reuses `compareRefs` for its merge-base call.
- Compare ref decoding tolerates malformed percent escapes (a bare `%` in a pathname would otherwise throw `URIError` inside the unguarded content-script scan) and strips a manually typed trailing slash.
- Renamed the now-shared types (`PrFile`→`ChangedFile`, `PrRefs`→`RefPair`, handler-local `PrContext`→`DiffContext`); the PR-endpoint method names stay.

Out of scope: cross-fork compares (`A...owner:branch`), single-ref and two-dot compares, blob views, prefetch on commit/compare pages. Compare file listings are capped at 300 by GitHub (files beyond the cap degrade to the existing treat-as-modified path).

## Testing

```
$ pnpm test
 Test Files  17 passed (17)
      Tests  211 passed (211)

$ pnpm e2e
  17 passed (2.4s)

$ pnpm typecheck && pnpm lint && pnpm build   # all clean
```

New unit tests: `parseDiffUrl` (pull/commit/compare matching, fork/single-ref/picker rejections, malformed-escape and trailing-slash tolerance), `getCommit` (first-parent base, 300-file pagination, root commit), `compareRefs`, `resolveRefSha`, and handler tests for commit/compare targets. New Playwright e2e: real extension + real wasm against a fake GitHub serving a commit page and a compare page end to end (`e2e/full.spec.ts`). Verified against the live GitHub API that `%2F`-encoded refs resolve and that the commit endpoint honors `per_page`/`page` for its files array. A multi-angle self-review ran on the diff; all six verified findings are fixed in `e4e5810`.