### PR TITLE
build: rebuild wasm before extension tests

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome ci .",
     "fmt": "biome check --write .",
+    "pretest": "zig build wasm",
     "test": "vitest run",
     "size": "node scripts/check-wasm-size.mjs",
     "e2e": "node build.mjs --e2e && playwright test"


### PR DESCRIPTION
## Summary

Add a `pretest` script to `extension/package.json` that runs `zig build wasm`, so `pnpm test` always rebuilds the core WASM artifact before the extension test suite loads it.

## Motivation

`extension/src/wasm/differ.test.ts` loads the git-ignored `zig-out/bin/prefablens.wasm` from the repo root, but nothing rebuilt it. After a core export change (e.g. #169 added `is_unity_yaml`), a stale local artifact made `pnpm test` fail with a confusing `TypeError: exp.is_unity_yaml is not a function`. This picks option 1 from the issue: rebuild transparently, since extension contributors already have Zig via mise.

Closes #173

## Changes

- Add `"pretest": "zig build wasm"` to `extension/package.json`. Invoked with cwd `extension/`, `zig build` resolves the repo-root `build.zig` via its upward search and installs to the root `zig-out/` — the exact command CI runs — with no stray `zig-out`/`.zig-cache` created under `extension/` (verified).
- CI impact: the extension job in `.github/workflows/ci.yml` already runs `zig build wasm` before `pnpm test`, so the pretest re-run there is a cached no-op (sub-second on a warm cache).

## Testing

Reproduced the missing/stale-artifact case in a fresh worktree (no `zig-out/`), then:

```
$ rm -f zig-out/bin/prefablens.wasm
$ cd extension && pnpm test
$ zig build wasm
$ vitest run

 Test Files  20 passed (20)
      Tests  231 passed (231)
   Duration  2.64s
```

The deleted `zig-out/bin/prefablens.wasm` was rebuilt by the pretest and the full suite passed. A second run (`pnpm run test`, which also triggers pre-scripts under pnpm 11) completed in 3.2s total including vitest, confirming the warm-cache rebuild is a cheap no-op.