### PR TITLE
fix: surface silent failures in the editor CLI path

### DIFF
--- a/editor/DotNetTests~/Package/Stubs/UnityEngineStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UnityEngineStubs.cs
@@ -42,4 +42,11 @@ namespace UnityEngine
         LowerCenter,
         LowerRight,
     }
+
+    public static class Debug
+    {
+        public static void LogException(System.Exception exception) { }
+
+        public static void LogWarning(object message) { }
+    }
 }

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -152,14 +152,37 @@ namespace PrefabLens
         /// Default install location. Under Library, relative to cwd (= Unity project root).
         public static string DefaultPath => Path.Combine("Library", "PrefabLens", Version, BinaryName);
 
-        /// A manual EditorPrefs override takes precedence. Otherwise the default location. If neither exists, null.
-        public static string Find()
+        /// Result of the CLI lookup. MissingOverride is non-null when the EditorPrefs
+        /// override points at a file that does not exist — reportable instead of a silent
+        /// fallback, and exactly the state the #162 settings page will display.
+        public readonly struct Location
         {
-            var manual = EditorPrefs.GetString(CliPathPref, "");
-            if (!string.IsNullOrEmpty(manual) && File.Exists(manual))
-                return manual;
-            return File.Exists(DefaultPath) ? DefaultPath : null;
+            /// Executable to run, or null when neither the override nor the default exists.
+            public readonly string Path;
+
+            public readonly string MissingOverride;
+
+            public Location(string path, string missingOverride)
+            {
+                Path = path;
+                MissingOverride = missingOverride;
+            }
         }
+
+        /// Pure lookup order (EditMode test target): a manual override takes precedence;
+        /// an override pointing at a missing file is reported, not silently skipped.
+        public static Location Locate(string manual, string defaultPath)
+        {
+            if (!string.IsNullOrEmpty(manual))
+            {
+                if (File.Exists(manual))
+                    return new Location(manual, null);
+                return new Location(File.Exists(defaultPath) ? defaultPath : null, manual);
+            }
+            return new Location(File.Exists(defaultPath) ? defaultPath : null, null);
+        }
+
+        public static Location Locate() => Locate(EditorPrefs.GetString(CliPathPref, ""), DefaultPath);
 
         /// Fetch from GitHub Releases, verify against the release's SHA256SUMS, and extract under
         /// Library. Returns the executable path on success, throws on failure (TimeoutException

--- a/editor/Editor/Cli.cs
+++ b/editor/Editor/Cli.cs
@@ -218,9 +218,7 @@ namespace PrefabLens
             }
             VerifySha256(bytes, sums, asset);
             ExtractTo(bytes, dir);
-
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                RunProcess("chmod", "+x \"" + DefaultPath + "\"", ".", RunTimeoutMs);
+            MarkExecutable(DefaultPath);
             DeleteStaleVersions(Path.GetDirectoryName(dir), Version);
             return DefaultPath;
         }
@@ -309,6 +307,21 @@ namespace PrefabLens
                 using var dst = File.Create(dest);
                 src.CopyTo(dst);
             }
+        }
+
+        /// Make the extracted binary executable (no-op on Windows). A silently failed chmod
+        /// used to surface later as an unrelated Process.Start error on first run, so a
+        /// non-zero exit fails the download step here, naming the binary path.
+        public static void MarkExecutable(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+            var res = RunProcess("chmod", "+x \"" + path + "\"", ".", RunTimeoutMs);
+            if (res.ExitCode != 0)
+                throw new InvalidOperationException(
+                    $"chmod +x failed for {path}: "
+                        + (string.IsNullOrEmpty(res.Stderr) ? $"exit {res.ExitCode}" : res.Stderr.Trim())
+                );
         }
 
         /// Drop cached binaries of other versions once the pinned one is in place.

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -114,6 +114,11 @@ namespace PrefabLens
                         + $"{loc.MissingOverride}. Falling back to the default location."
                 );
             }
+            else if (loc.MissingOverride == null)
+            {
+                // The override is gone or valid again: stop reporting it and re-arm the warning.
+                warnedOverride = null;
+            }
             var cli = loc.Path;
             if (cli == null)
             {

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -24,6 +24,7 @@ namespace PrefabLens
         CancellationTokenSource downloadCts;
         bool pendingRefresh;
         CancellationTokenSource runCts;
+        string warnedOverride; // last missing-override path already logged (no console spam on every focus)
 
         [MenuItem("Window/PrefabLens")]
         public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
@@ -104,7 +105,16 @@ namespace PrefabLens
                 pendingRefresh = true;
                 return;
             }
