### PR TITLE
ci: manage extension version with bump-my-version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -27,3 +27,8 @@ replace = '"version": "{new_version}"'
 filename = "editor/Editor/Cli.cs"
 search = 'public const string Version = "{current_version}"'
 replace = 'public const string Version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "extension/package.json"
+search = '"version": "{current_version}"'
+replace = '"version": "{new_version}"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,6 @@ jobs:
           git config user.name "${APP_SLUG}[bot]"
           git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           bump-my-version bump --new-version "$VERSION"
-          pnpm -C extension version "$VERSION" --no-git-tag-version --allow-same-version --no-git-checks
           git add -u
           git diff --cached --quiet || git commit -m "chore: release v$VERSION"
           git tag "v$VERSION"


### PR DESCRIPTION
## Summary

Make `bump-my-version bump` the single mechanism that updates all five version locations by adding `extension/package.json` to `.bumpversion.toml`, and drop the separate `pnpm version` step from `release.yml`.

## Motivation

`extension/package.json` was the only version location outside `.bumpversion.toml`, bumped by a separate `pnpm -C extension version` step in the release workflow. Running `bump-my-version bump` locally left it behind, and the release depended on two mechanisms that must both run.

Closes #158

## Changes

- Add `extension/package.json` as a fifth `[[tool.bumpversion.files]]` entry in `.bumpversion.toml`
- Remove the `pnpm -C extension version` line from the "Bump, commit, and tag" step in `release.yml` (with it, the `--no-git-checks` friction disappears)

## Testing

```
$ bump-my-version bump --new-version 99.0.0 --dry-run -vv 2>&1 | grep "Would change file"
  Would change file build.zig.zon:
  Would change file extension/manifest.json:
  Would change file editor/package.json:
  Would change file editor/Editor/Cli.cs:
  Would change file extension/package.json:
```

All five version locations are rewritten by the single `bump-my-version bump` invocation; `git status` stays clean after the dry run. The real workflow path is exercised at the next release.