### PR TITLE
feat: surface incomplete guid resolution

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -70,7 +70,16 @@ chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendRespon
     const tabId = sender.tab?.id;
     // semanticDiff requests always originate in a tab content script; guard defensively so a non-tab sender no-ops.
     const push = (m: GuidResolvedPush) => {
-      if (tabId !== undefined) void chrome.tabs.sendMessage(tabId, m).catch(() => {});
+      if (tabId === undefined) return;
+      // The final push releases the content-side indicator: retry a dropped tab message
+      // (SPA navigation races, transient port loss) before giving up. Intermediate pushes
+      // stay fire-and-forget — losing one only delays names until the final push.
+      const attempt = (left: number): void => {
+        void chrome.tabs.sendMessage(tabId, m).catch(() => {
+          if (m.done && left > 0) setTimeout(() => attempt(left - 1), 1000);
+        });
+      };
+      attempt(2);
     };
     void handler.semanticDiff(msg, push).then(sendResponse);
     return true; // async response

--- a/extension/src/background/resolution.test.ts
+++ b/extension/src/background/resolution.test.ts
@@ -92,8 +92,8 @@ describe("searchGuids", () => {
       cached: { g1: "Assets/Cached.cs" },
       search: { g2: "Assets/Found.cs" },
     });
-    const resolved = await resolution.searchGuids(["g1", "g2"], client, "o", "r", REPO_KEY);
-    expect(resolved).toEqual({ g1: "Assets/Cached.cs", g2: "Assets/Found.cs" });
+    const result = await resolution.searchGuids(["g1", "g2"], client, "o", "r", REPO_KEY);
+    expect(result).toEqual({ resolved: { g1: "Assets/Cached.cs", g2: "Assets/Found.cs" }, rateLimited: false });
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
     expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "g2");
     expect(guidCache.save).toHaveBeenCalledWith(REPO_KEY, { g2: "Assets/Found.cs" });
@@ -109,18 +109,20 @@ describe("searchGuids", () => {
   it("does not re-search misses but still emits their cached names later", async () => {
     // misses gates the search, not the name: an index resolution can land in guidCache afterwards.
     const { resolution, client, guidCache } = makeResolution(); // search misses
-    expect(await resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY)).toEqual({});
+    expect((await resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY)).resolved).toEqual({});
     guidCache.data[REPO_KEY] = { g1: "Assets/Later.cs" }; // as if the repo index wrote it later
-    expect(await resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY)).toEqual({ g1: "Assets/Later.cs" });
+    expect((await resolution.searchGuids(["g1"], client, "o", "r", REPO_KEY)).resolved).toEqual({
+      g1: "Assets/Later.cs",
+    });
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
   });
 
-  it("returns partial results when the rate limit interrupts the search loop", async () => {
+  it("returns partial results and reports the rate limit that interrupted the search loop", async () => {
     const { resolution, client } = makeResolution();
     client.searchMetaByGuid.mockResolvedValueOnce("Assets/First.cs").mockRejectedValueOnce(new RateLimitError("x"));
-    const resolved = await resolution.searchGuids(["g1", "g2", "g3"], client, "o", "r", REPO_KEY);
+    const result = await resolution.searchGuids(["g1", "g2", "g3"], client, "o", "r", REPO_KEY);
     // g1 survives, g2 aborts the loop, g3 is never attempted (the budget is already gone).
-    expect(resolved).toEqual({ g1: "Assets/First.cs" });
+    expect(result).toEqual({ resolved: { g1: "Assets/First.cs" }, rateLimited: true });
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(2);
   });
 
@@ -139,15 +141,18 @@ describe("searchGuids", () => {
     ];
     await vi.waitFor(() => expect(client.searchMetaByGuid).toHaveBeenCalled());
     release("Assets/S.cs");
-    expect(await Promise.all([a, b])).toEqual([{ g1: "Assets/S.cs" }, { g1: "Assets/S.cs" }]);
+    expect(await Promise.all([a, b])).toEqual([
+      { resolved: { g1: "Assets/S.cs" }, rateLimited: false },
+      { resolved: { g1: "Assets/S.cs" }, rateLimited: false },
+    ]);
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
   });
 
   it("does not treat Object.prototype members as cache hits (hostile guid)", async () => {
     const { resolution, client } = makeResolution({ cached: { g9: "Assets/X.cs" } });
-    const resolved = await resolution.searchGuids(["constructor"], client, "o", "r", REPO_KEY);
+    const result = await resolution.searchGuids(["constructor"], client, "o", "r", REPO_KEY);
     expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "constructor");
-    expect(resolved).toEqual({});
+    expect(result.resolved).toEqual({});
   });
 });
 
