### PR TITLE
fix: react ui card frame and raw diff flash

### DIFF
--- a/extension/e2e/fixtures/pr-files-react.html
+++ b/extension/e2e/fixtures/pr-files-react.html
@@ -18,7 +18,7 @@
                 </button>
               </div>
             </div>
-            <div class="Diff-module__diffContent">raw github diff table</div>
+            <div class="border position-relative rounded-bottom-2">raw github diff table</div>
           </div>
         </div>
         <div class="PullRequestDiffsList-module__diffEntry__djnVa">
@@ -33,7 +33,7 @@
                 </button>
               </div>
             </div>
-            <div class="Diff-module__diffContent">raw github diff table</div>
+            <div class="border position-relative rounded-bottom-2">raw github diff table</div>
           </div>
         </div>
         <div class="PullRequestDiffsList-module__diffEntry__djnVa">
@@ -48,7 +48,7 @@
                 </button>
               </div>
             </div>
-            <div class="Diff-module__diffContent">raw github diff table</div>
+            <div class="border position-relative rounded-bottom-2">raw github diff table</div>
           </div>
         </div>
       </div>

--- a/extension/e2e/react.spec.ts
+++ b/extension/e2e/react.spec.ts
@@ -70,12 +70,49 @@ test("detects unity files on the react layout and renders the semantic view", as
   await fooHeader(page).getByRole("button", { name: "Semantic" }).click();
   const view = page.locator("#diff-aaa111 [data-prefablens-view]");
   await expect(view).toContainText("MonoBehaviour");
-  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeHidden();
+  await expect(page.locator("#diff-aaa111 .border.rounded-bottom-2")).toBeHidden();
 
   // Back to raw restores github's body and hides ours
   await fooHeader(page).getByRole("button", { name: "Raw" }).click();
-  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeVisible();
+  await expect(page.locator("#diff-aaa111 .border.rounded-bottom-2")).toBeVisible();
   await expect(view).toBeHidden();
+});
+
+test("the semantic host recreates github's card frame in place of the hidden body", async ({ page }) => {
+  await stubChrome(page, cannedResponse);
+  await open(page);
+
+  await fooHeader(page).getByRole("button", { name: "Semantic" }).click();
+  const view = page.locator("#diff-aaa111 [data-prefablens-view]");
+  await expect(view).toContainText("MonoBehaviour");
+
+  // :host{all:initial} resets display to its spec initial value (inline), which
+  // would collapse the border into a line-box fragment — the host must be a block
+  await expect(view).toHaveCSS("display", "block");
+  // The frame github draws on the body it replaces: border + bottom-rounded corners
+  await expect(view).toHaveCSS("border-bottom-width", "1px");
+  await expect(view).toHaveCSS("border-bottom-left-radius", "6px");
+});
+
+test("a body remounted while semantic is active is hidden before it can paint", async ({ page }) => {
+  await stubChrome(page, cannedResponse);
+  await open(page);
+
+  await fooHeader(page).getByRole("button", { name: "Semantic" }).click();
+  await expect(page.locator("#diff-aaa111 [data-prefablens-view]")).toContainText("MonoBehaviour");
+
+  // Remount and measure inside ONE evaluate: the debounced rescan cannot run in
+  // between, so only the injected CSS rule can be hiding the fresh node here
+  const displayRightAfterAppend = await page.evaluate(() => {
+    const region = document.querySelector("#diff-aaa111")!;
+    region.querySelector(".border.rounded-bottom-2")!.remove();
+    const fresh = document.createElement("div");
+    fresh.className = "border position-relative rounded-bottom-2";
+    fresh.textContent = "raw github diff table";
+    region.append(fresh);
+    return getComputedStyle(fresh).display;
+  });
+  expect(displayRightAfterAppend).toBe("none");
 });
 
 test("global toggle mounts before the virtualized list, not inside a recycled item", async ({ page }) => {
@@ -102,7 +139,7 @@ test("github's collapse chevron hides the semantic view and re-hides a remounted
   await page.evaluate(() => {
     const region = document.querySelector("#diff-aaa111")!;
     region.querySelector(".octicon-chevron-down")!.setAttribute("class", "octicon octicon-chevron-right");
-    region.querySelector(".Diff-module__diffContent")!.remove();
+    region.querySelector(".border.rounded-bottom-2")!.remove();
   });
   await expect(view).toBeHidden();
 
@@ -112,12 +149,12 @@ test("github's collapse chevron hides the semantic view and re-hides a remounted
     const region = document.querySelector("#diff-aaa111")!;
     region.querySelector(".octicon-chevron-right")!.setAttribute("class", "octicon octicon-chevron-down");
     const body = document.createElement("div");
-    body.className = "Diff-module__diffContent";
+    body.className = "border position-relative rounded-bottom-2";
     body.textContent = "raw github diff table";
     region.append(body);
   });
   await expect(view).toBeVisible();
-  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeHidden();
+  await expect(page.locator("#diff-aaa111 .border.rounded-bottom-2")).toBeHidden();
 });
 
 test("virtualization: a fully remounted file re-attaches and inherits the semantic default", async ({ page }) => {
@@ -140,5 +177,5 @@ test("virtualization: a fully remounted file re-attaches and inherits the semant
   });
 
   await expect(page.locator("#diff-aaa111 [data-prefablens-view]")).toBeVisible();
-  await expect(page.locator("#diff-aaa111 .Diff-module__diffContent")).toBeHidden();
+  await expect(page.locator("#diff-aaa111 .border.rounded-bottom-2")).toBeHidden();
 });

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -215,7 +215,7 @@ const REACT_FIXTURE = `
               <button type="button" aria-expanded="true"><svg class="octicon octicon-chevron-down"></svg></button>
             </div>
           </div>
-          <div class="Diff-module__diffContent">raw diff</div>
+          <div class="border position-relative rounded-bottom-2">raw diff</div>
         </div>
       </div>
       <div class="PullRequestDiffsList-module__diffEntry__djnVa">
@@ -226,7 +226,7 @@ const REACT_FIXTURE = `
               <button type="button" aria-expanded="true"><svg class="octicon octicon-chevron-down"></svg></button>
             </div>
           </div>
