### PR TITLE
fix: repair the editor refresh lifecycle

### DIFF
--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -88,10 +88,20 @@ namespace PrefabLens
 
         /// Run bulk mode off the main thread. The callback is posted back through the
         /// caller's SynchronizationContext (Unity's main thread when called from the window).
-        public static void RunBulkAsync(string cliPath, string baseRef, Action<Result> onDone) =>
-            RunAsync(cliPath, QuoteArgs(BuildBulkArgs(baseRef)), onDone, SynchronizationContext.Current);
+        public static void RunBulkAsync(
+            string cliPath,
+            string baseRef,
+            Action<Result> onDone,
+            CancellationToken ct = default
+        ) => RunAsync(cliPath, QuoteArgs(BuildBulkArgs(baseRef)), onDone, SynchronizationContext.Current, ct);
 
-        public static void RunAsync(string file, string arguments, Action<Result> onDone, SynchronizationContext ctx)
+        public static void RunAsync(
+            string file,
+            string arguments,
+            Action<Result> onDone,
+            SynchronizationContext ctx,
+            CancellationToken ct = default
+        )
         {
             var workDir = Directory.GetCurrentDirectory();
             Task.Run(() =>
@@ -99,7 +109,7 @@ namespace PrefabLens
                 Result res;
                 try
                 {
-                    res = RunProcess(file, arguments, workDir, RunTimeoutMs);
+                    res = RunProcess(file, arguments, workDir, RunTimeoutMs, ct);
                 }
                 catch (Exception e)
                 {
@@ -304,9 +314,16 @@ namespace PrefabLens
             public string Stdout;
             public string Stderr;
             public bool TimedOut;
+            public bool Canceled;
         }
 
-        public static Result RunProcess(string file, string arguments, string workDir, int timeoutMs)
+        public static Result RunProcess(
+            string file,
+            string arguments,
+            string workDir,
+            int timeoutMs,
+            CancellationToken ct = default
+        )
         {
             var psi = new ProcessStartInfo(file, arguments)
             {
@@ -317,6 +334,21 @@ namespace PrefabLens
                 WorkingDirectory = workDir,
             };
             using var p = Process.Start(psi);
+            // Cancellation kills the child like the timeout path does; WaitForExit then
+            // returns promptly and the ct check below reports the run as canceled.
+            using var reg = ct.Register(() =>
+            {
+                try
+                {
+                    p.Kill();
+                }
+                catch (InvalidOperationException)
+                { /* race between cancel and exit */
+                }
+                catch (System.ComponentModel.Win32Exception)
+                { /* already terminating */
+                }
+            });
             // Avoid a two-way ReadToEnd deadlock: read one side asynchronously
             var stdout = p.StandardOutput.ReadToEndAsync();
             var stderr = p.StandardError.ReadToEndAsync();
@@ -340,6 +372,17 @@ namespace PrefabLens
                     Stdout = "",
                     Stderr = $"prefablens timed out after {timeoutMs / 1000}s and was killed",
                     TimedOut = true,
+                };
+            }
+            if (ct.IsCancellationRequested)
+            {
+                // Same rationale as the timeout path: the child was killed, don't block on its pipes.
+                return new Result
+                {
+                    ExitCode = -1,
+                    Stdout = "",
+                    Stderr = "prefablens run canceled",
+                    Canceled = true,
                 };
             }
             return new Result

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -22,6 +22,8 @@ namespace PrefabLens
         bool downloadAttempted;
         string downloadError;
         CancellationTokenSource downloadCts;
+        bool pendingRefresh;
+        CancellationTokenSource runCts;
 
         [MenuItem("Window/PrefabLens")]
         public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
@@ -79,6 +81,8 @@ namespace PrefabLens
             content = new VisualElement { style = { flexGrow = 1 } };
             split.Add(content);
             rootVisualElement.Add(split);
+            // Window-lifetime token for CLI runs; domain reload re-enters CreateGUI with a fresh one.
+            runCts = new CancellationTokenSource();
             Refresh();
         }
 
