### PR TITLE
refactor: share ref display ladder in display.zig

### DIFF
--- a/cli/src/display.zig
+++ b/cli/src/display.zig
@@ -22,6 +22,35 @@ pub fn componentName(c: model.ComponentDiff, resolved: ?*const core.json.Resolve
     return c.class_name orelse c.type_name;
 }
 
+/// How a reference value reads. Renderers switch on this and keep only their
+/// own escaping and decoration (e.g. the "(built-in)" suffix).
+pub const RefDisplay = union(enum) {
+    /// External ref resolved through the .meta index; reads as the asset path.
+    path: []const u8,
+    /// Ref into Unity's built-in resource files; reads as the object name.
+    builtin: []const u8,
+    /// Unresolved external ref; reads as "guid:<guid>".
+    guid: []const u8,
+    /// fileID 0, Unity's null reference; the Inspector shows it as None.
+    none,
+    /// Any other local ref; reads as "#<fileID>".
+    file_id: i64,
+};
+
+/// Resolution ladder for reference values: resolved asset path > built-in
+/// object name > raw guid > None for fileID 0 > local fileID. Single Zig
+/// source of truth for both CLI renderers; the extension's formatValue
+/// mirrors the same ladder (guarded by its parity tests).
+pub fn refDisplay(r: model.Ref, resolved: ?*const core.json.Resolver) RefDisplay {
+    if (r.guid) |g| {
+        if (resolved) |rr| if (rr.get(g)) |p| return .{ .path = p };
+        if (builtin_refs.name(g, r.file_id)) |n| return .{ .builtin = n };
+        return .{ .guid = g };
+    }
+    if (r.file_id == 0) return .none;
+    return .{ .file_id = r.file_id };
+}
+
 /// Heading status for the override group starting at `start`: that status if
 /// uniform within the group, modified if mixed.
 pub fn groupHeadingStatus(overrides: []const model.OverrideDiff, start: usize) model.Status {
@@ -67,4 +96,44 @@ test "unresolvedCount ignores built-in guids" {
         .needed_sources = &.{},
     };
     try std.testing.expectEqual(@as(usize, 1), unresolvedCount(res));
+}
+
+// refDisplay decision table, shared by render_tree's writeValueText and
+// render_html's writeValue (and mirrored by the extension's formatValue).
+
+test "refDisplay: resolved external ref reads as its asset path" {
+    var resolver = core.json.Resolver.init(std.testing.allocator);
+    defer resolver.deinit();
+    try resolver.put("abc123", "Assets/Materials/Fixture.mat");
+    const d = refDisplay(.{ .file_id = 2100000, .guid = "abc123", .type_id = 2 }, &resolver);
+    try std.testing.expectEqualStrings("Assets/Materials/Fixture.mat", d.path);
+}
+
+test "refDisplay: built-in ref reads as its object name" {
+    // No resolver: built-in names come from the checked-in table, not .meta files.
+    const d = refDisplay(.{ .file_id = 10202, .guid = builtin_refs.default_resources_guid, .type_id = 0 }, null);
+    try std.testing.expectEqualStrings("Cube", d.builtin);
+}
+
+test "refDisplay: built-in guid with unknown fileID falls back to the raw guid" {
+    // fileID 424242 is not in the table (e.g. an object added by a future Unity).
+    const d = refDisplay(.{ .file_id = 424242, .guid = builtin_refs.default_resources_guid, .type_id = 0 }, null);
+    try std.testing.expectEqualStrings(builtin_refs.default_resources_guid, d.guid);
+}
+
+test "refDisplay: unresolved external ref keeps the raw guid" {
+    var resolver = core.json.Resolver.init(std.testing.allocator);
+    defer resolver.deinit();
+    const d = refDisplay(.{ .file_id = 2100000, .guid = "abc123", .type_id = 2 }, &resolver);
+    try std.testing.expectEqualStrings("abc123", d.guid);
+}
+
+test "refDisplay: fileID 0 is Unity's null reference" {
+    const d = refDisplay(.{ .file_id = 0 }, null);
+    try std.testing.expectEqual(RefDisplay.none, d);
+}
+
+test "refDisplay: other local refs read as their fileID" {
+    const d = refDisplay(.{ .file_id = 42 }, null);
+    try std.testing.expectEqual(@as(i64, 42), d.file_id);
 }