@@ -205,7 +210,8 @@ describe("mergeSources", () => {
     expect(fetchBlob).toHaveBeenCalledWith(client, "o", "r", "Assets/Cyl.prefab", "head-sha", undefined);
     const assets = must(diffWithAssets.mock.calls[0]?.[2]);
     expect(new TextDecoder().decode(must(assets.get("src1")))).toBe("SRC");
-    expect(result).toMatchObject({ unresolvedGuids: [] });
+    expect(result.json).toMatchObject({ unresolvedGuids: [] });
+    expect(result.status).toBe("complete");
   });
 
   it("fetches a before-side source at base, riding the base-tree blob sha", async () => {
@@ -228,7 +234,7 @@ describe("mergeSources", () => {
     const unresolved: DiffV2 = { ...NEEDS, resolved: {} };
     const result = await resolution.mergeSources(unresolved, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
     expect(diffWithAssets).not.toHaveBeenCalled();
-    expect(result).toEqual(unresolved);
+    expect(result).toEqual({ json: unresolved, status: "complete" });
   });
 
   it("skips binary-serialized sources without counting them as progress", async () => {
@@ -242,16 +248,25 @@ describe("mergeSources", () => {
     const result = await resolution.mergeSources(NEEDS, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
     // Merging a binary source would be a no-op re-diff: give up and keep the first pass.
     expect(diffWithAssets).not.toHaveBeenCalled();
-    expect(result).toEqual(NEEDS);
+    expect(result).toEqual({ json: NEEDS, status: "complete" });
   });
 
-  it("degrades to the current diff when the source fetch fails", async () => {
+  it("degrades to the current diff and reports rateLimited when the source fetch hits the limit", async () => {
     const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
     const { resolution, client, fetchBlob } = makeResolution({ diffWithAssets });
     fetchBlob.mockRejectedValue(new RateLimitError("x"));
     const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
     const result = await resolution.mergeSources(NEEDS, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
-    expect(result).toEqual(NEEDS);
+    expect(result).toEqual({ json: NEEDS, status: "rateLimited" });
+  });
+
+  it("degrades to the current diff and reports failed on a non-rate-limit fetch error", async () => {
+    const diffWithAssets = vi.fn<Differ["diffWithAssets"]>(() => MERGED);
+    const { resolution, client, fetchBlob } = makeResolution({ diffWithAssets });
+    fetchBlob.mockRejectedValue(new Error("socket"));
+    const differ = { diff: vi.fn(() => DIFF), diffWithAssets, isUnityYaml: () => true };
+    const result = await resolution.mergeSources(NEEDS, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
+    expect(result).toEqual({ json: NEEDS, status: "failed" });
   });
 
   it("caps source re-diff rounds at 3 even while progressing", async () => {
@@ -280,7 +295,7 @@ describe("mergeSources", () => {
     };
     const result = await resolution.mergeSources(first, differ, ...BYTES, CTX, client, "o", "r", REPO_KEY);
     expect(diffWithAssets).toHaveBeenCalledTimes(3);
-    expect(result.neededSources).toEqual([{ guid: "s3", side: "after" }]); // degraded at the cap
+    expect(result.json.neededSources).toEqual([{ guid: "s3", side: "after" }]); // degraded at the cap
   });
 });
 
@@ -309,7 +324,7 @@ describe("resolveRemaining", () => {
     const pushes = await run(resolution, client, first, ["g1", "g2"]);
     // Index names arrive in an intermediate push; the final push carries the full json.
     expect(pushes[0]).toMatchObject({ resolved: { g1: "Assets/S.cs" }, done: false });
-    expect(must(pushes.at(-1))).toMatchObject({ done: true });
+    expect(must(pushes.at(-1))).toMatchObject({ done: true, status: "complete" });
     expect(must(pushes.at(-1)).json?.resolved).toEqual({ g1: "Assets/S.cs", g2: "Assets/Other.cs" });
     expect(client.searchMetaByGuid).toHaveBeenCalledTimes(1);
     expect(client.searchMetaByGuid).toHaveBeenCalledWith("o", "r", "g2");
@@ -335,17 +350,36 @@ describe("resolveRemaining", () => {
     const pushes = await run(resolution, client, first, []);
     expect(client.listMetaTree).not.toHaveBeenCalled();
     expect(diffWithAssets).toHaveBeenCalledTimes(1);
+    expect(must(pushes.at(-1))).toMatchObject({ done: true, status: "complete" });
     expect(must(pushes.at(-1)).json).toMatchObject({ unresolvedGuids: [] });
   });
 
-  it("still emits the done push when the pipeline fails", async () => {
+  it("marks the final push rateLimited when Code Search hits the limit", async () => {
+    // Rate-limited runs must be distinguishable from completed ones (issue #194).
+    const { resolution, client } = makeResolution();
+    client.searchMetaByGuid.mockRejectedValue(new RateLimitError("x"));
+    const first: DiffV2 = { ...DIFF, unresolvedGuids: ["g1"] };
+    const pushes = await run(resolution, client, first, ["g1"]);
+    expect(must(pushes.at(-1))).toMatchObject({ done: true, status: "rateLimited" });
+  });
+
+  it("still emits the done push, marked failed, when the pipeline crashes", async () => {
     // Waiters key off done: a crash that swallowed it would leave the indicator spinning forever.
     const { resolution, client, fetchPair } = makeResolution();
     fetchPair.mockRejectedValue(new Error("socket"));
     const first: DiffV2 = { ...DIFF, unresolvedGuids: [], neededSources: [{ guid: "src1", side: "after" }] };
     const pushes = await run(resolution, client, first, []);
     expect(pushes).toEqual([
-      { type: "guidResolved", owner: "o", repo: "r", target: REQ.target, path: REQ.path, resolved: {}, done: true },
+      {
+        type: "guidResolved",
+        owner: "o",
+        repo: "r",
+        target: REQ.target,
+        path: REQ.path,
+        resolved: {},
+        done: true,
+        status: "failed",
+      },
     ]);
   });
 });

--- a/extension/src/background/resolution.ts
+++ b/extension/src/background/resolution.ts
@@ -131,8 +131,9 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     return { resolved, rateLimited };
   }
 
-  /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search order.
-   *  mergeSources calls it internally, so keep the signature and behavior unchanged. */
+  /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search
+   *  order, reporting whether a rate limit truncated the search (mergeSources folds the
+   *  flag into its own status). */
   async function searchUnresolved(
     json: DiffV2,
     client: C,

--- a/extension/src/background/resolution.ts
+++ b/extension/src/background/resolution.ts
@@ -1,7 +1,7 @@
 import { type ChangedFile, type GithubClient, RateLimitError, type RefPair } from "../github/client";
 import { applyResolved, type GuidCache } from "../github/guids";
 import { type RepoIndexStore, syncRepoIndex } from "../github/repoIndex";
-import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../types";
+import type { DiffV2, GuidResolvedPush, ResolutionStatus, SemanticDiffRequest } from "../types";
 import type { Differ } from "../wasm/differ";
 import { createPromiseCache } from "./promiseCache";
 
@@ -44,7 +44,7 @@ export type Resolution<C extends SearchClient> = {
     owner: string,
     repo: string,
     repoKey: string,
-  ): Promise<Record<string, string>>;
+  ): Promise<{ resolved: Record<string, string>; rateLimited: boolean }>;
   getRepoIndex(
     client: C,
     owner: string,
@@ -62,7 +62,7 @@ export type Resolution<C extends SearchClient> = {
     owner: string,
     repo: string,
     repoKey: string,
-  ): Promise<DiffV2>;
+  ): Promise<{ json: DiffV2; status: ResolutionStatus }>;
   resolveRemaining(
     first: DiffV2,
     remaining: string[],
@@ -96,8 +96,8 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     owner: string,
     repo: string,
     repoKey: string,
-  ): Promise<Record<string, string>> {
-    if (!guids.length) return {};
+  ): Promise<{ resolved: Record<string, string>; rateLimited: boolean }> {
+    if (!guids.length) return { resolved: {}, rateLimited: false };
     // hasOwn: guids are arbitrary strings, so 'constructor' etc. don't falsely hit Object.prototype
     // The cached lookup covers all guids without going through misses: since index resolutions also land in guidCache,
     // a cached name is always emitted even if it's in misses (the search gatekeeper)
@@ -111,6 +111,7 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     }
     const searchable = unknown.filter((g) => !misses.has(`${repoKey}:${g}`));
     const found: Record<string, string> = {};
+    let rateLimited = false;
     for (const g of searchable.slice(0, MAX_SEARCHES)) {
       const key = `${repoKey}:${g}`;
       try {
@@ -118,12 +119,16 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
         if (path) resolved[g] = found[g] = path;
         else misses.add(key);
       } catch (err) {
-        if (err instanceof RateLimitError) break;
+        // A rate limit truncates the run: report it instead of degrading silently (#194).
+        if (err instanceof RateLimitError) {
+          rateLimited = true;
+          break;
+        }
         misses.add(key);
       }
     }
     if (Object.keys(found).length) await deps.guidCache.save(repoKey, found);
-    return resolved;
+    return { resolved, rateLimited };
   }
 
   /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search order.
@@ -134,11 +139,11 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     owner: string,
     repo: string,
     repoKey: string,
-  ): Promise<DiffV2> {
+  ): Promise<{ json: DiffV2; rateLimited: boolean }> {
     const resolved = { ...json.resolved };
     const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g));
     const found = await searchGuids(pending, client, owner, repo, repoKey);
-    return { ...json, resolved: { ...resolved, ...found } };
+    return { json: { ...json, resolved: { ...resolved, ...found.resolved } }, rateLimited: found.rateLimited };
   }
 
   /** Fetches and memoizes the whole-repo guid index. A repo that hit a rate limit is pinned to fallback for the SW lifetime. */
@@ -173,9 +178,10 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     owner: string,
     repo: string,
     repoKey: string,
-  ): Promise<DiffV2> {
+  ): Promise<{ json: DiffV2; status: ResolutionStatus }> {
     const assets = new Map<string, Uint8Array>();
     let current = first;
+    let rateLimited = false;
     for (let round = 0; round < MAX_SOURCE_ROUNDS; round++) {
       const needed = (current.neededSources ?? []).filter((s) => !assets.has(s.guid));
       if (!needed.length) break;
@@ -189,8 +195,9 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
         let bytes: Uint8Array | null = null;
         try {
           bytes = await deps.fetchBlob(client, owner, repo, path, sha, blobSha);
-        } catch {
-          return current; // rate limit etc.: degrade to the first-pass diff
+        } catch (err) {
+          // degrade to the first-pass diff, but tell the caller why (#194)
+          return { json: current, status: err instanceof RateLimitError ? "rateLimited" : "failed" };
         }
         if (!bytes) continue;
         // Sources resolved by guid can be binary-serialized too: merging
@@ -204,12 +211,21 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
       try {
         merged = differ.diffWithAssets(before, after, assets);
       } catch {
-        return current; // a merge failure degrades to the current result
+        return { json: current, status: "failed" }; // a merge failure degrades to the current result
       }
       // Merging surfaces new external references (script/material) inside the source, so resolve again.
-      current = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
+      const next = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
+      rateLimited ||= next.rateLimited;
+      current = next.json;
     }
-    return current;
+    return { json: current, status: rateLimited ? "rateLimited" : "complete" };
+  }
+
+  /** rateLimited wins over failed: it is the outcome a manual retry is most likely to fix. */
+  function combine(a: ResolutionStatus, b: ResolutionStatus): ResolutionStatus {
+    if (a === "rateLimited" || b === "rateLimited") return "rateLimited";
+    if (a === "failed" || b === "failed") return "failed";
+    return "complete";
   }
 
   /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.
@@ -248,18 +264,29 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
         }
       }
       // Only guids that aren't indexable or aren't in the index go to Code Search
-      const fromSearch = leftover.length ? await searchGuids(leftover, client, req.owner, req.repo, repoKey) : {};
-      let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...fromSearch } };
+      const search = leftover.length
+        ? await searchGuids(leftover, client, req.owner, req.repo, repoKey)
+        : { resolved: {}, rateLimited: false };
+      let status: ResolutionStatus = search.rateLimited ? "rateLimited" : "complete";
+      let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...search.resolved } };
       if (json.neededSources?.length) {
         // Resolution advanced, so redo source merging (picks up the case where the source guid resolved this time)
         const differ = await deps.getDiffer();
         const [before, after] = await deps.fetchPair(client, ctx, req.owner, req.repo, req.path);
-        json = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
+        const merged = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
+        json = merged.json;
+        status = combine(status, merged.status);
       }