@@ -91,8 +95,15 @@ namespace PrefabLens
 
         void Refresh()
         {
-            if (content == null || refreshing)
+            if (content == null)
                 return;
+            if (refreshing)
+            {
+                // A base-ref edit landed mid-run: run again when the in-flight run returns,
+                // instead of silently dropping the edit.
+                pendingRefresh = true;
+                return;
+            }
             var cli = Cli.Find();
             if (cli == null)
             {
@@ -107,19 +118,34 @@ namespace PrefabLens
             }
             refreshing = true;
             status.text = "Refreshing…";
-            Cli.RunBulkAsync(cli, baseRef.value, OnBulkDone);
+            // Capture the ref this run compares against: the field can change before it completes,
+            // and the completion callback must label the data with the ref it was produced from.
+            var runRef = baseRef.value;
+            Cli.RunBulkAsync(cli, runRef, res => OnBulkDone(res, runRef), runCts.Token);
         }
 
-        void OnBulkDone(Cli.Result res)
+        void OnBulkDone(Cli.Result res, string runRef)
         {
             refreshing = false;
-            if (content == null)
-                return; // unreachable given Refresh's own guard; kept as cheap defense
+            if (content == null || res.Canceled)
+                return; // window gone or closing: leave the UI alone
+            ShowBulkResult(res, runRef);
+            if (pendingRefresh)
+            {
+                // The base ref changed mid-run: the result above is already labeled with its own
+                // ref; now run again with the current field value.
+                pendingRefresh = false;
+                Refresh();
+            }
+        }
+
+        void ShowBulkResult(Cli.Result res, string runRef)
+        {
             // Unchanged output — the common focus-triggered refresh. Leave the whole UI
             // alone so the user's tree fold state survives; only restore the status line.
             if (res.ExitCode == 0 && res.Stdout == lastStdout)
             {
-                status.text = CountText();
+                status.text = CountText(runRef);
                 return;
             }
             content.Clear();
@@ -146,7 +172,7 @@ namespace PrefabLens
             lastStdout = res.Stdout;
             list.itemsSource = bulk.Entries;
             list.RefreshItems();
-            status.text = CountText();
+            status.text = CountText(runRef);
 
             if (bulk.Entries.Count == 0)
                 return;
@@ -159,12 +185,14 @@ namespace PrefabLens
             ShowEntry(bulk.Entries[idx]);
         }
 
-        string CountText() =>
-            bulk.Entries.Count == 0 ? $"No changes vs {BaseLabel()}" : $"{bulk.Entries.Count} changed vs {BaseLabel()}";
+        string CountText(string runRef) =>
+            bulk.Entries.Count == 0
+                ? $"No changes vs {BaseLabel(runRef)}"
+                : $"{bulk.Entries.Count} changed vs {BaseLabel(runRef)}";
 
-        string BaseLabel()
+        static string BaseLabel(string runRef)
         {
-            var r = baseRef.value?.Trim();
+            var r = runRef?.Trim();
             return string.IsNullOrEmpty(r) ? "HEAD" : r;
         }
 
@@ -278,8 +306,13 @@ namespace PrefabLens
             Refresh();
         }
 
-        /// Unity calls this when the window closes (and on domain reload): stop an in-flight download.
-        void OnDisable() => downloadCts?.Cancel();
+        /// Unity calls this when the window closes (and on domain reload): stop an
+        /// in-flight download and kill an in-flight CLI run (no 90 s orphan).
+        void OnDisable()
+        {
+            downloadCts?.Cancel();
+            runCts?.Cancel();
+        }
 
         void Note(string text)
         {

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -392,5 +392,64 @@ namespace PrefabLens.Tests
             );
             StringAssert.Contains("no entry", e.Message);
         }
