### PR TITLE
refactor: split handler caches and resolution pipeline

### DIFF
--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -18,8 +18,8 @@ import {
   targetKey,
 } from "../types";
 import { isUnityPath } from "../unity";
-import { must } from "../util/must";
 import { DiffError, type Differ } from "../wasm/differ";
+import { createPromiseCache } from "./promiseCache";
 
 type ClientLike = Pick<
   GithubClient,
@@ -102,18 +102,20 @@ type DiffOutcome =
   | { ok: false; error: "not-unity-yaml" };
 
 export function createHandler(deps: Deps): Handler {
-  // Per-PR context cache. The SW may be killed at any time; then we just re-fetch.
-  const contexts = new Map<string, { at: number; ctx: Promise<DiffContext> }>();
-  // sha+path → bytes Promise. Storing a Promise folds concurrent prefetch and manual-toggle requests into one fetch.
-  const blobs = new Map<string, Promise<Uint8Array | null>>();
+  // Per-PR context cache (60s ttl: a push moves headSha). The SW may be killed at any time; then we just re-fetch.
+  const contexts = createPromiseCache<DiffContext>({ ttlMs: CONTEXT_TTL_MS });
+  // sha+path → bytes. The promise fold shares one fetch between concurrent prefetch and manual-toggle requests.
+  const blobs = createPromiseCache<Uint8Array | null>({ max: BLOB_CACHE_MAX });
   // guids that missed in Code Search. Indexing lag means we don't persist these — SW lifetime only
   const misses = new Set<string>();
-  // repoKey:guid → in-flight search. Folds concurrent searches for the same guid into one (protects the 10 req/min)
-  const searches = new Map<string, Promise<string | null>>();
-  // baseSha:headSha:path → raw diff computation Promise. Keeps only successes (too-large/failure allow recomputation)
-  const diffs = new Map<string, Promise<DiffOutcome>>();
-  // repoKey@ref → whole-repo index Promise. null means not indexable (truncated/over the cap/failure)
-  const indexes = new Map<string, Promise<Record<string, string> | null>>();
+  // repoKey:guid → in-flight search, folding concurrent searches for the same guid into one (protects the
+  // 10 req/min). Nothing is retained after settling: guidCache/misses take over from there.
+  const searches = createPromiseCache<string | null>({ retain: () => false });
+  // baseSha:headSha:path → raw diff computation. too-large is dropped so force can recompute; not-unity-yaml
+  // is deterministic for the sha pair, so it stays cached alongside successes.
+  const diffs = createPromiseCache<DiffOutcome>({ retain: (o) => o.ok || o.error !== "too-large" });
+  // repoKey@ref → whole-repo index. null means not indexable (truncated/over the cap)
+  const indexes = createPromiseCache<Record<string, string> | null>();
   // A repo that hit a rate limit falls back for the SW lifetime (gives up on the index and defers to Code Search only)
   const indexFallback = new Set<string>();
 
@@ -143,13 +145,7 @@ export function createHandler(deps: Deps): Handler {
     for (const g of searchable.slice(0, MAX_SEARCHES)) {
       const key = `${repoKey}:${g}`;
       try {
-        let p = searches.get(key);
-        if (!p) {
-          p = client.searchMetaByGuid(owner, repo, g);
-          searches.set(key, p);
-          void p.catch(() => {}).then(() => searches.delete(key)); // after completion, guidCache/misses take over
-        }
-        const path = await p;
+        const path = await searches.get(key, () => client.searchMetaByGuid(owner, repo, g));
         if (path) resolved[g] = found[g] = path;
         else misses.add(key);
       } catch (err) {
@@ -185,21 +181,18 @@ export function createHandler(deps: Deps): Handler {
     ref: string,
   ): Promise<Record<string, string> | null> {
     if (indexFallback.has(repoKey)) return Promise.resolve(null);
-    const key = `${repoKey}@${ref}`;
-    const hit = indexes.get(key);
-    if (hit) return hit;
-    const p = syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref).catch((err: unknown) => {
-      indexes.delete(key); // don't cache failures: retry on the next visit
-      if (err instanceof RateLimitError) indexFallback.add(repoKey);
-      return null;
-    });
-    indexes.set(key, p);
-    return p;
+    return indexes
+      .get(`${repoKey}@${ref}`, () => syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref))
+      .catch((err: unknown) => {
+        // the cache has already dropped the failure, so the next visit retries
+        if (err instanceof RateLimitError) indexFallback.add(repoKey);
+        return null;
+      });
   }
 
   /** blobSha rides along when known (files API / merge-base tree): blob-by-sha latency is flat where
    *  contents-by-path stalls for seconds (#110). A 404 on the sha (force push) falls back to path+ref. */
-  async function fetchBlob(
+  function fetchBlob(
     client: ClientLike,
     owner: string,
     repo: string,
@@ -207,16 +200,12 @@ export function createHandler(deps: Deps): Handler {
     sha: string,
     blobSha?: string,
   ): Promise<Uint8Array | null> {
-    const key = blobSha ?? `${sha}:${path}`; // a blob sha never collides with the `${sha}:${path}` form
-    const hit = blobs.get(key); // the stored value is Promise<Uint8Array | null>, so undefined = not cached
-    if (hit !== undefined) return hit;
-    const p = blobSha
-      ? client.getBlobRaw(owner, repo, blobSha).then((bytes) => bytes ?? client.getFileAtRef(owner, repo, path, sha))
-      : client.getFileAtRef(owner, repo, path, sha);
-    p.catch(() => blobs.delete(key)); // don't keep failures: the next call can re-fetch
-    blobs.set(key, p);
-    if (blobs.size > BLOB_CACHE_MAX) blobs.delete(must(blobs.keys().next().value));
-    return p;
+    // a blob sha never collides with the `${sha}:${path}` form
+    return blobs.get(blobSha ?? `${sha}:${path}`, () =>
+      blobSha
+        ? client.getBlobRaw(owner, repo, blobSha).then((bytes) => bytes ?? client.getFileAtRef(owner, repo, path, sha))
+        : client.getFileAtRef(owner, repo, path, sha),
+    );
   }
 
   /** Retrieves the before/after blobs (status/previousPath rules follow the files API). */
@@ -295,10 +284,7 @@ export function createHandler(deps: Deps): Handler {
   }
 
   function loadContext(client: ClientLike, owner: string, repo: string, target: DiffTarget): Promise<DiffContext> {
-    const key = targetKey(owner, repo, target);
-    const entry = contexts.get(key);
-    if (entry && Date.now() - entry.at < CONTEXT_TTL_MS) return entry.ctx;
-    const ctx = (async () => {
+    return contexts.get(targetKey(owner, repo, target), async () => {
       const { refs, files } = await loadRefsAndFiles(client, owner, repo, target);
       const bySha = new Map(files.map((f) => [f.path, f.sha]));
       const [guidIndex, baseShas] = await Promise.all([
@@ -324,10 +310,7 @@ export function createHandler(deps: Deps): Handler {
         ),
       ]);
       return { refs, files, guidIndex, baseShas };
-    })();
-    contexts.set(key, { at: Date.now(), ctx });
-    ctx.catch(() => contexts.delete(key)); // don't cache failures
-    return ctx;
+    });
   }
 
   /** blob fetch → 25MB guard → plain diff, no further. Don't put resolution or mergeSources here
@@ -364,25 +347,13 @@ export function createHandler(deps: Deps): Handler {
     force: boolean,
   ): Promise<DiffOutcome> {
     const key = `${ctx.refs.baseSha}:${ctx.refs.headSha}:${path}`;
-    const hit = diffs.get(key);
-    if (hit) return hit;
-    const p = (async (): Promise<DiffOutcome> => {
+    return diffs.get(key, async (): Promise<DiffOutcome> => {
       const stored = await deps.diffStore.load(key); // a result left by a prior SW life
       if (stored) return { ok: true, json: stored };
       const outcome = await computeDiff(client, ctx, owner, repo, path, force);
       if (outcome.ok) void deps.diffStore.save(key, outcome.json);
       return outcome;
-    })();
-    diffs.set(key, p);
-    p.then(
-      (o) => {
-        // too-large allows a force recomputation; not-unity-yaml is
-        // deterministic for the sha pair, so keep it cached in memory
-        if (!o.ok && o.error === "too-large") diffs.delete(key);
-      },
-      () => diffs.delete(key),
-    );
-    return p;
+    });
   }
 
   /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -7,7 +7,7 @@ import {
   type RefPair,
 } from "../github/client";
 import { applyResolved, buildGuidIndex, type GuidCache } from "../github/guids";
-import { type RepoIndexStore, syncRepoIndex } from "../github/repoIndex";
+import type { RepoIndexStore } from "../github/repoIndex";
 import {
   type DiffTarget,
   type DiffV2,
@@ -20,6 +20,7 @@ import {
 import { isUnityPath } from "../unity";
 import { DiffError, type Differ } from "../wasm/differ";
 import { createPromiseCache } from "./promiseCache";
+import { createResolution, type DiffContext } from "./resolution";
 
 type ClientLike = Pick<
   GithubClient,
@@ -48,14 +49,6 @@ export type Deps = {
 export type Handler = {
   semanticDiff(req: SemanticDiffRequest, push: (msg: GuidResolvedPush) => void): Promise<SemanticDiffResponse>;
   prefetch(req: PrefetchRequest): Promise<void>;
-};
-
-// baseShas: path → blob sha at the base ref. null = tree unavailable (truncated/failed) → contents-api fallback
-type DiffContext = {
-  refs: RefPair;
-  files: ChangedFile[];
-  guidIndex: Map<string, string>;
-  baseShas: Map<string, string> | null;
 };
 
 /** The only per-kind logic: refs + changed-file discovery. Everything downstream is target-agnostic. */
@@ -88,8 +81,6 @@ async function loadRefsAndFiles(
 }
 
 const EMPTY = new Uint8Array(0);
-const MAX_SEARCHES = 10; // Code Search is authenticated 10 req/min — don't burn it all in one response
-const MAX_SOURCE_ROUNDS = 3; // re-diff cap for nested sources (independent of core's depth cap of 8)
 const CONTEXT_TTL_MS = 60_000; // PR context is short-lived because a push changes headSha
 const BLOB_CACHE_MAX = 32;
 const TOO_LARGE_BYTES = 25 * 1024 * 1024; // over 25MB renders on click
@@ -106,89 +97,9 @@ export function createHandler(deps: Deps): Handler {
   const contexts = createPromiseCache<DiffContext>({ ttlMs: CONTEXT_TTL_MS });
   // sha+path → bytes. The promise fold shares one fetch between concurrent prefetch and manual-toggle requests.
   const blobs = createPromiseCache<Uint8Array | null>({ max: BLOB_CACHE_MAX });
-  // guids that missed in Code Search. Indexing lag means we don't persist these — SW lifetime only
-  const misses = new Set<string>();
-  // repoKey:guid → in-flight search, folding concurrent searches for the same guid into one (protects the
-  // 10 req/min). Nothing is retained after settling: guidCache/misses take over from there.
-  const searches = createPromiseCache<string | null>({ retain: () => false });
   // baseSha:headSha:path → raw diff computation. too-large is dropped so force can recompute; not-unity-yaml
   // is deterministic for the sha pair, so it stays cached alongside successes.
   const diffs = createPromiseCache<DiffOutcome>({ retain: (o) => o.ok || o.error !== "too-large" });
-  // repoKey@ref → whole-repo index. null means not indexable (truncated/over the cap)
-  const indexes = createPromiseCache<Record<string, string> | null>();
-  // A repo that hit a rate limit falls back for the SW lifetime (gives up on the index and defers to Code Search only)
-  const indexFallback = new Set<string>();
-
-  /** Resolves guid[] in cache → Code Search order (the body of searchUnresolved itself).
-   *  A search failure (including rate limits) doesn't drop the diff: returns only what was resolved. */
-  async function searchGuids(
-    guids: string[],
-    client: ClientLike,
-    owner: string,
-    repo: string,
-    repoKey: string,
-  ): Promise<Record<string, string>> {
-    if (!guids.length) return {};
-    // hasOwn: guids are arbitrary strings, so 'constructor' etc. don't falsely hit Object.prototype
-    // The cached lookup covers all guids without going through misses: since index resolutions also land in guidCache,
-    // a cached name is always emitted even if it's in misses (the search gatekeeper)
-    const cached = await deps.guidCache.load(repoKey);
-    const resolved: Record<string, string> = {};
-    const unknown: string[] = [];
-    for (const g of guids) {
-      const hit = Object.hasOwn(cached, g) ? cached[g] : undefined;
-      if (hit !== undefined) resolved[g] = hit;
-      else unknown.push(g);
-    }
-    const searchable = unknown.filter((g) => !misses.has(`${repoKey}:${g}`));
-    const found: Record<string, string> = {};
-    for (const g of searchable.slice(0, MAX_SEARCHES)) {
-      const key = `${repoKey}:${g}`;
-      try {
-        const path = await searches.get(key, () => client.searchMetaByGuid(owner, repo, g));
-        if (path) resolved[g] = found[g] = path;
-        else misses.add(key);
-      } catch (err) {
-        if (err instanceof RateLimitError) break;
-        misses.add(key);
-      }
-    }
-    if (Object.keys(found).length) await deps.guidCache.save(repoKey, found);
-    return resolved;
-  }
-
-  /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search order.
-   *  mergeSources calls it internally, so keep the signature and behavior unchanged. */
-  async function searchUnresolved(
-    json: DiffV2,
-    client: ClientLike,
-    owner: string,
-    repo: string,
-    repoKey: string,
-  ): Promise<DiffV2> {
-    const resolved = { ...json.resolved };
-    const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g));
-    const found = await searchGuids(pending, client, owner, repo, repoKey);
-    return { ...json, resolved: { ...resolved, ...found } };
-  }
-
-  /** Fetches and memoizes the whole-repo guid index. A repo that hit a rate limit is pinned to fallback for the SW lifetime. */
-  function getRepoIndex(
-    client: ClientLike,
-    owner: string,
-    repo: string,
-    repoKey: string,
-    ref: string,
-  ): Promise<Record<string, string> | null> {
-    if (indexFallback.has(repoKey)) return Promise.resolve(null);
-    return indexes
-      .get(`${repoKey}@${ref}`, () => syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref))
-      .catch((err: unknown) => {
-        // the cache has already dropped the failure, so the next visit retries
-        if (err instanceof RateLimitError) indexFallback.add(repoKey);
-        return null;
-      });
-  }
 
   /** blobSha rides along when known (files API / merge-base tree): blob-by-sha latency is flat where
    *  contents-by-path stalls for seconds (#110). A 404 on the sha (force push) falls back to path+ref. */
@@ -230,58 +141,14 @@ export function createHandler(deps: Deps): Handler {
     ]);
   }
 