-            var cli = Cli.Find();
+            var loc = Cli.Locate();
+            if (loc.MissingOverride != null && loc.MissingOverride != warnedOverride)
+            {
+                warnedOverride = loc.MissingOverride;
+                Debug.LogWarning(
+                    $"PrefabLens: EditorPrefs '{Cli.CliPathPref}' points at a missing file: "
+                        + $"{loc.MissingOverride}. Falling back to the default location."
+                );
+            }
+            var cli = loc.Path;
             if (cli == null)
             {
                 // Fetch the pinned binary automatically, once per session; after a
@@ -238,6 +248,8 @@ namespace PrefabLens
             content.Clear();
             if (downloadError != null)
                 Note($"Download failed: {downloadError}");
+            if (warnedOverride != null)
+                Note($"Override '{Cli.CliPathPref}' points at a missing file: {warnedOverride}");
             Note($"prefablens CLI not found (v{Cli.Version}).");
             content.Add(
                 new Button(StartDownload)
@@ -283,7 +295,7 @@ namespace PrefabLens
                     : $"Downloading prefablens v{Cli.Version}… {read / 1024} KB";
         }
 
-        /// The success path re-resolves through Cli.Find instead of using the returned
+        /// The success path re-resolves through Cli.Locate instead of using the returned
         /// path, so the manual EditorPrefs override keeps precedence.
         void OnDownloadDone(string path, string error)
         {

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -171,8 +171,11 @@ namespace PrefabLens
             {
                 bulk = BulkModel.Parse(res.Stdout);
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                // The generic UI note stays short; the console carries the real reason
+                // (exception type + message) so a version mismatch is diagnosable.
+                Debug.LogException(e);
                 lastStdout = null;
                 status.text = "";
                 Note("Could not parse CLI output (CLI version mismatch?):");

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -523,5 +523,37 @@ namespace PrefabLens.Tests
                 Directory.Delete(dir, recursive: true);
             }
         }
+
+        [Test]
+        public void MarkExecutableMakesARealFileRunnable()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Ignore("chmod is a unix concern");
+            var file = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            File.WriteAllText(file, "#!/bin/sh\nexit 0\n");
+            try
+            {
+                Cli.MarkExecutable(file);
+                // The proof is execution: a fresh file is not executable until chmod succeeds.
+                var res = Cli.RunProcess(file, "", ".", timeoutMs: 10_000);
+                Assert.AreEqual(0, res.ExitCode);
+            }
+            finally
+            {
+                File.Delete(file);
+            }
+        }
+
+        [Test]
+        public void MarkExecutableFailsTheDownloadStepNamingTheBinaryPath()
+        {
+            // A swallowed chmod failure used to resurface later as an unrelated
+            // Process.Start error on first run; it must fail here, naming the path.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Ignore("chmod is a unix concern");
+            var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "prefablens");
+            var e = Assert.Throws<InvalidOperationException>(() => Cli.MarkExecutable(missing));
+            StringAssert.Contains(missing, e.Message);
+        }
     }
 }

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -451,5 +451,77 @@ namespace PrefabLens.Tests
             Assert.IsTrue(done.Wait(30_000), "callback never fired");
             Assert.IsTrue(got.Value.Canceled);
         }
+
+        [Test]
+        public void LocateUsesAnExistingOverrideAndReportsNothingMissing()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            var manual = Path.Combine(dir, "custom-prefablens");
+            File.WriteAllText(manual, "bin");
+            try
+            {
+                var loc = Cli.Locate(manual, Path.Combine(dir, "default-prefablens"));
+                Assert.AreEqual(manual, loc.Path);
+                Assert.IsNull(loc.MissingOverride);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Test]
+        public void LocateReportsAMissingOverrideWhileFallingBackToTheDefault()
+        {
+            // The silent-fallback bug: an override pointing at a deleted binary used to be
+            // indistinguishable from "no override set". The state must be reportable.
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            var def = Path.Combine(dir, "default-prefablens");
+            File.WriteAllText(def, "bin");
+            var gone = Path.Combine(dir, "gone-prefablens");
+            try
+            {
+                var loc = Cli.Locate(gone, def);
+                Assert.AreEqual(def, loc.Path);
+                Assert.AreEqual(gone, loc.MissingOverride);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Test]
+        public void LocateReportsAMissingOverrideEvenWhenNothingElseExists()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var gone = Path.Combine(dir, "gone-prefablens");
+            var loc = Cli.Locate(gone, Path.Combine(dir, "default-prefablens"));
+            Assert.IsNull(loc.Path);
+            Assert.AreEqual(gone, loc.MissingOverride);
+        }
+
+        [Test]
+        public void LocateWithoutAnOverrideUsesTheDefaultOrNothing()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(dir);
+            var def = Path.Combine(dir, "default-prefablens");
+            File.WriteAllText(def, "bin");
+            try
+            {
+                Assert.AreEqual(def, Cli.Locate("", def).Path);
+                Assert.IsNull(Cli.Locate("", def).MissingOverride);
+                var none = Cli.Locate("", Path.Combine(dir, "absent"));
+                Assert.IsNull(none.Path);
+                Assert.IsNull(none.MissingOverride);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Three swallowed failures in the editor CLI path become visible: the CLI-output parse exception now reaches the Unity console, an EditorPrefs override pointing at a missing file is reported instead of silently falling back, and a failed `chmod +x` fails the download step with a message naming the binary path.

## Motivation

`catch (Exception)` discarded the parse exception's type and message, `Cli.Find()` made a missing-override file indistinguishable from "no override set", and the ignored chmod result resurfaced later as an unrelated `Process.Start` failure on first run.

Closes #196

## Changes

- `Cli.Find()` replaced by `Cli.Locate()` returning `Location { Path, MissingOverride }`; the pure `Locate(manual, defaultPath)` overload is the EditMode test target and the state surface the #162 settings page will consume
- The window warns once per missing-override path via `Debug.LogWarning` (re-armed when the override clears, so a fixed-then-rebroken path warns again) and notes it on the missing-CLI screen
- The bulk-result parse path logs the underlying exception with `Debug.LogException` alongside the existing short UI note
- `chmod +x` extracted into `Cli.MarkExecutable(path)` (no-op on Windows) which throws naming the path on non-zero exit, flowing through the existing download error plumbing
- `UnityEngine.Debug` stub added to the DotNet test harness

## Testing

```
cd editor/DotNetTests~ && dotnet test Tests
Passed!  - Failed: 0, Passed: 62, Skipped: 0, Total: 62
```

62 tests = 56 baseline + 4 `Locate` tests (all four lookup cells, real temp files + real `File.Exists`) + 2 `MarkExecutable` tests (proof-by-execution of a real chmod, and the failure path asserting the thrown message names the path). csharpier clean. Window wiring is compile-gated through the DotNet harness; real Unity EditMode smoke remains the usual manual follow-up.