### PR TITLE
test: wire builtin_refs into cli test block

### DIFF
--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -19,6 +19,7 @@ test {
     _ = render_tree;
     _ = render_html;
     _ = unity_path;
+    _ = builtin_refs;
 }
 
 test "parseArgs: no operands = HEAD vs worktree, bulk" {


### PR DESCRIPTION
## Summary

Force-reference `builtin_refs` in the trailing test block of `cli/src/main.zig`, following the existing `_ = unity_path;` convention, so its tests are included in `zig build test` explicitly rather than only through a transitive import.

## Motivation

The test block force-references every private import except `builtin_refs` (`refAllDecls` only walks `pub` declarations, so private imports need an explicit `_ = <module>;`). Without the explicit reference, the two tests in `builtin_refs.zig` are only compiled because `display.zig` happens to import the file at file scope; if that import ever went away, the tests would silently drop out of the build.

Closes #193

## Changes

- Add `_ = builtin_refs;` to the trailing test block in `cli/src/main.zig`.

## Testing

Test count delta: **0** (178/178 before, 178/178 after; the CLI test step reports 81 in both runs). The two `builtin_refs.zig` tests were already compiled and running before this change, transitively via `display.zig`, which imports `builtin_refs.zig` at file scope and is itself force-referenced. The issue's premise that they were absent from the test build did not hold; this change makes their inclusion explicit and independent of the `display.zig` import.

Before (main):

```
Build Summary: 6/6 steps succeeded; 178/178 tests passed
+- run test 97 pass (97 total)
+- run test 81 pass (81 total)
```

After (this branch):

```
Build Summary: 6/6 steps succeeded; 178/178 tests passed
+- run test 97 pass (97 total)
+- run test 81 pass (81 total)
```

Verified the tests actually execute by temporarily inverting an expectation in `builtin_refs.zig`: `zig build test` then failed with `'builtin_refs.test.isBuiltinGuid matches exactly the two built-in resource files' failed` both with and without the new force-reference (80 pass, 1 fail in the CLI step), confirming the tests run in both states. The temporary breakage was reverted and is not part of this PR.