### PR TITLE
refactor: extract diff tree rows into DiffTree

### DIFF
--- a/editor/Editor/DiffTree.cs
+++ b/editor/Editor/DiffTree.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace PrefabLens
+{
+    /// Status colors for diff rows (same color tone as the Chrome renderer, per editor skin).
+    public static class Palette
+    {
+        public static Color Added => Hex(EditorGUIUtility.isProSkin ? 0x3fb950 : 0x1a7f37);
+        public static Color Removed => Hex(EditorGUIUtility.isProSkin ? 0xf85149 : 0xcf222e);
+        public static Color Modified => Hex(EditorGUIUtility.isProSkin ? 0xd29922 : 0x9a6700);
+        public static Color Muted => Hex(EditorGUIUtility.isProSkin ? 0x9198a1 : 0x59636e);
+
+        static Color Hex(int rgb) =>
+            new Color(((rgb >> 16) & 0xff) / 255f, ((rgb >> 8) & 0xff) / 255f, (rgb & 0xff) / 255f);
+    }
+
+    /// One run of text with an optional tint. Rows are span lists rather than rich text:
+    /// don't let repository-derived strings be interpreted as markup (same rationale as
+    /// the Chrome build's XSS test).
+    public readonly struct Span
+    {
+        public readonly string Text;
+        public readonly Color? Tint;
+
+        public Span(string text, Color? tint = null)
+        {
+            Text = text;
+            Tint = tint;
+        }
+    }
+
+    /// One rendered line: spans plus an optional leading icon.
+    public sealed class Row
+    {
+        public Texture Icon;
+        public readonly List<Span> Spans = new();
+
+        public Row Add(string text, Color? tint = null)
+        {
+            if (!string.IsNullOrEmpty(text))
+                Spans.Add(new Span(text, tint));
+            return this;
+        }
+
+        public Row WithIcon(Texture icon)
+        {
+            Icon = icon;
+            return this;
+        }
+    }
+
+    /// Maps a DiffModel to the row tree the window renders (same notation as the Chrome
+    /// renderer). Pure with respect to UIElements — PrefabLensWindow owns the TreeView
+    /// wiring — so `dotnet test` covers it via the DotNetTests~ stubs.
+    public static class DiffTree
+    {
+        /// A row and its children; the window converts this to TreeViewItemData.
+        public sealed class Item
+        {
+            public readonly Row Row;
+            public readonly List<Item> Children = new();
+
+            public Item(Row row) => Row = row;
+        }
+
+        public static List<Item> Build(DiffModel model)
+        {
+            var items = new List<Item>();
+            foreach (var n in model.Roots)
+                items.Add(NodeItem(n, model));
+            foreach (var c in model.Loose)
+                items.Add(ComponentItem(c, model));
+            return items;
+        }
+
+        public static Row Badge(DiffStatus s) =>
+            s switch
+            {
+                DiffStatus.Added => new Row().Add("+ ", Palette.Added),
+                DiffStatus.Removed => new Row().Add("− ", Palette.Removed),
+                DiffStatus.Modified => new Row().Add("~ ", Palette.Modified),
+                _ => new Row().Add("  "),
+            };
+
+        static Item NodeItem(NodeDiff n, DiffModel m)
+        {
+            var pi = n as PrefabInstanceDiff;
+            var row = Badge(n.Status).WithIcon(FindIcon(pi != null ? "Prefab Icon" : "GameObject Icon")).Add(n.Name);
+            if (pi?.SourceGuid != null)
+                row.Add(
+                    " ‹Prefab: " + (m.Resolved.TryGetValue(pi.SourceGuid, out var src) ? src : pi.SourceGuid) + "›",
+                    Palette.Muted
+                );
+            var item = new Item(row);
+            if (pi != null)
+                foreach (var ov in pi.Overrides)
+                    item.Children.Add(new Item(OverrideRow(ov, m)));
+            if (n.Components.Count > 0)
+            {
+                // Components fold as their own group one level below the object row (extension parity).
+                var group = new Item(Badge(DiffStatus.Unchanged).Add("Components", Palette.Muted));
+                foreach (var c in n.Components)
+                    group.Children.Add(ComponentItem(c, m));
+                item.Children.Add(group);
+            }
+            foreach (var ch in n.Children)
+                item.Children.Add(NodeItem(ch, m));
+            return item;
+        }
+
+        static Item ComponentItem(ComponentDiff c, DiffModel m)
+        {
+            var row = Badge(c.Status).WithIcon(ComponentIcon(c));
+            if (!string.IsNullOrEmpty(c.ClassName))
+                row.Add(c.ClassName).Add(" ‹Script›", Palette.Muted);
+            else if (c.ScriptGuid != null && m.Resolved.TryGetValue(c.ScriptGuid, out var p))
+                row.Add(Stem(p)).Add(" ‹Script›", Palette.Muted);
+            else
+                row.Add(c.TypeName);
+            var item = new Item(row);
+            foreach (var f in c.Fields)
+                item.Children.Add(new Item(FieldRow(f.Path, f.Status, f.Before, f.After, m)));
+            return item;
+        }
+
+        static Row OverrideRow(OverrideDiff ov, DiffModel m)
+        {
+            var label = ov.Group.Length > 0 && ov.Group != "Overrides" ? ov.Group + " / " + ov.Label : ov.Label;
+            return FieldRow(label, ov.Status, ov.Before, ov.After, m);
+        }
+
+        static Row FieldRow(string label, DiffStatus status, Value before, Value after, DiffModel m)
+        {
+            var row = Badge(status).Add(label + " ", Palette.Muted);
+            var b = ValueFormat.Format(before, m);
+            var a = ValueFormat.Format(after, m);
+            if (status == DiffStatus.Modified)
+                row.Add(b, Palette.Removed).Add(" → ", Palette.Muted).Add(a, Palette.Added);
+            else if (status == DiffStatus.Removed)
+                row.Add(b, Palette.Removed);
+            else
+                row.Add(a, status == DiffStatus.Added ? Palette.Added : (Color?)null);
+            return row;
+        }
+
+        /// Unity built-in icon lookup. Pro skin ships d_-prefixed variants, so probe those
+        /// first; FindTexture returns null silently for unknown names.
+        static Texture2D FindIcon(string name)
+        {
+            var dark = EditorGUIUtility.isProSkin ? EditorGUIUtility.FindTexture("d_" + name) : null;
+            return dark != null ? dark : EditorGUIUtility.FindTexture(name);
+        }
+
+        static Texture2D ComponentIcon(ComponentDiff c)
+        {
+            // Built-in components have "<TypeName> Icon" textures; script components use the script icon.
+            var builtin = c.ClassName == null && c.ScriptGuid == null ? FindIcon(c.TypeName + " Icon") : null;
+            return builtin != null ? builtin : FindIcon("cs Script Icon");
+        }
+
+        static string Stem(string path)
+        {
+            var name = Path.GetFileNameWithoutExtension(path);
+            return string.IsNullOrEmpty(name) ? path : name;
+        }
+    }
+}