-  /** Fetches neededSources (the source prefab of an added/removed instance) via the resolved
-   *  path and re-diffs with assets attached. The source guid rides on unresolvedGuids as an
-   *  m_SourcePrefab reference, so searchUnresolved has already done the path resolution.
-   *  Failure to resolve/fetch/merge degrades to the diff at that point (doesn't drop the whole thing). */
-  async function mergeSources(
-    first: DiffV2,
-    differ: Differ,
-    before: Uint8Array,
-    after: Uint8Array,
-    ctx: DiffContext,
-    client: ClientLike,
-    owner: string,
-    repo: string,
-    repoKey: string,
-  ): Promise<DiffV2> {
-    const assets = new Map<string, Uint8Array>();
-    let current = first;
-    for (let round = 0; round < MAX_SOURCE_ROUNDS; round++) {
-      const needed = (current.neededSources ?? []).filter((s) => !assets.has(s.guid));
-      if (!needed.length) break;
-      let progressed = false;
-      for (const s of needed) {
-        const path = current.resolved?.[s.guid];
-        if (path === undefined) continue;
-        const sha = s.side === "before" ? ctx.refs.baseSha : ctx.refs.headSha;
-        // sources aren't PR files, so only the base tree can supply a sha; the head side keeps the path fallback
-        const blobSha = s.side === "before" ? ctx.baseShas?.get(path) : undefined;
-        let bytes: Uint8Array | null = null;
-        try {
-          bytes = await fetchBlob(client, owner, repo, path, sha, blobSha);
-        } catch {
-          return current; // rate limit etc.: degrade to the first-pass diff
-        }
-        if (!bytes) continue;
-        // Sources resolved by guid can be binary-serialized too: merging
-        // them is a no-op re-diff, so don't count it as progress.
-        if (!differ.isUnityYaml(bytes)) continue;
-        assets.set(s.guid, bytes);
-        progressed = true;
-      }
-      if (!progressed) break;
-      let merged: DiffV2;
-      try {
-        merged = differ.diffWithAssets(before, after, assets);
-      } catch {
-        return current; // a merge failure degrades to the current result
-      }
-      // Merging surfaces new external references (script/material) inside the source, so resolve again.
-      current = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
-    }
-    return current;
-  }
+  // Repo-index and Code Search resolution plus source re-merge, sharing the handler's cached fetchers.
+  const resolution = createResolution({
+    guidCache: deps.guidCache,
+    repoIndexStore: deps.repoIndexStore,
+    getDiffer: () => deps.getDiffer(),
+    fetchBlob,
+    fetchPair,
+  });
 
   function loadContext(client: ClientLike, owner: string, repo: string, target: DiffTarget): Promise<DiffContext> {
     return contexts.get(targetKey(owner, repo, target), async () => {
@@ -356,57 +223,6 @@ export function createHandler(deps: Deps): Handler {
     });
   }
 
-  /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.
-   *  On failure it still emits a done push in catch to release waiters. */
-  async function resolveRemaining(
-    first: DiffV2,
-    remaining: string[],
-    client: ClientLike,
-    req: SemanticDiffRequest,
-    base: string,
-    ctx: DiffContext,
-    push: (msg: GuidResolvedPush) => void,
-  ): Promise<void> {
-    const repoKey = `${base}/${req.owner}/${req.repo}`;
-    const at = { owner: req.owner, repo: req.repo, target: req.target, path: req.path };
-    try {
-      // If remaining is empty (source re-merge only), don't wait on the index: the first index build can take tens of seconds and doesn't help resolution
-      const index = remaining.length
-        ? await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha)
-        : null;
-      const fromIndex: Record<string, string> = {};
-      let leftover = remaining;
-      if (index) {
-        for (const g of remaining) {
-          const hit = Object.hasOwn(index, g) ? index[g] : undefined;
-          if (hit !== undefined) fromIndex[g] = hit;
-        }
-        leftover = remaining.filter((g) => !Object.hasOwn(fromIndex, g));
-        if (Object.keys(fromIndex).length) {
-          // Also land it in guidCache: searchUnresolved inside mergeSources rebuilds resolved
-          // from ctx.guidIndex via applyResolved, so without going through guidCache the index-derived
-          // resolutions would vanish after the source re-merge (same reasoning as Code-Search-derived ones already restored this way).
-          await deps.guidCache.save(repoKey, fromIndex);
-          // Deliver the already-available names first (the structure is finalized by the later final push)
-          push({ type: "guidResolved", ...at, resolved: fromIndex, done: false });
-        }
-      }
-      // Only guids that aren't indexable or aren't in the index go to Code Search
-      const fromSearch = leftover.length ? await searchGuids(leftover, client, req.owner, req.repo, repoKey) : {};
-      let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...fromSearch } };
-      if (json.neededSources?.length) {
-        // Resolution advanced, so redo source merging (picks up the case where the source guid resolved this time)
-        const differ = await deps.getDiffer();
-        const [before, after] = await fetchPair(client, ctx, req.owner, req.repo, req.path);
-        json = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
-      }
-      push({ type: "guidResolved", ...at, resolved: {}, json, done: true }); // the final push replaces json
-    } catch (err) {
-      console.debug("prefablens: guid resolution aborted", err);
-      push({ type: "guidResolved", ...at, resolved: {}, done: true });
-    }
-  }
-
   async function semanticDiff(
     req: SemanticDiffRequest,
     push: (msg: GuidResolvedPush) => void,
@@ -424,7 +240,7 @@ export function createHandler(deps: Deps): Handler {
       // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push
       const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));
       if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