-          <div class="Diff-module__diffContent">raw diff</div>
+          <div class="border position-relative rounded-bottom-2">raw diff</div>
         </div>
       </div>
     </div>
@@ -260,7 +260,7 @@ describe("scanUnityFiles (react ui)", () => {
     const region = document.querySelector("#diff-aaa111")!;
     expect(region.children[1]).toBe(host);
     entry.setRawHidden(true);
-    const body = region.querySelector<HTMLElement>(".Diff-module__diffContent")!;
+    const body = region.querySelector<HTMLElement>(".border.rounded-bottom-2")!;
     expect(body.style.display).toBe("none");
     expect(host.style.display).not.toBe("none");
     expect(region.querySelector<HTMLElement>(".Diff-module__diffHeaderWrapper")!.style.display).not.toBe("none");
@@ -272,14 +272,59 @@ describe("scanUnityFiles (react ui)", () => {
     document.body.innerHTML = REACT_FIXTURE;
     const entry = scanUnityFiles(document)[0]!;
     entry.setRawHidden(true);
-    // Simulate a react remount: fresh body node without our inline style
+    // Simulate a react remount whose body does NOT carry today's border classes:
+    // the inline-style loop is the markup-drift fallback and must still hide it
     const region = document.querySelector("#diff-aaa111")!;
-    region.querySelector(".Diff-module__diffContent")!.remove();
+    region.querySelector(".border.rounded-bottom-2")!.remove();
     const fresh = document.createElement("div");
     fresh.className = "Diff-module__diffContent";
     region.append(fresh);
     entry.setRawHidden(true);
     expect(fresh.style.display).toBe("none");
+  });
+
+  it("gives the host the card frame that the hidden body carried", () => {
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    const host = document.createElement("div");
+    host.setAttribute("data-prefablens-view", "");
+    entry.attachHost(host);
+    // On this layout the border/rounded-bottom card chrome lives on the diff body,
+    // not the region: hiding the body removes the frame, so the host must recreate
+    // it (theme-following Primer variables, with fallbacks for non-github pages)
+    const style = host.getAttribute("style") ?? "";
+    expect(style).toContain("border:");
+    expect(style).toContain("var(--borderColor-default");
+    expect(style).toContain("border-radius: 0 0 6px 6px");
+    expect(style).toContain("var(--bgColor-default");
+  });
+
+  it("stamps a marker attribute and injects a stylesheet that hides fresh bodies", () => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    const region = document.querySelector("#diff-aaa111")!;
+    entry.setRawHidden(true);
+    // React remounts the body with no inline styles when a collapsed file expands;
+    // the debounced rescan re-hides it only ~200ms later. The marker + document-level
+    // rule pair hides the fresh body before first paint instead.
+    expect(region.hasAttribute("data-prefablens-raw-hidden")).toBe(true);
+    const style = document.head.querySelector("style[data-prefablens-hide-rule]");
+    expect(style?.textContent).toContain("[data-prefablens-raw-hidden] > .border.rounded-bottom-2");
+    // Un-hiding must lift the CSS rule too, or the restored body would stay invisible
+    entry.setRawHidden(false);
+    expect(region.hasAttribute("data-prefablens-raw-hidden")).toBe(false);
+  });
+
+  it("injects the hide stylesheet only once", () => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = REACT_FIXTURE;
+    const entry = scanUnityFiles(document)[0]!;
+    // sync() re-runs setRawHidden on every debounced scan, so injection must be idempotent
+    entry.setRawHidden(true);
+    entry.setRawHidden(true);
+    scanUnityFiles(document)[0]!.setRawHidden(true);
+    expect(document.head.querySelectorAll("style[data-prefablens-hide-rule]")).toHaveLength(1);
   });
 
   it("reports the chevron collapse state", () => {

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -93,6 +93,20 @@ function reactPath(header: HTMLElement): string | null {
   return text || null;
 }
 
+/** React remounts diff bodies with no inline styles (collapse/expand, re-renders), and
+ *  the debounced rescan re-hides them only ~200ms later — long enough to flash the raw
+ *  diff. This document-level rule, keyed on the region marker set by setRawHidden, hides
+ *  a fresh body before first paint. It targets the body's own classes rather than
+ *  "everything but the header" so github markup drift degrades back to the debounced
+ *  flash instead of hiding the file header. */
+function ensureHideRule(doc: Document): void {
+  if (doc.head.querySelector("style[data-prefablens-hide-rule]")) return;
+  const style = doc.createElement("style");
+  style.setAttribute("data-prefablens-hide-rule", "");
+  style.textContent = "[data-prefablens-raw-hidden] > .border.rounded-bottom-2 { display: none !important; }";
+  doc.head.append(style);
+}
+
 // GitHub's react diff UI (login-gated rollout). Class names are hashed CSS modules, so
 // anchors are role/id plus class-prefix matches; the body is "any region child that isn't
 // the header block", because its class is unstable and react recreates it constantly.
@@ -112,8 +126,19 @@ function scanReact(root: ParentNode): FileEntry[] {
     out.push({
       path,
       header,
-      attachHost: (host) => headerBlock().after(host),
+      attachHost(host) {
+        // The card frame lives on the diff body in this layout, so hiding the body
+        // strips it: recreate the same chrome on the host (theme-following variables,
+        // fallbacks for pages without Primer)
+        host.style.cssText =
+          "border: 1px solid var(--borderColor-default, #d1d9e0); border-radius: 0 0 6px 6px; background: var(--bgColor-default, #ffffff);";
+        headerBlock().after(host);
+      },
       setRawHidden(hidden) {
+        region.toggleAttribute("data-prefablens-raw-hidden", hidden);
+        if (hidden) ensureHideRule(region.ownerDocument);
+        // Inline fallback for bodies the CSS rule misses (markup drift): the rescan
+        // hides them one debounce late instead of never
         for (const child of region.children) {
           if (child === headerBlock() || child.hasAttribute("data-prefablens-view")) continue;
           (child as HTMLElement).style.display = hidden ? "none" : "";

--- a/extension/src/renderer/styles.ts
+++ b/extension/src/renderer/styles.ts
@@ -1,8 +1,11 @@
 /** Shadow-DOM stylesheet. Colors read Primer CSS variables (custom properties
  *  inherit through the shadow boundary on github.com, so every GitHub theme is
- *  followed automatically) and fall back to a built-in light/dark palette. */
+ *  followed automatically) and fall back to a built-in light/dark palette.
+ *  The host declares display: block because all: initial resets display to its
+ *  spec initial value (inline), which would break the card frame the react
+ *  layout draws on the host. */
 export const STYLES = `
-  :host { all: initial; }
+  :host { all: initial; display: block; }
   .pl-root {
     --pl-fg: var(--fgColor-default, #1f2328);
     --pl-muted: var(--fgColor-muted, #59636e);


### PR DESCRIPTION
## Summary

On the React diff UI, restore GitHub's card frame around the semantic view and stop the raw diff from flashing for ~200ms when a collapsed file is expanded.

## Motivation

On the React layout the border/rounded-bottom card chrome lives on the diff body (`div.border.position-relative.rounded-bottom-2`), not on the region container, so hiding the body stripped the frame and the semantic view sat frameless on the page background — made worse by `:host { all: initial }` resetting the host to `display: inline`. Separately, React remounts a fresh body (no inline styles) when a collapsed file expands, and the debounced rescan re-hid it only ~200ms later, flashing the raw diff (measured live: visible from t=15ms to t=218ms after the expand click).

Closes #177

## Changes

- React `attachHost` recreates the body's card chrome on the host (`border` / `border-radius: 0 0 6px 6px` / `background`, theme-following Primer variables with fallbacks)
- `:host` declares `display: block` (`all: initial` resets display to its spec initial value, `inline`; document-level rules and inline styles still win, so classic is unaffected)
- React `setRawHidden` stamps `data-prefablens-raw-hidden` on the region and injects a one-time document stylesheet hiding `[data-prefablens-raw-hidden] > .border.rounded-bottom-2 !important`, so a remounted body is hidden before first paint; the inline-style loop stays as a markup-drift fallback (drift degrades to the old debounced hide instead of hiding the file header)
- React fixtures (unit + e2e) updated to the live body markup (`border position-relative rounded-bottom-2`); one unit test keeps a legacy-class body to cover the fallback path
- New tests: host frame styles (unit + e2e computed CSS), marker attribute lifecycle, idempotent stylesheet injection, and an e2e proving a freshly appended body computes `display: none` synchronously

## Testing

- `pnpm test` — 229 passed
- `pnpm e2e` — 19 passed (chromium; includes the two new React specs)
- `pnpm typecheck`, `pnpm lint` — clean
- Live verification on github.com (unity-yaml-playground PR #2 `/changes`, CDP-injected `dist/content.js`):
  - Semantic host computes `display: block`, `border: 1px solid rgb(209,217,224)`, `border-radius: 0 0 6px 6px`, white background — identical to GitHub's own body frame; element screenshot shows the restored card
  - Collapse → expand with a rAF sampler while signed out of the extension (`pat-missing` + semantic default): body never visible across 92 samples (pre-fix: visible `display: block` from t=15ms to t=218ms)
  - Toggling back to Raw removes the marker attribute and restores the body (`display: block`, host hidden)