--- a/editor/Editor/DiffTree.cs.meta
+++ b/editor/Editor/DiffTree.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1326d0f8ac32411791c4a96430c9b767
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading;
 using UnityEditor;
 using UnityEngine;
@@ -280,7 +279,8 @@ namespace PrefabLens
         }
 
         static Row EntryRow(BulkEntry entry) =>
-            Badge(BulkModel.AggregateStatus(entry.Diff))
+            DiffTree
+                .Badge(BulkModel.AggregateStatus(entry.Diff))
                 .WithIcon(AssetDatabase.GetCachedIcon(entry.Path))
                 .Add(entry.Path);
 
@@ -321,74 +321,14 @@ namespace PrefabLens
             }
         }
 
-        /// Unity built-in icon lookup. Pro skin ships d_-prefixed variants, so probe those
-        /// first; FindTexture returns null silently for unknown names.
-        static Texture2D FindIcon(string name)
-        {
-            var dark = EditorGUIUtility.isProSkin ? EditorGUIUtility.FindTexture("d_" + name) : null;
-            return dark != null ? dark : EditorGUIUtility.FindTexture(name);
-        }
-
-        static Texture2D ComponentIcon(ComponentDiff c)
-        {
-            // Built-in components have "<TypeName> Icon" textures; script components use the script icon.
-            var builtin = c.ClassName == null && c.ScriptGuid == null ? FindIcon(c.TypeName + " Icon") : null;
-            return builtin != null ? builtin : FindIcon("cs Script Icon");
-        }
-
-        // ---- Tree rendering (same color tone and notation as the Chrome renderer) ----
-        // No rich text: don't let repository-derived strings be interpreted as markup (same rationale as the Chrome build's XSS test).
-
-        static class Palette
-        {
-            public static Color Added => Hex(EditorGUIUtility.isProSkin ? 0x3fb950 : 0x1a7f37);
-            public static Color Removed => Hex(EditorGUIUtility.isProSkin ? 0xf85149 : 0xcf222e);
-            public static Color Modified => Hex(EditorGUIUtility.isProSkin ? 0xd29922 : 0x9a6700);
-            public static Color Muted => Hex(EditorGUIUtility.isProSkin ? 0x9198a1 : 0x59636e);
-
-            static Color Hex(int rgb) =>
-                new Color(((rgb >> 16) & 0xff) / 255f, ((rgb >> 8) & 0xff) / 255f, (rgb & 0xff) / 255f);
-        }
-
-        readonly struct Span
-        {
-            public readonly string Text;
-            public readonly Color? Tint;
-
-            public Span(string text, Color? tint = null)
-            {
-                Text = text;
-                Tint = tint;
-            }
-        }
-
-        sealed class Row
-        {
-            public Texture Icon;
-            public readonly List<Span> Spans = new();
-
-            public Row Add(string text, Color? tint = null)
-            {
-                if (!string.IsNullOrEmpty(text))
-                    Spans.Add(new Span(text, tint));
-                return this;
-            }
-
-            public Row WithIcon(Texture icon)
-            {
-                Icon = icon;
-                return this;
-            }
-        }
+        // ---- Tree rendering: DiffTree builds the rows; only the UIElements wiring lives here ----
 
         static TreeView BuildTree(DiffModel model)
         {
             var id = 0;
             var items = new List<TreeViewItemData<Row>>();
-            foreach (var n in model.Roots)
-                items.Add(NodeItem(n, model, ref id));
-            foreach (var c in model.Loose)
-                items.Add(ComponentItem(c, model, ref id));
+            foreach (var item in DiffTree.Build(model))
+                items.Add(ToViewItem(item, ref id));
 
             var tree = new TreeView { fixedItemHeight = 18, style = { flexGrow = 1 } };
             tree.SetRootItems(items);
@@ -399,84 +339,13 @@ namespace PrefabLens
             return tree;
         }
 
