### PR TITLE
ci: build release artifacts before push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,21 +33,15 @@ jobs:
         run: |
           set -euo pipefail
           [ "$GITHUB_REF_NAME" = "main" ] || { echo "::error::run this workflow from main (got $GITHUB_REF_NAME)"; exit 1; }
-      - name: Bump, commit, and tag
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+      # The CLI compiles its version out of build.zig.zon, so the bump must
+      # precede the builds. The commit/tag/push happens after the builds so a
+      # failed build leaves nothing on origin and the workflow can be re-run.
+      - name: Bump version
         run: |
           set -euo pipefail
-          # Author the commit as the app; the +<id> email links it to the bot account.
-          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           bump-my-version bump --new-version "$VERSION"
+          # Stage the bump now so build outputs cannot leak into the commit.
           git add -u
-          git diff --cached --quiet || git commit -m "chore: release v$VERSION"
-          git tag "v$VERSION"
-          git push --atomic origin main "v$VERSION"
       - name: Build CLI for all targets
         run: |
           set -euo pipefail
@@ -70,6 +64,19 @@ jobs:
           pnpm -C extension build
           # Zip the dist contents (not the directory) so manifest.json sits at the zip root
           (cd extension/dist && zip -r "../../dist/prefablens-extension-$VERSION.zip" .)
+      - name: Commit, tag, and push
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          # Author the commit as the app; the +<id> email links it to the bot account.
+          user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git diff --cached --quiet || git commit -m "chore: release v$VERSION"
+          git tag "v$VERSION"
+          git push --atomic origin main "v$VERSION"
       - name: Create release
         env:
           # Publish as the App so the release isn't attributed to github-actions[bot].


### PR DESCRIPTION
## Summary

Reorder the release job so all six CLI targets and the extension zip are built and staged in `dist/` before the release commit, tag, and `git push --atomic` — a failed build now leaves nothing on `origin`.

## Motivation

`git push --atomic origin main "v$VERSION"` ran before any artifact was built. If any cross-compile or the extension build failed, `main` already carried the `chore: release` commit and the `vX.Y.Z` tag with no GitHub release attached, and a re-run failed at `git tag` because the tag already existed.

Closes #191

## Changes

- Split the old `Bump, commit, and tag` step into `Bump version` (runs first, since the CLI compiles its version out of `build.zig.zon`) and `Commit, tag, and push` (runs after all builds).
- `Bump version` stages the bumped files with `git add -u` immediately, so nothing a build writes to a tracked file can leak into the release commit.
- `Commit, tag, and push` keeps the exact bot-identity setup (`gh api /users/<app>[bot]` + `git config`) and the atomic push, moved verbatim after the build steps.
- Build steps, `Create release`, `publish-formula`, and `publish-extension` are unchanged.

New step order in the `release` job:

1. `create-github-app-token` / checkout / mise / `Validate input` (unchanged)
2. `Bump version` — `bump-my-version` edits the tree, `git add -u` stages it
3. `Build CLI for all targets` — six cross-compiles into `dist/`
4. `Build and package extension` — wasm + pnpm build into `dist/`
5. `Commit, tag, and push` — commit staged bump, `git tag`, `git push --atomic origin main "v$VERSION"`
6. `Create release` — `SHA256SUMS` + `gh release create`

Why a failed build leaves origin untouched: steps 2-4 only touch the runner's working tree and index (`.bumpversion.toml` has `commit = false`, `tag = false`, so `bump-my-version` never commits). The first command that contacts `origin` with a write is the atomic push in step 5, which runs only after every build succeeded. A re-run starts from a fresh checkout, so the same version input just bumps and builds again — no manual tag deletion needed. A successful run produces the same commit content (only the staged bump files), the same tag, and the same assets as before.

## Testing

- `ruby -ryaml -e 'YAML.load_file(".github/workflows/release.yml")'` → `YAML OK`
- `actionlint .github/workflows/release.yml` → 5 findings, all pre-existing: ran actionlint against main's version of the file and it reports the identical 5 (stale bundled schema for `create-github-app-token@v3` flags `client-id`, which the published releases prove works, plus SC2035 on `shasum -a 256 *.zip` in `Create release`). No new findings introduced.
- Step-order walkthrough above; the workflow itself cannot be executed outside a real release.