### PR TITLE
feat: let the editor window choose a base ref

### DIFF
--- a/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
@@ -94,10 +94,33 @@ namespace UnityEngine.UIElements
     public class VisualElement
     {
         public IStyle style { get; } = new Style();
+        public string tooltip { get; set; }
 
         public void Add(VisualElement child) { }
 
         public void Clear() { }
+    }
+
+    public delegate void EventCallback<in TEventType>(TEventType evt);
+
+    public class ChangeEvent<T>
+    {
+        public T previousValue { get; }
+        public T newValue { get; }
+    }
+
+    public class TextField : VisualElement
+    {
+        public TextField() { }
+
+        public TextField(string label) { }
+
+        public string value { get; set; }
+        public bool isDelayed { get; set; }
+
+        // In Unity this is INotifyValueChangedExtensions.RegisterValueChangedCallback;
+        // an instance method compiles against the identical call syntax.
+        public void RegisterValueChangedCallback(EventCallback<ChangeEvent<string>> callback) { }
     }
 
     public class Image : VisualElement

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -78,13 +78,18 @@ namespace PrefabLens
         }
 
         /// Bare invocation = bulk mode: HEAD vs working tree, all changed Unity files,
-        /// as a [{path, diff}] JSON array.
-        public static string[] BuildBulkArgs() => new[] { "--json" };
+        /// as a [{path, diff}] JSON array. A non-blank baseRef becomes the single ref
+        /// operand, which the CLI parses as base ref vs working tree (still bulk mode).
+        public static string[] BuildBulkArgs(string baseRef = null)
+        {
+            var r = baseRef?.Trim();
+            return string.IsNullOrEmpty(r) ? new[] { "--json" } : new[] { r, "--json" };
+        }
 
         /// Run bulk mode off the main thread. The callback is posted back through the
         /// caller's SynchronizationContext (Unity's main thread when called from the window).
-        public static void RunBulkAsync(string cliPath, Action<Result> onDone) =>
-            RunAsync(cliPath, QuoteArgs(BuildBulkArgs()), onDone, SynchronizationContext.Current);
+        public static void RunBulkAsync(string cliPath, string baseRef, Action<Result> onDone) =>
+            RunAsync(cliPath, QuoteArgs(BuildBulkArgs(baseRef)), onDone, SynchronizationContext.Current);
 
         public static void RunAsync(string file, string arguments, Action<Result> onDone, SynchronizationContext ctx)
         {

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -7,11 +7,12 @@ using UnityEngine.UIElements;
 
 namespace PrefabLens
 {
-    /// Master-detail view: UnityYAML assets that differ from HEAD on the left,
-    /// the selected asset's semantic diff on the right.
+    /// Master-detail view: UnityYAML assets that differ from the chosen base ref
+    /// (HEAD by default) on the left, the selected asset's semantic diff on the right.
     public sealed class PrefabLensWindow : EditorWindow
     {
         Label status;
+        TextField baseRef;
         ListView list;
         VisualElement content;
         BulkModel bulk = new();
@@ -46,6 +47,16 @@ namespace PrefabLens
                 },
             };
             toolbar.Add(status);
+            baseRef = new TextField("Base")
+            {
+                // Commit on Enter or focus loss instead of every keystroke, so each
+                // edit triggers exactly one CLI run.
+                isDelayed = true,
+                tooltip = "Git ref to compare against: branch, tag, or commit. Empty = HEAD.",
+                style = { width = 220 },
+            };
+            baseRef.RegisterValueChangedCallback(_ => Refresh());
+            toolbar.Add(baseRef);
             toolbar.Add(new Button(Refresh) { text = "Refresh" });
             rootVisualElement.Add(toolbar);
 
@@ -96,7 +107,7 @@ namespace PrefabLens
             }
             refreshing = true;
             status.text = "Refreshing…";
-            Cli.RunBulkAsync(cli, OnBulkDone);
+            Cli.RunBulkAsync(cli, baseRef.value, OnBulkDone);
         }
 
         void OnBulkDone(Cli.Result res)
@@ -148,7 +159,14 @@ namespace PrefabLens
             ShowEntry(bulk.Entries[idx]);
         }
 
