### PR TITLE
fix: zero out lint warnings with must() and strict indexing

### DIFF
--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -27,7 +27,7 @@ const BIG = `%YAML 1.1\n%TAG !u! tag:unity3d.com,2011:\n${"x".repeat(26 * 1024 *
 
 function startServer(): Promise<Server> {
   const server = createServer((req, res) => {
-    const url = new URL(req.url!, "http://127.0.0.1");
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
     const send = (body: string, type: string): void => {
       res.writeHead(200, { "content-type": type });
       res.end(body);

--- a/extension/e2e/react.spec.ts
+++ b/extension/e2e/react.spec.ts
@@ -100,17 +100,19 @@ test("github's collapse chevron hides the semantic view and re-hides a remounted
 
   // Collapse: react swaps the chevron icon and unmounts the body node
   await page.evaluate(() => {
-    const region = document.querySelector("#diff-aaa111")!;
-    region.querySelector(".octicon-chevron-down")!.setAttribute("class", "octicon octicon-chevron-right");
-    region.querySelector(".Diff-module__diffContent")!.remove();
+    const region = document.querySelector("#diff-aaa111");
+    if (!region) throw new Error("diff region missing");
+    region.querySelector(".octicon-chevron-down")?.setAttribute("class", "octicon octicon-chevron-right");
+    region.querySelector(".Diff-module__diffContent")?.remove();
   });
   await expect(view).toBeHidden();
 
   // Expand: react remounts a FRESH body node (no inline style) and swaps the icon back.
   // The per-scan sync must re-hide the new body and re-show our view.
   await page.evaluate(() => {
-    const region = document.querySelector("#diff-aaa111")!;
-    region.querySelector(".octicon-chevron-right")!.setAttribute("class", "octicon octicon-chevron-down");
+    const region = document.querySelector("#diff-aaa111");
+    if (!region) throw new Error("diff region missing");
+    region.querySelector(".octicon-chevron-right")?.setAttribute("class", "octicon octicon-chevron-down");
     const body = document.createElement("div");
     body.className = "Diff-module__diffContent";
     body.textContent = "raw github diff table";
@@ -130,7 +132,8 @@ test("virtualization: a fully remounted file re-attaches and inherits the semant
   // Scroll-out + scroll-in: react discards the whole list item and recreates it fresh,
   // without any of our nodes, marker attributes, or inline styles.
   await page.evaluate(() => {
-    const entry = document.querySelector("#diff-aaa111")!.parentElement!;
+    const entry = document.querySelector("#diff-aaa111")?.parentElement;
+    if (!entry) throw new Error("diff region missing");
     const clone = entry.cloneNode(true) as HTMLElement;
     clone.querySelector("[data-prefablens-view]")?.remove();
     clone.querySelector("[data-prefablens-toggle]")?.remove();

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -163,7 +163,7 @@ test("recovers after an error response", async ({ page }) => {
         sendMessage: (msg: { type?: string }) => {
           if (msg?.type !== "semanticDiff") return Promise.resolve();
           const w = window as unknown as Record<string, number>;
-          const call = w.__prefablensCalls!;
+          const call = w.__prefablensCalls ?? 0;
           w.__prefablensCalls = call + 1;
           return Promise.resolve(call === 0 ? { ok: false, error: "pat-missing" } : res);
         },

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -657,7 +657,7 @@ describe("createHandler", () => {
       };
       const merged: DiffV2 = { ...DIFF, unresolvedGuids: ["src1"] };
       const diffWithAssets = vi.fn(() => merged);
-      const { deps, client } = makeDeps({
+      const { deps } = makeDeps({
         files: [
           { path: "Assets/Foo.prefab", status: "modified" },
           { path: "Assets/Src.prefab.meta", status: "modified" },
@@ -766,7 +766,7 @@ describe("semanticDiff with push (two-stage)", () => {
     const { res, pushes } = await serveAndResolve(createHandler(deps), REQ);
     // The response returns immediately with empty resolved + pending. Names arrive via push (the crux of B4)
     expect(res).toEqual({ ok: true, json: { ...DIFF, resolved: {} }, pending: true });
-    const last = pushes.at(-1)!;
+    const last = must(pushes.at(-1));
     expect(last.done).toBe(true);
     expect(last.json?.resolved).toEqual({ g1: "Assets/Scripts/S.cs" });
     expect(guidCache.save).toHaveBeenCalledWith("https://api.github.com/o/r", { g1: "Assets/Scripts/S.cs" });

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { AuthError, type ChangedFile, RateLimitError } from "../github/client";
 import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../types";
+import { must } from "../util/must";
 import { DiffError, type Differ } from "../wasm/differ";
 import { createHandler, type Deps, type Handler } from "./handler";
 
@@ -598,8 +599,8 @@ describe("createHandler", () => {
       const res = await resolveFully(createHandler(deps), REQ);
       // side=after, so the source is fetched from head and its bytes land in assets.
       expect(client.getFileAtRef).toHaveBeenCalledWith("o", "r", "Assets/Cyl.prefab", "head-sha");
-      const assets = diffWithAssets.mock.calls[0]?.[2];
-      expect(new TextDecoder().decode(assets.get("src1")!)).toBe("SRC");
+      const assets = must(diffWithAssets.mock.calls[0]?.[2]);
+      expect(new TextDecoder().decode(must(assets.get("src1")))).toBe("SRC");
       // Even after the re-diff, resolved is restored from guidCache and persists.
       expect(res).toEqual({ ok: true, json: { ...MERGED, resolved: { src1: "Assets/Cyl.prefab" } } });
     });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -18,6 +18,7 @@ import {
   targetKey,
 } from "../types";
 import { isUnityPath } from "../unity";
+import { must } from "../util/must";
 import { DiffError, type Differ } from "../wasm/differ";
 
 type ClientLike = Pick<
@@ -133,7 +134,8 @@ export function createHandler(deps: Deps): Handler {
     const resolved: Record<string, string> = {};
     const unknown: string[] = [];
     for (const g of guids) {
-      if (Object.hasOwn(cached, g)) resolved[g] = cached[g]!;
+      const hit = Object.hasOwn(cached, g) ? cached[g] : undefined;
+      if (hit !== undefined) resolved[g] = hit;
       else unknown.push(g);
     }
     const searchable = unknown.filter((g) => !misses.has(`${repoKey}:${g}`));
@@ -213,7 +215,7 @@ export function createHandler(deps: Deps): Handler {
       : client.getFileAtRef(owner, repo, path, sha);
     p.catch(() => blobs.delete(key)); // don't keep failures: the next call can re-fetch
     blobs.set(key, p);
-    if (blobs.size > BLOB_CACHE_MAX) blobs.delete(blobs.keys().next().value!);
+    if (blobs.size > BLOB_CACHE_MAX) blobs.delete(must(blobs.keys().next().value));
     return p;
   }
 
@@ -404,7 +406,10 @@ export function createHandler(deps: Deps): Handler {
       const fromIndex: Record<string, string> = {};
       let leftover = remaining;
       if (index) {
-        for (const g of remaining) if (Object.hasOwn(index, g)) fromIndex[g] = index[g]!;
+        for (const g of remaining) {
+          const hit = Object.hasOwn(index, g) ? index[g] : undefined;
+          if (hit !== undefined) fromIndex[g] = hit;
+        }
         leftover = remaining.filter((g) => !Object.hasOwn(fromIndex, g));
         if (Object.keys(fromIndex).length) {
           // Also land it in guidCache: searchUnresolved inside mergeSources rebuilds resolved

--- a/extension/src/background/queue.test.ts
+++ b/extension/src/background/queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { RateLimitError } from "../github/client";
+import { must } from "../util/must";
 import { createQueue } from "./queue";
 
 // Line up manually-resolvable deferreds to observe execution order and concurrency
@@ -120,7 +121,7 @@ describe("createQueue rate limit backoff", () => {
     await flush();
     expect(waits.map((w) => w.ms)).toEqual([5_000]); // paused for exactly the advice
     expect(attempts).toBe(1); // nothing reruns while paused
-    waits[0]!.resolve();
+    must(waits[0]).resolve();
     await expect(task).resolves.toBe("ok");
     expect(attempts).toBe(2);
   });
@@ -134,9 +135,9 @@ describe("createQueue rate limit backoff", () => {
     });
     const cappedRejects = expect(capped).rejects.toBeInstanceOf(RateLimitError);
     await flush();
-    waits[0]!.resolve();
+    must(waits[0]).resolve();
     await flush();
-    waits[1]!.resolve();
+    must(waits[1]).resolve();
     await cappedRejects;
     // A secondary limit without headers gets the fallback wait
     const noAdvice = queue(async () => {
@@ -144,9 +145,9 @@ describe("createQueue rate limit backoff", () => {
     });
     const noAdviceRejects = expect(noAdvice).rejects.toBeInstanceOf(RateLimitError);
     await flush();
-    waits[2]!.resolve();
+    must(waits[2]).resolve();
     await flush();
-    waits[3]!.resolve();
+    must(waits[3]).resolve();
     await noAdviceRejects;
     expect(waits.map((w) => w.ms)).toEqual([60_000, 60_000, 30_000, 30_000]);
   });
@@ -161,9 +162,9 @@ describe("createQueue rate limit backoff", () => {
     });
     const taskRejects = expect(task).rejects.toBeInstanceOf(RateLimitError);
     await flush();
-    waits[0]!.resolve(); // resume → retry 1 fails
+    must(waits[0]).resolve(); // resume → retry 1 fails
     await flush();
-    waits[1]!.resolve(); // resume → retry 2 fails → reject
+    must(waits[1]).resolve(); // resume → retry 2 fails → reject
     await taskRejects;
     expect(attempts).toBe(3); // initial + 2 retries, then the manual-retry UI takes over
     expect(waits).toHaveLength(2);
@@ -186,7 +187,7 @@ describe("createQueue rate limit backoff", () => {
     });
     await flush();
     expect(ran).toBe(false); // held back while the queue is paused, not rejected
-    waits[0]!.resolve();
+    must(waits[0]).resolve();
     await expect(limited).resolves.toBe("retried");
     await expect(queued).resolves.toBe("later");
   });
@@ -210,7 +211,7 @@ describe("createQueue rate limit backoff", () => {
       { front: true },
     );
     await flush();
-    waits[0]!.resolve();
+    must(waits[0]).resolve();
     await Promise.all([prefetchTask, user]);
     expect(order).toEqual(["user", "prefetch-retry"]);
   });

--- a/extension/src/background/queue.ts
+++ b/extension/src/background/queue.ts
@@ -1,4 +1,5 @@
 import { RateLimitError } from "../github/client";
+import { must } from "../util/must";
 
 type Job = {
   run: () => Promise<unknown>;
@@ -37,7 +38,7 @@ export function createQueue(
 
   const pump = (): void => {
     while (!paused && active < limit && pending.length) {
-      const job = pending.shift()!;
+      const job = must(pending.shift());
       active++;
       // Normalize even a synchronous throw into a rejection: a leak here leaves active undecremented and jams the queue forever
       Promise.resolve()

--- a/extension/src/content/detect.test.ts
+++ b/extension/src/content/detect.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
+import { must } from "../util/must";
 import { parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 
 const FIXTURE = `
