### PR TITLE
feat: harden the editor CLI auto-download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,12 @@ jobs:
             zig build -Dtarget="$1" -Doptimize=ReleaseSafe
             (cd zig-out/bin && zip -j "../../dist/prefablens-$2.zip" "$3")
           }
-          build aarch64-macos    macos-arm64  prefablens
-          build x86_64-macos     macos-x64    prefablens
-          build x86_64-linux-gnu linux-x64    prefablens
-          build x86_64-windows   windows-x64  prefablens.exe
+          build aarch64-macos      macos-arm64   prefablens
+          build x86_64-macos       macos-x64     prefablens
+          build x86_64-linux-gnu   linux-x64     prefablens
+          build aarch64-linux-gnu  linux-arm64   prefablens
+          build x86_64-windows     windows-x64   prefablens.exe
+          build aarch64-windows    windows-arm64 prefablens.exe
       - name: Build and package extension
         run: |
           set -euo pipefail

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -184,6 +184,37 @@ namespace PrefabLens
             });
         }
 
+        /// GET url into memory, reporting (bytesSoFar, contentLengthOrMinusOne) after each chunk.
+        /// Blocking by design: Download() runs on a worker thread (see DownloadAsync).
+        public static byte[] FetchBytes(
+            HttpClient http,
+            string url,
+            Action<long, long> onProgress,
+            CancellationToken ct
+        )
+        {
+            // GetAwaiter().GetResult() unwraps AggregateException so callers see the original message.
+            using var res = http.SendAsync(
+                    new HttpRequestMessage(HttpMethod.Get, url),
+                    HttpCompletionOption.ResponseHeadersRead,
+                    ct
+                )
+                .GetAwaiter()
+                .GetResult();
+            res.EnsureSuccessStatusCode();
+            var total = res.Content.Headers.ContentLength ?? -1;
+            using var src = res.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+            using var dst = new MemoryStream();
+            var buf = new byte[64 * 1024];
+            int n;
+            while ((n = src.ReadAsync(buf, 0, buf.Length, ct).GetAwaiter().GetResult()) > 0)
+            {
+                dst.Write(buf, 0, n);
+                onProgress?.Invoke(dst.Length, total);
+            }
+            return dst.ToArray();
+        }
+
         public static void ExtractTo(byte[] zipBytes, string dir)
         {
             using var zip = new ZipArchive(new MemoryStream(zipBytes));

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -26,10 +26,10 @@ namespace PrefabLens
         public static string ReleaseAssetName(bool isWindows, bool isMac, bool isArm64)
         {
             if (isWindows)
-                return "prefablens-windows-x64.zip";
+                return isArm64 ? "prefablens-windows-arm64.zip" : "prefablens-windows-x64.zip";
             if (isMac)
                 return isArm64 ? "prefablens-macos-arm64.zip" : "prefablens-macos-x64.zip";
-            return "prefablens-linux-x64.zip";
+            return isArm64 ? "prefablens-linux-arm64.zip" : "prefablens-linux-x64.zip";
         }
 
         public static string DownloadUrl(string version, string assetName) =>

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor;
@@ -34,6 +36,41 @@ namespace PrefabLens
 
         public static string DownloadUrl(string version, string assetName) =>
             $"https://github.com/hashiiiii/PrefabLens/releases/download/v{version}/{assetName}";
+
+        /// Hex digest for assetName from `shasum -a 256` output (the release's SHA256SUMS); null when absent.
+        public static string ExpectedSha256(string sha256Sums, string assetName)
+        {
+            foreach (var line in sha256Sums.Split('\n'))
+            {
+                var parts = line.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && parts[1] == assetName)
+                    return parts[0];
+            }
+            return null;
+        }
+
+        public static string Sha256Hex(byte[] bytes)
+        {
+            using var sha = SHA256.Create();
+            var hash = sha.ComputeHash(bytes);
+            var sb = new StringBuilder(hash.Length * 2);
+            foreach (var b in hash)
+                sb.Append(b.ToString("x2"));
+            return sb.ToString();
+        }
+
+        /// Reject a tampered or corrupted release asset before it reaches ExtractTo.
+        public static void VerifySha256(byte[] bytes, string sha256Sums, string assetName)
+        {
+            var expected = ExpectedSha256(sha256Sums, assetName);
+            if (expected == null)
+                throw new InvalidOperationException($"SHA256SUMS has no entry for {assetName}");
+            var actual = Sha256Hex(bytes);
+            if (!string.Equals(actual, expected, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidOperationException(
+                    $"SHA256 mismatch for {assetName}: expected {expected}, got {actual}"
+                );
+        }
 
         /// Bare invocation = bulk mode: HEAD vs working tree, all changed Unity files,
         /// as a [{path, diff}] JSON array.

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -107,11 +107,17 @@ namespace PrefabLens
                         Stderr = e.Message,
                     };
                 }
