### PR TITLE
test: add ext list and value format parity tests

### DIFF
--- a/extension/src/renderer/value_format.parity.test.ts
+++ b/extension/src/renderer/value_format.parity.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+// The diff.v2 value display rules are hand-copied in four places: the
+// extension's formatValue (render.ts), the Unity editor's ValueFormat.cs, and
+// the CLI's writeValueText (render_tree.zig) / writeValue (render_html.zig).
+// Each parser below pulls the output literal of every branch out of one
+// implementation's source; the tests compare those records against the
+// extension's, so changing e.g. "None" in one place fails until all four move
+// together (issue #152). The guid resolution order (resolved path, then
+// built-in name, then raw guid) is checked via source positions.
+
+type Rules = {
+  missing: string; // absent side of an added/removed row
+  nullRef: string; // {fileID: 0}, Unity's null reference
+  localRefPrefix: string; // other document-local fileIDs
+  guidPrefix: string; // unresolved external reference
+  builtinSuffix: string; // built-in asset, after the object name
+};
+
+function read(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+}
+
+// Slice one top-level function out of a source file: from its header to the
+// first closing brace at column 0.
+function fnSlice(src: string, header: string): string {
+  const start = src.indexOf(header);
+  expect(start, `${header} not found`).toBeGreaterThanOrEqual(0);
+  return src.slice(start, src.indexOf("\n}", start));
+}
+
+function extract(src: string, re: RegExp, what: string): string {
+  const m = src.match(re);
+  expect(m, `${what} not found`).not.toBeNull();
+  return m![1]!;
+}
+
+// Assert the guid branch tries its lookups in order: resolved → built-in → raw.
+function expectResolveOrder(src: string, resolved: string, builtin: string, raw: string): void {
+  const a = src.indexOf(resolved);
+  const b = src.indexOf(builtin);
+  const c = src.indexOf(raw);
+  expect(a, `${resolved} not found`).toBeGreaterThanOrEqual(0);
+  expect(b, `${builtin} after ${resolved}`).toBeGreaterThan(a);
+  expect(c, `${raw} after ${builtin}`).toBeGreaterThan(b);
+}
+
+function tsRules(): Rules {
+  const fn = fnSlice(read("./render.ts"), "function formatValue");
+  expectResolveOrder(fn, "diff.resolved", "builtinName(", "`guid:");
+  return {
+    missing: extract(fn, /value === null\) return "([^"]*)"/, "null branch"),
+    nullRef: extract(fn, /\? "([^"]*)" :/, "fileID 0 branch"),
+    localRefPrefix: extract(fn, /: `([^`$]*)\$\{fileId\}`/, "local ref branch"),
+    guidPrefix: extract(fn, /return `([^`$]*)\$\{guid\}`/, "raw guid branch"),
+    builtinSuffix: extract(fn, /`\$\{builtin\}([^`]*)`/, "built-in branch"),
+  };
+}
+
+function csRules(): Rules {
+  const src = read("../../../editor/Editor/ValueFormat.cs");
+  expectResolveOrder(src, "m.Resolved.TryGetValue", "BuiltinRefs.Name", '"guid:"');
+  return {
+    missing: extract(src, /IsNull\)\s*return "([^"]*)"/, "null branch"),
+    nullRef: extract(src, /== "0" \? "([^"]*)"/, "fileID 0 branch"),
+    localRefPrefix: extract(src, /: "([^"]*)" \+ v\.RefFileId/, "local ref branch"),
+    guidPrefix: extract(src, /return "([^"]*)" \+ v\.RefGuid/, "raw guid branch"),
+    builtinSuffix: extract(src, /return builtin \+ "([^"]*)"/, "built-in branch"),
+  };
+}
+
+function zigTreeRules(): Rules {
+  const fn = fnSlice(read("../../../cli/src/render_tree.zig"), "fn writeValueText");
+  expectResolveOrder(fn, "rr.get(g)", "builtin_refs.name(", "guid:");
+  return {
+    missing: extract(fn, /orelse \{\s*try w\.writeAll\("([^"]*)"\)/, "null branch"),
+    nullRef: extract(fn, /file_id == 0\) \{[\s\S]*?writeAll\("([^"]*)"\)/, "fileID 0 branch"),
+    localRefPrefix: extract(fn, /print\("([^"{]*)\{d\}"/, "local ref branch"),
+    guidPrefix: extract(fn, /print\("([^"{]*)\{s\}", \.\{g\}\)/, "raw guid branch"),
+    builtinSuffix: extract(fn, /print\("\{s\}([^"]*)"/, "built-in branch"),
+  };
+}
+
+function zigHtmlRules(): Rules {
+  const fn = fnSlice(read("../../../cli/src/render_html.zig"), "fn writeValue(");
+  expectResolveOrder(fn, "rr.get(g)", "builtin_refs.name(", "guid:");
+  return {
+    missing: extract(fn, /orelse \{\s*try w\.writeAll\("([^"]*)"\)/, "null branch"),
+    nullRef: extract(fn, /file_id == 0\) \{[\s\S]*?writeAll\("([^"]*)"\)/, "fileID 0 branch"),
+    localRefPrefix: extract(fn, /print\("([^"{]*)\{d\}"/, "local ref branch"),
+    guidPrefix: extract(fn, /writeAll\("([^"]*)"\);\s*try writeEscaped\(w, g\)/, "raw guid branch"),
+    builtinSuffix: extract(fn, /writeEscaped\(w, builtin\);\s*try w\.writeAll\("([^"]*)"\)/, "built-in branch"),
+  };
+}
+
+it("editor ValueFormat.cs formats values like the extension's formatValue", () => {
+  expect(csRules()).toEqual(tsRules());
+});
+
+it("CLI render_tree.zig formats values like the extension's formatValue", () => {
+  expect(zigTreeRules()).toEqual(tsRules());
+});
+
+it("CLI render_html.zig formats values like the extension's formatValue", () => {
+  expect(zigHtmlRules()).toEqual(tsRules());
+});
+
+it("both CLI renderers collapse composite nodes the same way", () => {
+  // diff.v2 flattens vectors and the like into scalars before they reach the
+  // extension or the editor, so map/seq fallbacks exist only in the two CLI
+  // renderers that walk the model tree directly.
+  const tree = fnSlice(read("../../../cli/src/render_tree.zig"), "fn writeValueText");
+  const html = fnSlice(read("../../../cli/src/render_html.zig"), "fn writeValue(");
+  const collapse = (src: string) => ({
+    map: extract(src, /\.map => try w\.writeAll\("([^"]*)"\)/, "map branch"),
+    seq: extract(src, /\.seq => try w\.writeAll\("([^"]*)"\)/, "seq branch"),
+  });
+  expect(collapse(html)).toEqual(collapse(tree));
+});

--- a/extension/src/unity.parity.test.ts
+++ b/extension/src/unity.parity.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+// The UnityYAML extension prefilter is hand-copied in three places: the CLI's
+// git-side gate (unity_path.zig), the extension's path check (unity.ts), and
+// the demo site's fixture gate (build.mjs). All three match case-insensitively,
+// so parity is over lowercased, sorted sets (issue #152).
+
+function read(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf8");
+}
+
+function tsExtensions(): string[] {
+  // unity.ts encodes the list as a single alternation: /\.(prefab|unity|...)$/i
+  const m = read("./unity.ts").match(/\/\\\.\(([^)]+)\)\$\/i/);
+  expect(m, "UNITY_PATH regex not found in unity.ts").not.toBeNull();
+  return m![1]!
+    .split("|")
+    .map((e) => e.toLowerCase())
+    .sort();
+}
+
+function zigExtensions(): string[] {
+  const src = read("../../cli/src/unity_path.zig");
+  const start = src.indexOf("const extensions = [_][]const u8{");
+  expect(start, "extensions array not found in unity_path.zig").toBeGreaterThan(0);
+  const body = src.slice(start, src.indexOf("};", start));
+  return [...body.matchAll(/"\.([^"]+)"/g)].map((m) => m[1]!.toLowerCase()).sort();
+}
+
+function mjsExtensions(): string[] {
+  const src = read("../../site/build.mjs");
+  const start = src.indexOf("const UNITY_EXTENSIONS = [");
+  expect(start, "UNITY_EXTENSIONS array not found in build.mjs").toBeGreaterThan(0);
+  const body = src.slice(start, src.indexOf("];", start));
+  return [...body.matchAll(/"\.([^"]+)"/g)].map((m) => m[1]!.toLowerCase()).sort();
+}
+
+it("CLI unity_path.zig gates the same extensions as the extension", () => {
+  const ts = tsExtensions();
+  expect(ts).toContain("prefab"); // guard: an empty parse must not pass vacuously
+  expect(zigExtensions()).toEqual(ts);
+});
+
+it("site build.mjs gates the same extensions as the extension", () => {
+  expect(mjsExtensions()).toEqual(tsExtensions());
+});


### PR DESCRIPTION
## Summary

Adds two parity tests that fail whenever the hand-synced UnityYAML extension list (3 copies) or the diff.v2 value formatting rules (4 copies) diverge across languages.

## Motivation

Cross-language tables kept in sync by comment alone had no CI guard, unlike the builtin-ref and CSS class tables already covered by `builtin_refs.parity.test.ts` / `styles.parity.test.ts`. Forgetting one copy would make the CLI and the extension disagree on which files to diff, or render the same value differently across surfaces.

Closes #152

## Changes

- `extension/src/unity.parity.test.ts`: extracts the extension list from `cli/src/unity_path.zig`, `extension/src/unity.ts`, and `site/build.mjs`, and compares the lowercased sets (all three match case-insensitively).
- `extension/src/renderer/value_format.parity.test.ts`: extracts each branch's output literal (`—`, `None`, `#`, `guid:`, ` (built-in)`) and the guid resolution order (resolved → built-in → raw) from `render.ts`, `ValueFormat.cs`, `render_tree.zig`, and `render_html.zig`, comparing each against the extension's rules. Also cross-checks the CLI-only `{...}`/`[...]` composite fallbacks between the two Zig renderers.
- No production code or CI changes: both tests match the existing `src/**/*.test.ts` vitest include, so the CI extension job picks them up as-is. Neither needs the wasm binary.

## Testing

- `pnpm test` (extension): 19 files, 206 tests passed (200 existing + 6 new).
- `pnpm typecheck` and `pnpm lint`: clean (the 6 new `noNonNullAssertion` warnings match the existing parity test idiom; `biome ci` exits 0).
- Divergence drills, each reverted afterwards:
  - removed `".brush"` from `site/build.mjs` → the build.mjs parity test failed
  - removed `".brush"` from `cli/src/unity_path.zig` → the unity_path.zig parity test failed
  - changed `"None"` to `"Null"` in `editor/Editor/ValueFormat.cs` → the ValueFormat.cs parity test failed with `nullRef: "Null"` vs `"None"`