### PR TITLE
feat: add a Preferences page for the CLI path override

### DIFF
--- a/editor/DotNetTests~/Package/Stubs/UnityEditorStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UnityEditorStubs.cs
@@ -19,6 +19,26 @@ namespace UnityEditor
         public MenuItem(string itemName, bool isValidateFunction = false) { }
     }
 
+    public enum SettingsScope
+    {
+        User,
+        Project,
+    }
+
+    public class SettingsProvider
+    {
+        public SettingsProvider(
+            string path,
+            SettingsScope scopes,
+            System.Collections.Generic.IEnumerable<string> keywords = null
+        ) { }
+
+        public Action<string, UnityEngine.UIElements.VisualElement> activateHandler { get; set; }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class SettingsProviderAttribute : Attribute { }
+
     public static class EditorPrefs
     {
         // In-memory store: PathOverride round-trips are real behavior under the
@@ -38,6 +58,8 @@ namespace UnityEditor
         public static void DisplayProgressBar(string title, string info, float progress) { }
 
         public static void ClearProgressBar() { }
+
+        public static string OpenFilePanel(string title, string directory, string extension) => "";
     }
 
     public static class AssetDatabase

--- a/editor/Editor/PrefabLensSettings.cs
+++ b/editor/Editor/PrefabLensSettings.cs
@@ -8,11 +8,15 @@ namespace PrefabLens
     /// page can never drift from the window's resolution behavior.
     public static class PrefabLensSettings
     {
-        /// One line naming the binary Locate would run right now.
-        public static string ResolvedLabel(Cli.Location loc, string version) =>
-            loc.Path != null
-                ? $"Resolved CLI: {loc.Path}"
-                : $"Resolved CLI: not found — v{version} downloads on the next refresh";
+        /// One line naming the binary Locate would run right now, tagged with its source
+        /// (the broken-override case gets its own MissingOverrideNote line instead).
+        public static string ResolvedLabel(Cli.Location loc, string version)
+        {
+            if (loc.Path == null)
+                return $"Resolved CLI: not found — the PrefabLens window downloads v{version} on its next refresh";
+            var source = loc.Path == Cli.DefaultPath ? "downloaded" : "override";
+            return $"Resolved CLI ({source}): {loc.Path}";
+        }
 
         /// Warning line for an override pointing at a missing file; null when healthy.
         public static string MissingOverrideNote(Cli.Location loc) =>
@@ -44,7 +48,9 @@ namespace PrefabLens
             };
             path.RegisterValueChangedCallback(e =>
             {
-                Cli.PathOverride = e.newValue;
+                // Trim: a pasted path with trailing whitespace would otherwise fail
+                // File.Exists with an invisible cause in the warning line.
+                Cli.PathOverride = e.newValue?.Trim();
                 Sync(resolved, warning);
             });
             box.Add(path);

--- a/editor/Editor/PrefabLensSettings.cs
+++ b/editor/Editor/PrefabLensSettings.cs
@@ -1,0 +1,85 @@
+using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace PrefabLens
+{
+    /// Preferences > PrefabLens: edit the CLI path override and see which binary
+    /// actually runs. All state goes through Cli.PathOverride / Cli.Locate so the
+    /// page can never drift from the window's resolution behavior.
+    public static class PrefabLensSettings
+    {
+        /// One line naming the binary Locate would run right now.
+        public static string ResolvedLabel(Cli.Location loc, string version) =>
+            loc.Path != null
+                ? $"Resolved CLI: {loc.Path}"
+                : $"Resolved CLI: not found — v{version} downloads on the next refresh";
+
+        /// Warning line for an override pointing at a missing file; null when healthy.
+        public static string MissingOverrideNote(Cli.Location loc) =>
+            loc.MissingOverride != null ? $"Override points at a missing file: {loc.MissingOverride}" : null;
+
+        [SettingsProvider]
+        public static SettingsProvider Create() =>
+            new SettingsProvider("Preferences/PrefabLens", SettingsScope.User, new[] { "prefablens", "cli", "diff" })
+            {
+                activateHandler = (_, root) => Build(root),
+            };
+
+        static void Build(VisualElement root)
+        {
+            var box = new VisualElement { style = { marginLeft = 10, marginTop = 10 } };
+            root.Add(box);
+
+            var resolved = new Label { style = { marginTop = 6, whiteSpace = WhiteSpace.Normal } };
+            var warning = new Label { style = { marginTop = 2, whiteSpace = WhiteSpace.Normal } };
+
+            var path = new TextField("CLI path override")
+            {
+                value = Cli.PathOverride,
+                // Commit on Enter or focus loss so each edit re-resolves exactly once.
+                isDelayed = true,
+                tooltip =
+                    $"Manual prefablens binary. Empty = auto-download v{Cli.Version} under Library. "
+                    + $"Stored in EditorPrefs '{Cli.CliPathPref}'.",
+            };
+            path.RegisterValueChangedCallback(e =>
+            {
+                Cli.PathOverride = e.newValue;
+                Sync(resolved, warning);
+            });
+            box.Add(path);
+
+            var browse = new Button(() =>
+            {
+                var picked = EditorUtility.OpenFilePanel("Select prefablens binary", "", "");
+                if (string.IsNullOrEmpty(picked))
+                    return; // canceled: keep the current override
+                Cli.PathOverride = picked;
+                path.value = picked;
+                Sync(resolved, warning);
+            })
+            {
+                text = "Browse…",
+                style =
+                {
+                    alignSelf = Align.FlexStart,
+                    marginLeft = 6,
+                    marginTop = 2,
+                },
+            };
+            box.Add(browse);
+
+            box.Add(resolved);
+            box.Add(warning);
+            Sync(resolved, warning);
+        }
+
+        /// Re-derives the diagnostic lines from the current resolution state.
+        static void Sync(Label resolved, Label warning)
+        {
+            var loc = Cli.Locate();
+            resolved.text = ResolvedLabel(loc, Cli.Version);
+            warning.text = MissingOverrideNote(loc) ?? "";
+        }
+    }
+}

--- a/editor/Editor/PrefabLensSettings.cs.meta
+++ b/editor/Editor/PrefabLensSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b2b10b29a0646358eeb7f961ddee20a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/editor/Tests/Editor/SettingsTests.cs
+++ b/editor/Tests/Editor/SettingsTests.cs
@@ -5,11 +5,21 @@ namespace PrefabLens.Tests
     public class SettingsTests
     {
         [Test]
-        public void ResolvedLabelNamesTheBinaryThatWouldRun()
+        public void ResolvedLabelTagsTheDownloadedBinary()
         {
-            var loc = new Cli.Location("Library/PrefabLens/0.7.1/prefablens", null);
+            var loc = new Cli.Location(Cli.DefaultPath, null);
             Assert.AreEqual(
-                "Resolved CLI: Library/PrefabLens/0.7.1/prefablens",
+                $"Resolved CLI (downloaded): {Cli.DefaultPath}",
+                PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
+            );
+        }
+
+        [Test]
+        public void ResolvedLabelTagsAnOverrideBinary()
+        {
+            var loc = new Cli.Location("/custom/prefablens", null);
+            Assert.AreEqual(
+                "Resolved CLI (override): /custom/prefablens",
                 PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
             );
         }
@@ -20,7 +30,7 @@ namespace PrefabLens.Tests
             // The page must not show a blank/None path: say what will happen instead.
             var loc = new Cli.Location(null, null);
             Assert.AreEqual(
-                "Resolved CLI: not found — v0.7.1 downloads on the next refresh",
+                "Resolved CLI: not found — the PrefabLens window downloads v0.7.1 on its next refresh",
                 PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
             );
         }

--- a/editor/Tests/Editor/SettingsTests.cs
+++ b/editor/Tests/Editor/SettingsTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+
+namespace PrefabLens.Tests
+{
+    public class SettingsTests
+    {
+        [Test]
+        public void ResolvedLabelNamesTheBinaryThatWouldRun()
+        {
+            var loc = new Cli.Location("Library/PrefabLens/0.7.1/prefablens", null);
+            Assert.AreEqual(
+                "Resolved CLI: Library/PrefabLens/0.7.1/prefablens",
+                PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
+            );
+        }
+
+        [Test]
+        public void ResolvedLabelExplainsTheDownloadWhenNothingExists()
+        {
+            // The page must not show a blank/None path: say what will happen instead.
+            var loc = new Cli.Location(null, null);
+            Assert.AreEqual(
+                "Resolved CLI: not found — v0.7.1 downloads on the next refresh",
+                PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
+            );
+        }
+
+        [Test]
+        public void MissingOverrideNoteSurfacesTheBrokenPath()
+        {
+            // Same state #196 made reportable: an override pointing at a missing file.
+            var broken = new Cli.Location("Library/PrefabLens/0.7.1/prefablens", "/gone/prefablens");
+            Assert.AreEqual(
+                "Override points at a missing file: /gone/prefablens",
+                PrefabLensSettings.MissingOverrideNote(broken)
+            );
+            Assert.IsNull(PrefabLensSettings.MissingOverrideNote(new Cli.Location(null, null)));
+        }
+    }
+}

--- a/editor/Tests/Editor/SettingsTests.cs.meta
+++ b/editor/Tests/Editor/SettingsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c661e94884414a3198c20a825785de1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Adds a Preferences > PrefabLens page that shows and edits the CLI path override and displays which binary would actually run (override vs downloaded cache) — the `PrefabLens.CliPath` key stops being discoverable only from an in-window error message.

## Motivation

The override existed but had no settings surface; users had to write EditorPrefs by hand, and the missing-override state introduced by #196 had nowhere to show up outside the window's error notes.

Closes #162

## Changes

- UIElements-based `SettingsProvider` (`Preferences/PrefabLens`, user scope): a delayed `TextField` bound to `Cli.PathOverride` (commits trim whitespace; clearing deletes the key), a Browse… button via `EditorUtility.OpenFilePanel`, and two diagnostic lines
- `Resolved CLI (override|downloaded): <path>` names the binary `Cli.Locate()` would run and its source; the not-found state explains that the window downloads the pinned version on its next refresh
- `Override points at a missing file: <path>` surfaces the #196 missing-override state on the page
- Both display strings are pure static helpers tested in `DotNetTests~`; resolution logic is untouched (`Cli.PathOverride` / `Cli.Locate()` stay the single source of truth)
- DotNet harness stubs added: `SettingsProvider` / `SettingsScope` / `SettingsProviderAttribute` / `EditorUtility.OpenFilePanel`

## Testing

```
cd editor/DotNetTests~ && dotnet test Tests
Passed!  - Failed: 0, Passed: 73, Skipped: 0, Total: 73
```

73 = 69 baseline + 4 label-helper tests (downloaded tag, override tag, not-found wording, missing-override note). The final review verified against the Unity 2022.3 reference source that `SettingsWindow` clears the panel before every provider activation, so the append-based build cannot duplicate UI. Real Unity manual smoke (page render, Browse, window pickup on focus, key deletion on clear) is the usual follow-up.