@@ -127,18 +128,19 @@ describe("scanUnityFiles", () => {
       "Assets/Data/Config.asset",
     ]);
     // Behavior replaces the old `content` field: hiding acts on the .js-file-content element
-    const content = document.querySelector<HTMLElement>(".file .js-file-content")!;
-    entries[0]!.setRawHidden(true);
+    const content = must(document.querySelector<HTMLElement>(".file .js-file-content"));
+    const entry = must(entries[0]);
+    entry.setRawHidden(true);
     expect(content.style.display).toBe("none");
-    entries[0]!.setRawHidden(false);
+    entry.setRawHidden(false);
     expect(content.style.display).toBe("");
     // Classic collapse is handled by Primer's Details CSS, not by us
-    expect(entries[0]!.collapsed()).toBe(false);
+    expect(entry.collapsed()).toBe(false);
     // The global bar anchors on the .file container
-    expect(entries[0]!.globalAnchor()).toBe(document.querySelector(".file"));
+    expect(entry.globalAnchor()).toBe(document.querySelector(".file"));
     // The host lands right after the content and opts into the Details collapse CSS
     const host = document.createElement("div");
-    entries[0]!.attachHost(host);
+    entry.attachHost(host);
     expect(content.nextElementSibling).toBe(host);
     expect(host.classList.contains("Details-content--hidden")).toBe(true);
   });
