### PR TITLE
ci: add dependency caches and dedup site build

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,37 @@
+name: Build site inputs
+description: Install tools and build the CLI, WASM bundle, and demo bundle shared by the CI site job and the Pages deploy job
+
+runs:
+  using: composite
+  steps:
+    - name: Install tools
+      uses: jdx/mise-action@v4
+    - name: Restore Zig global cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/zig
+        key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
+        restore-keys: |
+          ${{ runner.os }}-zig-
+    - name: Resolve pnpm store directory
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+    - name: Restore pnpm store cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('extension/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+    - name: Build CLI and WASM
+      shell: bash
+      run: |
+        zig build
+        zig build wasm
+    - name: Build demo bundle
+      shell: bash
+      working-directory: extension
+      run: |
+        pnpm install --frozen-lockfile
+        pnpm run demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+      - name: Restore Zig global cache
+        # Windows Zig caching was measured as not worth it (see PR #36 context)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/zig
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
+          restore-keys: |
+            ${{ runner.os }}-zig-
       - name: Lint
         run: zig build lint
       - name: Test
@@ -32,6 +41,33 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+      - name: Restore Zig global cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/zig
+          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
+          restore-keys: |
+            ${{ runner.os }}-zig-
+      - name: Resolve pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm store cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('extension/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(grep -oE '@playwright/test@[0-9]+\.[0-9]+\.[0-9]+' extension/pnpm-lock.yaml | head -n 1 | cut -d '@' -f 3)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Restore Playwright browser cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
       - name: WASM build and golden
         run: |
           zig build wasm
@@ -57,6 +93,13 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install tools
         uses: jdx/mise-action@v4
+      - name: Restore NuGet package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('editor/**/*.csproj', 'editor/.config/dotnet-tools.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Lint
         working-directory: editor
         run: |
@@ -77,17 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Install tools
-        uses: jdx/mise-action@v4
-      - name: Build CLI and WASM
-        run: |
-          zig build
-          zig build wasm
-      - name: Build demo bundle
-        working-directory: extension
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run demo
+      - name: Build site inputs
+        uses: ./.github/actions/build-site
       - name: Site checks
         working-directory: site
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,17 +21,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
-      - name: Install tools
-        uses: jdx/mise-action@v4
-      - name: Build CLI and WASM
-        run: |
-          zig build
-          zig build wasm
-      - name: Build demo bundle
-        working-directory: extension
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm run demo
+      - name: Build site inputs
+        uses: ./.github/actions/build-site
       - name: Build site
         working-directory: site
         run: node build.mjs


### PR DESCRIPTION
## Summary

Adds `actions/cache` steps for the pnpm store, Playwright browsers, NuGet packages, and the Zig global cache, and extracts the duplicated site build recipe into a composite action consumed by both `ci.yml` and `pages.yml`.

## Motivation

CI had no dependency caching at all, so every run re-downloaded the pnpm store, NuGet packages, Zig global cache artifacts, and the Chromium binary (`pnpm exec playwright install` being the most expensive). The site build recipe was also duplicated between the CI `site` job and the Pages deploy job.

Closes #166

## Changes

- New composite action `.github/actions/build-site/action.yml` with the exact shared recipe (mise install, `zig build` + `zig build wasm`, extension `pnpm install --frozen-lockfile` + `pnpm run demo`) plus Zig and pnpm caches; consumed by the CI `site` job and the Pages `deploy` job
- `core` job: Zig global cache (`~/.cache/zig`) keyed on `build.zig.zon`, Linux only — Windows Zig caching was previously measured as not worth it (PR #36 context)
- `extension` job: Zig global cache, pnpm store cache keyed on `extension/pnpm-lock.yaml`, and Playwright browser cache (`~/.cache/ms-playwright`) keyed on the Playwright version resolved from the lockfile
- `editor` job: NuGet cache (`~/.nuget/packages`) keyed on the csproj files and `dotnet-tools.json`
- `packaging` job: unchanged (shell script only, nothing to cache)
- No job's test content changed; action versions use tags per renovate policy

## Testing

- `actionlint .github/workflows/ci.yml .github/workflows/pages.yml` — clean (pre-existing findings in untouched `pr-issue-gate.yml`/`release.yml` come from a stale local action schema)
- YAML parse check on all three files — OK
- Playwright version extraction verified locally: `grep -oE '@playwright/test@[0-9]+\.[0-9]+\.[0-9]+' extension/pnpm-lock.yaml | head -n 1 | cut -d '@' -f 3` yields `1.61.1`
- Cold vs warm measured on run [29518518546](https://github.com/hashiiiii/PrefabLens/actions/runs/29518518546): attempt 1 (cold, empty caches) vs attempt 2 (rerun with warm caches) — see below

## Cold vs warm timings

Job wall-clock times from `gh run view --json jobs` (attempt 1 vs attempt 2 of the same run):

| Job | Cold | Warm | Delta |
|---|---|---|---|
| core (ubuntu-latest) | 53s | 55s | +2s |
| core (windows-latest) | 97s | 122s | +25s (uncached by design; runner variance) |
| extension | 67s | 67s | 0s (downloads eliminated, offset by cache restore time) |
| editor | 25s | 28s | +3s |
| packaging | 6s | 4s | -2s (no caches; baseline noise) |
| site | 37s | 26s | **-11s (-30%)** |

Step-level wins inside the extension job on the warm run:

- Extension E2E: 29s -> 22s — the Chromium download is fully skipped
- Extension checks (pnpm install): cold `resolved 97, reused 0, downloaded 97` -> warm `resolved 97, reused 97, downloaded 0`
- WASM build and golden: 10s -> 6s (Zig global cache)

### Cache-hit evidence (warm run, attempt 2)

Extension job — all four caches hit on the primary key, and the E2E step contains no download lines:

```
Restore Zig global cache        Cache restored from key: Linux-zig-c721df58...
Restore pnpm store cache        Cache restored from key: Linux-pnpm-16bf0fc2...
Restore Playwright browser cache  Cache restored from key: Linux-playwright-1.61.1
Post Restore Playwright browser cache  Cache hit occurred on the primary key Linux-playwright-1.61.1, not saving cache.
```

For contrast, the cold run's E2E step downloaded the browser:

```
Downloading Chrome for Testing 149.0.7827.55 (playwright chromium v1228) from https://cdn.playwright.dev/builds/cft/149.0.7827.55/linux64/chrome-linux64.zip
Downloading FFmpeg (playwright ffmpeg v1011) from https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
```

Other jobs on the warm run: `core (ubuntu-latest)` hit `Linux-zig-...`, `editor` hit `Linux-nuget-...`, `site` (via the composite action) hit both `Linux-zig-...` and `Linux-pnpm-...`. No cache misses anywhere on the warm run.

Note on totals: overall run wall clock is dominated by the Windows core job, which is intentionally uncached and swung +25s between attempts (known runner noise — the same reason the perf gate is Linux-only). The durable win is that all package/browser downloads (Chromium, FFmpeg, pnpm store, NuGet) are eliminated on warm runs, which also insulates CI from registry/CDN slowness; the runners' network happened to be fast during these measurements.