-                if (ctx != null)
-                    ctx.Post(_ => onDone(res), null);
-                else
-                    onDone(res);
+                Post(ctx, () => onDone(res));
             });
+        }
+
+        /// Invoke on the captured context when there is one (Unity's main thread), directly otherwise.
+        static void Post(SynchronizationContext ctx, Action action)
+        {
+            if (ctx != null)
+                ctx.Post(_ => action(), null);
+            else
+                action();
         }
 
         /// Minimal quoting for ProcessStartInfo.Arguments (handles asset paths with spaces).
@@ -191,27 +197,34 @@ namespace PrefabLens
         )
         {
             var ctx = SynchronizationContext.Current;
+            // Coalesce the per-chunk callbacks (network reads can be TCP-segment sized) so the
+            // main thread sees one post per visible change, not thousands per download.
+            Action<long, long> progress = null;
+            if (onProgress != null)
+            {
+                long lastStep = -1;
+                progress = (read, total) =>
+                {
+                    var step = total > 0 ? read * 100 / total : read >> 18;
+                    if (step == lastStep)
+                        return;
+                    lastStep = step;
+                    Post(ctx, () => onProgress(read, total));
+                };
+            }
             Task.Run(() =>
             {
                 string path = null;
                 string error = null;
                 try
                 {
-                    path = Download(
-                        onProgress == null || ctx == null
-                            ? onProgress
-                            : (read, total) => ctx.Post(_ => onProgress(read, total), null),
-                        ct
-                    );
+                    path = Download(progress, ct);
                 }
                 catch (Exception e)
                 {
                     error = e.Message;
                 }
-                if (ctx != null)
-                    ctx.Post(_ => onDone(path, error), null);
-                else
-                    onDone(path, error);
+                Post(ctx, () => onDone(path, error));
             });
         }
 
@@ -235,7 +248,8 @@ namespace PrefabLens
             res.EnsureSuccessStatusCode();
             var total = res.Content.Headers.ContentLength ?? -1;
             using var src = res.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
-            using var dst = new MemoryStream();
+            // Sized up front so a multi-MB body doesn't go through doubling reallocations.
+            using var dst = new MemoryStream(total > 0 && total <= int.MaxValue ? (int)total : 0);
             var buf = new byte[64 * 1024];
             int n;
             while ((n = src.ReadAsync(buf, 0, buf.Length, ct).GetAwaiter().GetResult()) > 0)

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -23,6 +23,11 @@ namespace PrefabLens
         /// the CLI surfaces its own specific error first. This is the last-resort safety net against freezing the Unity main thread.
         public const int RunTimeoutMs = 90_000;
 
+        /// Upper bound on the whole download (SHA256SUMS + zip). Explicit so a stalled connection
+        /// can't silently hold the status line for HttpClient's default 100 s; generous for slow
+        /// links because the window offers Cancel.
+        public const int DownloadTimeoutMs = 120_000;
+
         // ---- Pure functions (EditMode test targets) ----
 
         public static string ReleaseAssetName(bool isWindows, bool isMac, bool isArm64)