-      void resolveRemaining(withPr, remaining, client, req, base, ctx, push);
+      void resolution.resolveRemaining(withPr, remaining, client, req, base, ctx, push);
       return { ok: true, json: withPr, pending: true };
     } catch (err) {
       if (err instanceof RateLimitError) return { ok: false, error: "rate-limited" };
@@ -444,7 +260,7 @@ export function createHandler(deps: Deps): Handler {
       const client = deps.makeClient(base, settings.pat, "prefetch");
       const ctx = await loadContext(client, req.owner, req.repo, { kind: "pull", prNumber: req.prNumber });
       // Run independently of raw-diff prefetch (index sync speeds up the 3-stage resolution at serve time)
-      void getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
+      void resolution.getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
       const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
       for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
         const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);

--- a/extension/src/background/promiseCache.test.ts
+++ b/extension/src/background/promiseCache.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPromiseCache } from "./promiseCache";
+
+describe("createPromiseCache", () => {
+  it("computes once per key and serves the cached promise afterwards", async () => {
+    const compute = vi.fn(async () => "value");
+    const cache = createPromiseCache<string>();
+    expect(await cache.get("k", compute)).toBe("value");
+    expect(await cache.get("k", compute)).toBe("value");
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it("folds concurrent gets for the same key into one in-flight compute", async () => {
+    // The handler caches store Promises exactly so that a prefetch and a manual
+    // toggle racing on the same blob/diff key share a single fetch.
+    let release!: (v: string) => void;
+    const compute = vi.fn(
+      () =>
+        new Promise<string>((r) => {
+          release = r;
+        }),
+    );
+    const cache = createPromiseCache<string>();
+    const [a, b] = [cache.get("k", compute), cache.get("k", compute)];
+    release("v");
+    expect(await Promise.all([a, b])).toEqual(["v", "v"]);
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a rejected compute so the next get retries", async () => {
+    // A transient network failure must not poison the cache for the SW lifetime.
+    const compute = vi.fn().mockRejectedValueOnce(new Error("socket")).mockResolvedValue("ok");
+    const cache = createPromiseCache<string>();
+    await expect(cache.get("k", compute)).rejects.toThrow("socket");
+    expect(await cache.get("k", compute)).toBe("ok");
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps entries fresh within the ttl and recomputes after it elapses", async () => {
+    // Mirrors the 60s PR-context cache: a push moves headSha, so staleness is time-bounded.
+    vi.useFakeTimers();
+    try {
+      const compute = vi.fn(async () => "v");
+      const cache = createPromiseCache<string>({ ttlMs: 60_000 });
+      await cache.get("k", compute);
+      vi.setSystemTime(Date.now() + 59_000);
+      await cache.get("k", compute);
+      expect(compute).toHaveBeenCalledTimes(1);
+      vi.setSystemTime(Date.now() + 2_000); // 61 seconds total
+      await cache.get("k", compute);
+      expect(compute).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("evicts the oldest entry beyond max (insertion order)", async () => {
+    // Blob bytes are capped at 32 entries; the first-inserted key goes first.
+    const cache = createPromiseCache<string>({ max: 2 });
+    const compute = vi.fn(async () => "v");
+    await cache.get("a", compute);
+    await cache.get("b", compute);
+    await cache.get("c", compute); // evicts "a"
+    await cache.get("b", compute); // still cached
+    await cache.get("a", compute); // recomputed
+    expect(compute).toHaveBeenCalledTimes(4);
+  });
+
+  it("drops settled values the retain policy rejects", async () => {
+    // too-large diffs are dropped so a forced recompute can succeed later;
+    // in-flight searches are dropped on settle so guidCache/misses take over.
+    const compute = vi.fn(async () => "drop");
+    const cache = createPromiseCache<string>({ retain: (v) => v !== "drop" });
+    await cache.get("k", compute);
+    await cache.get("k", compute);
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps settled values the retain policy accepts", async () => {
+    const compute = vi.fn(async () => "keep");
+    const cache = createPromiseCache<string>({ retain: (v) => v === "keep" });
+    await cache.get("k", compute);
+    await cache.get("k", compute);
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+
+  it("still folds concurrent gets while a retain-rejected compute is in flight", async () => {
+    // The searches cache retains nothing, yet concurrent searches for the same
+    // guid must fold into one request (protects the 10 req/min budget).
+    let release!: (v: string) => void;
+    const compute = vi.fn(
+      () =>
+        new Promise<string>((r) => {
+          release = r;
+        }),
+    );
+    const cache = createPromiseCache<string>({ retain: () => false });
+    const [a, b] = [cache.get("k", compute), cache.get("k", compute)];
+    release("v");
+    expect(await Promise.all([a, b])).toEqual(["v", "v"]);
+    expect(compute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extension/src/background/promiseCache.ts
+++ b/extension/src/background/promiseCache.ts
@@ -1,0 +1,39 @@
+import { must } from "../util/must";
+
+export type PromiseCache<V> = {
+  /** Returns the cached promise for the key, computing (and caching) it on a miss. */
+  get(key: string, compute: () => Promise<V>): Promise<V>;
+};
+
+export type PromiseCacheOptions<V> = {
+  /** Entries older than this recompute on the next get (the stale promise is overwritten in place). */
+  ttlMs?: number;
+  /** Beyond this many entries the oldest-inserted key is evicted. */
+  max?: number;
+  /** Decides whether a settled value stays cached; entries whose value it rejects are dropped. Default keeps everything. */
+  retain?: (value: V) => boolean;
+};
+
+/** Keyed memoization of async computations for the background handler's caches.
+ *  Storing the Promise itself folds concurrent requests for the same key into one
+ *  computation; rejections are always dropped so the next get can retry. */
+export function createPromiseCache<V>(options: PromiseCacheOptions<V> = {}): PromiseCache<V> {
+  const { ttlMs, max, retain } = options;
+  const entries = new Map<string, { at: number; promise: Promise<V> }>();
+  return {
+    get(key, compute) {
+      const hit = entries.get(key);
+      if (hit && (ttlMs === undefined || Date.now() - hit.at < ttlMs)) return hit.promise;
+      const promise = compute();
+      promise.then(
+        (value) => {
+          if (retain && !retain(value)) entries.delete(key);
+        },
+        () => entries.delete(key), // never cache failures
+      );
+      entries.set(key, { at: Date.now(), promise });
+      if (max !== undefined && entries.size > max) entries.delete(must(entries.keys().next().value));
+      return promise;
+    },
+  };
+}

--- a/extension/src/background/resolution.test.ts
+++ b/extension/src/background/resolution.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it, vi } from "vitest";
+import { RateLimitError } from "../github/client";
+import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../types";
+import { must } from "../util/must";
+import type { Differ } from "../wasm/differ";
+import { createResolution, type DiffContext, type SearchClient } from "./resolution";
+
+const REPO_KEY = "https://api.github.com/o/r";
+
+const DIFF: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: ["g1"], roots: [], loose: [] };
+
+const CTX: DiffContext = {
+  refs: { baseSha: "base-sha", headSha: "head-sha" },
+  files: [],
+  guidIndex: new Map(),
+  baseShas: null,
+};
+
+const REQ: SemanticDiffRequest = {
+  type: "semanticDiff",
+  owner: "o",
+  repo: "r",
+  target: { kind: "pull", prNumber: 1 },
+  path: "Assets/Foo.prefab",
+};
+
+function makeResolution(overrides?: {
+  cached?: Record<string, string>; // initial contents of guidCache
+  search?: Record<string, string | null>; // guid → asset path (null = no hit)
+  blobs?: Record<string, string>; // `${path}@${sha}` → text served by the injected fetchBlob
+  diffWithAssets?: Differ["diffWithAssets"];
+  isUnityYaml?: Differ["isUnityYaml"];
+  metas?: Array<{ path: string; sha: string }>; // whole-repo .meta listing (repo index)
+  metaTexts?: Record<string, string | null>; // blob sha → .meta text (repo index)
+}) {
+  const cacheData: Record<string, Record<string, string>> = {};
+  if (overrides?.cached) cacheData[REPO_KEY] = { ...overrides.cached };
+  const guidCache = {
+    data: cacheData,
+    load: vi.fn(async (repo: string) => cacheData[repo] ?? {}),
+    save: vi.fn(async (repo: string, entries: Record<string, string>) => {
+      cacheData[repo] = { ...cacheData[repo], ...entries };
+    }),
+  };
+  // Mirrors the RepoIndexStore interface. Starts empty per test.
+  const guidsData: Record<string, Record<string, string>> = {};
+  const indexData: Record<string, { treeSha: string; guids: Record<string, string> }> = {};
+  const repoIndexStore = {
+    loadGuids: vi.fn(async (repo: string) => guidsData[repo] ?? {}),
+    saveGuids: vi.fn(async (repo: string, entries: Record<string, string>) => {
+      guidsData[repo] = { ...guidsData[repo], ...entries };
+    }),
+    loadIndex: vi.fn(async (repo: string) => indexData[repo]),
+    saveIndex: vi.fn(async (repo: string, index: { treeSha: string; guids: Record<string, string> }) => {
+      indexData[repo] = index;
+    }),
+  };
+  const client = {
+    searchMetaByGuid: vi.fn(async (_o: string, _r: string, guid: string) => overrides?.search?.[guid] ?? null),
+    listMetaTree: vi.fn(async () => ({ truncated: false, metas: overrides?.metas ?? [] })),
+    batchBlobTexts: vi.fn(async () => overrides?.metaTexts ?? {}),
+  };
+  const differ: Differ = {
+    diff: vi.fn(() => DIFF),
+    diffWithAssets: overrides?.diffWithAssets ?? vi.fn(() => DIFF),
+    // Fixture contents are shorthand strings, not real UnityYAML: accept by default.
+    isUnityYaml: overrides?.isUnityYaml ?? (() => true),
+  };
+  // The handler injects its blob-cache-backed fetchers; the pipeline only sees these seams.
+  const fetchBlob = vi.fn(
+    async (_client: SearchClient, _o: string, _r: string, path: string, sha: string, _blobSha?: string) => {
+      const text = overrides?.blobs?.[`${path}@${sha}`];
+      return text === undefined ? null : new TextEncoder().encode(text);
+    },
+  );
+  const fetchPair = vi.fn(
+    async (): Promise<[Uint8Array, Uint8Array]> => [new TextEncoder().encode("b"), new TextEncoder().encode("a")],
+  );
+  const resolution = createResolution({
+    guidCache,
+    repoIndexStore,
+    getDiffer: async () => differ,
+    fetchBlob,
+    fetchPair,
+  });
+  return { resolution, client, guidCache, repoIndexStore, differ, fetchBlob, fetchPair };
+}
+
+describe("searchGuids", () => {
+  it("serves cached guids and searches only the unknown ones, persisting hits", async () => {
+    const { resolution, client, guidCache } = makeResolution({
+      cached: { g1: "Assets/Cached.cs" },
+      search: { g2: "Assets/Found.cs" },
+    });
+    const resolved = await resolution.searchGuids(["g1", "g2"], client, "o", "r", REPO_KEY);
+    expect(resolved).toEqual({ g1: "Assets/Cached.cs", g2: "Assets/Found.cs" });
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+    expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "g2");
+    expect(guidCache.save).toHaveBeenCalledWith(REPO_KEY, { g2: "Assets/Found.cs" });
+  });
+
+  it("caps code searches at 10 per call", async () => {
+    const { resolution, client } = makeResolution();
+    const guids = Array.from({ length: 12 }, (_, i) => `g${i}`);
+    await resolution.searchGuids(guids, client, "o", "r", REPO_KEY);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(10);
+  });
+
+  it("does not re-search misses but still emits their cached names later", async () => {
+    // misses gates the search, not the name: an index resolution can land in guidCache afterwards.
+    const { resolution, client, guidCache } = makeResolution(); // search misses
+    expect(await resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY)).toEqual({});
+    guidCache.data[REPO_KEY] = { g1: "Assets/Later.cs" }; // as if the repo index wrote it later
+    expect(await resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY)).toEqual({ g1: "Assets/Later.cs" });
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns partial results when the rate limit interrupts the search loop", async () => {
+    const { resolution, client } = makeResolution();
+    client.searchMetaByGuid.mockResolvedValueOnce("Assets/First.cs").mockRejectedValueOnce(new RateLimitError("x"));
+    const resolved = await resolution.searchGuids(["g1", "g2", "g3"], client, "o", "r", REPO_KEY);
+    // g1 survives, g2 aborts the loop, g3 is never attempted (the budget is already gone).
+    expect(resolved).toEqual({ g1: "Assets/First.cs" });
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(2);
+  });
+
+  it("folds concurrent searches for the same guid into one request", async () => {
+    const { resolution, client } = makeResolution();
+    let release!: (v: string) => void;
+    client.searchMetaByGuid.mockImplementation(
+      () =>
+        new Promise((r) => {
+          release = r;
+        }),
+    );
+    const [a, b] = [
+      resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY),
+      resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY),
+    ];
+    await vi.waitFor(() => expect(client.searchMetaByGuid).toHaveBeenCalled());
+    release("Assets/S.cs");
+    expect(await Promise.all([a, b])).toEqual([{ g1: "Assets/S.cs" }, { g1: "Assets/S.cs" }]);
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat Object.prototype members as cache hits (hostile guid)", async () => {
+    const { resolution, client } = makeResolution({ cached: { g9: "Assets/X.cs" } });
+    const resolved = await resolution.searchGuids(["constructor"], client, "o", "r", REPO_KEY);
+    expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "constructor");
+    expect(resolved).toEqual({});
+  });
+});
+
+describe("getRepoIndex", () => {
+  it("memoizes the index per repoKey@ref", async () => {
+    const { resolution, client, repoIndexStore } = makeResolution({
+      metas: [{ path: "Assets/S.cs.meta", sha: "sha1" }],
+      metaTexts: { sha1: "guid: g1\n" },
+    });
+    const first = await resolution.getRepoIndex(client, "o", "r", REPO_KEY, "head-sha");
+    expect(first).toEqual({ g1: "Assets/S.cs" });
+    await resolution.getRepoIndex(client, "o", "r", REPO_KEY, "head-sha");
+    // The second call folds on the cached promise: not even the store is consulted again.
+    expect(repoIndexStore.loadIndex).toHaveBeenCalledTimes(1);
+    expect(client.listMetaTree).toHaveBeenCalledTimes(1);
+  });
+
+  it("pins the repo to fallback for the session after a rate limit", async () => {
+    const { resolution, client } = makeResolution();
+    client.listMetaTree.mockRejectedValue(new RateLimitError("x"));
+    expect(await resolution.getRepoIndex(client, "o", "r", REPO_KEY, "head-sha")).toBeNull();
+    expect(await resolution.getRepoIndex(client, "o", "r", REPO_KEY, "head-sha")).toBeNull();
+    expect(client.listMetaTree).toHaveBeenCalledTimes(1); // fallback: Code Search only from here on
+  });
+
+  it("retries after a non-rate-limit failure instead of caching it", async () => {
+    const { resolution, client } = makeResolution({
+      metas: [{ path: "Assets/S.cs.meta", sha: "sha1" }],
+      metaTexts: { sha1: "guid: g1\n" },
+    });
+    client.listMetaTree.mockRejectedValueOnce(new Error("socket"));
+    expect(await resolution.getRepoIndex(client, "o", "r", REPO_KEY, "head-sha")).toBeNull();
+    expect(await resolution.getRepoIndex(client, "o", "r", REPO_KEY, "head-sha")).toEqual({ g1: "Assets/S.cs" });
+  });
+});
+
+describe("mergeSources", () => {
+  const BYTES: [Uint8Array, Uint8Array] = [new TextEncoder().encode("b"), new TextEncoder().encode("a")];
+  const NEEDS: DiffV2 = {
+    ...DIFF,
+    unresolvedGuids: ["src1"],
+    resolved: { src1: "Assets/Cyl.prefab" },
+    neededSources: [{ guid: "src1", side: "after" }],
+  };
+  const MERGED: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: [], roots: [], loose: [] };
+
+  it("fetches an after-side source at head and re-diffs with assets", async () => {
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
+    const { resolution, client, fetchBlob } = makeResolution({
+      diffWithAssets,
+      blobs: { "Assets/Cyl.prefab@head-sha": "SRC" },
+    });
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
+    const result = await resolution.mergeSources(NEEDS, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
+    expect(fetchBlob).toHaveBeenCalledWith(client, "o", "r", "Assets/Cyl.prefab", "head-sha", undefined);
+    const assets = must(diffWithAssets.mock.calls[0]?.[2]);
+    expect(new TextDecoder().decode(must(assets.get("src1")))).toBe("SRC");
+    expect(result).toMatchObject({ unresolvedGuids: [] });
+  });
+
+  it("fetches a before-side source at base, riding the base-tree blob sha", async () => {
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
+    const { resolution, client, fetchBlob } = makeResolution({
+      diffWithAssets,
+      blobs: { "Assets/Cyl.prefab@base-sha": "OLD" },
+    });
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
+    const ctx: DiffContext = { ...CTX, baseShas: new Map([["Assets/Cyl.prefab", "cyl-base"]]) };
+    const before: DiffV2 = { ...NEEDS, neededSources: [{ guid: "src1", side: "before" }] };
+    await resolution.mergeSources(before, differ, ...BYTES, ctx, client, "o", "r", REPO_KEY);
+    expect(fetchBlob).toHaveBeenCalledWith(client, "o", "r", "Assets/Cyl.prefab", "base-sha", "cyl-base");
+  });
+
+  it("returns the first-pass diff when the source path is unresolved", async () => {
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
+    const { resolution, client } = makeResolution({ diffWithAssets });
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
+    const unresolved: DiffV2 = { ...NEEDS, resolved: {} };
+    const result = await resolution.mergeSources(unresolved, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
+    expect(diffWithAssets).not.toHaveBeenCalled();
+    expect(result).toEqual(unresolved);
+  });
+
+  it("skips binary-serialized sources without counting them as progress", async () => {
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
+    const { resolution, client } = makeResolution({
+      diffWithAssets,
+      isUnityYaml: () => false,
+      blobs: { "Assets/Cyl.prefab@head-sha": "\x00binary" },
+    });
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => false };
+    const result = await resolution.mergeSources(NEEDS, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
+    // Merging a binary source would be a no-op re-diff: give up and keep the first pass.
+    expect(diffWithAssets).not.toHaveBeenCalled();
+    expect(result).toEqual(NEEDS);
+  });
+
+  it("degrades to the current diff when the source fetch fails", async () => {
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
+    const { resolution, client, fetchBlob } = makeResolution({ diffWithAssets });
+    fetchBlob.mockRejectedValue(new RateLimitError("x"));
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
+    const result = await resolution.mergeSources(NEEDS, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
+    expect(result).toEqual(NEEDS);
+  });
+
+  it("caps source re-diff rounds at 3 even while progressing", async () => {
+    // Each merge output requests the next source, which always resolves: without the cap
+    // a deep source chain would keep re-diffing forever.
+    let round = 0;
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>((): DiffV2 => {
+      round += 1;
+      return { ...DIFF, unresolvedGuids: [`s${round}`], neededSources: [{ guid: `s${round}`, side: "after" }] };
+    });
+    const { resolution, client } = makeResolution({
+      diffWithAssets,
+      cached: { s1: "Assets/S1.prefab", s2: "Assets/S2.prefab", s3: "Assets/S3.prefab" },
+      blobs: {
+        "Assets/S0.prefab@head-sha": "S0",
+        "Assets/S1.prefab@head-sha": "S1",
+        "Assets/S2.prefab@head-sha": "S2",
+      },
+    });
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
+    const first: DiffV2 = {
+      ...DIFF,
+      unresolvedGuids: [],
+      resolved: { s0: "Assets/S0.prefab" },
+      neededSources: [{ guid: "s0", side: "after" }],
+    };
+    const result = await resolution.mergeSources(first, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
+    expect(diffWithAssets).toHaveBeenCalledTimes(3);
+    expect(result.neededSources).toEqual([{ guid: "s3", side: "after" }]); // degraded at the cap
+  });
+});
+
+describe("resolveRemaining", () => {
+  async function run(
+    resolution: ReturnType<typeof makeResolution>["resolution"],
+    client: SearchClient,
+    first: DiffV2,
+    remaining: string[],
+    ctx: DiffContext = CTX,
+  ): Promise<GuidResolvedPush[]> {
+    const pushes: GuidResolvedPush[] = [];
+    await resolution.resolveRemaining(first, remaining, client, REQ, "https://api.github.com", ctx, (m) =>
+      pushes.push(m),
+    );
+    return pushes;
+  }
+
+  it("resolves via the repo index first and searches only the leftover", async () => {
+    const { resolution, client, guidCache } = makeResolution({
+      metas: [{ path: "Assets/S.cs.meta", sha: "sha1" }],
+      metaTexts: { sha1: "guid: g1\n" },
+      search: { g2: "Assets/Other.cs" },
+    });
+    const first: DiffV2 = { ...DIFF, unresolvedGuids: ["g1", "g2"] };
+    const pushes = await run(resolution, client, first, ["g1", "g2"]);
+    // Index names arrive in an intermediate push; the final push carries the full json.
+    expect(pushes[0]).toMatchObject({ resolved: { g1: "Assets/S.cs" }, done: false });
+    expect(must(pushes.at(-1))).toMatchObject({ done: true });
+    expect(must(pushes.at(-1)).json?.resolved).toEqual({ g1: "Assets/S.cs", g2: "Assets/Other.cs" });
+    expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
+    expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "g2");
+    // Index results land in guidCache so a later source re-merge can restore them.
+    expect(guidCache.save).toHaveBeenCalledWith(REPO_KEY, { g1: "Assets/S.cs" });
+  });
+
+  it("skips the index when only a source re-merge is pending", async () => {
+    // The first index build can take tens of seconds and cannot help: no guid names are missing.
+    const merged: DiffV2 = { ...DIFF, unresolvedGuids: [] };
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => merged);
+    const { resolution, client } = makeResolution({
+      diffWithAssets,
+      cached: { src1: "Assets/Src.prefab" },
+      blobs: { "Assets/Src.prefab@head-sha": "SRC" },
+    });
+    const first: DiffV2 = {
+      ...DIFF,
+      unresolvedGuids: ["src1"],
+      resolved: { src1: "Assets/Src.prefab" },
+      neededSources: [{ guid: "src1", side: "after" }],
+    };
+    const pushes = await run(resolution, client, first, []);
+    expect(client.listMetaTree).not.toHaveBeenCalled();
+    expect(diffWithAssets).toHaveBeenCalledTimes(1);
+    expect(must(pushes.at(-1)).json).toMatchObject({ unresolvedGuids: [] });
+  });
+
+  it("still emits the done push when the pipeline fails", async () => {
+    // Waiters key off done: a crash that swallowed it would leave the indicator spinning forever.
+    const { resolution, client, fetchPair } = makeResolution();
+    fetchPair.mockRejectedValue(new Error("socket"));
+    const first: DiffV2 = { ...DIFF, unresolvedGuids: [], neededSources: [{ guid: "src1", side: "after" }] };
+    const pushes = await run(resolution, client, first, []);
+    expect(pushes).toEqual([
+      { type: "guidResolved", owner: "o", repo: "r", target: REQ.target, path: REQ.path, resolved: {}, done: true },
+    ]);
+  });
+});

--- a/extension/src/background/resolution.ts
+++ b/extension/src/background/resolution.ts
@@ -1,0 +1,267 @@
+import { type ChangedFile, type GithubClient, RateLimitError, type RefPair } from "../github/client";
+import { applyResolved, type GuidCache } from "../github/guids";
+import { type RepoIndexStore, syncRepoIndex } from "../github/repoIndex";
+import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../types";
+import type { Differ } from "../wasm/differ";
+import { createPromiseCache } from "./promiseCache";
+
+/** What the pipeline itself calls on the GitHub client. Callers thread their richer
+ *  client through the generic C, so the injected fetchers keep their own view of it. */
+export type SearchClient = Pick<GithubClient, "searchMetaByGuid" | "listMetaTree" | "batchBlobTexts">;
+
+// baseShas: path → blob sha at the base ref. null = tree unavailable (truncated/failed) → contents-api fallback
+export type DiffContext = {
+  refs: RefPair;
+  files: ChangedFile[];
+  guidIndex: Map<string, string>;
+  baseShas: Map<string, string> | null;
+};
+
+const MAX_SEARCHES = 10; // Code Search is authenticated 10 req/min — don't burn it all in one response
+const MAX_SOURCE_ROUNDS = 3; // re-diff cap for nested sources (independent of core's depth cap of 8)
+
+export type ResolutionDeps<C extends SearchClient> = {
+  guidCache: GuidCache;
+  repoIndexStore: RepoIndexStore;
+  getDiffer(): Promise<Differ>;
+  /** The handler's cached blob fetcher (sha+path keyed, blob-sha fast path). */
+  fetchBlob(
+    client: C,
+    owner: string,
+    repo: string,
+    path: string,
+    sha: string,
+    blobSha?: string,
+  ): Promise<Uint8Array | null>;
+  /** The handler's before/after pair fetcher (status/previousPath rules follow the files API). */
+  fetchPair(client: C, ctx: DiffContext, owner: string, repo: string, path: string): Promise<[Uint8Array, Uint8Array]>;
+};
+
+export type Resolution<C extends SearchClient> = {
+  searchGuids(
+    guids: string[],
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+  ): Promise<Record<string, string>>;
+  getRepoIndex(
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+    ref: string,
+  ): Promise<Record<string, string> | null>;
+  mergeSources(
+    first: DiffV2,
+    differ: Differ,
+    before: Uint8Array,
+    after: Uint8Array,
+    ctx: DiffContext,
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+  ): Promise<DiffV2>;
+  resolveRemaining(
+    first: DiffV2,
+    remaining: string[],
+    client: C,
+    req: SemanticDiffRequest,
+    base: string,
+    ctx: DiffContext,
+    push: (msg: GuidResolvedPush) => void,
+  ): Promise<void>;
+};
+
+/** Guid resolution beyond the in-PR .meta index: whole-repo index → Code Search, plus the
+ *  source prefab re-merge that resolution unlocks. Owns the search/index caches; blob and
+ *  diff caching stay with the handler, injected through fetchBlob/fetchPair. */
+export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>): Resolution<C> {
+  // guids that missed in Code Search. Indexing lag means we don't persist these — SW lifetime only
+  const misses = new Set<string>();
+  // repoKey:guid → in-flight search, folding concurrent searches for the same guid into one (protects the
+  // 10 req/min). Nothing is retained after settling: guidCache/misses take over from there.
+  const searches = createPromiseCache<string | null>({ retain: () => false });
+  // repoKey@ref → whole-repo index. null means not indexable (truncated/over the cap)
+  const indexes = createPromiseCache<Record<string, string> | null>();
+  // A repo that hit a rate limit falls back for the SW lifetime (gives up on the index and defers to Code Search only)
+  const indexFallback = new Set<string>();
+
+  /** Resolves guid[] in cache → Code Search order (the body of searchUnresolved itself).
+   *  A search failure (including rate limits) doesn't drop the diff: returns only what was resolved. */
+  async function searchGuids(
+    guids: string[],
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+  ): Promise<Record<string, string>> {
+    if (!guids.length) return {};
+    // hasOwn: guids are arbitrary strings, so 'constructor' etc. don't falsely hit Object.prototype
+    // The cached lookup covers all guids without going through misses: since index resolutions also land in guidCache,
+    // a cached name is always emitted even if it's in misses (the search gatekeeper)
+    const cached = await deps.guidCache.load(repoKey);
+    const resolved: Record<string, string> = {};
+    const unknown: string[] = [];
+    for (const g of guids) {
+      const hit = Object.hasOwn(cached, g) ? cached[g] : undefined;
+      if (hit !== undefined) resolved[g] = hit;
+      else unknown.push(g);
+    }
+    const searchable = unknown.filter((g) => !misses.has(`${repoKey}:${g}`));
+    const found: Record<string, string> = {};
+    for (const g of searchable.slice(0, MAX_SEARCHES)) {
+      const key = `${repoKey}:${g}`;
+      try {
+        const path = await searches.get(key, () => client.searchMetaByGuid(owner, repo, g));
+        if (path) resolved[g] = found[g] = path;
+        else misses.add(key);
+      } catch (err) {
+        if (err instanceof RateLimitError) break;
+        misses.add(key);
+      }
+    }
+    if (Object.keys(found).length) await deps.guidCache.save(repoKey, found);
+    return resolved;
+  }
+
+  /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search order.
+   *  mergeSources calls it internally, so keep the signature and behavior unchanged. */
+  async function searchUnresolved(
+    json: DiffV2,
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+  ): Promise<DiffV2> {
+    const resolved = { ...json.resolved };
+    const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g));
+    const found = await searchGuids(pending, client, owner, repo, repoKey);
+    return { ...json, resolved: { ...resolved, ...found } };
+  }
+
+  /** Fetches and memoizes the whole-repo guid index. A repo that hit a rate limit is pinned to fallback for the SW lifetime. */
+  function getRepoIndex(
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+    ref: string,
+  ): Promise<Record<string, string> | null> {
+    if (indexFallback.has(repoKey)) return Promise.resolve(null);
+    return indexes
+      .get(`${repoKey}@${ref}`, () => syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref))
+      .catch((err: unknown) => {
+        // the cache has already dropped the failure, so the next visit retries
+        if (err instanceof RateLimitError) indexFallback.add(repoKey);
+        return null;
+      });
+  }
+
+  /** Fetches neededSources (the source prefab of an added/removed instance) via the resolved
+   *  path and re-diffs with assets attached. The source guid rides on unresolvedGuids as an
+   *  m_SourcePrefab reference, so searchUnresolved has already done the path resolution.
+   *  Failure to resolve/fetch/merge degrades to the diff at that point (doesn't drop the whole thing). */
+  async function mergeSources(
+    first: DiffV2,
+    differ: Differ,
+    before: Uint8Array,
+    after: Uint8Array,
+    ctx: DiffContext,
+    client: C,
+    owner: string,
+    repo: string,
+    repoKey: string,
+  ): Promise<DiffV2> {
+    const assets = new Map<string, Uint8Array>();
+    let current = first;
+    for (let round = 0; round < MAX_SOURCE_ROUNDS; round++) {
+      const needed = (current.neededSources ?? []).filter((s) => !assets.has(s.guid));
+      if (!needed.length) break;
+      let progressed = false;
+      for (const s of needed) {
+        const path = current.resolved?.[s.guid];
+        if (path === undefined) continue;
+        const sha = s.side === "before" ? ctx.refs.baseSha : ctx.refs.headSha;
+        // sources aren't PR files, so only the base tree can supply a sha; the head side keeps the path fallback
+        const blobSha = s.side === "before" ? ctx.baseShas?.get(path) : undefined;
+        let bytes: Uint8Array | null = null;
+        try {
+          bytes = await deps.fetchBlob(client, owner, repo, path, sha, blobSha);
+        } catch {
+          return current; // rate limit etc.: degrade to the first-pass diff
+        }
+        if (!bytes) continue;
+        // Sources resolved by guid can be binary-serialized too: merging
+        // them is a no-op re-diff, so don't count it as progress.
+        if (!differ.isUnityYaml(bytes)) continue;
+        assets.set(s.guid, bytes);
+        progressed = true;
+      }
+      if (!progressed) break;
+      let merged: DiffV2;
+      try {
+        merged = differ.diffWithAssets(before, after, assets);
+      } catch {
+        return current; // a merge failure degrades to the current result
+      }
+      // Merging surfaces new external references (script/material) inside the source, so resolve again.
+      current = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
+    }
+    return current;
+  }
+
+  /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.
+   *  On failure it still emits a done push in catch to release waiters. */
+  async function resolveRemaining(
+    first: DiffV2,
+    remaining: string[],
+    client: C,
+    req: SemanticDiffRequest,
+    base: string,
+    ctx: DiffContext,
+    push: (msg: GuidResolvedPush) => void,
+  ): Promise<void> {
+    const repoKey = `${base}/${req.owner}/${req.repo}`;
+    const at = { owner: req.owner, repo: req.repo, target: req.target, path: req.path };
+    try {
+      // If remaining is empty (source re-merge only), don't wait on the index: the first index build can take tens of seconds and doesn't help resolution
+      const index = remaining.length
+        ? await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha)
+        : null;
+      const fromIndex: Record<string, string> = {};
+      let leftover = remaining;
+      if (index) {
+        for (const g of remaining) {
+          const hit = Object.hasOwn(index, g) ? index[g] : undefined;
+          if (hit !== undefined) fromIndex[g] = hit;
+        }
+        leftover = remaining.filter((g) => !Object.hasOwn(fromIndex, g));
+        if (Object.keys(fromIndex).length) {
+          // Also land it in guidCache: searchUnresolved inside mergeSources rebuilds resolved
+          // from ctx.guidIndex via applyResolved, so without going through guidCache the index-derived
+          // resolutions would vanish after the source re-merge (same reasoning as Code-Search-derived ones already restored this way).
+          await deps.guidCache.save(repoKey, fromIndex);
+          // Deliver the already-available names first (the structure is finalized by the later final push)
+          push({ type: "guidResolved", ...at, resolved: fromIndex, done: false });
+        }
+      }
+      // Only guids that aren't indexable or aren't in the index go to Code Search
+      const fromSearch = leftover.length ? await searchGuids(leftover, client, req.owner, req.repo, repoKey) : {};
+      let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...fromSearch } };
+      if (json.neededSources?.length) {
+        // Resolution advanced, so redo source merging (picks up the case where the source guid resolved this time)
+        const differ = await deps.getDiffer();
+        const [before, after] = await deps.fetchPair(client, ctx, req.owner, req.repo, req.path);
+        json = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
+      }
+      push({ type: "guidResolved", ...at, resolved: {}, json, done: true }); // the final push replaces json
+    } catch (err) {
+      console.debug("prefablens: guid resolution aborted", err);
+      push({ type: "guidResolved", ...at, resolved: {}, done: true });
+    }
+  }
+
+  return { searchGuids, getRepoIndex, mergeSources, resolveRemaining };
+}