--- a/cli/src/render_html.zig
+++ b/cli/src/render_html.zig
@@ -298,7 +298,6 @@ test "html: unresolved guids surface the --project hint as a note" {
 
 const model = core.model;
 const display = @import("display.zig");
-const builtin_refs = @import("builtin_refs.zig");
 
 pub const FileDiff = struct {
     /// null for a single unnamed report (plain two-file mode / single git target).
@@ -573,27 +572,20 @@ fn writeValue(w: *std.Io.Writer, node: ?*const model.Node, resolved: ?*const cor
     };
     switch (n.*) {
         .scalar => |s| try writeEscaped(w, s),
-        .ref => |r| {
-            if (r.guid) |g| {
-                if (resolved) |rr| {
-                    if (rr.get(g)) |p| {
-                        try writeEscaped(w, p);
-                        return;
-                    }
-                }
-                if (builtin_refs.name(g, r.file_id)) |builtin| {
-                    try writeEscaped(w, builtin);
-                    try w.writeAll(" (built-in)");
-                    return;
-                }
+        // The resolution ladder lives in display.refDisplay; this switch adds
+        // only the HTML escaping and decoration.
+        .ref => |r| switch (display.refDisplay(r, resolved)) {
+            .path => |p| try writeEscaped(w, p),
+            .builtin => |b| {
+                try writeEscaped(w, b);
+                try w.writeAll(" (built-in)");
+            },
+            .guid => |g| {
                 try w.writeAll("guid:");
                 try writeEscaped(w, g);
-            } else if (r.file_id == 0) {
-                // Unity's null reference; the Inspector shows it as None.
-                try w.writeAll("None");
-            } else {
-                try w.print("#{d}", .{r.file_id});
-            }
+            },
+            .none => try w.writeAll("None"),
+            .file_id => |id| try w.print("#{d}", .{id}),
         },
         .map => try w.writeAll("{...}"),
         .seq => try w.writeAll("[...]"),

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -389,7 +389,6 @@ test "render: structural summary row shows label only, no dangling value" {
 
 const model = core.model;
 const display = @import("display.zig");
-const builtin_refs = @import("builtin_refs.zig");
 
 pub const Color = struct {
     pub const reset = "\x1b[0m";
@@ -639,28 +638,15 @@ fn writeValueText(w: *std.Io.Writer, node: ?*const model.Node, resolved: ?*const
     };
     switch (n.*) {
         .scalar => |s| try w.writeAll(s),
-        .ref => |r| {
-            if (r.guid) |g| {
-                // Same rule as render_html's writeValue (and the extension's
-                // formatValue): a resolved external ref reads as its asset path,
-                // a Unity built-in ref as its object name.
-                if (resolved) |rr| {
-                    if (rr.get(g)) |p| {
-                        try w.writeAll(p);
-                        return;
-                    }
-                }
-                if (builtin_refs.name(g, r.file_id)) |builtin| {
-                    try w.print("{s} (built-in)", .{builtin});
-                    return;
-                }
-                try w.print("guid:{s}", .{g});
-            } else if (r.file_id == 0) {
-                // Unity's null reference; the Inspector shows it as None.
-                try w.writeAll("None");
-            } else {
-                try w.print("#{d}", .{r.file_id});
-            }
+        // The resolution ladder lives in display.refDisplay, the single Zig
+        // source of truth (the extension's formatValue mirrors it); this
+        // switch adds only the plain-text decoration.
+        .ref => |r| switch (display.refDisplay(r, resolved)) {
+            .path => |p| try w.writeAll(p),
+            .builtin => |b| try w.print("{s} (built-in)", .{b}),
+            .guid => |g| try w.print("guid:{s}", .{g}),
+            .none => try w.writeAll("None"),
+            .file_id => |id| try w.print("#{d}", .{id}),
         },
         .map => try w.writeAll("{...}"),
         .seq => try w.writeAll("[...]"),

--- a/extension/src/renderer/value_format.parity.test.ts
+++ b/extension/src/renderer/value_format.parity.test.ts
@@ -3,14 +3,17 @@ import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
 import { must } from "../util/must";
 
-// The diff.v2 value display rules are hand-copied in four places: the
+// The diff.v2 value display rules are hand-copied across languages: the
 // extension's formatValue (render.ts), the Unity editor's ValueFormat.cs, and
-// the CLI's writeValueText (render_tree.zig) / writeValue (render_html.zig).
-// Each parser below pulls the output literal of every branch out of one
-// implementation's source; the tests compare those records against the
-// extension's, so changing e.g. "None" in one place fails until all four move
-// together (issue #152). The guid resolution order (resolved path, then
-// built-in name, then raw guid) is checked via source positions.
+// the CLI, where the guid resolution ladder lives once in display.zig's
+// refDisplay (issue #155) while the output literals stay in writeValueText
+// (render_tree.zig) / writeValue (render_html.zig). Each parser below pulls
+// the output literal of every branch out of one implementation's source; the
+// tests compare those records against the extension's, so changing e.g.
+// "None" in one place fails until all four move together (issue #152). The
+// guid resolution order (resolved path, then built-in name, then raw guid) is
+// checked via source positions, and each CLI renderer is pinned to
+// display.refDisplay so the ladder cannot be re-forked.
 
 type Rules = {
   missing: string; // absent side of an added/removed row
@@ -74,10 +77,12 @@ function csRules(): Rules {
 
 function zigTreeRules(): Rules {
   const fn = fnSlice(read("../../../cli/src/render_tree.zig"), "fn writeValueText");
-  expectResolveOrder(fn, "rr.get(g)", "builtin_refs.name(", "guid:");
+  // The renderer must decorate the shared ladder, not re-fork it; the ladder
+  // order itself is checked once against display.zig below.
+  expect(fn, "writeValueText goes through display.refDisplay").toContain("display.refDisplay(");
   return {
     missing: extract(fn, /orelse \{\s*try w\.writeAll\("([^"]*)"\)/, "null branch"),
-    nullRef: extract(fn, /file_id == 0\) \{[\s\S]*?writeAll\("([^"]*)"\)/, "fileID 0 branch"),
+    nullRef: extract(fn, /\.none => try w\.writeAll\("([^"]*)"\)/, "fileID 0 branch"),
     localRefPrefix: extract(fn, /print\("([^"{]*)\{d\}"/, "local ref branch"),
     guidPrefix: extract(fn, /print\("([^"{]*)\{s\}", \.\{g\}\)/, "raw guid branch"),
     builtinSuffix: extract(fn, /print\("\{s\}([^"]*)"/, "built-in branch"),
@@ -86,13 +91,14 @@ function zigTreeRules(): Rules {
 
 function zigHtmlRules(): Rules {
   const fn = fnSlice(read("../../../cli/src/render_html.zig"), "fn writeValue(");
-  expectResolveOrder(fn, "rr.get(g)", "builtin_refs.name(", "guid:");
+  // Same pin as zigTreeRules: escaping and decoration only, no forked ladder.
+  expect(fn, "writeValue goes through display.refDisplay").toContain("display.refDisplay(");
   return {
     missing: extract(fn, /orelse \{\s*try w\.writeAll\("([^"]*)"\)/, "null branch"),
-    nullRef: extract(fn, /file_id == 0\) \{[\s\S]*?writeAll\("([^"]*)"\)/, "fileID 0 branch"),
+    nullRef: extract(fn, /\.none => try w\.writeAll\("([^"]*)"\)/, "fileID 0 branch"),
     localRefPrefix: extract(fn, /print\("([^"{]*)\{d\}"/, "local ref branch"),
     guidPrefix: extract(fn, /writeAll\("([^"]*)"\);\s*try writeEscaped\(w, g\)/, "raw guid branch"),
-    builtinSuffix: extract(fn, /writeEscaped\(w, builtin\);\s*try w\.writeAll\("([^"]*)"\)/, "built-in branch"),
+    builtinSuffix: extract(fn, /writeEscaped\(w, b\);\s*try w\.writeAll\("([^"]*)"\)/, "built-in branch"),
   };
 }
 
@@ -106,6 +112,12 @@ it("CLI render_tree.zig formats values like the extension's formatValue", () => 
 
 it("CLI render_html.zig formats values like the extension's formatValue", () => {
   expect(zigHtmlRules()).toEqual(tsRules());
+});
+
+it("CLI display.zig resolves guid refs in the extension's order", () => {
+  // The single Zig source of truth for the ladder both renderers switch on.
+  const fn = fnSlice(read("../../../cli/src/display.zig"), "pub fn refDisplay");
+  expectResolveOrder(fn, "rr.get(g)", "builtin_refs.name(", ".guid = g");
 });
 
 it("both CLI renderers collapse composite nodes the same way", () => {


### PR DESCRIPTION
## Summary

Move the reference-value resolution ladder shared by the tree and HTML renderers into a single `display.refDisplay` function; the renderers keep only their own escaping and decoration.

## Motivation

`writeValueText` (`render_tree.zig`) and `writeValue` (`render_html.zig`) implemented the same ladder (resolved asset path > built-in object name > raw guid > None for fileID 0 > local fileID) twice, held together by a three-way-sync comment.

Closes #155

## Changes

- Add `display.RefDisplay` (tagged union: `path` / `builtin` / `guid` / `none` / `file_id`) and `display.refDisplay(r: model.Ref, resolved: ?*const core.json.Resolver) RefDisplay` as the single Zig source of truth, with inline decision-table tests
- `render_tree.writeValueText` and `render_html.writeValue` now switch on the result and keep only their plain-text decoration and HTML escaping
- Drop the now-unused `builtin_refs` imports from both renderers and replace the sync comment with a pointer to `display.refDisplay` (the extension's `formatValue` mirrors the ladder, guarded by the parity tests from #172)

## Testing

- `zig build test` — green; the existing inline renderer tests that pin the output pass unchanged, plus 6 new `refDisplay` tests in `display.zig`
- Byte-identical check against an `origin/main` build on a fixture diff covering all five ladder outcomes (resolved path, built-in name, built-in guid with unknown fileID, unresolved guid, None, `#fileID`): `cmp` of `--color --project`, `--html --project`, and `--no-color --no-project` outputs — all identical