-      push({ type: "guidResolved", ...at, resolved: {}, json, done: true }); // the final push replaces json
+      push({ type: "guidResolved", ...at, resolved: {}, json, done: true, status }); // the final push replaces json
     } catch (err) {
       console.debug("prefablens: guid resolution aborted", err);
-      push({ type: "guidResolved", ...at, resolved: {}, done: true });
+      push({
+        type: "guidResolved",
+        ...at,
+        resolved: {},
+        done: true,
+        status: err instanceof RateLimitError ? "rateLimited" : "failed",
+      });
     }
   }
 

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -22,7 +22,7 @@ import { type DiffPage, type FileEntry, parseDiffUrl, parsePrPage, scanUnityFile
 import { fillDeviceCode } from "./devicePage";
 import { createSignIn, type PendingSignIn } from "./signin";
 import { createToggle, type Toggle, type View } from "./toggle";
-import { createViewRegistry } from "./views";
+import { createViewRegistry, type ViewEntry } from "./views";
 import { createViewState, type ViewState } from "./viewstate";
 
 const ERROR_TEXT: Record<BackgroundError, string> = {
@@ -39,6 +39,18 @@ const views = createViewRegistry();
 
 function countUnresolved(json: DiffV2): number {
   return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g)).length;
+}
+
+// If the final push is lost (dropped tab message, killed service worker), flip the
+// indicator to the retryable incomplete state instead of spinning forever.
+const WATCHDOG_MS = 120_000;
+
+function armWatchdog(view: ViewEntry): void {
+  clearTimeout(view.watchdog);
+  view.watchdog = window.setTimeout(
+    () => render(view.root, view.json, { incomplete: { onRetry: view.retry } }),
+    WATCHDOG_MS,
+  );
 }
 
 // Targets of the global switch: drives the toggle + display of already-attached files from outside