@@ -252,29 +254,29 @@ describe("scanUnityFiles (react ui)", () => {
 
   it("hides every region child except the header block and our host", () => {
     document.body.innerHTML = REACT_FIXTURE;
-    const entry = scanUnityFiles(document)[0]!;
+    const entry = must(scanUnityFiles(document)[0]);
     const host = document.createElement("div");
     host.setAttribute("data-prefablens-view", "");
     entry.attachHost(host);
     // Host goes right after the header wrapper, inside the region
-    const region = document.querySelector("#diff-aaa111")!;
+    const region = must(document.querySelector("#diff-aaa111"));
     expect(region.children[1]).toBe(host);
     entry.setRawHidden(true);
-    const body = region.querySelector<HTMLElement>(".Diff-module__diffContent")!;
+    const body = must(region.querySelector<HTMLElement>(".Diff-module__diffContent"));
     expect(body.style.display).toBe("none");
     expect(host.style.display).not.toBe("none");
-    expect(region.querySelector<HTMLElement>(".Diff-module__diffHeaderWrapper")!.style.display).not.toBe("none");
+    expect(must(region.querySelector<HTMLElement>(".Diff-module__diffHeaderWrapper")).style.display).not.toBe("none");
     entry.setRawHidden(false);
     expect(body.style.display).toBe("");
   });
 
   it("re-resolves body nodes on every call because react recreates them", () => {
     document.body.innerHTML = REACT_FIXTURE;
-    const entry = scanUnityFiles(document)[0]!;
+    const entry = must(scanUnityFiles(document)[0]);
     entry.setRawHidden(true);
     // Simulate a react remount: fresh body node without our inline style
-    const region = document.querySelector("#diff-aaa111")!;
-    region.querySelector(".Diff-module__diffContent")!.remove();
+    const region = must(document.querySelector("#diff-aaa111"));
+    must(region.querySelector(".Diff-module__diffContent")).remove();
     const fresh = document.createElement("div");
     fresh.className = "Diff-module__diffContent";
     region.append(fresh);
@@ -284,10 +286,10 @@ describe("scanUnityFiles (react ui)", () => {
 
   it("reports the chevron collapse state", () => {
     document.body.innerHTML = REACT_FIXTURE;
-    const entry = scanUnityFiles(document)[0]!;
+    const entry = must(scanUnityFiles(document)[0]);
     expect(entry.collapsed()).toBe(false);
     // React swaps the chevron icon when the file is collapsed
-    const icon = document.querySelector("#diff-aaa111 .octicon-chevron-down")!;
+    const icon = must(document.querySelector("#diff-aaa111 .octicon-chevron-down"));
     icon.setAttribute("class", "octicon octicon-chevron-right");
     expect(entry.collapsed()).toBe(true);
   });
@@ -295,15 +297,15 @@ describe("scanUnityFiles (react ui)", () => {
   it("also reads collapse from the header's collapsed module class", () => {
     // Second signal, independent of the icon: github stamps this class on the header row
     document.body.innerHTML = REACT_FIXTURE;
-    const entry = scanUnityFiles(document)[0]!;
-    const header = document.querySelector("#diff-aaa111 .DiffFileHeader-module__diff-file-header")!;
+    const entry = must(scanUnityFiles(document)[0]);
+    const header = must(document.querySelector("#diff-aaa111 .DiffFileHeader-module__diff-file-header"));
     header.classList.add("DiffFileHeader-module__collapsed__aB3cD");
     expect(entry.collapsed()).toBe(true);
   });
 
   it("anchors the global bar on the virtualized list root", () => {
     document.body.innerHTML = REACT_FIXTURE;
-    const entry = scanUnityFiles(document)[0]!;
+    const entry = must(scanUnityFiles(document)[0]);
     expect(entry.globalAnchor()).toBe(document.querySelector('[data-testid="progressive-diffs-list"]'));
   });
 

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -1,5 +1,6 @@
 import type { DiffTarget } from "../types";
 import { isUnityPath } from "../unity";
+import { must } from "../util/must";
 
 export type FileEntry = {
   path: string;
@@ -32,17 +33,18 @@ export function parseDiffUrl(pathname: string): DiffPage | null {
     /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/(?:files(?:\/|$)|changes(?:\/[\da-f]{7,40}\.\.[\da-f]{7,40})?\/?$)/.exec(
       pathname,
     );
-  if (pr) return { owner: pr[1]!, repo: pr[2]!, target: { kind: "pull", prNumber: Number(pr[3]!) } };
+  if (pr) return { owner: must(pr[1]), repo: must(pr[2]), target: { kind: "pull", prNumber: Number(must(pr[3])) } };
   // Single-commit views: standalone /commit/SHA, plus the in-PR classic /commits/SHA and
   // react /changes/SHA — all show one commit against its parent
   const commit = /^\/([^/]+)\/([^/]+)\/(?:pull\/\d+\/(?:commits|changes)|commit)\/([\da-f]{7,40})\/?$/.exec(pathname);
-  if (commit) return { owner: commit[1]!, repo: commit[2]!, target: { kind: "commit", sha: commit[3]! } };
+  if (commit)
+    return { owner: must(commit[1]), repo: must(commit[2]), target: { kind: "commit", sha: must(commit[3]) } };
   const compare = /^\/([^/]+)\/([^/]+)\/compare\/(.+?)\.\.\.(.+?)\/?$/.exec(pathname);
   if (compare) {
-    const base = decodeRef(compare[3]!);
-    const head = decodeRef(compare[4]!);
+    const base = decodeRef(must(compare[3]));
+    const head = decodeRef(must(compare[4]));
     if (base.includes(":") || head.includes(":")) return null;
-    return { owner: compare[1]!, repo: compare[2]!, target: { kind: "compare", base, head } };
+    return { owner: must(compare[1]), repo: must(compare[2]), target: { kind: "compare", base, head } };
   }
   return null;
 }
@@ -50,7 +52,7 @@ export function parseDiffUrl(pathname: string): DiffPage | null {
 /** Matches any PR tab (the prefetch trigger). Different role from the diff-page-only parseDiffUrl. */
 export function parsePrPage(pathname: string): { owner: string; repo: string; prNumber: number } | null {
   const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(\/|$)/.exec(pathname);
-  return m ? { owner: m[1]!, repo: m[2]!, prNumber: Number(m[3]!) } : null;
+  return m ? { owner: must(m[1]), repo: must(m[2]), prNumber: Number(must(m[3])) } : null;
 }
 
 // Defensively searches GitHub's Files changed (classic DOM). If it doesn't match, ends harmlessly with an empty array.

--- a/extension/src/content/devicePage.test.ts
+++ b/extension/src/content/devicePage.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
+import { must } from "../util/must";
 import { fillDeviceCode } from "./devicePage";
 
 const PENDING = { userCode: "ABCD-1234", expiresAt: 10_000 };
@@ -47,8 +48,8 @@ describe("fillDeviceCode", () => {
     document.body.innerHTML = FORM;
     expect(fillDeviceCode(document, PENDING, 5_000)).toBe(true);
     // The hyphen input carries value "-" from the server; it must neither block the fill nor be overwritten.
-    expect(document.querySelector<HTMLInputElement>('input[name="user-code-4"]')!.value).toBe("-");
-    expect(document.querySelector<HTMLInputElement>('input[name="authenticity_token"]')!.value).toBe("tok");
+    expect(must(document.querySelector<HTMLInputElement>('input[name="user-code-4"]')).value).toBe("-");
+    expect(must(document.querySelector<HTMLInputElement>('input[name="authenticity_token"]')).value).toBe("tok");
   });
 
   it("does not touch anything once the pending code expired", () => {
@@ -59,15 +60,15 @@ describe("fillDeviceCode", () => {
 
   it("does not clobber a box the user already typed into", () => {
     document.body.innerHTML = FORM;
-    boxes()[2]!.value = "X";
+    must(boxes()[2]).value = "X";
     expect(fillDeviceCode(document, PENDING, 5_000)).toBe(false);
-    expect(boxes()[0]!.value).toBe("");
-    expect(boxes()[2]!.value).toBe("X");
+    expect(must(boxes()[0]).value).toBe("");
+    expect(must(boxes()[2]).value).toBe("X");
   });
 
   it("no-ops when the box count does not match the code length (unknown layout)", () => {
     document.body.innerHTML = FORM;
-    boxes()[7]!.remove();
+    must(boxes()[7]).remove();
     expect(fillDeviceCode(document, PENDING, 5_000)).toBe(false);
     expect(boxes().every((b) => b.value === "")).toBe(true);
   });

--- a/extension/src/content/devicePage.ts
+++ b/extension/src/content/devicePage.ts
@@ -10,7 +10,7 @@ export function fillDeviceCode(doc: Document, pending: PendingSignIn, now: numbe
   const chars = pending.userCode.replace(/-/g, "");
   if (boxes.length !== chars.length || boxes.some((box) => box.value)) return false;
   boxes.forEach((box, i) => {
-    box.value = chars[i]!;
+    box.value = chars.charAt(i);
     // GitHub's auto-advance JS listens per box; keep it in sync with the programmatic fill.
     box.dispatchEvent(new Event("input", { bubbles: true }));
   });

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -16,6 +16,7 @@ import {
   type SemanticDiffResponse,
   targetKey,
 } from "../types";
+import { must } from "../util/must";
 import { type DiffPage, type FileEntry, parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 import { fillDeviceCode } from "./devicePage";
 import { createSignIn, type PendingSignIn } from "./signin";
@@ -95,7 +96,8 @@ function attach(state: ViewState): void {
   // dead appliers every scan, not just on PR change (also plugs the classic soft leak).
   for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
   const entries = scanUnityFiles(document);
-  if (entries.length) ensureGlobalToggle(state, entries[0]!);
+  const first = entries[0];
+  if (first) ensureGlobalToggle(state, first);
   for (const entry of entries) attachToggle(state, page, entry);
   // Re-assert view state: react remounts diff bodies under still-marked headers, which
   // silently undoes the inline hide. All sync operations are idempotent and fetch-free.
@@ -157,7 +159,7 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
     }
     sync(view);
     if (requested) return; // cache only successful results per file (re-toggle doesn't re-fetch)
-    const root = host.shadowRoot!;
+    const root = must(host.shadowRoot);
     const request = (force?: boolean): void => {
       requested = true;
       renderLoading(root);

--- a/extension/src/demo.ts
+++ b/extension/src/demo.ts
@@ -13,6 +13,7 @@ import { createViewState } from "./content/viewstate";
 import { applyResolved } from "./github/resolved";
 import { render, renderError, renderLoading } from "./renderer/render";
 import type { DiffV2 } from "./types";
+import { must } from "./util/must";
 import { createDiffer, type Differ } from "./wasm/differ";
 
 async function fetchBytes(url: string | undefined): Promise<Uint8Array<ArrayBuffer>> {
@@ -60,7 +61,7 @@ function attachFile(
   initial: View,
 ): (view: View) => void {
   // Non-null: site/build.mjs always nests the header in a .file with a .js-file-content sibling.
-  const content = header.parentElement!.querySelector<HTMLElement>(".js-file-content")!;
+  const content = must(header.parentElement?.querySelector<HTMLElement>(".js-file-content"));
   let host: HTMLDivElement | undefined;
   let root: ShadowRoot | undefined;
   let rendered = false;
@@ -123,7 +124,7 @@ async function main(): Promise<void> {
   });
 
   // Global bar above the first Unity file, same anchor rule as the content script.
-  const firstFile = headers[0].closest(".file")!;
+  const firstFile = must(headers[0]?.closest(".file"));
   const bar = document.createElement("div");
   bar.setAttribute("data-prefablens-global", "");
   const label = document.createElement("span");

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { must } from "../util/must";
 import { ApiError, AuthError, GithubClient, graphqlUrl, RateLimitError } from "./client";
 
 // fetch fake that returns a fixed path→response table. It also records calls.
@@ -76,7 +77,7 @@ describe("GithubClient", () => {
     const { fn, calls } = fakeFetch({ "/git/blobs/": () => new Response(new Uint8Array([1, 2, 3])) });
     const client = new GithubClient("https://api.github.com", "tok", fn);
     const bytes = await client.getBlobRaw("o", "r", "blob1");
-    expect([...bytes!]).toEqual([1, 2, 3]);
+    expect([...must(bytes)]).toEqual([1, 2, 3]);
     expect(calls[0]?.url).toBe("https://api.github.com/repos/o/r/git/blobs/blob1");
     expect(calls[0]?.headers.accept).toBe("application/vnd.github.raw+json");
   });
@@ -91,7 +92,7 @@ describe("GithubClient", () => {
     const { fn, calls } = fakeFetch({ "/contents/": () => new Response(new Uint8Array([1, 2, 3])) });
     const client = new GithubClient("https://api.github.com", "tok", fn);
     const bytes = await client.getFileAtRef("o", "r", "Assets/My Prefab#1.prefab", "sha1");
-    expect([...bytes!]).toEqual([1, 2, 3]);
+    expect([...must(bytes)]).toEqual([1, 2, 3]);
     expect(calls[0]?.url).toContain("/contents/Assets/My%20Prefab%231.prefab?ref=sha1");
     expect(calls[0]?.headers.accept).toBe("application/vnd.github.raw+json");
   });

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import type { DeviceCode, PollResult } from "../github/deviceFlow";
+import { must } from "../util/must";
 import { initOptions, OPTIONS_BODY, type SignInFlow } from "./options";
 
 function fakeStorage(initial: Record<string, unknown> = {}) {
@@ -173,7 +174,7 @@ describe("initOptions", () => {
       fakeStorage(),
       fakeFlow(() => pending),
     );
-    const signin = document.querySelector<HTMLButtonElement>("#signin")!;
+    const signin = must(document.querySelector<HTMLButtonElement>("#signin"));
     signin.click();
     await flush();
     // Poll still unresolved: a second click must be impossible

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -1,4 +1,5 @@
 import { type DeviceCode, type PollResult, pollForToken, requestDeviceCode } from "../github/deviceFlow";
+import { must } from "../util/must";
 
 // Keep the form body on the TS side: options.html and the jsdom tests share the same markup.
 export const OPTIONS_BODY = `
@@ -31,13 +32,13 @@ export type SignInFlow = {
 };
 
 export async function initOptions(doc: Document, storage: StorageLike, flow: SignInFlow): Promise<void> {
-  const signinState = doc.querySelector<HTMLElement>("#signin-state")!;
-  const signinButton = doc.querySelector<HTMLButtonElement>("#signin")!;
-  const flowArea = doc.querySelector<HTMLElement>("#flow")!;
-  const userCode = doc.querySelector<HTMLElement>("#user-code")!;
-  const verifyLink = doc.querySelector<HTMLAnchorElement>("#verify-link")!;
-  const copyButton = doc.querySelector<HTMLButtonElement>("#copy-code")!;
-  const status = doc.querySelector<HTMLElement>("#status")!;
+  const signinState = must(doc.querySelector<HTMLElement>("#signin-state"));
+  const signinButton = must(doc.querySelector<HTMLButtonElement>("#signin"));
+  const flowArea = must(doc.querySelector<HTMLElement>("#flow"));
+  const userCode = must(doc.querySelector<HTMLElement>("#user-code"));
+  const verifyLink = must(doc.querySelector<HTMLAnchorElement>("#verify-link"));
+  const copyButton = must(doc.querySelector<HTMLButtonElement>("#copy-code"));
+  const status = must(doc.querySelector<HTMLElement>("#status"));
 
   const showSignedIn = (pat: unknown): void => {
     signinState.textContent = pat ? "Signed in" : "Not signed in";

--- a/extension/src/renderer/builtin_refs.parity.test.ts
+++ b/extension/src/renderer/builtin_refs.parity.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
+import { must } from "../util/must";
 import { BUILTIN_EXTRA_GUID, BUILTIN_REFS, DEFAULT_RESOURCES_GUID } from "./builtin_refs";
 
 // All three tables are generated from the same Unity dump (issue #104). This
@@ -9,7 +10,7 @@ import { BUILTIN_EXTRA_GUID, BUILTIN_REFS, DEFAULT_RESOURCES_GUID } from "./buil
 function zigEntries(section: string): Record<string, string> {
   const out: Record<string, string> = {};
   for (const m of section.matchAll(/\.\{ \.file_id = (\d+), \.name = "([^"]*)" \}/g)) {
-    out[m[1]!] = m[2]!;
+    out[must(m[1])] = must(m[2]);
   }
   return out;
 }
@@ -34,7 +35,7 @@ it("guid constants match between the Zig and TS tables", () => {
 function csEntries(section: string): Record<string, string> {
   const out: Record<string, string> = {};
   for (const m of section.matchAll(/\{ "(\d+)", "([^"]*)" \},/g)) {
-    out[m[1]!] = m[2]!;
+    out[must(m[1])] = must(m[2]);
   }
   return out;
 }

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DiffV2 } from "../types";
+import { must } from "../util/must";
 import {
   detectTheme,
   render,
@@ -102,7 +103,7 @@ describe("render", () => {
   it("shows field values as before → after and resolves the component to its script stem", () => {
     const root = freshRoot();
     render(root, DIFF);
-    const text = root.querySelector(".pl-root")!.textContent!;
+    const text = must(root.querySelector(".pl-root")?.textContent);
     expect(text).toContain("volume");
     expect(text).toContain("0.5");
     expect(text).toContain("0.8");
@@ -115,14 +116,14 @@ describe("render", () => {
     const root = freshRoot();
     render(root, DIFF);
     const rows = [...root.querySelectorAll(".pl-field")];
-    const added = rows.find((r) => r.textContent?.includes("newField"))!;
+    const added = must(rows.find((r) => r.textContent?.includes("newField")));
     expect(added.textContent).toBe("newField1");
   });
 
   it("falls back to the raw guid when unresolved and to #fileId for local refs", () => {
     const root = freshRoot();
     render(root, DIFF);
-    const text = root.querySelector(".pl-root")!.textContent!;
+    const text = must(root.querySelector(".pl-root")?.textContent);
     expect(text).toContain("#100"); // local ref
     expect(text).toContain("ghi"); // unresolved guid stays visible
   });
@@ -156,7 +157,7 @@ describe("render", () => {
     };
     const root = freshRoot();
     render(root, builtin);
-    const text = root.querySelector(".pl-root")!.textContent!;
+    const text = must(root.querySelector(".pl-root")?.textContent);
     expect(text).toContain("Cube (built-in)"); // known fileID → table name
     expect(text).toContain("guid:0000000000000000e000000000000000"); // unknown fileID keeps the raw guid
   });
@@ -192,7 +193,7 @@ describe("render", () => {
     };
     const root = freshRoot();
     render(root, nullRef);
-    const text = root.querySelector(".pl-root")!.textContent!;
+    const text = must(root.querySelector(".pl-root")?.textContent);
     expect(text).toContain("None"); // {fileID: 0} reads as the Inspector's None
     expect(text).toContain("#42"); // non-zero local refs keep #fileId
     expect(text).not.toContain("#0");
@@ -231,7 +232,7 @@ describe("render", () => {
     const onRender = vi.fn();
     renderTooLarge(root, 26 * 1024 * 1024, onRender);
     expect(root.textContent).toContain("Large file (26 MB)");
-    const button = root.querySelector<HTMLButtonElement>("button.pl-render")!;
+    const button = must(root.querySelector<HTMLButtonElement>("button.pl-render"));
     expect(button.textContent).toBe("Render anyway");
     button.click();
     expect(onRender).toHaveBeenCalledTimes(1);
@@ -473,7 +474,7 @@ describe("render", () => {
   it("indents component cards one level deeper than child GameObjects", () => {
     const root = freshRoot();
     render(root, DIFF);
-    const kids = root.querySelector("details.pl-go > .pl-kids")!;
+    const kids = must(root.querySelector("details.pl-go > .pl-kids"));
     // Gear cards live inside the group's own kids box (extra indent + guide line)...
     expect(kids.querySelector("details.pl-components > .pl-kids > details.pl-comp")).not.toBeNull();
     // ...while the child GameObject stays directly on the hierarchy spine.
@@ -509,7 +510,7 @@ describe("render", () => {
   it("renders unity-style rows: chevron, icon and status badge", () => {
     const root = freshRoot();
     render(root, DIFF);
-    const summary = root.querySelector("details.pl-go > summary")!;
+    const summary = must(root.querySelector("details.pl-go > summary"));
     expect(summary.classList.contains("pl-row")).toBe(true);
     expect(summary.querySelector(".pl-chevron svg")).not.toBeNull();
     expect(summary.querySelector(".pl-icon svg")).not.toBeNull();
@@ -520,9 +521,9 @@ describe("render", () => {
     const root = freshRoot();
     render(root, INSTANCE);
     // Plane is unchanged: no badge chip at all, not a blank one
-    const plane = root.querySelector("details.pl-go > summary")!;
+    const plane = must(root.querySelector("details.pl-go > summary"));
     expect(plane.querySelector(".pl-badge")).toBeNull();
-    const icon = root.querySelector("details.pl-pi > summary .pl-icon")!;
+    const icon = must(root.querySelector("details.pl-pi > summary .pl-icon"));
     expect(icon.classList.contains("pl-icon-prefab")).toBe(true);
   });
 
@@ -530,16 +531,16 @@ describe("render", () => {
     const root = freshRoot();
     render(root, DIFF);
     const summaries = [...root.querySelectorAll("details.pl-go > summary")];
-    const weapon = summaries.find((s) => s.textContent?.includes("Weapon"))!;
+    const weapon = must(summaries.find((s) => s.textContent?.includes("Weapon")));
     expect(weapon.classList.contains("pl-leaf")).toBe(true);
-    const player = summaries.find((s) => s.textContent?.includes("Player"))!;
+    const player = must(summaries.find((s) => s.textContent?.includes("Player")));
     expect(player.classList.contains("pl-leaf")).toBe(false);
   });
 
   it("renderLoading shows an accessible skeleton tree instead of text", () => {
     const root = freshRoot();
     renderLoading(root);
-    const box = root.querySelector(".pl-skeleton")!;
+    const box = must(root.querySelector(".pl-skeleton"));
     expect(box.getAttribute("role")).toBe("status");
     expect(box.getAttribute("aria-busy")).toBe("true");
     expect(box.getAttribute("aria-label")).toContain("Computing semantic diff");
@@ -573,7 +574,7 @@ describe("detectTheme", () => {
     // GitHub's default is auto: a value that is neither dark nor light defers to matchMedia
     document.documentElement.setAttribute("data-color-mode", "auto");
     expect(detectTheme(document)).toBe("light"); // jsdom has no matchMedia → fall back to light
-    const win = document.defaultView!;
+    const win = must(document.defaultView);
     win.matchMedia = ((query: string) => ({
       matches: query === "(prefers-color-scheme: dark)",
     })) as unknown as typeof win.matchMedia;

--- a/extension/src/renderer/value_format.parity.test.ts
+++ b/extension/src/renderer/value_format.parity.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
+import { must } from "../util/must";
 
 // The diff.v2 value display rules are hand-copied in four places: the
 // extension's formatValue (render.ts), the Unity editor's ValueFormat.cs, and
@@ -34,7 +35,7 @@ function fnSlice(src: string, header: string): string {
 function extract(src: string, re: RegExp, what: string): string {
   const m = src.match(re);
   expect(m, `${what} not found`).not.toBeNull();
-  return m![1]!;
+  return must(m?.[1]);
 }
 
 // Assert the guid branch tries its lookups in order: resolved → built-in → raw.

--- a/extension/src/unity.parity.test.ts
+++ b/extension/src/unity.parity.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
+import { must } from "./util/must";
 
 // The UnityYAML extension prefilter is hand-copied in three places: the CLI's
 // git-side gate (unity_path.zig), the extension's path check (unity.ts), and
@@ -15,7 +16,7 @@ function tsExtensions(): string[] {
   // unity.ts encodes the list as a single alternation: /\.(prefab|unity|...)$/i
   const m = read("./unity.ts").match(/\/\\\.\(([^)]+)\)\$\/i/);
   expect(m, "UNITY_PATH regex not found in unity.ts").not.toBeNull();
-  return m![1]!
+  return must(m?.[1])
     .split("|")
     .map((e) => e.toLowerCase())
     .sort();
@@ -26,7 +27,7 @@ function zigExtensions(): string[] {
   const start = src.indexOf("const extensions = [_][]const u8{");
   expect(start, "extensions array not found in unity_path.zig").toBeGreaterThan(0);
   const body = src.slice(start, src.indexOf("};", start));
-  return [...body.matchAll(/"\.([^"]+)"/g)].map((m) => m[1]!.toLowerCase()).sort();
+  return [...body.matchAll(/"\.([^"]+)"/g)].map((m) => must(m[1]).toLowerCase()).sort();
 }
 
 function mjsExtensions(): string[] {
@@ -34,7 +35,7 @@ function mjsExtensions(): string[] {
   const start = src.indexOf("const UNITY_EXTENSIONS = [");
   expect(start, "UNITY_EXTENSIONS array not found in build.mjs").toBeGreaterThan(0);
   const body = src.slice(start, src.indexOf("];", start));
-  return [...body.matchAll(/"\.([^"]+)"/g)].map((m) => m[1]!.toLowerCase()).sort();
+  return [...body.matchAll(/"\.([^"]+)"/g)].map((m) => must(m[1]).toLowerCase()).sort();
 }
 
 it("CLI unity_path.zig gates the same extensions as the extension", () => {

--- a/extension/src/util/must.test.ts
+++ b/extension/src/util/must.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { must } from "./must";
+
+describe("must", () => {
+  it("returns present values unchanged, including falsy ones", () => {
+    // 0 / "" / false are valid payloads; only null and undefined are absent.
+    expect(must(0)).toBe(0);
+    expect(must("")).toBe("");
+    expect(must(false)).toBe(false);
+  });
+
+  it("throws on null and on undefined", () => {
+    expect(() => must(null)).toThrowError(/invariant/);
+    expect(() => must(undefined)).toThrowError(/invariant/);
+  });
+});

--- a/extension/src/util/must.ts
+++ b/extension/src/util/must.ts
@@ -1,0 +1,6 @@
+/** Runtime-checked replacement for the banned `!` assertion: returns the value
+ *  when present and fails loudly at the call site when the invariant breaks. */
+export function must<T>(v: T | null | undefined): T {
+  if (v == null) throw new Error("invariant violated: value is absent");
+  return v;
+}

--- a/extension/src/wasm/differ.test.ts
+++ b/extension/src/wasm/differ.test.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 import { readFileSync } from "node:fs";
 import { beforeAll, describe, expect, it } from "vitest";
+import { must } from "../util/must";
 import { createDiffer, DiffError, type Differ } from "./differ";
 
 const enc = new TextEncoder();
@@ -79,7 +80,7 @@ Transform:
     // With assets: merged, so neededSources disappears and it becomes a full enumeration with overrides applied.
     const merged = differ.diffWithAssets(new Uint8Array(0), variant, new Map([["srcguid", source]]));
     expect(merged.neededSources).toBeUndefined();
-    const inst = merged.roots[0]!;
+    const inst = must(merged.roots[0]);
     expect(inst.kind).toBe("prefabInstance");
     if (inst.kind !== "prefabInstance") return;
     expect(inst.overrides).toEqual([]);

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -71,7 +71,7 @@ export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
     } finally {
       if (before.length) exp.free(bp, before.length);
       if (after.length) exp.free(ap, after.length);
-      if (assets !== undefined && assets.length) exp.free(tp, assets.length);
+      if (assets?.length) exp.free(tp, assets.length);
     }
   }
 

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -21,18 +21,15 @@ type Exports = {
  *  1:1 with parseAssets in core/src/wasm.zig. */
 export function encodeAssets(assets: Map<string, Uint8Array>): Uint8Array {
   const enc = new TextEncoder();
-  const guids = [...assets.keys()].map((g) => enc.encode(g));
+  const entries = [...assets].map(([guid, data]) => ({ guid: enc.encode(guid), data }));
   let total = 4;
-  let i = 0;
-  for (const data of assets.values()) total += 8 + guids[i++]?.length + data.length;
+  for (const { guid, data } of entries) total += 8 + guid.length + data.length;
   const out = new Uint8Array(total);
   const view = new DataView(out.buffer);
   let off = 0;
   view.setUint32(off, assets.size, true);
   off += 4;
-  i = 0;
-  for (const data of assets.values()) {
-    const guid = guids[i++]!;
+  for (const { guid, data } of entries) {
     view.setUint32(off, guid.length, true);
     out.set(guid, off + 4);
     off += 4 + guid.length;
@@ -48,16 +45,21 @@ export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
   const exp = instance.exports as unknown as Exports;
 
   function call(before: Uint8Array, after: Uint8Array, assets?: Uint8Array): DiffV2 {
-    const bufs = assets === undefined ? [before, after] : [before, after, assets];
-    const ptrs = bufs.map((b) => (b.length ? exp.alloc(b.length) : 0));
+    const alloc = (b: Uint8Array): number => (b.length ? exp.alloc(b.length) : 0);
+    const bp = alloc(before);
+    const ap = alloc(after);
+    const tp = assets === undefined ? 0 : alloc(assets);
     // Copy after the last alloc: memory.grow detaches older views
-    bufs.forEach((b, i) => {
-      new Uint8Array(exp.memory.buffer, ptrs[i]!, b.length).set(b);
-    });
+    const copy = (ptr: number, b: Uint8Array): void => {
+      new Uint8Array(exp.memory.buffer, ptr, b.length).set(b);
+    };
+    copy(bp, before);
+    copy(ap, after);
+    if (assets !== undefined) copy(tp, assets);
     const rp =
       assets === undefined
-        ? exp.diff(ptrs[0]!, before.length, ptrs[1]!, after.length)
-        : exp.diff_with_assets(ptrs[0]!, before.length, ptrs[1]!, after.length, ptrs[2]!, assets.length);
+        ? exp.diff(bp, before.length, ap, after.length)
+        : exp.diff_with_assets(bp, before.length, ap, after.length, tp, assets.length);
     try {
       if (rp === 0) throw new DiffError("OutOfMemory");
       const len = new DataView(exp.memory.buffer).getUint32(rp, true);
@@ -67,9 +69,9 @@ export async function createDiffer(wasmBytes: BufferSource): Promise<Differ> {
       if (parsed.schema !== "prefablens.diff.v2") throw new DiffError((parsed as DiffErrorV1).error);
       return parsed;
     } finally {
-      bufs.forEach((b, i) => {
-        if (b.length) exp.free(ptrs[i]!, b.length);
-      });
+      if (before.length) exp.free(bp, before.length);
+      if (after.length) exp.free(ap, after.length);
+      if (assets !== undefined && assets.length) exp.free(tp, assets.length);
     }
   }
 

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     "outDir": "dist",
     "types": [


### PR DESCRIPTION
## Summary

Zeroes out all 115 Biome warnings in `extension/` (114 `noNonNullAssertion` + 1 `noUnusedVariables`) and restores `noUncheckedIndexedAccess: true` in tsconfig, replacing every `!` non-null assertion with a runtime-checked `must()` helper, narrowing, or restructuring.

## Motivation

Closes #176.

The original tsconfig had `noUncheckedIndexedAccess`, which made the `!` assertions necessary; the Biome setup commit (8daaee0) dropped the flag, so the recommended `noNonNullAssertion` rule has been flagging the orphaned assertions ever since — silently, because `biome ci` exits 0 on warnings and GitHub truncates annotations at 10 per step. Three unguarded index accesses crept in while the flag was off; restoring it prevents more.

## Changes

- Add `must<T>(v: T | null | undefined): T` (`src/util/must.ts`) — a runtime-checked replacement for `!` that fails loudly at the call site
- Restore `noUncheckedIndexedAccess: true` in `tsconfig.json` and fix the 3 sites it exposes
- Restructure `src/wasm/differ.ts`: pair structure in `encodeAssets`, named locals in `call()` (TLV layout and the alloc-all-then-copy-all order required by `memory.grow` are preserved)
- Replace all remaining `!` in src with `must()` / narrowing; `Object.hasOwn` guards in `handler.ts` are kept intentionally — guids parse from attacker-controllable YAML, and dropping `hasOwn` would resolve inherited keys like `__proto__`/`constructor` (the plan originally mandated dropping it; this is a deliberate correction, do not "simplify" it back)
- Rewrite test/e2e assertion sites (`must()` in unit tests; `?.` and inline guard-throws in `page.evaluate` browser-context blocks, which cannot import modules)
- Drop the unused `client` binding in `handler.test.ts`

With a zero-warning baseline, Biome's automatic GitHub annotations now surface any new warning inline on the PR diff, and it disappears on the fixing push.

## Testing

- `pnpm lint` — `Checked 54 files. Found 0 warnings` (was 115)
- `pnpm typecheck` — green with `noUncheckedIndexedAccess` on
- `pnpm test` — 228/228 (226 baseline + 2 new `must()` tests)
- `pnpm e2e` — 17/17
- `pnpm run build` — green
- TLV layout cross-checked 1:1 against `core/src/wasm.zig` `parseAssets` during review