@@ -135,22 +140,39 @@ namespace PrefabLens
             return File.Exists(DefaultPath) ? DefaultPath : null;
         }
 
-        /// Fetch from GitHub Releases and extract under Library. Returns the executable path on success, throws on failure.
+        /// Fetch from GitHub Releases, verify against the release's SHA256SUMS, and extract under
+        /// Library. Returns the executable path on success, throws on failure (TimeoutException
+        /// after DownloadTimeoutMs, OperationCanceledException when ct is cancelled).
         /// Synchronous and free of Unity API calls so it can run on a worker thread (see DownloadAsync).
-        public static string Download()
+        public static string Download(Action<long, long> onProgress = null, CancellationToken ct = default)
         {
             var asset = ReleaseAssetName(
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
                 RuntimeInformation.IsOSPlatform(OSPlatform.OSX),
                 RuntimeInformation.ProcessArchitecture == Architecture.Arm64
             );
-            var url = DownloadUrl(Version, asset);
             var dir = Path.GetDirectoryName(DefaultPath);
             Directory.CreateDirectory(dir);
 
             using var http = new HttpClient();
-            // GetAwaiter().GetResult() unwraps AggregateException so onDone sees the HttpRequestException message.
-            var bytes = http.GetByteArrayAsync(url).GetAwaiter().GetResult();
+            // One deadline for the whole operation. HttpClient.Timeout is disabled because it
+            // only covers the headers once the body is streamed.
+            http.Timeout = Timeout.InfiniteTimeSpan;
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(DownloadTimeoutMs);
+            byte[] bytes;
+            string sums;
+            try
+            {
+                // SHA256SUMS first: a missing/broken release fails fast, before the multi-MB zip.
+                sums = Encoding.UTF8.GetString(FetchBytes(http, DownloadUrl(Version, "SHA256SUMS"), null, cts.Token));
+                bytes = FetchBytes(http, DownloadUrl(Version, asset), onProgress, cts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                throw new TimeoutException($"download timed out after {DownloadTimeoutMs / 1000}s");
+            }
+            VerifySha256(bytes, sums, asset);
             ExtractTo(bytes, dir);
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -159,10 +181,14 @@ namespace PrefabLens
             return DefaultPath;
         }
 
-        /// Run Download() off the main thread. The outcome is posted back through the caller's
-        /// SynchronizationContext (Unity's main thread when called from the window).
+        /// Run Download() off the main thread. Progress and the outcome are posted back through
+        /// the caller's SynchronizationContext (Unity's main thread when called from the window).
         /// Exactly one of (path, error) is non-null.
-        public static void DownloadAsync(Action<string, string> onDone)
+        public static void DownloadAsync(
+            Action<string, string> onDone,
+            Action<long, long> onProgress = null,
+            CancellationToken ct = default
+        )
         {
             var ctx = SynchronizationContext.Current;
             Task.Run(() =>
@@ -171,7 +197,12 @@ namespace PrefabLens
                 string error = null;
                 try
                 {
-                    path = Download();
+                    path = Download(
+                        onProgress == null || ctx == null
+                            ? onProgress
+                            : (read, total) => ctx.Post(_ => onProgress(read, total), null),
+                        ct
+                    );
                 }
                 catch (Exception e)
                 {

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -217,7 +217,9 @@ namespace PrefabLens
             content.Clear();
             downloadCts = new CancellationTokenSource();
             content.Add(
-                new Button(() => downloadCts.Cancel())
+                // Null-conditional: the button outlives the download (until the next content.Clear),
+                // and OnDownloadDone nulls the field on the same thread as this click handler.
+                new Button(() => downloadCts?.Cancel())
                 {
                     text = "Cancel",
                     style = { alignSelf = Align.FlexStart, marginLeft = 6 },
@@ -254,8 +256,13 @@ namespace PrefabLens
                 ShowMissingCli();
                 return;
             }
+            // Drop the Cancel button now; Refresh only rebuilds content once the bulk run returns.
+            content.Clear();
             Refresh();
         }
+
+        /// Unity calls this when the window closes (and on domain reload): stop an in-flight download.
+        void OnDisable() => downloadCts?.Cancel();
 
         void Note(string text)
         {

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -20,6 +21,7 @@ namespace PrefabLens
         bool refreshing;
         bool downloadAttempted;
         string downloadError;
+        CancellationTokenSource downloadCts;
 
         [MenuItem("Window/PrefabLens")]
         public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
@@ -213,7 +215,25 @@ namespace PrefabLens
             lastStdout = null;
             status.text = $"Downloading prefablens v{Cli.Version}…";
             content.Clear();
-            Cli.DownloadAsync(OnDownloadDone);
+            downloadCts = new CancellationTokenSource();
+            content.Add(
+                new Button(() => downloadCts.Cancel())
+                {
+                    text = "Cancel",
+                    style = { alignSelf = Align.FlexStart, marginLeft = 6 },
+                }
+            );
+            Cli.DownloadAsync(OnDownloadDone, OnDownloadProgress, downloadCts.Token);
+        }
+
+        void OnDownloadProgress(long read, long total)
+        {
+            if (content == null)
+                return;
+            status.text =
+                total > 0
+                    ? $"Downloading prefablens v{Cli.Version}… {read * 100 / total}%"
+                    : $"Downloading prefablens v{Cli.Version}… {read / 1024} KB";
         }
 
         /// The success path re-resolves through Cli.Find instead of using the returned
@@ -221,9 +241,14 @@ namespace PrefabLens
         void OnDownloadDone(string path, string error)
         {
             refreshing = false;
+            // A user-initiated cancel is not a failure: show the plain missing-CLI screen
+            // with its retry button instead of "Download failed: …".
+            var canceled = downloadCts != null && downloadCts.IsCancellationRequested;
+            downloadCts?.Dispose();
+            downloadCts = null;
             if (content == null)
                 return;
-            downloadError = error;
+            downloadError = canceled ? null : error;
             if (error != null)
             {
                 ShowMissingCli();

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using NUnit.Framework;
 
@@ -226,6 +228,56 @@ namespace PrefabLens.Tests
             // Cleanup must be a silent no-op, not a DirectoryNotFoundException.
             var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Assert.DoesNotThrow(() => Cli.DeleteStaleVersions(root, keep: "0.6.1"));
+        }
+
+        [Test]
+        public void ExpectedSha256FindsTheAssetLine()
+        {
+            // shasum -a 256 text-mode output: "<hex>  <name>" (two spaces), one line per asset.
+            var sums = "aaaa  prefablens-linux-x64.zip\nbbbb  prefablens-macos-arm64.zip\n";
+            Assert.AreEqual("bbbb", Cli.ExpectedSha256(sums, "prefablens-macos-arm64.zip"));
+            Assert.IsNull(Cli.ExpectedSha256(sums, "prefablens-windows-x64.zip"));
+        }
+
+        [Test]
+        public void Sha256HexMatchesAKnownVector()
+        {
+            // FIPS 180-2 test vector for "abc".
+            Assert.AreEqual(
+                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+                Cli.Sha256Hex(Encoding.ASCII.GetBytes("abc"))
+            );
+        }
+
+        [Test]
+        public void VerifySha256AcceptsAMatchingArchive()
+        {
+            var sums = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  prefablens-macos-arm64.zip\n";
+            Assert.DoesNotThrow(() =>
+                Cli.VerifySha256(Encoding.ASCII.GetBytes("abc"), sums, "prefablens-macos-arm64.zip")
+            );
+        }
+
+        [Test]
+        public void VerifySha256RejectsACorruptedArchive()
+        {
+            // A byte flipped after publication must fail before extraction, naming both digests.
+            var sums = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  prefablens-macos-arm64.zip\n";
+            var e = Assert.Throws<InvalidOperationException>(() =>
+                Cli.VerifySha256(Encoding.ASCII.GetBytes("abd"), sums, "prefablens-macos-arm64.zip")
+            );
+            StringAssert.Contains("mismatch", e.Message);
+            StringAssert.Contains("ba7816bf", e.Message);
+        }
+
+        [Test]
+        public void VerifySha256RejectsAnAssetMissingFromSums()
+        {
+            // A release missing the entry is as suspect as a bad hash: never extract unverified bytes.
+            var e = Assert.Throws<InvalidOperationException>(() =>
+                Cli.VerifySha256(new byte[0], "aaaa  other.zip\n", "prefablens-linux-arm64.zip")
+            );
+            StringAssert.Contains("no entry", e.Message);
         }
     }
 }

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -17,6 +17,10 @@ namespace PrefabLens.Tests
                 Cli.ReleaseAssetName(isWindows: true, isMac: false, isArm64: false)
             );
             Assert.AreEqual(
+                "prefablens-windows-arm64.zip",
+                Cli.ReleaseAssetName(isWindows: true, isMac: false, isArm64: true)
+            );
+            Assert.AreEqual(
                 "prefablens-macos-arm64.zip",
                 Cli.ReleaseAssetName(isWindows: false, isMac: true, isArm64: true)
             );
@@ -27,6 +31,10 @@ namespace PrefabLens.Tests
             Assert.AreEqual(
                 "prefablens-linux-x64.zip",
                 Cli.ReleaseAssetName(isWindows: false, isMac: false, isArm64: false)
+            );
+            Assert.AreEqual(
+                "prefablens-linux-arm64.zip",
+                Cli.ReleaseAssetName(isWindows: false, isMac: false, isArm64: true)
             );
         }
 

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -2,9 +2,13 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace PrefabLens.Tests
@@ -228,6 +232,93 @@ namespace PrefabLens.Tests
             // Cleanup must be a silent no-op, not a DirectoryNotFoundException.
             var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Assert.DoesNotThrow(() => Cli.DeleteStaleVersions(root, keep: "0.6.1"));
+        }
+
+        /// One-shot HTTP server on a loopback socket: real HttpClient traffic, no mocks.
+        /// Sends Content-Length: body.Length but only the first sendOnly bytes, then blocks
+        /// on release — that models a stalled connection for the cancellation test.
+        static TcpListener ServeOnce(byte[] body, int sendOnly, ManualResetEventSlim release, out int port)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            Task.Run(() =>
+            {
+                using var client = listener.AcceptTcpClient();
+                var stream = client.GetStream();
+                // Drain the request head so the client is not reset mid-request.
+                stream.Read(new byte[4096], 0, 4096);
+                var head = Encoding.ASCII.GetBytes(
+                    $"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n"
+                );
+                stream.Write(head, 0, head.Length);
+                stream.Write(body, 0, sendOnly);
+                stream.Flush();
+                if (sendOnly < body.Length)
+                    release.Wait(30_000);
+            });
+            return listener;
+        }
+
+        [Test]
+        public void FetchBytesReportsProgressAndReturnsTheExactBody()
+        {
+            var body = new byte[200_000];
+            new Random(42).NextBytes(body);
+            using var release = new ManualResetEventSlim();
+            var listener = ServeOnce(body, sendOnly: body.Length, release, out var port);
+            try
+            {
+                using var http = new HttpClient();
+                long lastRead = 0,
+                    lastTotal = 0;
+                var got = Cli.FetchBytes(
+                    http,
+                    $"http://127.0.0.1:{port}/",
+                    (read, total) =>
+                    {
+                        lastRead = read;
+                        lastTotal = total;
+                    },
+                    CancellationToken.None
+                );
+                Assert.AreEqual(body, got);
+                // The final callback must report completion against the advertised Content-Length,
+                // otherwise the window's percentage never reaches 100%.
+                Assert.AreEqual(body.Length, lastRead);
+                Assert.AreEqual(body.Length, lastTotal);
+            }
+            finally
+            {
+                release.Set();
+                listener.Stop();
+            }
+        }
+
+        [Test]
+        public void FetchBytesCancelsMidStream()
+        {
+            // The server stalls after half the body; cancelling from the first progress
+            // callback must abort the blocked read instead of waiting for more bytes.
+            var body = new byte[200_000];
+            using var release = new ManualResetEventSlim();
+            var listener = ServeOnce(body, sendOnly: body.Length / 2, release, out var port);
+            try
+            {
+                using var http = new HttpClient();
+                using var cts = new CancellationTokenSource();
+                var sw = Stopwatch.StartNew();
+                Assert.Catch<OperationCanceledException>(() =>
+                    Cli.FetchBytes(http, $"http://127.0.0.1:{port}/", (read, total) => cts.Cancel(), cts.Token)
+                );
+                sw.Stop();
+                Assert.Less(sw.ElapsedMilliseconds, 30_000, "cancellation must not degrade into a full wait");
+            }
+            finally
+            {
+                release.Set();
+                listener.Stop();
+            }
         }
 
         [Test]