@@ -174,7 +186,17 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
         force,
       }).then((res) => {
         if (res.ok) {
-          views.set(viewKey, { root, json: res.json });
+          views.set(viewKey, {
+            root,
+            json: res.json,
+            // Retry re-runs the whole request: the diff itself is cached, so this only
+            // re-enters background resolution (requested must reset or request() no-ops).
+            retry: () => {
+              requested = false;
+              request(force);
+            },
+          });
+          if (res.pending) armWatchdog(must(views.get(viewKey)));
           // Always show it while pending: even if all names are resolved, source merging may remain
           return render(root, res.json, { resolving: res.pending ? Math.max(countUnresolved(res.json), 1) : 0 });
         }
@@ -256,8 +278,15 @@ async function init(): Promise<void> {
     if (msg?.type !== "guidResolved") return;
     const view = views.get(`${targetKey(msg.owner, msg.repo, msg.target)}:${msg.path}`);
     if (!view) return; // already navigated to a different diff page, etc.: drop silently
+    clearTimeout(view.watchdog);
     // The final push replaces json (mergeSources may change the structure), an intermediate push merges resolved
     view.json = msg.json ?? { ...view.json, resolved: { ...view.json.resolved, ...msg.resolved } };
+    if (msg.done && msg.status !== undefined && msg.status !== "complete") {
+      // The run gave up: keep the names that did arrive, offer a manual retry (#194).
+      render(view.root, view.json, { incomplete: { onRetry: view.retry } });
+      return;
+    }
+    if (!msg.done) armWatchdog(view);
     render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(countUnresolved(view.json), 1) });
   });
 

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -201,6 +201,13 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
           return render(root, res.json, { resolving: res.pending ? Math.max(countUnresolved(res.json), 1) : 0 });
         }
         requested = false; // don't cache errors: let the next toggle re-fetch
