### PR TITLE
perf: cut rescan debounce to 50ms

### DIFF
--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -259,7 +259,10 @@ async function init(): Promise<void> {
     render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(countUnresolved(view.json), 1) });
   });
 
-  // GitHub is an SPA: an initial scan + MutationObserver follows lazy loading and tab navigation (200ms debounce).
+  // GitHub is an SPA: an initial scan + MutationObserver follows lazy loading and tab navigation.
+  // 50ms debounce keeps collapse/expand tracking under the ~100ms sluggishness threshold while
+  // still batching mutation storms: a full scan pass measured ~0.75ms on a 21-file PR, so even
+  // back-to-back rescans are negligible (the scan is fetch-free and idempotent).
   attach(state);
   let scheduled = false;
   new MutationObserver(() => {
@@ -268,7 +271,7 @@ async function init(): Promise<void> {
     setTimeout(() => {
       scheduled = false;
       attach(state);
-    }, 200);
+    }, 50);
   }).observe(document.body, { childList: true, subtree: true });
 }
 


### PR DESCRIPTION
## Summary

Reduce the content script's MutationObserver rescan debounce from 200ms to 50ms so the semantic view follows GitHub's collapse/expand without perceptible lag.

## Motivation

Collapse/expand tracking (`sync()`) only runs inside the debounced rescan, so the semantic host lagged ~215-221ms behind GitHub's own 4-14ms body unmount/mount — above the ~100ms threshold where interaction reads as sluggish. A full scan pass measured ~0.75ms on a 21-file /changes page, so the 200ms debounce guarded far less work than it cost in latency; the rescan is fetch-free and idempotent, so higher frequency carries no rate-limit or correctness risk.

Closes #179

## Changes

- `extension/src/content/index.ts`: debounce 200ms → 50ms, comment updated with the measured rationale

## Testing

- `pnpm test` — 229 passed
- `pnpm e2e` — 19 passed
- `pnpm typecheck`, `pnpm lint` — clean
- Live before/after on github.com (unity-yaml-playground PR #2 `/changes`, CDP-injected build, rAF sampling): collapse host-hide latency 221ms → 70ms, expand host-show latency 215ms → 62ms; the raw body stayed invisible throughout both directions (PR #178's flash fix intact)
- No new timing-assertion test on purpose: a wall-clock latency bound would be flaky on CI runners, and the existing e2e suite exercises the debounced-rescan flows independent of the constant