### PR TITLE
docs: add CLI reference, editor guide, changelog policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,15 @@ comment and is converted to draft until the issue-first flow catches up.
 For security vulnerabilities, do **not** open a public issue — follow
 [SECURITY.md](SECURITY.md) instead.
 
+## Releases and changelog
+
+There is no curated `CHANGELOG.md`, by decision. The release history lives in
+[GitHub Releases](https://github.com/hashiiiii/PrefabLens/releases): notes are
+generated from the squash-merged pull requests since the previous tag, and PR
+titles follow the `type: subject` convention, so the generated notes are already
+grouped and readable. When writing a PR title, remember it becomes a release
+note line verbatim.
+
 ## License
 
 By contributing, you agree that your contributions are licensed under the

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Full reference — every flag, exit code, and resolution rule: [docs/cli.md](doc
 
 Open `Window > PrefabLens`. The window lists every changed UnityYAML asset vs HEAD and shows the selected asset's semantic diff. The CLI binary is downloaded automatically from GitHub Releases.
 
+Details — configuration, the CLI download, troubleshooting: [docs/editor.md](docs/editor.md).
+
 ## Supported files
 
 Text-serialized Unity assets such as `.prefab`, `.unity`, `.asset`, `.mat`, `.anim`, and `.controller`. Excludes `.meta`, `.asmdef`, and other non-UnityYAML formats.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ prefablens --open main                  # write the report to a temp file and op
 Operands ending in a Unity YAML extension (`.prefab`, `.unity`, `.asset`, ...) are
 treated as paths; everything else is a git ref.
 
+Full reference — every flag, exit code, and resolution rule: [docs/cli.md](docs/cli.md).
+
 ### Unity Editor
 
 Open `Window > PrefabLens`. The window lists every changed UnityYAML asset vs HEAD and shows the selected asset's semantic diff. The CLI binary is downloaded automatically from GitHub Releases.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,8 +42,11 @@ Recognized Unity YAML extensions:
 
 `.meta`, `.asmdef`, and other non-UnityYAML files are never treated as paths — an
 operand like `Foo.meta` is parsed as a git ref and will fail in git, by design.
-A binary-serialized asset (no Force Text) fails to parse; switch the project to
-text serialization for meaningful diffs.
+A binary-serialized asset (no Force Text) passed as an explicit path produces a
+silent empty diff, not an error: the parser finds no YAML document headers, which
+is indistinguishable from "no changes". Bulk (git) mode content-sniffs candidates
+and skips binary files up front; explicit path operands are never second-guessed.
+Switch the project to text serialization for meaningful diffs.
 
 ## Options
 
@@ -68,7 +71,8 @@ text serialization for meaningful diffs.
   `unresolvedGuids`; resolved names appear in `resolved` when a project scan ran.
 - **html** (`--html` / `--open`): one self-contained page, no external assets.
   With `--open` the report file is named `prefablens-<stem>-<millis>.html` and
-  written to `$TMPDIR` (or `%TEMP%` on Windows, `/tmp` as the last fallback).
+  written to the first of `TMPDIR`, `TEMP`, or `/tmp` (checked in that order, on
+  every platform).
   Failing to launch a browser prints a warning but still exits 0 — the path was
   already printed. Failing to write the report is an error (exit 1).
 
@@ -92,7 +96,7 @@ in `unresolvedGuids` in JSON.
 
 | Code | Meaning |
 |---|---|
-| 0 | Success — including "no changed Unity files" in bulk mode. |
+| 0 | Success — including bulk mode finding nothing to diff (prints `no Unity YAML changes`). |
 | 1 | Runtime error: git failed or timed out, a file could not be read, the `--project` directory could not be read, input nested too deeply, or the `--open` report could not be written. One-line `error: …` message on stderr. |
 | 2 | Usage error: unknown flag, too many arguments, conflicting flags, or a missing operand after `--project`. Usage/hint on stderr. |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,7 +4,7 @@
 component / field level changes instead of raw YAML lines. It reads either a git
 repository (comparing refs and the working tree) or two files directly.
 
-Quick-start examples live in the [README](../README.md#cli-2); this page is the full
+Quick-start examples live in the [README](../README.md#usage); this page is the full
 reference.
 
 ## Synopsis
@@ -17,8 +17,9 @@ prefablens [flags] <before> <after>
 ## Operands and argument resolution
 
 An operand ending in a Unity YAML extension (case-insensitive) is a **path**;
-anything else is a **git ref**. There are no positional rules beyond that — flags,
-refs, and paths may appear in any order.
+anything else is a **git ref**. Flags may appear anywhere among the operands. Among
+operands of the same kind, order is significant: the first ref (or path) is the
+before side and the second is the after side.
 
 | Operands | Meaning |
 |---|---|
@@ -26,8 +27,8 @@ refs, and paths may appear in any order.
 | `<path>` | HEAD vs working tree, one file |
 | `<ref>` | ref vs working tree, all changed Unity files |
 | `<ref> <path>` | ref vs working tree, one file |
-| `<ref> <ref>` | ref vs ref, all changed Unity files |
-| `<ref> <ref> <path>` | ref vs ref, one file |
+| `<ref> <ref>` | first ref (before) vs second ref (after), all changed Unity files |
+| `<ref> <ref> <path>` | first ref (before) vs second ref (after), one file |
 | `<before> <after>` (two paths) | plain two-file compare, no git involved |
 
 More than two refs, more than two paths, or mixing two paths with a ref is an
@@ -96,7 +97,7 @@ in `unresolvedGuids` in JSON.
 
 | Code | Meaning |
 |---|---|
-| 0 | Success — including bulk mode finding nothing to diff (prints `no Unity YAML changes`). |
+| 0 | Success — including bulk mode finding nothing to diff (prints `no Unity YAML changes`, or `[]` with `--json`). |
 | 1 | Runtime error: git failed or timed out, a file could not be read, the `--project` directory could not be read, input nested too deeply, or the `--open` report could not be written. One-line `error: …` message on stderr. |
 | 2 | Usage error: unknown flag, too many arguments, conflicting flags, or a missing operand after `--project`. Usage/hint on stderr. |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,120 @@
+# prefablens CLI reference
+
+`prefablens` renders semantic diffs for text-serialized Unity assets: GameObject /
+component / field level changes instead of raw YAML lines. It reads either a git
+repository (comparing refs and the working tree) or two files directly.
+
+Quick-start examples live in the [README](../README.md#cli-2); this page is the full
+reference.
+
+## Synopsis
+
+```
+prefablens [--json|--html] [--open] [--project DIR|--no-project] [--color|--no-color] [<ref>] [<ref>] [<path>]
+prefablens [flags] <before> <after>
+```
+
+## Operands and argument resolution
+
+An operand ending in a Unity YAML extension (case-insensitive) is a **path**;
+anything else is a **git ref**. There are no positional rules beyond that — flags,
+refs, and paths may appear in any order.
+
+| Operands | Meaning |
+|---|---|
+| (none) | HEAD vs working tree, all changed Unity files (bulk mode) |
+| `<path>` | HEAD vs working tree, one file |
+| `<ref>` | ref vs working tree, all changed Unity files |
+| `<ref> <path>` | ref vs working tree, one file |
+| `<ref> <ref>` | ref vs ref, all changed Unity files |
+| `<ref> <ref> <path>` | ref vs ref, one file |
+| `<before> <after>` (two paths) | plain two-file compare, no git involved |
+
+More than two refs, more than two paths, or mixing two paths with a ref is an
+error (`too many arguments`, exit 2).
+
+Recognized Unity YAML extensions:
+`.prefab` `.unity` `.asset` `.mat` `.anim` `.controller` `.overrideController`
+`.physicMaterial` `.physicsMaterial2D` `.playable` `.mask` `.brush` `.flare`
+`.fontsettings` `.guiskin` `.giparams` `.renderTexture` `.spriteatlas`
+`.spriteatlasv2` `.terrainlayer` `.mixer` `.shadervariants` `.preset` `.signal`
+`.lighting` `.scenetemplate`
+
+`.meta`, `.asmdef`, and other non-UnityYAML files are never treated as paths — an
+operand like `Foo.meta` is parsed as a git ref and will fail in git, by design.
+A binary-serialized asset (no Force Text) fails to parse; switch the project to
+text serialization for meaningful diffs.
+
+## Options
+
+| Flag | Effect |
+|---|---|
+| `--json` | Emit `prefablens.diff.v2` JSON. In bulk mode the output is a `[{path, diff}]` array; exit 0 always yields valid JSON (an array, possibly empty), never prose. |
+| `--html` | Emit a self-contained HTML report on stdout. |
+| `--open` | Implies `--html`; writes the report to a temp file, prints its path on stdout, and opens it in a browser. Conflicts with `--json`. |
+| `--project DIR` | Unity project root for guid resolution, and the git repo dir. An unreadable DIR is an error (exit 1). |
+| `--no-project` | Skip the default guid-resolution scan. Conflicts with `--project`. |
+| `--color` | Force ANSI colors in tree output (useful when piping). |
+| `--no-color` | Disable ANSI colors; wins over `--color` and TTY detection. |
+| `--version` | Print `prefablens X.Y.Z` on stdout and exit 0. Short-circuits everything else. |
+| `-h`, `--help` | Print usage on stdout and exit 0. Short-circuits everything else. |
+
+## Output formats
+
+- **tree** (default): human-readable hierarchy on stdout. Colors are on when
+  stdout is a TTY, forced by `--color`, and always suppressed by `--no-color`.
+- **json** (`--json`): the `prefablens.diff.v2` schema (single-file mode) or a
+  `[{path, diff}]` array (bulk mode). Unresolved guid references are listed in
+  `unresolvedGuids`; resolved names appear in `resolved` when a project scan ran.
+- **html** (`--html` / `--open`): one self-contained page, no external assets.
+  With `--open` the report file is named `prefablens-<stem>-<millis>.html` and
+  written to `$TMPDIR` (or `%TEMP%` on Windows, `/tmp` as the last fallback).
+  Failing to launch a browser prints a warning but still exits 0 — the path was
+  already printed. Failing to write the report is an error (exit 1).
+
+## Guid resolution
+
+Unity serializes references as `{fileID, guid, type}`. prefablens resolves guids
+to asset paths in three ways:
+
+1. `--project DIR`: scan DIR's `.meta` files up front and resolve against them.
+2. Default (git mode, no `--project`, no `--no-project`): resolve lazily against
+   the repository root — the scan runs only when the computed diffs actually
+   contain unresolved references, so ref-free changes cost nothing. A failed or
+   empty scan degrades to unresolved output.
+3. Built-in engine references (default materials, meshes, and so on) resolve by
+   name with no scan at all.
+
+Unresolved references render as `guid:<hex>` in tree/HTML output and stay listed
+in `unresolvedGuids` in JSON.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success — including "no changed Unity files" in bulk mode. |
+| 1 | Runtime error: git failed or timed out, a file could not be read, the `--project` directory could not be read, input nested too deeply, or the `--open` report could not be written. One-line `error: …` message on stderr. |
+| 2 | Usage error: unknown flag, too many arguments, conflicting flags, or a missing operand after `--project`. Usage/hint on stderr. |
+
+Anything else crashing with a Zig error trace is a prefablens bug, not a user
+mistake — the trace is the bug report; please file it.
+
+## Limits and environment
+
+- Input files are capped at 64 MiB each.
+- git subprocesses time out after 60 s (surfaced as `error: git timed out …`, exit 1).
+- `TMPDIR` / `TEMP` control where `--open` writes its report (fallback `/tmp`).
+
+## Examples
+
+```bash
+prefablens                                  # HEAD vs working tree, everything, as a tree
+prefablens Assets/Player.prefab             # one file vs HEAD
+prefablens main                             # main vs working tree
+prefablens v0.6.0 v0.7.0                    # tag vs tag
+prefablens HEAD~1 HEAD Assets/Boss.unity    # one file between two refs
+prefablens before.prefab after.prefab       # no git: compare two files
+prefablens --json main | jq '.[].path'      # bulk JSON, changed paths only
+prefablens --open main                      # HTML report in the browser
+prefablens --project . --no-color HEAD~3    # explicit project scan, plain text
+```

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -50,7 +50,7 @@ The window runs the `prefablens` CLI as a child process. On first use it
 downloads the pinned version automatically from GitHub Releases:
 
 - Download target: `Library/PrefabLens/<version>/prefablens` (`.exe` on
-  Windows), relative to the project root. `Library/` is not version-controlled,
+  Windows), relative to the project root. `Library/` is not meant to be version-controlled,
   so the binary never enters your repository.
 - Integrity: the release's `SHA256SUMS` is fetched first and the zip is verified
   against it before extraction. A mismatch aborts the install.

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -1,0 +1,125 @@
+# PrefabLens for the Unity Editor
+
+The editor package shows semantic diffs of your working tree inside Unity:
+which UnityYAML assets changed against a chosen git ref, and what changed inside
+each one at the GameObject / component / field level.
+
+## Requirements
+
+- Unity 2022.3 or newer.
+- The project is inside a git repository (the CLI shells out to git).
+- Text asset serialization (Edit > Project Settings > Editor > Asset
+  Serialization > Force Text) — binary-serialized assets cannot be diffed.
+
+## Installation
+
+Via [OpenUPM](https://openupm.com/packages/com.hashiiiii.prefablens/):
+
+```bash
+openupm add com.hashiiiii.prefablens
+```
+
+Or without the openupm CLI: add the scoped registry as described on the package
+page, or install straight from git via Package Manager > Add package from git
+URL:
+
+```
+https://github.com/hashiiiii/PrefabLens.git?path=editor
+```
+
+## The PrefabLens window
+
+Open **Window > PrefabLens**.
+
+- The left pane lists every changed UnityYAML asset compared to the **Base**
+  ref; the right pane shows the selected asset's semantic diff.
+- **Base** accepts a branch, tag, or commit; empty means HEAD. The field commits
+  on Enter or focus loss, and each committed edit triggers exactly one CLI run —
+  edits made while a run is in flight are queued and re-run automatically once
+  the in-flight run returns.
+- The status line always names the ref the displayed data was produced from
+  (for example `3 changed vs HEAD`).
+- The window refreshes when it gains focus and via the **Refresh** button.
+- Reference fields resolve guids through the local `AssetDatabase`, so script
+  and prefab references display as project paths.
+
+## The CLI binary
+
+The window runs the `prefablens` CLI as a child process. On first use it
+downloads the pinned version automatically from GitHub Releases:
+
+- Download target: `Library/PrefabLens/<version>/prefablens` (`.exe` on
+  Windows), relative to the project root. `Library/` is not version-controlled,
+  so the binary never enters your repository.
+- Integrity: the release's `SHA256SUMS` is fetched first and the zip is verified
+  against it before extraction. A mismatch aborts the install.
+- On macOS/Linux the binary is marked executable; a failed `chmod` fails the
+  download with the binary path in the message.
+- Older cached versions under `Library/PrefabLens/` are deleted after a
+  successful install.
+- The whole download is capped at 120 s and can be canceled from the window.
+- CLI runs are capped at 90 s; closing the window kills an in-flight run.
+
+When neither the override nor a downloaded binary is available, the window
+shows a `prefablens CLI not found (v<version>).` screen instead of the diff
+panes, with a **Download from GitHub Releases** button and a reminder that a
+manual path can be set via the `PrefabLens.CliPath` EditorPrefs key. If the
+previous auto-download attempt failed, its error appears above that message;
+if a broken CLI path override caused the screen, that is called out above it
+too (see [Using your own CLI binary](#using-your-own-cli-binary)).
+
+## Using your own CLI binary
+
+Preferences > **PrefabLens** (Edit > Preferences on Windows/Linux, Unity >
+Settings on macOS) exposes the override:
+
+- **CLI path override** — an absolute path to a `prefablens` binary. Empty means
+  "auto-download the pinned version". The page also offers Browse….
+- **Resolved CLI (override|downloaded): …** — the binary the window would run
+  right now, tagged with where it came from, for diagnostics. When neither the
+  override nor a downloaded binary exists it instead reads `Resolved CLI: not
+  found — the PrefabLens window downloads v<version> on its next refresh`. A
+  broken override additionally shows `Override points at a missing file: …`
+  underneath.
+- The setting is stored in the `PrefabLens.CliPath` EditorPrefs key (per-machine,
+  not per-project), so it can also be set from scripts:
+
+```csharp
+UnityEditor.EditorPrefs.SetString("PrefabLens.CliPath", "/usr/local/bin/prefablens");
+```
+
+Resolution order: the override wins when its file exists; otherwise the
+downloaded binary under `Library/` is used if present. An override pointing at
+a missing file falls back to that downloaded binary if it exists, or otherwise
+to an automatic download attempt (the missing-CLI screen instead, if a
+previous attempt in this session already failed). The broken override itself
+is reported in three places: a console warning
+(`PrefabLens: EditorPrefs 'PrefabLens.CliPath' points at a missing file: <path>.
+Falling back to the default location.`), a note on the missing-CLI screen
+(`Override 'PrefabLens.CliPath' points at a missing file: <path>`), and the
+Preferences page (`Override points at a missing file: <path>`). Fix or clear
+the override to silence all three. The console warning specifically is logged
+once per distinct missing path, not on every refresh; clearing or fixing the
+override re-arms it, so a later broken path is reported too.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| `Download failed: …` in the window | Network/proxy blocked GitHub Releases, or the SHA-256 check failed. Retry, or download the zip manually from Releases and point the CLI path override at the extracted binary. |
+| A one-line error from the CLI, or `prefablens exited with N` when the CLI printed nothing | The CLI's own error (stderr) — most commonly the project is not inside a git repository, or git timed out. See [docs/cli.md](cli.md) for the CLI's error contract. |
+| `Could not parse CLI output (CLI version mismatch?)` | The binary at the override path is too old/new for this package. The Unity console carries the exact parse exception. Clear the override or update the binary. |
+| `prefablens timed out after 90s and was killed` | A hung git or an enormous working tree. Check `git status` performance in that repository. |
+| Everything shows as changed / nothing parses | The project is serializing assets as binary. Switch to Force Text. |
+
+## How the window invokes the CLI
+
+For the curious (and for debugging): a refresh runs
+
+```
+prefablens [<base-ref>] --json
+```
+
+with the project root as the working directory, and renders the resulting
+`[{path, diff}]` array. Everything documented in [docs/cli.md](cli.md) about
+bulk mode and guid resolution applies as-is.

--- a/docs/editor.md
+++ b/docs/editor.md
@@ -37,8 +37,9 @@ Open **Window > PrefabLens**.
   on Enter or focus loss, and each committed edit triggers exactly one CLI run —
   edits made while a run is in flight are queued and re-run automatically once
   the in-flight run returns.
-- The status line always names the ref the displayed data was produced from
-  (for example `3 changed vs HEAD`).
+- After a refresh completes, the status line names the ref the displayed data was
+  produced from (for example `3 changed vs HEAD`) — even if the Base field has
+  already been edited again. While a run is in flight it shows `Refreshing…`.
 - The window refreshes when it gains focus and via the **Refresh** button.
 - Reference fields resolve guids through the local `AssetDatabase`, so script
   and prefab references display as project paths.
@@ -108,9 +109,9 @@ override re-arms it, so a later broken path is reported too.
 |---|---|
 | `Download failed: …` in the window | Network/proxy blocked GitHub Releases, or the SHA-256 check failed. Retry, or download the zip manually from Releases and point the CLI path override at the extracted binary. |
 | A one-line error from the CLI, or `prefablens exited with N` when the CLI printed nothing | The CLI's own error (stderr) — most commonly the project is not inside a git repository, or git timed out. See [docs/cli.md](cli.md) for the CLI's error contract. |
-| `Could not parse CLI output (CLI version mismatch?)` | The binary at the override path is too old/new for this package. The Unity console carries the exact parse exception. Clear the override or update the binary. |
+| `Could not parse CLI output (CLI version mismatch?):` | The binary at the override path is too old/new for this package. The Unity console carries the exact parse exception. Clear the override or update the binary. |
 | `prefablens timed out after 90s and was killed` | A hung git or an enormous working tree. Check `git status` performance in that repository. |
-| Everything shows as changed / nothing parses | The project is serializing assets as binary. Switch to Force Text. |
+| Edited assets never appear in the changed list | The project is serializing assets as binary; bulk mode content-sniffs candidates and silently skips non-text files (see [docs/cli.md](cli.md)). Switch Edit > Project Settings > Editor > Asset Serialization to Force Text. |
 
 ## How the window invokes the CLI
 


### PR DESCRIPTION
## Summary

Adds the user-facing reference docs that so far existed only as README snippets: a full CLI reference (`docs/cli.md`), an editor configuration guide (`docs/editor.md`), and a written-down changelog policy in CONTRIBUTING.md. README stays the quick-start surface and gains two link lines.

## Motivation

CLI options, exit codes, and the ref-vs-path rules lived only in README snippets; the `PrefabLens.CliPath` override was discoverable only from an in-window message; release-notes policy was implicit. Docs are increasingly read by AI assistants, so the reference aims for completeness — every flag, every exit code, every failure mode.

Closes #165

## Changes

- `docs/cli.md`: synopsis, operand resolution (before/after order made explicit, all 26 Unity YAML extensions), all 9 flags with conflicts, output formats, guid resolution tiers, exit codes 0/1/2 with the binary's real messages, limits (64 MiB, 60 s git timeout), environment, examples
- `docs/editor.md`: requirements, installation, window behavior (queued mid-run edits, ref-labeled status), the CLI auto-download pipeline (SHA256SUMS-first, chmod, stale cleanup, 120 s/90 s caps), the Preferences override page with all three missing-override reporting surfaces quoted verbatim, troubleshooting table
- `CONTRIBUTING.md`: "Releases and changelog" — no curated CHANGELOG.md by decision; generated release notes from conventional-commit squash titles are canonical
- `README.md`: two link lines (CLI reference, editor guide)

## Testing

Docs were verified against ground truth, not transcribed: the built binary's `--help` / `--version` / error paths were executed (unknown flag → exit 2, conflicting flags → exit 2, unreadable file → exit 1, binary-asset explicit-path compare → exit 0 with empty diff), the 26-extension list was diffed programmatically against `cli/src/unity_path.zig`, and every editor constant/string was grepped back to `Cli*.cs` / `PrefabLensWindow.cs` / `PrefabLensSettings.cs` / `RefreshGate.cs`. Review rounds caught and fixed three real doc-vs-source mismatches (binary-asset "fails to parse" claim, misquoted no-changes message, inverted binary-serialization symptom) before this PR.