### PR TITLE
fix: point site store link at the CWS listing

### DIFF
--- a/site/build.mjs
+++ b/site/build.mjs
@@ -18,8 +18,8 @@ const DEMO = join(ROOT, "extension", "dist", "demo.js");
 const FIXTURES = join(SITE, "fixtures");
 const DIST = join(SITE, "dist");
 
-// Mirror of the UnityYAML extension gate in cli/src/unity_path.zig (and the
-// extension's detect.ts): only these paths get semantic views; anything else
+// Mirror of the UnityYAML extension gate in cli/src/unity_path.zig (and
+// extension/src/unity.ts): only these paths get semantic views; anything else
 // (e.g. .meta) would keep GitHub's plain diff in the mock.
 const UNITY_EXTENSIONS = [
   ".prefab", ".unity", ".asset", ".mat", ".anim", ".controller",

--- a/site/static/index.html
+++ b/site/static/index.html
@@ -99,7 +99,7 @@
         <dl>
           <dt>Chrome extension</dt>
           <dd>
-            <a href="https://chromewebstore.google.com/search/PrefabLens">Chrome Web Store</a> —
+            <a href="https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip">Chrome Web Store</a> —
             adds the Raw / Semantic toggle to Unity files on GitHub pull requests.
           </dd>
           <dt>CLI — Homebrew</dt>


### PR DESCRIPTION
## Summary

Point the demo site's Chrome Web Store link at the PrefabLens listing instead of a search results page, and fix a stale source pointer in a `site/build.mjs` comment.

## Motivation

The site linked `chromewebstore.google.com/search/PrefabLens` while `README.md` links the actual listing, and the `build.mjs` comment still named `detect.ts` although the Unity extension list has lived in `extension/src/unity.ts` since the content-sniff refactor.

Closes #197

## Changes

- `site/static/index.html`: replace the store search URL with the listing URL used by `README.md` (`https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip`)
- `site/build.mjs`: update the extension-gate comment to point at `extension/src/unity.ts` instead of `detect.ts`

## Testing

- `zig build && zig build wasm`, then `pnpm install --frozen-lockfile && pnpm run demo` in `extension/` to produce the site inputs
- `node --test src/*.test.mjs && node build.mjs` in `site/`: 4 tests pass, `site built at .../site/dist`
- `grep -rn chromewebstore site/dist/` shows only the new listing URL in `dist/index.html`
- `pnpm vitest run src/unity.parity.test.ts` in `extension/`: 2 tests pass (the parity test that greps `build.mjs` and `unity.ts`)