-        string CountText() => bulk.Entries.Count == 0 ? "No changes vs HEAD" : $"{bulk.Entries.Count} changed vs HEAD";
+        string CountText() =>
+            bulk.Entries.Count == 0 ? $"No changes vs {BaseLabel()}" : $"{bulk.Entries.Count} changed vs {BaseLabel()}";
+
+        string BaseLabel()
+        {
+            var r = baseRef.value?.Trim();
+            return string.IsNullOrEmpty(r) ? "HEAD" : r;
+        }
 
         int IndexOfPath(string path)
         {

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -132,6 +132,28 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void BuildBulkArgsWithABaseRefComparesRefVsWorkingTree()
+        {
+            // CLI grammar (cli/src/main.zig parseArgs): one operand without a Unity YAML
+            // extension is a git ref, so `prefablens <ref> --json` is ref vs working tree,
+            // still bulk mode because no path operand is given.
+            Assert.AreEqual(new[] { "main", "--json" }, Cli.BuildBulkArgs("main"));
+            Assert.AreEqual(new[] { "HEAD~1", "--json" }, Cli.BuildBulkArgs("HEAD~1"));
+        }
+
+        [Test]
+        public void BuildBulkArgsTreatsABlankBaseRefAsTheDefault()
+        {
+            // The window feeds a free-form text field straight in: null, empty, and
+            // whitespace-only must all keep the default invocation byte-for-byte, and
+            // surrounding whitespace must not leak into the git ref.
+            Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs(null));
+            Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs(""));
+            Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs("   "));
+            Assert.AreEqual(new[] { "main", "--json" }, Cli.BuildBulkArgs(" main "));
+        }
+
+        [Test]
         public void RunAsyncInvokesTheCallbackOffTheBlockedCaller()
         {
             // ctx: null exercises the no-SynchronizationContext fallback; a posted callback


### PR DESCRIPTION
## Summary

Adds a "Base" text field to the PrefabLens editor window so the diff list can be computed against any git ref (branch, tag, or commit) instead of always HEAD vs working tree.

## Motivation

The CLI already supports arbitrary ref comparison (`prefablens main`, `prefablens HEAD~1`), but the window hardcoded the bare bulk invocation, so reviewing a branch or a past commit inside Unity was impossible.

Closes #161

## Changes

- `Cli.BuildBulkArgs` takes an optional `baseRef`; a non-blank ref becomes the single ref operand (`{ ref, --json }`), which the CLI's `parseArgs` treats as base ref vs working tree, still in bulk mode. Null, empty, and whitespace-only input keep the default `{ --json }` byte-for-byte; surrounding whitespace is trimmed.
- `Cli.RunBulkAsync` passes the base ref through.
- `PrefabLensWindow` gains a delayed "Base" `TextField` in the toolbar (commits on Enter or focus loss, so each edit triggers exactly one CLI run) with a tooltip; the status line now names the chosen base (`N changed vs main`). Empty field = HEAD, identical to the previous behavior.
- `DotNetTests~` UIElements stubs gain the minimal `TextField` surface (`value`, `isDelayed`, `RegisterValueChangedCallback`) plus `VisualElement.tooltip`, mirroring Unity 2022.3 signatures.

## Testing

- Verified the CLI grammar in `cli/src/main.zig` (`parseArgs` and its tests): one operand without a Unity YAML extension is a git ref; `<ref>` with empty `after_ref` means ref vs working tree, bulk when no path operand is present.
- TDD: added `BuildBulkArgsWithABaseRefComparesRefVsWorkingTree` and `BuildBulkArgsTreatsABlankBaseRefAsTheDefault` first, watched them fail (CS1501), then implemented.

```
$ dotnet test DotNetTests~/Tests
Passed!  - Failed:     0, Passed:    53, Skipped:     0, Total:    53, Duration: 748 ms

$ dotnet csharpier check . --no-msbuild-check
Checked 18 files in 121ms.
```

Manual smoke in a real Unity editor (typing a branch name into the Base field and checking the list) is deferred to the maintainer — it was not performed here.