+
+        [Test]
+        public void RunProcessCancellationKillsTheChildQuickly()
+        {
+            // Closing the window cancels an in-flight run: the child must die immediately,
+            // not survive until the 90 s timeout safety net fires.
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c ping -n 60 127.0.0.1 > NUL" : "-c \"sleep 60\"";
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(300);
+            var sw = Stopwatch.StartNew();
+            var res = Cli.RunProcess(file, args, ".", timeoutMs: 60_000, ct: cts.Token);
+            sw.Stop();
+            Assert.IsTrue(res.Canceled, "expected the killed run to be reported as canceled");
+            Assert.AreNotEqual(0, res.ExitCode);
+            Assert.Less(sw.ElapsedMilliseconds, 30_000, "cancellation must not degrade into waiting out the timeout");
+        }
+
+        [Test]
+        public void RunProcessWithAnUncanceledTokenBehavesAsBefore()
+        {
+            // The token is additive: a live token must not disturb the normal exit path.
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c echo hello" : "-c \"echo hello\"";
+            using var cts = new CancellationTokenSource();
+            var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs, ct: cts.Token);
+            Assert.IsFalse(res.Canceled);
+            Assert.AreEqual(0, res.ExitCode);
+            StringAssert.Contains("hello", res.Stdout);
+        }
+
+        [Test]
+        public void RunAsyncCancellationPostsACanceledResult()
+        {
+            // OnDisable cancels the window CTS; the posted Result must say Canceled so
+            // OnBulkDone can skip touching the (closing) UI instead of rendering into it.
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var file = isWindows ? "cmd.exe" : "/bin/sh";
+            var args = isWindows ? "/c ping -n 60 127.0.0.1 > NUL" : "-c \"sleep 60\"";
+            using var cts = new CancellationTokenSource();
+            Cli.Result? got = null;
+            using var done = new ManualResetEventSlim();
+            Cli.RunAsync(
+                file,
+                args,
+                r =>
+                {
+                    got = r;
+                    done.Set();
+                },
+                ctx: null,
+                ct: cts.Token
+            );
+            cts.CancelAfter(300);
+            Assert.IsTrue(done.Wait(30_000), "callback never fired");
+            Assert.IsTrue(got.Value.Canceled);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the three lifecycle gaps in the PrefabLens editor window: a base-ref edit committed during an in-flight CLI run is no longer dropped, the status line always names the ref the displayed data was produced from, and closing the window cancels an in-flight bulk run instead of leaving the child process alive for up to 90 s.

## Motivation

`Refresh()` early-returned while `refreshing` was set without rescheduling, `OnBulkDone` built the status line from the live `baseRef.value` (labeling old-ref data with the new ref), and `RunAsync`/`RunProcess` took no `CancellationToken` so `OnDisable` could only cancel downloads, not runs.

Closes #195

## Changes

- `Cli.Result` gains `Canceled`; `RunProcess`/`RunAsync`/`RunBulkAsync` gain a defaulted `CancellationToken` that kills the child process on cancellation (reusing the timeout path's kill/no-drain reasoning)
- `PrefabLensWindow` tracks a `pendingRefresh` flag when `Refresh()` bails on `refreshing` and re-enters `Refresh()` from `OnBulkDone`, so mid-run base-ref edits coalesce into one follow-up run
- The run's ref is captured in the run closure and threaded to `OnBulkDone`/`ShowBulkResult`/`CountText`; `BaseLabel` is static so it cannot read the live field
- A window-lifetime `runCts` is created in `CreateGUI` and canceled in `OnDisable` alongside `downloadCts`

## Testing

```
cd editor/DotNetTests~ && dotnet test Tests
Passed!  - Failed: 0, Passed: 56, Skipped: 0, Total: 56
```

56 tests = 53 baseline + 3 new cancellation tests (`RunProcessCancellationKillsTheChildQuickly`, `RunProcessWithAnUncanceledTokenBehavesAsBefore`, `RunAsyncCancellationPostsACanceledResult`), all real processes, no mocks. `dotnet csharpier check` clean. Window lifecycle changes are compile-gated through the DotNet harness (Unity API stubs); real Unity EditMode smoke (close-while-refreshing, domain reload mid-run, mid-run ref edit) is the usual manual follow-up.