### PR DESCRIPTION
## Summary

The editor's CLI auto-download now verifies the zip against the release's `SHA256SUMS` before extraction, streams with visible progress, is cancelable from the window, has an explicit 120 s timeout, and downloads native arm64 binaries on Linux/Windows arm64.

## Motivation

`Download()` accepted any bytes GitHub returned (no integrity check despite releases publishing `SHA256SUMS`), could hang the status line for HttpClient's default 100 s with no progress or cancel, and handed x64 binaries to linux-arm64/windows-arm64 editors.

Closes #164

## Changes

- `Cli.ExpectedSha256` / `Sha256Hex` / `VerifySha256`: parse the release's `SHA256SUMS` and reject a tampered or corrupted zip before `ExtractTo`, with both digests in the error
- `Cli.FetchBytes`: streamed GET with per-chunk progress callbacks and mid-stream `CancellationToken` support
- `Cli.Download`/`DownloadAsync`: fetch `SHA256SUMS` first (fail fast), one linked-CTS deadline (`DownloadTimeoutMs` = 120 s → `TimeoutException`), progress posted through the caller's `SynchronizationContext`
- `PrefabLensWindow`: percentage progress in the status line, a Cancel button during download; user cancel returns to the plain missing-CLI screen instead of "Download failed"
- `ReleaseAssetName`: maps arm64 on Windows/Linux; `release.yml` builds `aarch64-linux-gnu` / `aarch64-windows` so the assets exist from the next release (version pin bumps in lockstep, so the pinned URL always matches)

## Testing

```
$ cd editor && dotnet csharpier check . --no-msbuild-check && dotnet test DotNetTests~/Tests
Checked 16 files in 131ms.
Passed!  - Failed:     0, Passed:    41, Skipped:     0, Total:    41
```

- 7 new tests: SHA256SUMS parsing, FIPS 180-2 vector, accept/reject (corrupted zip, missing entry), and `FetchBytes` progress + mid-stream cancel against a real loopback TCP server (no mocks)
- Real Unity 2022.3.62f3 EditMode (batchmode, smoke project with the package as a `file:` dependency): 41/41 passed, including both `FetchBytes` socket tests under Mono
- Cross-targets smoke-built locally: `zig build -Dtarget=aarch64-linux-gnu` and `-Dtarget=aarch64-windows` both compile (`prefablens.exe`: PE32+ Aarch64)
- Residual manual check: window GUI smoke (progress %, Cancel button behavior) in an interactive editor