+        const view = views.get(viewKey);
+        if (view) {
+          // A failed retry must not wipe the diff the user is reading: keep the
+          // tree and re-offer the retry affordance instead of a bare error panel.
+          render(root, view.json, { incomplete: { onRetry: view.retry } });
+          return;
+        }
         if (res.error === "too-large") renderTooLarge(root, res.bytes, () => request(true));
         else if (res.error === "pat-missing" || res.error === "auth-failed") {
           authRetries.add(() => {

--- a/extension/src/content/views.test.ts
+++ b/extension/src/content/views.test.ts
@@ -15,7 +15,7 @@ function makeRoot(connected: boolean): ShadowRoot {
 describe("createViewRegistry", () => {
   it("returns stored entries by key and misses unknown keys", () => {
     const views = createViewRegistry();
-    const entry = { root: makeRoot(true), json: DIFF };
+    const entry = { root: makeRoot(true), json: DIFF, retry: () => {} };
     views.set("o/r#1:Assets/Foo.prefab", entry);
     expect(views.get("o/r#1:Assets/Foo.prefab")).toBe(entry);
     expect(views.get("o/r#2:Assets/Foo.prefab")).toBeUndefined();
@@ -27,8 +27,8 @@ describe("createViewRegistry", () => {
     const views = createViewRegistry();
     const liveHost = document.createElement("div");
     document.body.append(liveHost);
-    const live = { root: liveHost.attachShadow({ mode: "open" }), json: DIFF };
-    const dead = { root: makeRoot(false), json: DIFF };
+    const live = { root: liveHost.attachShadow({ mode: "open" }), json: DIFF, retry: () => {} };
+    const dead = { root: makeRoot(false), json: DIFF, retry: () => {} };
     views.set("live", live);
     views.set("dead", dead);
     views.pruneDisconnected();
@@ -41,7 +41,7 @@ describe("createViewRegistry", () => {
     const views = createViewRegistry();
     const host = document.createElement("div");
     document.body.append(host);
-    views.set("k", { root: host.attachShadow({ mode: "open" }), json: DIFF });
+    views.set("k", { root: host.attachShadow({ mode: "open" }), json: DIFF, retry: () => {} });
     host.remove();
     views.pruneDisconnected();
     expect(views.get("k")).toBeUndefined();

--- a/extension/src/content/views.ts
+++ b/extension/src/content/views.ts
@@ -1,7 +1,14 @@
 import type { DiffV2 } from "../types";
 
 // json is mutated in place by the push listener (merge resolved / replace on the final push)
-export type ViewEntry = { root: ShadowRoot; json: DiffV2 };
+export type ViewEntry = {
+  root: ShadowRoot;
+  json: DiffV2;
+  /** Re-requests this file's semantic diff (incomplete-resolution affordance). */
+  retry(): void;
+  /** Timer that flips the view to the incomplete state if the final push never arrives. */
+  watchdog?: number;
+};
 
 export type ViewRegistry = {
   set(key: string, entry: ViewEntry): void;

--- a/extension/src/content/views.ts
+++ b/extension/src/content/views.ts
@@ -24,7 +24,11 @@ export function createViewRegistry(): ViewRegistry {
     get: (key) => views.get(key),
     // Views killed by an SPA navigation: not only ignore late pushes to them, but also cut the reference
     pruneDisconnected() {
-      for (const [key, view] of views) if (!view.root.host.isConnected) views.delete(key);
+      for (const [key, view] of views) {
+        if (view.root.host.isConnected) continue;
+        clearTimeout(view.watchdog); // don't let an orphaned timer render into a detached root
+        views.delete(key);
+      }
     },
   };
 }

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -13,7 +13,11 @@ export function detectTheme(doc: Document): "light" | "dark" {
   return doc.defaultView?.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: number }): void {
+export function render(
+  root: ShadowRoot,
+  diff: DiffV2,
+  opts?: { resolving?: number; incomplete?: { onRetry(): void } },
+): void {
   const container = mount(root);
   // Resolving indicator: the diff body is correct from the start, only reference names fill in later
   if (opts?.resolving) {
@@ -22,6 +26,16 @@ export function render(root: ShadowRoot, diff: DiffV2, opts?: { resolving?: numb
     spin.className = "pl-spinner";
     busy.prepend(spin);
     container.append(busy);
+  } else if (opts?.incomplete) {
+    // Resolution gave up (rate limit or error): say so instead of pretending it finished (#194).
+    const bar = note("pl-resolving", "Some references were not resolved (GitHub rate limit or error).", ALERT);
+    const retry = document.createElement("button");
+    retry.type = "button";
+    retry.className = "pl-render";
+    retry.textContent = "Retry";
+    retry.addEventListener("click", opts.incomplete.onRetry);
+    bar.append(retry);
+    container.append(bar);
   }
   for (const node of diff.roots) container.append(renderNode(node, diff));
   const loose = diff.loose.map((c) => renderComponent(c, diff));

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -106,6 +106,10 @@ export type SemanticDiffResponse =
   | { ok: false; error: BackgroundError }
   | { ok: false; error: "too-large"; bytes: number };
 
+// Outcome of the background resolution pipeline. Anything but "complete" means the run
+// gave up early (rate limit or error) and a manual retry may resolve more references.
+export type ResolutionStatus = "complete" | "rateLimited" | "failed";
+
 // Async push from background → content (the second stage of the two-stage response).
 export type GuidResolvedPush = {
   type: "guidResolved";
@@ -116,4 +120,5 @@ export type GuidResolvedPush = {
   resolved: Record<string, string>;
   json?: DiffV2; // carried on the final push when mergeSources updated the structure (content replaces the view)
   done: boolean; // when true, resolution is finished (sent even with empty resolved = the cue to turn off the indicator)
+  status?: ResolutionStatus; // rides on every done push: the content script keeps the indicator up unless "complete"
 };


### PR DESCRIPTION
## Summary

When background guid resolution is cut short (GitHub rate limit or an error), the extension now shows an explicit "resolution incomplete — Retry" state instead of silently rendering raw `guid:...` references identically to a completed run, and the resolving indicator can no longer spin forever when the final push is lost.

## Motivation

The resolution pipeline swallowed rate limits at three points (`resolution.ts` search loop, both `mergeSources` degrade paths) and pushed `done: true` even from its catch path, so the content script turned the indicator off the same way whether resolution completed or gave up. A dropped final tab message left the indicator spinning with no re-delivery.

Closes #194

## Changes

- Thread a `ResolutionStatus` (`complete | rateLimited | failed`) through `searchGuids` → `mergeSources` → `resolveRemaining`; every `done: true` push now carries it (rateLimited wins over failed in the combined verdict)
- Content script maps a non-complete final push to an "incomplete — Retry" note that keeps the rendered diff; Retry re-issues the request (the raw diff is cached, so only resolution re-runs)
- A 120 s watchdog (armed while pending, re-armed on intermediate pushes, cleared on every push) flips a lost-final-push spinner to the same retryable state; orphaned timers are cleared on SPA-navigation prune
- Background retries the final push up to 3 attempts 1 s apart; intermediate pushes stay fire-and-forget
- A failed retry re-renders the existing diff with the incomplete bar instead of wiping it with an error panel

## Testing

```
cd extension && pnpm run typecheck && pnpm run lint && pnpm test && pnpm run build
Test Files  24 passed (24) / Tests  266 passed (266)
```

266 tests = 264 baseline + net-new pipeline coverage: rateLimited and failed statuses asserted through `searchGuids`, both `mergeSources` degrade paths, and `resolveRemaining` final pushes (including the crash path's exact-equality assertion). UI wiring (content/renderer/background glue) is typecheck/lint/build-gated per the existing structure.