-        static TreeViewItemData<Row> NodeItem(NodeDiff n, DiffModel m, ref int id)
-        {
-            var pi = n as PrefabInstanceDiff;
-            var children = new List<TreeViewItemData<Row>>();
-            if (pi != null)
-                foreach (var ov in pi.Overrides)
-                    children.Add(new TreeViewItemData<Row>(id++, OverrideRow(ov, m)));
-            if (n.Components.Count > 0)
-            {
-                // Components fold as their own group one level below the object row (extension parity).
-                var comps = new List<TreeViewItemData<Row>>();
-                foreach (var c in n.Components)
-                    comps.Add(ComponentItem(c, m, ref id));
-                children.Add(
-                    new TreeViewItemData<Row>(id++, Badge(DiffStatus.Unchanged).Add("Components", Palette.Muted), comps)
-                );
-            }
-            foreach (var ch in n.Children)
-                children.Add(NodeItem(ch, m, ref id));
-
-            var row = Badge(n.Status).WithIcon(FindIcon(pi != null ? "Prefab Icon" : "GameObject Icon")).Add(n.Name);
-            if (pi?.SourceGuid != null)
-                row.Add(
-                    " ‹Prefab: " + (m.Resolved.TryGetValue(pi.SourceGuid, out var src) ? src : pi.SourceGuid) + "›",
-                    Palette.Muted
-                );
-            return new TreeViewItemData<Row>(id++, row, children);
-        }
-
-        static TreeViewItemData<Row> ComponentItem(ComponentDiff c, DiffModel m, ref int id)
+        /// Ids only need to be unique within one TreeView; each ShowEntry builds a fresh one.
+        static TreeViewItemData<Row> ToViewItem(DiffTree.Item item, ref int id)
         {
             var children = new List<TreeViewItemData<Row>>();
-            foreach (var f in c.Fields)
-                children.Add(new TreeViewItemData<Row>(id++, FieldRow(f.Path, f.Status, f.Before, f.After, m)));
-
-            var row = Badge(c.Status).WithIcon(ComponentIcon(c));
-            if (!string.IsNullOrEmpty(c.ClassName))
-                row.Add(c.ClassName).Add(" ‹Script›", Palette.Muted);
-            else if (c.ScriptGuid != null && m.Resolved.TryGetValue(c.ScriptGuid, out var p))
-                row.Add(Stem(p)).Add(" ‹Script›", Palette.Muted);
-            else
-                row.Add(c.TypeName);
-            return new TreeViewItemData<Row>(id++, row, children);
-        }
-
-        static Row OverrideRow(OverrideDiff ov, DiffModel m)
-        {
-            var label = ov.Group.Length > 0 && ov.Group != "Overrides" ? ov.Group + " / " + ov.Label : ov.Label;
-            return FieldRow(label, ov.Status, ov.Before, ov.After, m);
-        }
-
-        static Row FieldRow(string label, DiffStatus status, Value before, Value after, DiffModel m)
-        {
-            var row = Badge(status).Add(label + " ", Palette.Muted);
-            var b = ValueFormat.Format(before, m);
-            var a = ValueFormat.Format(after, m);
-            if (status == DiffStatus.Modified)
-                row.Add(b, Palette.Removed).Add(" → ", Palette.Muted).Add(a, Palette.Added);
-            else if (status == DiffStatus.Removed)
-                row.Add(b, Palette.Removed);
-            else
-                row.Add(a, status == DiffStatus.Added ? Palette.Added : (Color?)null);
-            return row;
-        }
-
-        static Row Badge(DiffStatus s) =>
-            s switch
-            {
-                DiffStatus.Added => new Row().Add("+ ", Palette.Added),
-                DiffStatus.Removed => new Row().Add("− ", Palette.Removed),
-                DiffStatus.Modified => new Row().Add("~ ", Palette.Modified),
-                _ => new Row().Add("  "),
-            };
-
-        static string Stem(string path)
-        {
-            var name = Path.GetFileNameWithoutExtension(path);
-            return string.IsNullOrEmpty(name) ? path : name;
+            foreach (var ch in item.Children)
+                children.Add(ToViewItem(ch, ref id));
+            return new TreeViewItemData<Row>(id++, item.Row, children);
         }
     }
 }