--- a/extension/src/content/authRetries.test.ts
+++ b/extension/src/content/authRetries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAuthRetries } from "./authRetries";
+
+describe("createAuthRetries", () => {
+  it("runs every registered retry once on flush and empties the queue", () => {
+    // Several files can sit on auth-error panels at once; one token landing retries them all,
+    // and a second storage event (echo or unrelated pat rewrite) must not retry again.
+    const retries = createAuthRetries();
+    const a = vi.fn();
+    const b = vi.fn();
+    retries.add(a);
+    retries.add(b);
+    retries.flush();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    retries.flush();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a retry registered during flush for the next flush", () => {
+    // A retry that fails again re-registers itself from inside the flush: it must land in
+    // the queue for the next token, not be wiped by the clear that is already in progress.
+    const retries = createAuthRetries();
+    const again = vi.fn();
+    retries.add(() => retries.add(again));
+    retries.flush();
+    expect(again).not.toHaveBeenCalled(); // queued, not run in the same flush
+    retries.flush();
+    expect(again).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers the same retry only once (set semantics)", () => {
+    // Every scan re-runs show() on an error panel; identical registrations must not
+    // stack up into duplicate requests when the token finally arrives.
+    const retries = createAuthRetries();
+    const retry = vi.fn();
+    retries.add(retry);
+    retries.add(retry);
+    retries.flush();
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extension/src/content/authRetries.ts
+++ b/extension/src/content/authRetries.ts
@@ -1,0 +1,19 @@
+export type AuthRetries = {
+  add(retry: () => void): void;
+  flush(): void;
+};
+
+/** Files whose panels are stuck on an auth error register a retry; a token landing
+ *  in storage flushes them all at once. */
+export function createAuthRetries(): AuthRetries {
+  const retries = new Set<() => void>();
+  return {
+    add: (retry) => void retries.add(retry),
+    flush() {
+      // Clear before running: a retry that fails again re-registers itself for the next token.
+      const pending = [...retries];
+      retries.clear();
+      for (const retry of pending) retry();
+    },
+  };
+}

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -17,10 +17,12 @@ import {
   targetKey,
 } from "../types";
 import { must } from "../util/must";
+import { createAuthRetries } from "./authRetries";
 import { type DiffPage, type FileEntry, parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 import { fillDeviceCode } from "./devicePage";
 import { createSignIn, type PendingSignIn } from "./signin";
 import { createToggle, type Toggle, type View } from "./toggle";
+import { createViewRegistry } from "./views";
 import { createViewState, type ViewState } from "./viewstate";
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
@@ -33,7 +35,7 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
 };
 
 // path → render target. When a push (guidResolved) arrives, merge resolved and re-render
-const views = new Map<string, { root: ShadowRoot; json: DiffV2 }>();
+const views = createViewRegistry();
 
 function countUnresolved(json: DiffV2): number {
   return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g)).length;
@@ -47,7 +49,7 @@ let currentPage = ""; // overrides are valid only while on the diff page: discar
 let prefetchedPr = ""; // send prefetch just once across all PR tabs, including the conversation tab
 
 // Files whose panels are stuck on an auth error: all retried once a token lands in storage.
-const authRetries = new Set<() => void>();
+const authRetries = createAuthRetries();
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 const signIn = createSignIn({
@@ -90,7 +92,7 @@ function attach(state: ViewState): void {
   if (key !== currentPage) {
     currentPage = key;
     state.clearOverrides();
-    for (const [k, v] of views) if (!v.root.host.isConnected) views.delete(k); // not only ignore late pushes to views killed by navigation, but also cut the reference
+    views.pruneDisconnected(); // not only ignore late pushes to views killed by navigation, but also cut the reference
   }
   // The react ui virtualizes the list and discards off-screen DOM continuously, so prune
   // dead appliers every scan, not just on PR change (also plugs the classic soft leak).
@@ -245,9 +247,7 @@ async function init(): Promise<void> {
     if (next === "raw" || next === "semantic") state.applyExternal(next);
     if (typeof changes.pat?.newValue === "string" && changes.pat.newValue) {
       // A token just landed (this tab's own flow or another surface): retry every auth-blocked panel.
-      const retries = [...authRetries];
-      authRetries.clear();
-      for (const retry of retries) retry();
+      authRetries.flush();
     }
   });
 

--- a/extension/src/content/views.test.ts
+++ b/extension/src/content/views.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import type { DiffV2 } from "../types";
+import { createViewRegistry } from "./views";
+
+const DIFF: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: [], roots: [], loose: [] };
+
+/** Builds a shadow root the way attachToggle does; connected controls whether the host is in the DOM. */
+function makeRoot(connected: boolean): ShadowRoot {
+  const host = document.createElement("div");
+  if (connected) document.body.append(host);
+  return host.attachShadow({ mode: "open" });
+}
+
+describe("createViewRegistry", () => {
+  it("returns stored entries by key and misses unknown keys", () => {
+    const views = createViewRegistry();
+    const entry = { root: makeRoot(true), json: DIFF };
+    views.set("o/r#1:Assets/Foo.prefab", entry);
+    expect(views.get("o/r#1:Assets/Foo.prefab")).toBe(entry);
+    expect(views.get("o/r#2:Assets/Foo.prefab")).toBeUndefined();
+  });
+
+  it("prunes views whose host left the DOM and keeps live ones", () => {
+    // An SPA navigation swaps the diff DOM out from under us: pruning both ignores
+    // late pushes aimed at the dead view and cuts the reference so it can be collected.
+    const views = createViewRegistry();
+    const liveHost = document.createElement("div");
+    document.body.append(liveHost);
+    const live = { root: liveHost.attachShadow({ mode: "open" }), json: DIFF };
+    const dead = { root: makeRoot(false), json: DIFF };
+    views.set("live", live);
+    views.set("dead", dead);
+    views.pruneDisconnected();
+    expect(views.get("live")).toBe(live);
+    expect(views.get("dead")).toBeUndefined();
+  });
+
+  it("prunes a view that was connected at render time but removed since", () => {
+    // The realistic sequence: render while attached, github replaces the container, then prune runs.
+    const views = createViewRegistry();
+    const host = document.createElement("div");
+    document.body.append(host);
+    views.set("k", { root: host.attachShadow({ mode: "open" }), json: DIFF });
+    host.remove();
+    views.pruneDisconnected();
+    expect(views.get("k")).toBeUndefined();
+  });
+});

--- a/extension/src/content/views.ts
+++ b/extension/src/content/views.ts
@@ -1,0 +1,23 @@
+import type { DiffV2 } from "../types";
+
+// json is mutated in place by the push listener (merge resolved / replace on the final push)
+export type ViewEntry = { root: ShadowRoot; json: DiffV2 };
+
+export type ViewRegistry = {
+  set(key: string, entry: ViewEntry): void;
+  get(key: string): ViewEntry | undefined;
+  pruneDisconnected(): void;
+};
+
+/** path-keyed render targets: when a push (guidResolved) arrives, the matching entry re-renders. */
+export function createViewRegistry(): ViewRegistry {
+  const views = new Map<string, ViewEntry>();
+  return {
+    set: (key, entry) => void views.set(key, entry),
+    get: (key) => views.get(key),
+    // Views killed by an SPA navigation: not only ignore late pushes to them, but also cut the reference
+    pruneDisconnected() {
+      for (const [key, view] of views) if (!view.root.host.isConnected) views.delete(key);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Splits the extension background handler into a cache module (`promiseCache.ts`) and a guid resolution pipeline module (`resolution.ts`), leaving `handler.ts` as orchestration, and adds unit coverage for the `content/index.ts` auth-retry and SPA view-GC branches via two small seams.

## Motivation

`createHandler` had grown into the extension's largest unit: seven module-scoped caches and ~10 nested async functions in one closure. The cache layer and the resolution pipeline (`searchGuids` / `getRepoIndex` / `resolveRemaining` / `mergeSources`) are separable concerns, and the `authRetries` / view-GC branches in the content script were only covered by the coarse e2e net.

Closes #154

## Changes

- `background/promiseCache.ts`: keyed async memoization with the exact policies the handler caches used — in-flight promise folding, drop-on-rejection, optional ttl (contexts), FIFO cap (blobs), and a retain policy (searches, diffs). `contexts` / `blobs` / `diffs` stay in `handler.ts`; `searches` / `indexes` move with the pipeline.
- `background/resolution.ts`: `createResolution` owns `misses` / `searches` / `indexes` / `indexFallback` and the moved-verbatim `searchGuids`, `searchUnresolved`, `getRepoIndex`, `mergeSources`, `resolveRemaining`. The handler injects its cached `fetchBlob` / `fetchPair` through the existing `Deps`-style injection; the client threads through a generic constrained to the three methods the pipeline itself calls.
- `handler.ts` (497 → 283 lines) keeps refs/files discovery, blob/pair fetching, diff computation, and prefetch; its public surface (`Deps`, `Handler`, `createHandler`) is unchanged, and `handler.test.ts` is untouched.
- Content-addressed cache keys (`baseSha:headSha:path`, blob sha, `repoKey:guid`, `repoKey@ref`), in-flight folding, and the index → Code Search resolution order are preserved exactly.
- `content/authRetries.ts` + `content/views.ts`: minimal seams extracted from `content/index.ts` (identical runtime behavior — same Set/Map semantics, clear-before-run flush, prune-on-page-change) so the retry mechanism and view GC are unit-testable.
- New tests: `promiseCache.test.ts` (8), `resolution.test.ts` (18), `authRetries.test.ts` (3), `views.test.ts` (3).

Note: the pretest wasm rebuild from #173 landed via #183 and this branch is rebased on it; no `package.json` changes here.

## Testing

```
$ cd extension && pnpm test
 Test Files  22 passed (22)
      Tests  264 passed (264)

$ pnpm typecheck
$ tsc --noEmit          # clean

$ pnpm lint
$ biome ci .
Checked 62 files in 39ms. No fixes applied.

$ pnpm build
$ node build.mjs        # bundles cleanly
```

The pre-existing 795-line `handler.test.ts` passes unchanged (no assertion or import edits).