--- a/editor/Tests/Editor/DiffTreeTests.cs
+++ b/editor/Tests/Editor/DiffTreeTests.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace PrefabLens.Tests
+{
+    // Pins the DiffModel -> rows/spans mapping that PrefabLensWindow renders verbatim
+    // (same color tone and notation as the Chrome renderer). Tints are compared against
+    // Palette properties rather than raw hex so the tests hold under both editor skins.
+    public class DiffTreeTests
+    {
+        static List<DiffTree.Item> Build(string json) => DiffTree.Build(DiffModel.Parse(json));
+
+        static void AssertSpan(Span s, string text, Color? tint)
+        {
+            Assert.AreEqual(text, s.Text);
+            Assert.AreEqual(tint, s.Tint);
+        }
+
+        [Test]
+        public void BadgeMarksMirrorTheChromeRenderer()
+        {
+            // + / − / ~ prefixes tinted with the status color; unchanged keeps a
+            // two-space placeholder (no tint) so names stay column-aligned.
+            AssertSpan(DiffTree.Badge(DiffStatus.Added).Spans[0], "+ ", Palette.Added);
+            AssertSpan(DiffTree.Badge(DiffStatus.Removed).Spans[0], "− ", Palette.Removed);
+            AssertSpan(DiffTree.Badge(DiffStatus.Modified).Spans[0], "~ ", Palette.Modified);
+            AssertSpan(DiffTree.Badge(DiffStatus.Unchanged).Spans[0], "  ", null);
+        }
+
+        [Test]
+        public void RowSuppressesNullAndEmptySpans()
+        {
+            // A node with no name must not emit an empty Label after the badge.
+            var row = new Row().Add(null).Add("");
+            Assert.AreEqual(0, row.Spans.Count);
+        }
+
+        [Test]
+        public void NodesComeBeforeLooseComponents()
+        {
+            // Root order matches the model: scene objects first, then components whose
+            // owner GameObject is outside the diff (extension parity).
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[{""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""unchanged"",""components"":[],""children"":[]}],
+                ""loose"":[{""kind"":""component"",""fileId"":""2"",""classId"":135,""typeName"":""SphereCollider"",""scriptGuid"":null,""className"":null,""status"":""added"",""fields"":[]}]
+            }";
+            var items = Build(json);
+            Assert.AreEqual(2, items.Count);
+            AssertSpan(items[0].Row.Spans[1], "Plane", null);
+            AssertSpan(items[1].Row.Spans[0], "+ ", Palette.Added);
+            AssertSpan(items[1].Row.Spans[1], "SphereCollider", null);
+        }
+
+        [Test]
+        public void ComponentsFoldUnderAMutedGroupRow()
+        {
+            // Components sit in their own "Components" group one level below the object
+            // row, so the object's children fold independently (extension parity).
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[{""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""modified"",
+                    ""components"":[{""kind"":""component"",""fileId"":""4"",""classId"":4,""typeName"":""Transform"",""scriptGuid"":null,""className"":null,""status"":""modified"",""fields"":[]}],
+                    ""children"":[]}],
+                ""loose"":[]
+            }";
+            var items = Build(json);
+            AssertSpan(items[0].Row.Spans[0], "~ ", Palette.Modified);
+            var group = items[0].Children[0];
+            AssertSpan(group.Row.Spans[0], "  ", null);
+            AssertSpan(group.Row.Spans[1], "Components", Palette.Muted);
+            AssertSpan(group.Children[0].Row.Spans[1], "Transform", null);
+        }
+
+        [Test]
+        public void ModifiedFieldReadsBeforeArrowAfter()
+        {
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[],
+                ""loose"":[{""kind"":""component"",""fileId"":""4"",""classId"":4,""typeName"":""Transform"",""scriptGuid"":null,""className"":null,""status"":""modified"",
+                    ""fields"":[{""path"":""Position"",""status"":""modified"",""before"":""(0, 0, 0)"",""after"":""(1, 0, 0)""}]}]
+            }";
+            var field = Build(json)[0].Children[0].Row;
+            AssertSpan(field.Spans[0], "~ ", Palette.Modified);
+            AssertSpan(field.Spans[1], "Position ", Palette.Muted); // trailing space separates label and value
+            AssertSpan(field.Spans[2], "(0, 0, 0)", Palette.Removed);
+            AssertSpan(field.Spans[3], " → ", Palette.Muted);
+            AssertSpan(field.Spans[4], "(1, 0, 0)", Palette.Added);
+        }
+
+        [Test]
+        public void SingleSidedFieldsShowOnlyTheExistingValue()
+        {
+            // removed -> before only (red); added -> after only (green);
+            // unchanged -> after with no tint. One fixture covers all three branches.
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[],
+                ""loose"":[{""kind"":""component"",""fileId"":""2"",""classId"":54,""typeName"":""Rigidbody"",""scriptGuid"":null,""className"":null,""status"":""modified"",
+                    ""fields"":[
+                        {""path"":""Speed"",""status"":""removed"",""before"":""2"",""after"":null},
+                        {""path"":""Mass"",""status"":""added"",""before"":null,""after"":""10""},
+                        {""path"":""Drag"",""status"":""unchanged"",""before"":""0"",""after"":""0""}
+                    ]}]
+            }";
+            var fields = Build(json)[0].Children;
+            Assert.AreEqual(3, fields[0].Row.Spans.Count);
+            AssertSpan(fields[0].Row.Spans[2], "2", Palette.Removed);
+            Assert.AreEqual(3, fields[1].Row.Spans.Count);
+            AssertSpan(fields[1].Row.Spans[2], "10", Palette.Added);
+            Assert.AreEqual(3, fields[2].Row.Spans.Count);
+            AssertSpan(fields[2].Row.Spans[2], "0", null);
+        }
+
+        [Test]
+        public void PrefabInstanceShowsItsSourceAfterTheName()
+        {
+            // Resolved source guid reads as the asset path; unresolved keeps the raw guid.
+            const string json =
+                @"{
+                ""unresolvedGuids"":[""xyz""],
+                ""resolved"":{""srcguid"":""Assets/Prefabs/Cylinder.prefab""},
+                ""roots"":[
+                    {""kind"":""prefabInstance"",""fileId"":""1001"",""name"":""Cylinder"",""status"":""added"",""sourceGuid"":""srcguid"",""overrides"":[],""components"":[],""children"":[]},
+                    {""kind"":""prefabInstance"",""fileId"":""1002"",""name"":""Sphere"",""status"":""unchanged"",""sourceGuid"":""xyz"",""overrides"":[],""components"":[],""children"":[]}
+                ],
+                ""loose"":[]
+            }";
+            var items = Build(json);
+            AssertSpan(items[0].Row.Spans[1], "Cylinder", null);
+            AssertSpan(items[0].Row.Spans[2], " ‹Prefab: Assets/Prefabs/Cylinder.prefab›", Palette.Muted);
+            AssertSpan(items[1].Row.Spans[2], " ‹Prefab: xyz›", Palette.Muted);
+        }
+
+        [Test]
+        public void OverrideLabelJoinsGroupWithSlash()
+        {
+            // "Group / Label" — except the catch-all "Overrides" group and the empty
+            // group, which read as the bare label.
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[{""kind"":""prefabInstance"",""fileId"":""1001"",""name"":""Cylinder"",""status"":""modified"",""sourceGuid"":null,
+                    ""overrides"":[
+                        {""group"":""Transform"",""label"":""Position"",""status"":""modified"",""before"":""0"",""after"":""1""},
+                        {""group"":""Overrides"",""label"":""Active"",""status"":""modified"",""before"":""0"",""after"":""1""},
+                        {""group"":"""",""label"":""Name"",""status"":""modified"",""before"":""a"",""after"":""b""}
+                    ],
+                    ""components"":[],""children"":[]}],
+                ""loose"":[]
+            }";
+            var overrides = Build(json)[0].Children;
+            AssertSpan(overrides[0].Row.Spans[1], "Transform / Position ", Palette.Muted);
+            AssertSpan(overrides[1].Row.Spans[1], "Active ", Palette.Muted);
+            AssertSpan(overrides[2].Row.Spans[1], "Name ", Palette.Muted);
+        }
+
+        [Test]
+        public void ComponentNamePrefersClassNameThenResolvedScriptThenTypeName()
+        {
+            const string json =
+                @"{
+                ""unresolvedGuids"":[""ghost""],
+                ""resolved"":{""runner"":""Assets/Scripts/Runner.cs""},
+                ""roots"":[],
+                ""loose"":[
+                    {""kind"":""component"",""fileId"":""1"",""classId"":114,""typeName"":""MonoBehaviour"",""scriptGuid"":null,""className"":""Mover"",""status"":""added"",""fields"":[]},
+                    {""kind"":""component"",""fileId"":""2"",""classId"":114,""typeName"":""MonoBehaviour"",""scriptGuid"":""runner"",""className"":null,""status"":""added"",""fields"":[]},
+                    {""kind"":""component"",""fileId"":""3"",""classId"":114,""typeName"":""MonoBehaviour"",""scriptGuid"":""ghost"",""className"":null,""status"":""added"",""fields"":[]},
+                    {""kind"":""component"",""fileId"":""4"",""classId"":4,""typeName"":""Transform"",""scriptGuid"":null,""className"":null,""status"":""added"",""fields"":[]}
+                ]
+            }";
+            var items = Build(json);
+            // The C# class name from the CLI wins outright.
+            AssertSpan(items[0].Row.Spans[1], "Mover", null);
+            AssertSpan(items[0].Row.Spans[2], " ‹Script›", Palette.Muted);
+            // A resolved script guid reads as the script's file stem.
+            AssertSpan(items[1].Row.Spans[1], "Runner", null);
+            AssertSpan(items[1].Row.Spans[2], " ‹Script›", Palette.Muted);
+            // Unresolved guid falls back to the Unity type name, without the Script tag.
+            Assert.AreEqual(2, items[2].Row.Spans.Count);
+            AssertSpan(items[2].Row.Spans[1], "MonoBehaviour", null);
+            // Built-in components always read as the type name.
+            AssertSpan(items[3].Row.Spans[1], "Transform", null);
+        }
+
+        [Test]
+        public void NodeChildrenOrderIsOverridesThenComponentsThenChildNodes()
+        {
+            // Mirrors the Inspector's mental model: instance overrides at the top,
+            // then the Components group, then nested objects.
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[{""kind"":""prefabInstance"",""fileId"":""1001"",""name"":""Cylinder"",""status"":""modified"",""sourceGuid"":null,
+                    ""overrides"":[{""group"":""Transform"",""label"":""Position"",""status"":""modified"",""before"":""0"",""after"":""1""}],
+                    ""components"":[{""kind"":""component"",""fileId"":""4"",""classId"":4,""typeName"":""Transform"",""scriptGuid"":null,""className"":null,""status"":""modified"",""fields"":[]}],
+                    ""children"":[{""kind"":""gameObject"",""fileId"":""5"",""name"":""Cap"",""status"":""unchanged"",""components"":[],""children"":[]}]}],
+                ""loose"":[]
+            }";
+            var children = Build(json)[0].Children;
+            Assert.AreEqual(3, children.Count);
+            AssertSpan(children[0].Row.Spans[1], "Transform / Position ", Palette.Muted);
+            AssertSpan(children[1].Row.Spans[1], "Components", Palette.Muted);
+            AssertSpan(children[2].Row.Spans[1], "Cap", null);
+        }
+    }
+}

--- a/editor/Tests/Editor/DiffTreeTests.cs.meta
+++ b/editor/Tests/Editor/DiffTreeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e54895c56a746f9952e20ee2ad1facd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Extracts the tree rendering logic (`Palette` / `Span` / `Row` / node-item building) out of `PrefabLensWindow` into a new pure-logic class `DiffTree`, and adds `dotnet test` coverage for row building from representative diffs.

## Motivation

The DiffModel -> rows/spans mapping lived inside the ~450-line window class, entangled with UI state, and had zero tests — regressions in row building and styling were only catchable manually in a real Unity editor. Following the pure-vs-integration split already used in `Cli.cs`, the mapping is now testable on the plain dotnet SDK via the `DotNetTests~` stubs.

Closes #157

## Changes

- New `editor/Editor/DiffTree.cs`: `Palette`, `Span`, `Row` (public, moved verbatim) and `DiffTree.Build(DiffModel)` which returns a pure `Item` tree (row + children). Named `DiffTree` rather than the issue's suggested `DiffTreeView` to match the existing concise-noun convention (`DiffModel`, `BulkModel`, `ValueFormat`) — the actual view wiring stays in the window.
- `PrefabLensWindow` keeps the state machine, download flow, and UIElements wiring only: `BuildTree` now maps `DiffTree.Item` -> `TreeViewItemData<Row>` (id assignment stays window-side, since ids are a TreeView concern), `RenderRow` / `EntryRow` unchanged apart from delegating to `DiffTree.Badge`.
- New `editor/Tests/Editor/DiffTreeTests.cs` (10 tests, written first, red before the extraction): badge marks per status, modified `before → after` span sequence, single-sided fields, Components group row, prefab-instance source suffix (resolved and unresolved), override `Group / Label` composition, component naming precedence (className -> resolved script stem -> typeName), root and child ordering, empty-span suppression. Tints are asserted against `Palette` properties instead of raw hex so the tests hold under both editor skins (stubs and a real pro-skin Unity).
- Unity `.meta` files added for both new `.cs` files.

No visual or behavioral change intended; the moved code is verbatim except for the `TreeViewItemData` -> `Item` substitution.

## Testing

```
$ dotnet test DotNetTests~/Tests   # from editor/
Passed!  - Failed:     0, Passed:    51, Skipped:     0, Total:    51, Duration: 728 ms - PrefabLens.Editor.Tests.dll (net10.0)
```

(41 tests on main; the 10 new DiffTree tests failed to compile before the extraction, as expected for test-first.)

```
$ dotnet csharpier check . --no-msbuild-check
Checked 18 files in 125ms.
```

Not performed: the real-Unity manual smoke check (open Window/PrefabLens and confirm the tree renders identically) is deferred to the maintainer.