### PR TITLE
feat: support GitHub Enterprise Server and ghe.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,12 @@ Without the [openupm-cli](https://github.com/openupm/openupm-cli), add the scope
 
 Shows semantic diffs for UnityYAML files on the GitHub pull request Files changed tab. Sign in with GitHub from the first diff panel (or the extension options page); authorization uses the GitHub device flow, so no token setup is needed.
 
-> [!NOTE]
-> The extension is currently available on github.com only.
+#### GitHub Enterprise
+
+GitHub Enterprise Server and ghe.com instances are supported. Open the extension options, add
+your instance URL under "Enterprise instances" (Chrome asks for host permission on that click),
+reload the instance tab, and paste a personal access token with repo read access for the
+instance. Sign in with GitHub (device flow) stays github.com-only.
 
 ### CLI
 

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -30,7 +30,6 @@ await build({
   target: "chrome120",
   minify: true,
   outdir: "dist",
-  define: { __API_BASE__: JSON.stringify(e2e ? "http://127.0.0.1:8471" : "https://api.github.com") },
 });
 
 const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));

--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -34,7 +34,8 @@ await build({
 
 const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
 if (e2e) {
-  // --e2e: grant and target the fixed port the fake-GitHub server in full.spec.ts listens on
+  // --e2e: grant and statically inject into the fake-GitHub server from full.spec.ts. The API
+  // base needs no wiring — the runtime resolves it from the page origin (GHES shape for loopback).
   manifest.host_permissions.push("http://127.0.0.1/*");
   manifest.content_scripts.push({ matches: ["http://127.0.0.1/*"], js: ["content.js"], run_at: "document_idle" });
 }

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -1,7 +1,9 @@
 /// <reference types="node" />
 // Runs detection → real background → real WASM → render end-to-end with the actual extension (--load-extension).
-// Uses a local HTTP server as "GitHub": the --e2e build bakes __API_BASE__ to this fixed port and
-// statically registers the content script for it (see build.mjs), so no dynamic permission grant is needed.
+// Uses a local HTTP server as "GitHub": the --e2e build statically registers the content script for it
+// (see build.mjs), so no dynamic permission grant is needed. The loopback origin resolves to the GHES
+// API shape (REST under /api/v3, GraphQL at /api/graphql) with a per-instance PAT, so this suite
+// exercises the Enterprise layout end-to-end; github.com shapes are covered by unit tests.
 
 import { readFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
@@ -11,7 +13,7 @@ import { type BrowserContext, chromium, expect, test } from "@playwright/test";
 const DIST = fileURLToPath(new URL("../dist", import.meta.url));
 const fixture = readFileSync(new URL("./fixtures/pr-files.html", import.meta.url), "utf8");
 
-// Matches the port baked into __API_BASE__ by build.mjs --e2e
+// Matches the loopback host the --e2e build statically injects into (see build.mjs)
 const PORT = 8471;
 
 // Same minimal prefab as core/tests/wasm_golden.test.mjs: the output is pinned by the golden
@@ -34,24 +36,24 @@ function startServer(): Promise<Server> {
     };
     const json = (body: unknown): void => send(JSON.stringify(body), "application/json");
     // Every ref pair shares one empty tree: blob fetches then fall back to the contents API below
-    if (url.pathname.startsWith("/repos/o/r/git/trees/")) return json({ truncated: false, tree: [] });
+    if (url.pathname.startsWith("/api/v3/repos/o/r/git/trees/")) return json({ truncated: false, tree: [] });
     switch (url.pathname) {
       case "/o/r/pull/1/files":
         return send(fixture, "text/html");
-      case "/repos/o/r/pulls/1/files":
+      case "/api/v3/repos/o/r/pulls/1/files":
         return json([
           { filename: "Assets/Foo.prefab", status: "modified" },
           { filename: "Assets/Big.unity", status: "modified" },
           { filename: "Assets/Baked.asset", status: "modified" },
         ]);
-      case "/repos/o/r/pulls/1":
+      case "/api/v3/repos/o/r/pulls/1":
         return json({ base: { sha: "B" }, head: { sha: "H" } });
-      case "/repos/o/r/compare/B...H":
+      case "/api/v3/repos/o/r/compare/B...H":
         return json({ merge_base_commit: { sha: "MB" } });
       // Commit page: same classic DOM, but discovery goes through the commit API (base = first parent)
       case "/o/r/commit/abcdef0":
         return send(fixture, "text/html");
-      case "/repos/o/r/commits/abcdef0":
+      case "/api/v3/repos/o/r/commits/abcdef0":
         return json({
           sha: "HC",
           parents: [{ sha: "PC" }],
@@ -60,27 +62,27 @@ function startServer(): Promise<Server> {
       // Compare page: merge base from the compare API, head resolved via the sha media type
       case "/o/r/compare/main...topic":
         return send(fixture, "text/html");
-      case "/repos/o/r/compare/main...topic":
+      case "/api/v3/repos/o/r/compare/main...topic":
         return json({
           merge_base_commit: { sha: "MC" },
           files: [{ filename: "Assets/Foo.prefab", status: "modified" }],
         });
-      case "/repos/o/r/commits/topic":
+      case "/api/v3/repos/o/r/commits/topic":
         return send("HT\n", "application/vnd.github.sha");
-      case "/repos/o/r/contents/Assets/Foo.prefab": {
+      case "/api/v3/repos/o/r/contents/Assets/Foo.prefab": {
         // MB/PC/MC are the base side of the pull/commit/compare flows respectively
         const ref = url.searchParams.get("ref") ?? "";
         return send(["MB", "PC", "MC"].includes(ref) ? BEFORE : AFTER, "application/vnd.github.raw+json");
       }
-      case "/repos/o/r/contents/Assets/Big.unity":
+      case "/api/v3/repos/o/r/contents/Assets/Big.unity":
         return send(BIG, "application/vnd.github.raw+json");
       // A binary-serialized .asset (LightingDataAsset etc.): passes the path
       // prefilter, must be rejected by the real wasm content sniff.
-      case "/repos/o/r/contents/Assets/Baked.asset":
+      case "/api/v3/repos/o/r/contents/Assets/Baked.asset":
         return send("\x00\x01PK-binary-payload", "application/vnd.github.raw+json");
-      case "/search/code":
+      case "/api/v3/search/code":
         return json({ items: [{ path: "Assets/Scripts/Sound.cs.meta" }] });
-      case "/graphql":
+      case "/api/graphql":
         return json({ data: { repository: {} } });
       default:
         res.writeHead(404);
@@ -105,10 +107,14 @@ test.beforeAll(async () => {
   sw ??= await context.waitForEvent("serviceworker");
   const extensionId = new URL(sw.url()).host;
 
-  // Seed the token directly in storage (sign-in is the only UI path; the fake server ignores its value)
+  // Seed a per-instance token directly in storage (the options UI is the real path; the fake
+  // server ignores its value). The loopback origin is an enterprise instance, not github.com.
   const options = await context.newPage();
   await options.goto(`chrome-extension://${extensionId}/options.html`);
-  await options.evaluate(() => chrome.storage.local.set({ pat: "tok" }));
+  await options.evaluate(
+    (origin) => chrome.storage.local.set({ instances: { [origin]: { pat: "tok" } } }),
+    `http://127.0.0.1:${PORT}`,
+  );
   await options.close();
 });
 

--- a/extension/e2e/smoke.spec.ts
+++ b/extension/e2e/smoke.spec.ts
@@ -179,7 +179,9 @@ test("recovers after an error response", async ({ page }) => {
     };
   }, cannedResponse);
 
-  await page.goto("https://prefablens.test/owner/repo/pull/1/files");
+  // The sign-in panel is github.com-only (enterprise instances get the PAT panel instead),
+  // so this test must run on the real origin — every request is intercepted by the routes above.
+  await page.goto("https://github.com/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
   const unityHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
@@ -316,7 +318,9 @@ test("signs in with the device flow from the PR page and auto-recovers", async (
     };
   }, cannedResponse);
 
-  await page.goto("https://prefablens.test/owner/repo/pull/1/files");
+  // The device flow only runs on github.com (enterprise instances get the PAT panel instead),
+  // so this test must run on the real origin — every request is intercepted by the routes above.
+  await page.goto("https://github.com/owner/repo/pull/1/files");
   await page.addScriptTag({ path: "dist/content.js" });
 
   const unityHeader = page.locator('.file-header[data-path="Assets/Foo.prefab"]');

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,8 +9,9 @@
     "48": "images/icon48.png",
     "128": "images/icon128.png"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "scripting"],
   "host_permissions": ["https://api.github.com/*", "https://github.com/*"],
+  "optional_host_permissions": ["*://*/*"],
   "background": { "service_worker": "background.js" },
   "content_scripts": [
     {

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -726,7 +726,13 @@ describe("prefetch", () => {
 
   it("persists prefetched diffs to the diff store (sw restart survival)", async () => {
     const { deps } = makeDeps();
-    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({
+      type: "prefetch",
+      origin: "https://github.com",
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+    });
     expect(deps.diffStore.save).toHaveBeenCalledWith("base-sha:head-sha:Assets/Foo.prefab", DIFF);
   });
 
@@ -746,7 +752,13 @@ describe("prefetch", () => {
     }));
     files.push({ path: "README.md", status: "modified" });
     const { deps, client } = makeDeps({ files });
-    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({
+      type: "prefetch",
+      origin: "https://github.com",
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+    });
     const paths = new Set(client.getFileAtRef.mock.calls.map((c) => c[2]));
     expect(paths.has("README.md")).toBe(false);
     expect(paths.size).toBe(100); // cut off at the cap
@@ -767,13 +779,25 @@ describe("prefetch", () => {
     const { deps, client } = makeDeps();
     client.getFileAtRef.mockRejectedValue(new RateLimitError("x"));
     await expect(
-      createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 }),
+      createHandler(deps).prefetch({
+        type: "prefetch",
+        origin: "https://github.com",
+        owner: "o",
+        repo: "r",
+        prNumber: 1,
+      }),
     ).resolves.toBeUndefined();
   });
 
   it("returns without network when the pat is missing", async () => {
     const { deps, client } = makeDeps({ pat: undefined });
-    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({
+      type: "prefetch",
+      origin: "https://github.com",
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+    });
     expect(client.getPrRefs).not.toHaveBeenCalled();
   });
 });
@@ -885,7 +909,13 @@ describe("semanticDiff with push (two-stage)", () => {
 
   it("kicks the repo index sync from prefetch", async () => {
     const { deps, client } = makeDeps();
-    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({
+      type: "prefetch",
+      origin: "https://github.com",
+      owner: "o",
+      repo: "r",
+      prNumber: 1,
+    });
     await vi.waitFor(() => expect(client.listMetaTree).toHaveBeenCalledWith("o", "r", "head-sha"));
   });
 });

--- a/extension/src/background/handler.test.ts
+++ b/extension/src/background/handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { AuthError, type ChangedFile, RateLimitError } from "../github/client";
+import type { HostApi } from "../github/hosts";
 import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../types";
 import { must } from "../util/must";
 import { DiffError, type Differ } from "../wasm/differ";
@@ -7,6 +8,7 @@ import { createHandler, type Deps, type Handler } from "./handler";
 
 const REQ: SemanticDiffRequest = {
   type: "semanticDiff",
+  origin: "https://github.com",
   owner: "o",
   repo: "r",
   target: { kind: "pull", prNumber: 1 },
@@ -95,10 +97,10 @@ function makeDeps(overrides?: {
     }),
   };
   const deps: Deps = {
-    getSettings: async () => ({
+    getSettings: async (_origin: string) => ({
       pat: Object.hasOwn(overrides ?? {}, "pat") ? overrides?.pat : "tok",
     }),
-    makeClient: (_base: string, _token: string, _lane: "user" | "prefetch") => client,
+    makeClient: (_api: HostApi, _token: string, _lane: "user" | "prefetch") => client,
     getDiffer: async () => differ,
     guidCache,
     diffStore,
@@ -139,6 +141,35 @@ describe("createHandler", () => {
     const res = await resolveFully(createHandler(deps), REQ);
     expect(res).toEqual({ ok: false, error: "pat-missing" });
     expect(client.getPrRefs).not.toHaveBeenCalled();
+  });
+
+  it("resolves the API per request origin and keys repo caches by the instance REST base", async () => {
+    const apis: HostApi[] = [];
+    const { deps, guidCache } = makeDeps({ search: { g1: "Assets/S.cs" } });
+    const inner = deps.makeClient;
+    deps.makeClient = (api, token, lane) => {
+      apis.push(api);
+      return inner(api, token, lane);
+    };
+    const res = await resolveFully(createHandler(deps), { ...REQ, origin: "https://github.example.com" });
+    expect(res.ok).toBe(true);
+    expect(apis[0]?.restBase).toBe("https://github.example.com/api/v3");
+    // Code-Search resolutions must land under the GHES-keyed repo, not the github.com one:
+    // two instances hosting the same o/r must never share guid caches (AC: host-keyed caches)
+    expect(guidCache.data["https://github.example.com/api/v3/o/r"]).toEqual({ g1: "Assets/S.cs" });
+    expect(guidCache.data["https://api.github.com/o/r"]).toBeUndefined();
+  });
+
+  it("passes the request origin to getSettings (per-instance credentials)", async () => {
+    const origins: string[] = [];
+    const { deps } = makeDeps();
+    const inner = deps.getSettings;
+    deps.getSettings = (origin) => {
+      origins.push(origin);
+      return inner(origin);
+    };
+    await resolveFully(createHandler(deps), { ...REQ, origin: "https://acme.ghe.com" });
+    expect(origins).toEqual(["https://acme.ghe.com"]);
   });
 
   it("diffs base/head blobs and attaches resolved guids", async () => {
@@ -672,7 +703,7 @@ describe("createHandler", () => {
         diffWithAssets,
       });
       const handler = createHandler(deps);
-      await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+      await handler.prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
       expect(diffWithAssets).not.toHaveBeenCalled(); // prefetch stops at raw
       const res = await resolveFully(handler, REQ);
       expect(res.ok).toBe(true);
@@ -685,7 +716,7 @@ describe("prefetch", () => {
   it("precomputes diffs so a later toggle serves without new blob fetches", async () => {
     const { deps, client } = makeDeps();
     const handler = createHandler(deps);
-    await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+    await handler.prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
     expect(client.searchMetaByGuid).not.toHaveBeenCalled(); // prefetch doesn't touch the 10 req/min Code Search
     const fetchesAfterPrefetch = client.getFileAtRef.mock.calls.length;
     const res = await resolveFully(handler, REQ);
@@ -695,7 +726,7 @@ describe("prefetch", () => {
 
   it("persists prefetched diffs to the diff store (sw restart survival)", async () => {
     const { deps } = makeDeps();
-    await createHandler(deps).prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
     expect(deps.diffStore.save).toHaveBeenCalledWith("base-sha:head-sha:Assets/Foo.prefab", DIFF);
   });
 
@@ -715,7 +746,7 @@ describe("prefetch", () => {
     }));
     files.push({ path: "README.md", status: "modified" });
     const { deps, client } = makeDeps({ files });
-    await createHandler(deps).prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
     const paths = new Set(client.getFileAtRef.mock.calls.map((c) => c[2]));
     expect(paths.has("README.md")).toBe(false);
     expect(paths.size).toBe(100); // cut off at the cap
@@ -726,7 +757,7 @@ describe("prefetch", () => {
     const { deps, client } = makeDeps();
     client.getFileAtRef.mockResolvedValue(big);
     const handler = createHandler(deps);
-    await handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+    await handler.prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
     expect(deps.diffStore.save).not.toHaveBeenCalled();
     // A later manual toggle still shows the too-large gate as before
     expect(await resolveFully(handler, REQ)).toEqual({ ok: false, error: "too-large", bytes: big.length * 2 });
@@ -736,13 +767,13 @@ describe("prefetch", () => {
     const { deps, client } = makeDeps();
     client.getFileAtRef.mockRejectedValue(new RateLimitError("x"));
     await expect(
-      createHandler(deps).prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 }),
+      createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 }),
     ).resolves.toBeUndefined();
   });
 
   it("returns without network when the pat is missing", async () => {
     const { deps, client } = makeDeps({ pat: undefined });
-    await createHandler(deps).prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
     expect(client.getPrRefs).not.toHaveBeenCalled();
   });
 });
@@ -752,7 +783,7 @@ it("dedupes a concurrent user toggle against an in-flight prefetch compute", asy
   const { deps, client } = makeDeps();
   const handler = createHandler(deps);
   const [, res] = await Promise.all([
-    handler.prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 }),
+    handler.prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 }),
     resolveFully(handler, REQ),
   ]);
   expect(res.ok).toBe(true);
@@ -854,7 +885,7 @@ describe("semanticDiff with push (two-stage)", () => {
 
   it("kicks the repo index sync from prefetch", async () => {
     const { deps, client } = makeDeps();
-    await createHandler(deps).prefetch({ type: "prefetch", owner: "o", repo: "r", prNumber: 1 });
+    await createHandler(deps).prefetch({ type: "prefetch", origin: "https://github.com", owner: "o", repo: "r", prNumber: 1 });
     await vi.waitFor(() => expect(client.listMetaTree).toHaveBeenCalledWith("o", "r", "head-sha"));
   });
 });

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -1,12 +1,6 @@
-import {
-  API_BASE,
-  AuthError,
-  type ChangedFile,
-  type GithubClient,
-  RateLimitError,
-  type RefPair,
-} from "../github/client";
+import { AuthError, type ChangedFile, type GithubClient, RateLimitError, type RefPair } from "../github/client";
 import { applyResolved, buildGuidIndex, type GuidCache } from "../github/guids";
+import { type HostApi, resolveApi } from "../github/hosts";
 import type { RepoIndexStore } from "../github/repoIndex";
 import {
   type DiffTarget,
@@ -38,8 +32,8 @@ type ClientLike = Pick<
 >;
 
 export type Deps = {
-  getSettings(): Promise<{ pat?: string }>;
-  makeClient(base: string, token: string, lane: "user" | "prefetch"): ClientLike;
+  getSettings(origin: string): Promise<{ pat?: string }>;
+  makeClient(api: HostApi, token: string, lane: "user" | "prefetch"): ClientLike;
   getDiffer(): Promise<Differ>;
   guidCache: GuidCache;
   diffStore: { load(key: string): Promise<DiffV2 | undefined>; save(key: string, json: DiffV2): Promise<void> };
@@ -150,8 +144,16 @@ export function createHandler(deps: Deps): Handler {
     fetchPair,
   });
 
-  function loadContext(client: ClientLike, owner: string, repo: string, target: DiffTarget): Promise<DiffContext> {
-    return contexts.get(targetKey(owner, repo, target), async () => {
+  function loadContext(
+    origin: string,
+    client: ClientLike,
+    owner: string,
+    repo: string,
+    target: DiffTarget,
+  ): Promise<DiffContext> {
+    // Two instances can host the same owner/repo/PR number, so the context key carries the
+    // origin. The sha-keyed blob/diff caches stay shared: shas are content-addressed.
+    return contexts.get(`${origin}:${targetKey(owner, repo, target)}`, async () => {
       const { refs, files } = await loadRefsAndFiles(client, owner, repo, target);
       const bySha = new Map(files.map((f) => [f.path, f.sha]));
       const [guidIndex, baseShas] = await Promise.all([
@@ -228,11 +230,11 @@ export function createHandler(deps: Deps): Handler {
     push: (msg: GuidResolvedPush) => void,
   ): Promise<SemanticDiffResponse> {
     try {
-      const settings = await deps.getSettings();
+      const api = resolveApi(req.origin);
+      const settings = await deps.getSettings(req.origin);
       if (!settings.pat) return { ok: false, error: "pat-missing" };
-      const base = API_BASE;
-      const client = deps.makeClient(base, settings.pat, "user");
-      const ctx = await loadContext(client, req.owner, req.repo, req.target);
+      const client = deps.makeClient(api, settings.pat, "user");
+      const ctx = await loadContext(req.origin, client, req.owner, req.repo, req.target);
       const outcome = await getDiff(client, ctx, req.owner, req.repo, req.path, req.force === true);
       if (!outcome.ok) return outcome;
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
@@ -240,7 +242,7 @@ export function createHandler(deps: Deps): Handler {
       // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push
       const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));
       if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
-      void resolution.resolveRemaining(withPr, remaining, client, req, base, ctx, push);
+      void resolution.resolveRemaining(withPr, remaining, client, req, api.restBase, ctx, push);
       return { ok: true, json: withPr, pending: true };
     } catch (err) {
       if (err instanceof RateLimitError) return { ok: false, error: "rate-limited" };
@@ -254,13 +256,19 @@ export function createHandler(deps: Deps): Handler {
    *  — Code Search is a scarce 10 req/min resource and mergeSources depends on resolution, so leave them to serve time. */
   async function prefetch(req: PrefetchRequest): Promise<void> {
     try {
-      const settings = await deps.getSettings();
+      const api = resolveApi(req.origin);
+      const settings = await deps.getSettings(req.origin);
       if (!settings.pat) return;
-      const base = API_BASE;
-      const client = deps.makeClient(base, settings.pat, "prefetch");
-      const ctx = await loadContext(client, req.owner, req.repo, { kind: "pull", prNumber: req.prNumber });
+      const client = deps.makeClient(api, settings.pat, "prefetch");
+      const ctx = await loadContext(req.origin, client, req.owner, req.repo, { kind: "pull", prNumber: req.prNumber });
       // Run independently of raw-diff prefetch (index sync speeds up the 3-stage resolution at serve time)
-      void resolution.getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
+      void resolution.getRepoIndex(
+        client,
+        req.owner,
+        req.repo,
+        `${api.restBase}/${req.owner}/${req.repo}`,
+        ctx.refs.headSha,
+      );
       const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
       for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
         const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -24,7 +24,7 @@ const handler = createHandler({
       return { pat: stored.pat as string | undefined };
     }
     const stored = await chrome.storage.local.get(["instances"]);
-    return { pat: ((stored.instances as Instances | undefined) ?? {})[origin]?.pat };
+    return { pat: (stored.instances as Instances | undefined)?.[origin]?.pat };
   },
   makeClient: (api, token, lane) => new GithubClient(api, token, queuedFetch(lane === "user")),
   getDiffer() {

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,4 +1,5 @@
 import { GithubClient } from "../github/client";
+import { GITHUB_ORIGIN, type Instances, permissionPatterns, scriptId, scriptSyncPlan } from "../github/hosts";
 import type { BackgroundRequest, GuidResolvedPush } from "../types";
 import { createDiffer, type Differ } from "../wasm/differ";
 import { createSessionDiffStore } from "./diffStore";
@@ -16,11 +17,16 @@ const queuedFetch =
     queue(() => fetch(input, init), { front });
 
 const handler = createHandler({
-  async getSettings() {
-    const stored = await chrome.storage.local.get(["pat"]);
-    return { pat: stored.pat as string | undefined };
+  async getSettings(origin) {
+    // github.com keeps its legacy `pat` key (device flow writes there); other instances live under `instances`.
+    if (origin === GITHUB_ORIGIN) {
+      const stored = await chrome.storage.local.get(["pat"]);
+      return { pat: stored.pat as string | undefined };
+    }
+    const stored = await chrome.storage.local.get(["instances"]);
+    return { pat: ((stored.instances as Instances | undefined) ?? {})[origin]?.pat };
   },
-  makeClient: (base, token, lane) => new GithubClient(base, token, queuedFetch(lane === "user")),
+  makeClient: (api, token, lane) => new GithubClient(api, token, queuedFetch(lane === "user")),
   getDiffer() {
     // Lazy singleton. If the SW restarts, just re-fetch.
     differ ??= fetch(chrome.runtime.getURL("prefablens.wasm"))
@@ -66,6 +72,8 @@ const handler = createHandler({
 });
 
 chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendResponse) => {
+  // The sender is authoritative for the instance origin: a message can be crafted, sender.origin cannot.
+  const senderOrigin = sender.origin ?? (sender.url ? new URL(sender.url).origin : undefined);
   if (msg?.type === "semanticDiff") {
     const tabId = sender.tab?.id;
     // semanticDiff requests always originate in a tab content script; guard defensively so a non-tab sender no-ops.
@@ -81,9 +89,41 @@ chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendRespon
       };
       attempt(2);
     };
-    void handler.semanticDiff(msg, push).then(sendResponse);
+    void handler.semanticDiff(senderOrigin ? { ...msg, origin: senderOrigin } : msg, push).then(sendResponse);
     return true; // async response
   }
-  if (msg?.type === "prefetch") void handler.prefetch(msg);
-  return undefined; // prefetch doesn't respond (fire-and-forget)
+  if (msg?.type === "prefetch") void handler.prefetch(senderOrigin ? { ...msg, origin: senderOrigin } : msg);
+  if (msg?.type === "openOptions") void chrome.runtime.openOptionsPage();
+  return undefined; // prefetch/openOptions don't respond (fire-and-forget)
 });
+
+/** Re-registers instance content scripts. Dynamic registrations are cleared on extension
+ *  update and permissions can be revoked from chrome://extensions, so every SW start
+ *  reconciles the registry against permission-granted instances. */
+async function syncInstanceScripts(): Promise<void> {
+  const stored = await chrome.storage.local.get(["instances"]);
+  const instances = (stored.instances as Instances | undefined) ?? {};
+  const granted: string[] = [];
+  for (const origin of Object.keys(instances)) {
+    const ok = await chrome.permissions.contains({ origins: permissionPatterns(origin) }).catch(() => false);
+    if (ok) granted.push(origin);
+  }
+  const registered = await chrome.scripting.getRegisteredContentScripts();
+  const plan = scriptSyncPlan(
+    registered.map((s) => s.id),
+    granted,
+  );
+  if (plan.remove.length) await chrome.scripting.unregisterContentScripts({ ids: plan.remove }).catch(() => {});
+  if (plan.add.length) {
+    await chrome.scripting.registerContentScripts(
+      plan.add.map((origin) => ({
+        id: scriptId(origin),
+        matches: [`${origin}/*`],
+        js: ["content.js"],
+        runAt: "document_idle" as const,
+        persistAcrossSessions: true,
+      })),
+    );
+  }
+}
+void syncInstanceScripts().catch((err: unknown) => console.debug("prefablens: instance script sync failed", err));

--- a/extension/src/background/resolution.test.ts
+++ b/extension/src/background/resolution.test.ts
@@ -18,6 +18,7 @@ const CTX: DiffContext = {
 
 const REQ: SemanticDiffRequest = {
   type: "semanticDiff",
+  origin: "https://github.com",
   owner: "o",
   repo: "r",
   target: { kind: "pull", prNumber: 1 },

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,8 +1,10 @@
 import { pollForToken, requestDeviceCode } from "../github/deviceFlow";
+import { GITHUB_ORIGIN, type Instances } from "../github/hosts";
 import {
   render,
   renderError,
   renderLoading,
+  renderPatNeeded,
   renderSignIn,
   renderSignInPending,
   renderTooLarge,
@@ -11,6 +13,7 @@ import {
   type BackgroundError,
   type DiffV2,
   type GuidResolvedPush,
+  type OpenOptionsRequest,
   type PrefetchRequest,
   type SemanticDiffRequest,
   type SemanticDiffResponse,
@@ -63,6 +66,9 @@ let prefetchedPr = ""; // send prefetch just once across all PR tabs, including 
 // Files whose panels are stuck on an auth error: all retried once a token lands in storage.
 const authRetries = createAuthRetries();
 
+// The device flow (and its /login/device autofill) is github.com-only; enterprise instances use a PAT.
+const onGithubCom = location.origin === GITHUB_ORIGIN;
+
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 const signIn = createSignIn({
   // Same-origin on github.com: the device flow needs no background relay and no extra permissions.
@@ -77,6 +83,14 @@ const signIn = createSignIn({
 
 /** Auth-error panel driving the device flow; failures land back here so the user can retry. */
 function signInPanel(root: ShadowRoot, message: string): void {
+  if (!onGithubCom) {
+    // No per-instance OAuth app exists, so the device flow cannot run here: steer to the PAT setting.
+    renderPatNeeded(
+      root,
+      () => void chrome.runtime.sendMessage({ type: "openOptions" } satisfies OpenOptionsRequest).catch(() => {}),
+    );
+    return;
+  }
   renderSignIn(root, message, () => {
     void signIn({
       showPending: (userCode, verificationUri) =>
@@ -254,10 +268,13 @@ function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
 
 async function init(): Promise<void> {
   // On the device-verification page the only job is pre-filling the code the PR page issued.
+  // A GHES /login/device page never gets the autofill: the pending code was issued by github.com.
   if (location.pathname === "/login/device") {
-    const stored = await chrome.storage.local.get(["signin"]).catch(() => ({}) as Record<string, unknown>);
-    const pending = stored.signin as PendingSignIn | undefined;
-    if (pending) fillDeviceCode(document, pending, Date.now());
+    if (onGithubCom) {
+      const stored = await chrome.storage.local.get(["signin"]).catch(() => ({}) as Record<string, unknown>);
+      const pending = stored.signin as PendingSignIn | undefined;
+      if (pending) fillDeviceCode(document, pending, Date.now());
+    }
     return;
   }
 
@@ -283,6 +300,9 @@ async function init(): Promise<void> {
       // A token just landed (this tab's own flow or another surface): retry every auth-blocked panel.
       authRetries.flush();
     }
+    // Same cue for enterprise instances: a PAT saved in the options page for this origin.
+    const instances = changes.instances?.newValue as Instances | undefined;
+    if (instances?.[location.origin]?.pat) authRetries.flush();
   });
 
   // guid resolution push from background (the second stage of the two-stage response): re-render if the matching view exists

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -94,7 +94,11 @@ function attach(state: ViewState): void {
       prefetchedPr = prKey;
       // fire-and-forget: don't wait on the response, ignore failures (the manual-toggle path is separately alive)
       void (
-        chrome.runtime.sendMessage({ type: "prefetch", ...prPage } satisfies PrefetchRequest) as Promise<unknown>
+        chrome.runtime.sendMessage({
+          type: "prefetch",
+          origin: location.origin,
+          ...prPage,
+        } satisfies PrefetchRequest) as Promise<unknown>
       ).catch(() => {});
     }
   }
@@ -179,6 +183,7 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
       renderLoading(root);
       void requestDiff({
         type: "semanticDiff",
+        origin: location.origin,
         owner: page.owner,
         repo: page.repo,
         target: page.target,

--- a/extension/src/demo.ts
+++ b/extension/src/demo.ts
@@ -1,8 +1,8 @@
 // Live demo for the site's extension.html: the mock PR page runs the
 // extension's real renderer, toggle, and WASM diff engine, wired the same way
 // as the content script minus the GitHub API and auth layers (never import
-// anything that pulls github/client.ts — its module init needs the build-time
-// __API_BASE__ define, absent from the demo build). Living in the extension
+// anything that pulls github/client.ts — the demo has no GitHub instance to
+// talk to and must stay free of that dependency). Living in the extension
 // toolchain keeps the demo type-checked against the modules it uses;
 // `node build.mjs --demo` bundles it as dist/demo.js for site/build.mjs.
 // Diff inputs are fixture files served next to the page; site/build.mjs marks

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -126,11 +126,7 @@ describe("GithubClient", () => {
   });
 
   it("searchMetaByGuid returns null on no hits, non-meta hits, and 422", async () => {
-    const empty = new GithubClient(
-      GITHUB_API,
-      "tok",
-      fakeFetch({ "/search/code": () => json({ items: [] }) }).fn,
-    );
+    const empty = new GithubClient(GITHUB_API, "tok", fakeFetch({ "/search/code": () => json({ items: [] }) }).fn);
     expect(await empty.searchMetaByGuid("o", "r", "g")).toBeNull();
     const odd = new GithubClient(
       GITHUB_API,
@@ -161,11 +157,7 @@ describe("GithubClient", () => {
     // secondary is 403 + retry-after, and newer APIs use 429.
     // secondary sometimes has no header (only the body message) — octokit also decides by the message.
     const at = (status: number, headers: Record<string, string>, body = "") =>
-      new GithubClient(
-        GITHUB_API,
-        "tok",
-        fakeFetch({ "/pulls/1": () => new Response(body, { status, headers }) }).fn,
-      );
+      new GithubClient(GITHUB_API, "tok", fakeFetch({ "/pulls/1": () => new Response(body, { status, headers }) }).fn);
     await expect(at(403, { "x-ratelimit-remaining": "0" }).getPrRefs("o", "r", 1)).rejects.toBeInstanceOf(
       RateLimitError,
     );

--- a/extension/src/github/client.test.ts
+++ b/extension/src/github/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { must } from "../util/must";
-import { ApiError, AuthError, GithubClient, graphqlUrl, RateLimitError } from "./client";
+import { ApiError, AuthError, GithubClient, RateLimitError } from "./client";
+import { resolveApi } from "./hosts";
 
 // fetch fake that returns a fixed path→response table. It also records calls.
 // Matching is url.includes(key), so keys must be unique substrings
@@ -21,6 +22,9 @@ function fakeFetch(routes: Record<string, () => Response>) {
 const json = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 
+// The github.com HostApi — what the runtime resolves for https://github.com pages.
+const GITHUB_API = resolveApi("https://github.com");
+
 describe("GithubClient", () => {
   it("default fetchFn survives strict-this runtimes (Chrome Illegal invocation)", async () => {
     // Chrome's fetch throws Illegal invocation when called with a non-global this.
@@ -34,7 +38,7 @@ describe("GithubClient", () => {
     }
     globalThis.fetch = strictFetch as typeof fetch;
     try {
-      const client = new GithubClient("https://api.github.com", "tok"); // fetchFn omitted = default
+      const client = new GithubClient(GITHUB_API, "tok"); // fetchFn omitted = default
       await expect(client.getFileAtRef("o", "r", "a.prefab", "sha")).resolves.not.toBeNull();
     } finally {
       globalThis.fetch = realFetch;
@@ -46,7 +50,7 @@ describe("GithubClient", () => {
       "/compare/base-tip...head-sha": () => json({ merge_base_commit: { sha: "merge-base" } }),
       "/pulls/7": () => json({ base: { sha: "base-tip" }, head: { sha: "head-sha" } }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const refs = await client.getPrRefs("o", "r", 7);
     expect(refs).toEqual({ baseSha: "merge-base", headSha: "head-sha" });
     expect(calls[0]?.headers.authorization).toBe("Bearer tok");
@@ -61,7 +65,7 @@ describe("GithubClient", () => {
       "&page=1": () => json(page1),
       "&page=2": () => json(page2),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const files = await client.listPrFiles("o", "r", 1);
     expect(files).toHaveLength(101);
     // sha is the head-side blob (base-side for removed files) — fetchPair fetches by it instead of path+ref
@@ -75,7 +79,7 @@ describe("GithubClient", () => {
 
   it("getBlobRaw requests raw bytes by blob sha", async () => {
     const { fn, calls } = fakeFetch({ "/git/blobs/": () => new Response(new Uint8Array([1, 2, 3])) });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const bytes = await client.getBlobRaw("o", "r", "blob1");
     expect([...must(bytes)]).toEqual([1, 2, 3]);
     expect(calls[0]?.url).toBe("https://api.github.com/repos/o/r/git/blobs/blob1");
@@ -84,13 +88,13 @@ describe("GithubClient", () => {
 
   it("getBlobRaw returns null on 404 (sha gone after a force push)", async () => {
     const { fn } = fakeFetch({});
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     expect(await client.getBlobRaw("o", "r", "gone")).toBeNull();
   });
 
   it("getFileAtRef requests raw content with URL-encoded path segments", async () => {
     const { fn, calls } = fakeFetch({ "/contents/": () => new Response(new Uint8Array([1, 2, 3])) });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const bytes = await client.getFileAtRef("o", "r", "Assets/My Prefab#1.prefab", "sha1");
     expect([...must(bytes)]).toEqual([1, 2, 3]);
     expect(calls[0]?.url).toContain("/contents/Assets/My%20Prefab%231.prefab?ref=sha1");
@@ -99,14 +103,14 @@ describe("GithubClient", () => {
 
   it("getFileAtRef returns null on 404 (file absent on that side)", async () => {
     const { fn } = fakeFetch({});
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     expect(await client.getFileAtRef("o", "r", "gone.prefab", "sha1")).toBeNull();
   });
 
   it("maps 401/403 to AuthError and other failures to ApiError", async () => {
-    const auth = new GithubClient("https://api.github.com", "bad", fakeFetch({ "/pulls/1": () => json({}, 401) }).fn);
+    const auth = new GithubClient(GITHUB_API, "bad", fakeFetch({ "/pulls/1": () => json({}, 401) }).fn);
     await expect(auth.getPrRefs("o", "r", 1)).rejects.toBeInstanceOf(AuthError);
-    const boom = new GithubClient("https://api.github.com", "tok", fakeFetch({ "/pulls/1": () => json({}, 500) }).fn);
+    const boom = new GithubClient(GITHUB_API, "tok", fakeFetch({ "/pulls/1": () => json({}, 500) }).fn);
     await expect(boom.getPrRefs("o", "r", 1)).rejects.toBeInstanceOf(ApiError);
   });
 
@@ -114,7 +118,7 @@ describe("GithubClient", () => {
     const { fn, calls } = fakeFetch({
       "/search/code": () => json({ items: [{ path: "Assets/Scripts/Player.cs.meta" }] }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     expect(await client.searchMetaByGuid("o", "r", "abc123")).toBe("Assets/Scripts/Player.cs");
     expect(calls[0]?.url).toContain(
       `/search/code?q=${encodeURIComponent('"abc123" repo:o/r extension:meta')}&per_page=1`,
@@ -123,20 +127,20 @@ describe("GithubClient", () => {
 
   it("searchMetaByGuid returns null on no hits, non-meta hits, and 422", async () => {
     const empty = new GithubClient(
-      "https://api.github.com",
+      GITHUB_API,
       "tok",
       fakeFetch({ "/search/code": () => json({ items: [] }) }).fn,
     );
     expect(await empty.searchMetaByGuid("o", "r", "g")).toBeNull();
     const odd = new GithubClient(
-      "https://api.github.com",
+      GITHUB_API,
       "tok",
       fakeFetch({ "/search/code": () => json({ items: [{ path: "README.md" }] }) }).fn,
     );
     expect(await odd.searchMetaByGuid("o", "r", "g")).toBeNull();
     // 422: repository not indexed, etc. Treated as "unresolved" rather than an ApiError
     const unindexed = new GithubClient(
-      "https://api.github.com",
+      GITHUB_API,
       "tok",
       fakeFetch({ "/search/code": () => json({ message: "Validation Failed" }, 422) }).fn,
     );
@@ -145,7 +149,7 @@ describe("GithubClient", () => {
 
   it("searchMetaByGuid propagates rate limiting", async () => {
     const limited = new GithubClient(
-      "https://api.github.com",
+      GITHUB_API,
       "tok",
       fakeFetch({ "/search/code": () => new Response("", { status: 403, headers: { "retry-after": "60" } }) }).fn,
     );
@@ -158,7 +162,7 @@ describe("GithubClient", () => {
     // secondary sometimes has no header (only the body message) — octokit also decides by the message.
     const at = (status: number, headers: Record<string, string>, body = "") =>
       new GithubClient(
-        "https://api.github.com",
+        GITHUB_API,
         "tok",
         fakeFetch({ "/pulls/1": () => new Response(body, { status, headers }) }).fn,
       );
@@ -193,7 +197,7 @@ describe("GithubClient", () => {
           files: [{ filename: "Assets/Foo.prefab", status: "modified", sha: "blob-head" }],
         }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const commit = await client.getCommit("o", "r", "abc1234");
     // GitHub's commit page diffs against the first parent; so do we
     expect(commit).toEqual({
@@ -210,7 +214,7 @@ describe("GithubClient", () => {
       "&page=1": () => json({ sha: "root-sha", parents: [], files: page1 }),
       "&page=2": () => json({ sha: "root-sha", parents: [], files: [{ filename: "last.cs", status: "added" }] }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const commit = await client.getCommit("o", "r", "root-sha");
     expect(commit.parentSha).toBeNull(); // root commit: every file is added, no base side exists
     expect(commit.files).toHaveLength(301);
@@ -224,7 +228,7 @@ describe("GithubClient", () => {
           files: [{ filename: "Assets/Foo.prefab", status: "removed", sha: "blob-base" }],
         }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const cmp = await client.compareRefs("o", "r", "feat/x", "main");
     expect(cmp).toEqual({
       mergeBaseSha: "merge-base",
@@ -236,7 +240,7 @@ describe("GithubClient", () => {
 
   it("resolveRefSha asks for the sha media type and trims the text body", async () => {
     const { fn, calls } = fakeFetch({ "/commits/main": () => new Response("full-head-sha\n") });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     await expect(client.resolveRefSha("o", "r", "main")).resolves.toBe("full-head-sha");
     expect(calls[0]?.headers.accept).toBe("application/vnd.github.sha");
   });
@@ -245,7 +249,7 @@ describe("GithubClient", () => {
     const { fn } = fakeFetch({
       "/pulls/7": () => new Response("slow down", { status: 403, headers: { "retry-after": "12" } }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const err = await client.getPrRefs("o", "r", 7).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(RateLimitError);
     // retry-after is seconds; the queue consumes milliseconds
@@ -261,7 +265,7 @@ describe("GithubClient", () => {
           headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(reset) },
         }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const err = (await client.getPrRefs("o", "r", 7).catch((e: unknown) => e)) as RateLimitError;
     // reset is an absolute epoch: allow scheduling slack around the 30s target
     expect(err.retryAfterMs).toBeGreaterThan(25_000);
@@ -272,7 +276,7 @@ describe("GithubClient", () => {
     const { fn } = fakeFetch({
       "/pulls/7": () => new Response('{"message":"You have exceeded a secondary rate limit."}', { status: 403 }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const err = (await client.getPrRefs("o", "r", 7).catch((e: unknown) => e)) as RateLimitError;
     expect(err).toBeInstanceOf(RateLimitError);
     expect(err.retryAfterMs).toBeUndefined();
@@ -287,16 +291,40 @@ describe("GithubClient", () => {
           headers: { "content-type": "application/json", "x-ratelimit-reset": String(reset) },
         }),
     });
-    const client = new GithubClient("https://api.github.com", "tok", fn);
+    const client = new GithubClient(GITHUB_API, "tok", fn);
     const err = (await client.batchBlobTexts("o", "r", ["oid1"]).catch((e: unknown) => e)) as RateLimitError;
     expect(err).toBeInstanceOf(RateLimitError);
     expect(err.retryAfterMs).toBeGreaterThan(0);
   });
 });
 
-describe("graphqlUrl", () => {
-  it("appends /graphql to the REST base", () => {
-    expect(graphqlUrl("https://api.github.com")).toBe("https://api.github.com/graphql");
+describe("per-instance request shapes", () => {
+  it("sends x-github-api-version and targets api.github.com on github.com", async () => {
+    const { fn, calls } = fakeFetch({
+      "/commits/main": () => new Response("head-sha\n"),
+      "/graphql": () => json({ data: { repository: {} } }),
+    });
+    const client = new GithubClient(GITHUB_API, "tok", fn);
+    await client.resolveRefSha("o", "r", "main");
+    await client.batchBlobTexts("o", "r", []);
+    expect(calls[0]?.url).toBe("https://api.github.com/repos/o/r/commits/main");
+    expect(calls[0]?.headers["x-github-api-version"]).toBe("2022-11-28");
+    expect(calls[1]?.url).toBe("https://api.github.com/graphql");
+  });
+
+  it("omits x-github-api-version on GHES and posts GraphQL to /api/graphql", async () => {
+    const { fn, calls } = fakeFetch({
+      "/commits/main": () => new Response("head-sha\n"),
+      "/graphql": () => json({ data: { repository: {} } }),
+    });
+    const client = new GithubClient(resolveApi("https://github.example.com"), "tok", fn);
+    await client.resolveRefSha("o", "r", "main");
+    await client.batchBlobTexts("o", "r", []);
+    // REST rides under /api/v3 on the instance origin; the version header is a github.com/ghe.com contract
+    expect(calls[0]?.url).toBe("https://github.example.com/api/v3/repos/o/r/commits/main");
+    expect(calls[0]?.headers["x-github-api-version"]).toBeUndefined();
+    // GraphQL is /api/graphql on GHES, not /api/v3/graphql — resolved, never derived from the REST base
+    expect(calls[1]?.url).toBe("https://github.example.com/api/graphql");
   });
 });
 
@@ -317,7 +345,7 @@ describe("listMetaTree", () => {
           { status: 200 },
         ),
     );
-    const client = new GithubClient("https://api.github.com", "tok", fetchFn);
+    const client = new GithubClient(GITHUB_API, "tok", fetchFn);
     const res = await client.listMetaTree("o", "r", "H");
     expect(fetchFn.mock.calls[0]?.[0]).toBe("https://api.github.com/repos/o/r/git/trees/H?recursive=1");
     expect(res).toEqual({
@@ -346,7 +374,7 @@ describe("listBlobShas", () => {
           { status: 200 },
         ),
     );
-    const client = new GithubClient("https://api.github.com", "tok", fetchFn);
+    const client = new GithubClient(GITHUB_API, "tok", fetchFn);
     const res = await client.listBlobShas("o", "r", "merge-base");
     expect(fetchFn.mock.calls[0]?.[0]).toBe("https://api.github.com/repos/o/r/git/trees/merge-base?recursive=1");
     expect(res.truncated).toBe(false);
@@ -364,7 +392,7 @@ describe("batchBlobTexts", () => {
           status: 200,
         }),
     );
-    const client = new GithubClient("https://api.github.com", "tok", fetchFn);
+    const client = new GithubClient(GITHUB_API, "tok", fetchFn);
     const res = await client.batchBlobTexts("o", "r", ["sha1", "sha2"]);
     expect(fetchFn.mock.calls[0]?.[0]).toBe("https://api.github.com/graphql");
     const init = fetchFn.mock.calls[0]?.[1] as RequestInit;
@@ -380,13 +408,13 @@ describe("batchBlobTexts", () => {
     const fetchFn = vi.fn(
       async () => new Response(JSON.stringify({ errors: [{ type: "RATE_LIMITED" }] }), { status: 200 }),
     );
-    const client = new GithubClient("https://api.github.com", "tok", fetchFn);
+    const client = new GithubClient(GITHUB_API, "tok", fetchFn);
     await expect(client.batchBlobTexts("o", "r", ["sha1"])).rejects.toBeInstanceOf(RateLimitError);
   });
 
   it("maps http 403 with retry-after to RateLimitError (shared classification)", async () => {
     const fetchFn = vi.fn(async () => new Response("slow down", { status: 403, headers: { "retry-after": "60" } }));
-    const client = new GithubClient("https://api.github.com", "tok", fetchFn);
+    const client = new GithubClient(GITHUB_API, "tok", fetchFn);
     await expect(client.batchBlobTexts("o", "r", ["sha1"])).rejects.toBeInstanceOf(RateLimitError);
   });
 });

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -1,3 +1,5 @@
+import type { HostApi } from "./hosts";
+
 export class AuthError extends Error {}
 export class RateLimitError extends Error {
   /** Backoff advice from response headers; undefined when GitHub gave none. */
@@ -37,17 +39,10 @@ const toChangedFile = (f: DiffEntry): ChangedFile => ({
   sha: f.sha,
 });
 
-// The REST base is fixed at build time (see build.mjs's esbuild define).
-export const API_BASE = __API_BASE__;
-
-/** Derives the GraphQL endpoint from the REST base. */
-export function graphqlUrl(restBase: string): string {
-  return `${restBase}/graphql`;
-}
-
 export class GithubClient {
   constructor(
-    private readonly base: string,
+    // REST base, GraphQL URL, and version-header policy resolved per instance (see hosts.ts).
+    private readonly api: HostApi,
     private readonly token: string,
     // Defaulting to bare `fetch` makes `this` in `this.fetchFn(...)` the instance,
     // which fails with Illegal invocation on Chrome (Node's fetch ignores this).
@@ -73,13 +68,9 @@ export class GithubClient {
   }
 
   private async request(path: string, accept: string): Promise<Response> {
-    return this.rawRequest(`${this.base}${path}`, {
-      headers: {
-        accept,
-        authorization: `Bearer ${this.token}`,
-        "x-github-api-version": "2022-11-28",
-      },
-    });
+    const headers: Record<string, string> = { accept, authorization: `Bearer ${this.token}` };
+    if (this.api.versioned) headers["x-github-api-version"] = "2022-11-28";
+    return this.rawRequest(`${this.api.restBase}${path}`, { headers });
   }
 
   private async json<T>(path: string): Promise<T> {
@@ -236,7 +227,7 @@ export class GithubClient {
       .map((oid, i) => `b${i}: object(oid: ${JSON.stringify(oid)}) { ... on Blob { text } }`)
       .join("\n");
     const query = `query { repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(repo)}) {\n${aliases}\n} }`;
-    const res = await this.rawRequest(graphqlUrl(this.base), {
+    const res = await this.rawRequest(this.api.graphqlUrl, {
       method: "POST",
       headers: {
         accept: "application/json",

--- a/extension/src/github/hosts.test.ts
+++ b/extension/src/github/hosts.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { GITHUB_ORIGIN, permissionPatterns, resolveApi, scriptId, scriptSyncPlan } from "./hosts";
+
+describe("resolveApi", () => {
+  it("maps github.com to the api.github.com pair with the version header", () => {
+    expect(resolveApi(GITHUB_ORIGIN)).toEqual({
+      restBase: "https://api.github.com",
+      graphqlUrl: "https://api.github.com/graphql",
+      versioned: true,
+    });
+  });
+
+  it("maps a ghe.com data-residency origin to its api subdomain", () => {
+    // Enterprise Cloud data residency: web at <sub>.ghe.com, API at api.<sub>.ghe.com
+    expect(resolveApi("https://acme.ghe.com")).toEqual({
+      restBase: "https://api.acme.ghe.com",
+      graphqlUrl: "https://api.acme.ghe.com/graphql",
+      versioned: true,
+    });
+  });
+
+  it("maps a GHES origin to /api/v3 and /api/graphql without the version header", () => {
+    // GHES serves GraphQL at /api/graphql, NOT /api/v3/graphql — the pair cannot be derived
+    // from the REST base. The version header is omitted: GHES only accepts its own date value.
+    expect(resolveApi("https://github.example.com")).toEqual({
+      restBase: "https://github.example.com/api/v3",
+      graphqlUrl: "https://github.example.com/api/graphql",
+      versioned: false,
+    });
+  });
+
+  it("keeps the origin's scheme and port for GHES (e2e loopback)", () => {
+    expect(resolveApi("http://127.0.0.1:8471").restBase).toBe("http://127.0.0.1:8471/api/v3");
+  });
+});
+
+describe("permissionPatterns", () => {
+  it("needs only the instance origin for GHES (API is same-origin)", () => {
+    expect(permissionPatterns("https://github.example.com")).toEqual(["https://github.example.com/*"]);
+  });
+
+  it("adds the api subdomain for ghe.com (API is cross-origin)", () => {
+    expect(permissionPatterns("https://acme.ghe.com")).toEqual([
+      "https://acme.ghe.com/*",
+      "https://api.acme.ghe.com/*",
+    ]);
+  });
+});
+
+describe("scriptSyncPlan", () => {
+  it("registers granted origins that are missing and drops registrations without a backing instance", () => {
+    // "some-other-extension-script" lacks the prefablens prefix: sync must never touch foreign IDs
+    const plan = scriptSyncPlan(
+      [scriptId("https://old.example.com"), "some-other-extension-script"],
+      ["https://new.example.com"],
+    );
+    expect(plan).toEqual({ add: ["https://new.example.com"], remove: [scriptId("https://old.example.com")] });
+  });
+
+  it("is a no-op when registrations already match", () => {
+    expect(scriptSyncPlan([scriptId("https://a.example.com")], ["https://a.example.com"])).toEqual({
+      add: [],
+      remove: [],
+    });
+  });
+});

--- a/extension/src/github/hosts.ts
+++ b/extension/src/github/hosts.ts
@@ -1,0 +1,54 @@
+// GitHub instance model: which API endpoints and permissions a page origin implies.
+// github.com and plain Enterprise Cloud live on github.com; data-residency Enterprise
+// Cloud is `<sub>.ghe.com` with the API on an `api.` subdomain; anything else is treated
+// as GHES, which serves REST under /api/v3 and GraphQL under /api/graphql on the same origin.
+
+export const GITHUB_ORIGIN = "https://github.com";
+
+export type HostApi = {
+  restBase: string;
+  graphqlUrl: string;
+  // Calendar-versioned API (x-github-api-version): github.com and ghe.com accept 2022-11-28;
+  // GHES accepts only its own release's date, so the header is omitted there.
+  versioned: boolean;
+};
+
+// origin → { pat }. github.com is absent by design: its token stays under the legacy `pat` key.
+export type Instances = Record<string, { pat?: string }>;
+
+export function resolveApi(origin: string): HostApi {
+  if (origin === GITHUB_ORIGIN) {
+    return { restBase: "https://api.github.com", graphqlUrl: "https://api.github.com/graphql", versioned: true };
+  }
+  const host = new URL(origin).host;
+  if (host.endsWith(".ghe.com")) {
+    return { restBase: `https://api.${host}`, graphqlUrl: `https://api.${host}/graphql`, versioned: true };
+  }
+  return { restBase: `${origin}/api/v3`, graphqlUrl: `${origin}/api/graphql`, versioned: false };
+}
+
+/** Host permission patterns an instance needs: the page origin, plus the API origin when it differs. */
+export function permissionPatterns(origin: string): string[] {
+  const patterns = [`${origin}/*`];
+  const host = new URL(origin).host;
+  if (host.endsWith(".ghe.com")) patterns.push(`https://api.${host}/*`);
+  return patterns;
+}
+
+// Dynamic content-script registrations are namespaced so sync never touches foreign IDs.
+export const SCRIPT_PREFIX = "prefablens-instance:";
+
+export function scriptId(origin: string): string {
+  return `${SCRIPT_PREFIX}${origin}`;
+}
+
+/** Diffs current registrations against permission-granted instances (registrations are
+ *  cleared on extension update, and permissions can be revoked from chrome://extensions). */
+export function scriptSyncPlan(registeredIds: string[], grantedOrigins: string[]): { add: string[]; remove: string[] } {
+  const want = new Set(grantedOrigins.map(scriptId));
+  const have = new Set(registeredIds);
+  return {
+    add: grantedOrigins.filter((origin) => !have.has(scriptId(origin))),
+    remove: registeredIds.filter((id) => id.startsWith(SCRIPT_PREFIX) && !want.has(id)),
+  };
+}

--- a/extension/src/github/resolved.ts
+++ b/extension/src/github/resolved.ts
@@ -2,8 +2,7 @@ import type { DiffV2 } from "../types";
 
 /** Host-side resolution seam. Attaches with the same scoping rule as core's "resolved".
  *  Lives apart from guids.ts so the site demo bundle (src/demo.ts) can import it
- *  without pulling the GitHub client (whose module init needs the build-time
- *  __API_BASE__ define). */
+ *  without pulling the GitHub client and its instance-resolution machinery. */
 export function applyResolved(diff: DiffV2, index: Map<string, string>): DiffV2 {
   const resolved: Record<string, string> = {};
   for (const g of diff.unresolvedGuids) {

--- a/extension/src/globals.d.ts
+++ b/extension/src/globals.d.ts
@@ -1,2 +1,0 @@
-// esbuild's `define` (see build.mjs) inlines this at build time; vitest.config.ts defines it for tests.
-declare const __API_BASE__: string;

--- a/extension/src/options/options.test.ts
+++ b/extension/src/options/options.test.ts
@@ -27,6 +27,33 @@ function fakeClipboard() {
   };
 }
 
+// Records permission/registration calls; grant=false simulates the user declining Chrome's prompt.
+function fakeInstanceIo(grant = true) {
+  const granted: string[][] = [];
+  const removed: string[][] = [];
+  const registered: string[] = [];
+  const unregistered: string[] = [];
+  return {
+    granted,
+    removed,
+    registered,
+    unregistered,
+    async requestPermission(patterns: string[]) {
+      granted.push(patterns);
+      return grant;
+    },
+    async removePermission(patterns: string[]) {
+      removed.push(patterns);
+    },
+    async registerScript(origin: string) {
+      registered.push(origin);
+    },
+    async unregisterScript(origin: string) {
+      unregistered.push(origin);
+    },
+  };
+}
+
 const code: DeviceCode = {
   deviceCode: "dc1",
   userCode: "ABCD-1234",
@@ -54,6 +81,7 @@ describe("initOptions", () => {
       document,
       fakeStorage({ pat: "tok" }),
       fakeFlow(async () => ({ status: "ok", token: "tok" })),
+      fakeInstanceIo(),
     );
     expect(document.querySelector("#signin-state")?.textContent).toBe("Signed in");
   });
@@ -64,6 +92,7 @@ describe("initOptions", () => {
       document,
       fakeStorage(),
       fakeFlow(async () => ({ status: "ok", token: "tok" })),
+      fakeInstanceIo(),
     );
     expect(document.querySelector("#signin-state")?.textContent).toBe("Not signed in");
   });
@@ -75,6 +104,7 @@ describe("initOptions", () => {
       document,
       storage,
       fakeFlow(async () => ({ status: "ok", token: "tok123" })),
+      fakeInstanceIo(),
     );
     document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
@@ -92,6 +122,7 @@ describe("initOptions", () => {
       document,
       storage,
       fakeFlow(async () => ({ status: "denied" })),
+      fakeInstanceIo(),
     );
     document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
@@ -108,6 +139,7 @@ describe("initOptions", () => {
       document,
       storage,
       fakeFlow(async () => ({ status: "expired" })),
+      fakeInstanceIo(),
     );
     document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
@@ -129,6 +161,7 @@ describe("initOptions", () => {
           throw new Error("network down");
         },
       ),
+      fakeInstanceIo(),
     );
     document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
@@ -148,6 +181,7 @@ describe("initOptions", () => {
       document,
       storage,
       fakeFlow(() => pending),
+      fakeInstanceIo(),
     );
     document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
@@ -173,6 +207,7 @@ describe("initOptions", () => {
       document,
       fakeStorage(),
       fakeFlow(() => pending),
+      fakeInstanceIo(),
     );
     const signin = must(document.querySelector<HTMLButtonElement>("#signin"));
     signin.click();
@@ -188,11 +223,85 @@ describe("initOptions", () => {
   it("copies the user code to the clipboard", async () => {
     document.body.innerHTML = OPTIONS_BODY;
     const flow = fakeFlow(async () => ({ status: "denied" }));
-    await initOptions(document, fakeStorage(), flow);
+    await initOptions(document, fakeStorage(), flow, fakeInstanceIo());
     document.querySelector<HTMLButtonElement>("#signin")?.click();
     await flush();
     document.querySelector<HTMLButtonElement>("#copy-code")?.click();
     await flush();
     expect(flow.clipboard.writes).toEqual(["ABCD-1234"]);
+  });
+});
+
+describe("enterprise instances", () => {
+  const denied = () => fakeFlow(async () => ({ status: "denied" }));
+
+  it("adds an instance: permission request, script registration, storage entry", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage();
+    const io = fakeInstanceIo();
+    await initOptions(document, storage, denied(), io);
+    // input beyond the origin is normalized away
+    must(document.querySelector<HTMLInputElement>("#instance-origin")).value = "https://github.example.com/some/page";
+    must(document.querySelector<HTMLButtonElement>("#instance-add-button")).click();
+    await flush();
+    // GHES needs only its own origin pattern (the API is same-origin under /api/v3)
+    expect(io.granted).toEqual([["https://github.example.com/*"]]);
+    expect(io.registered).toEqual(["https://github.example.com"]);
+    expect(storage.data.instances).toEqual({ "https://github.example.com": {} });
+    expect(document.querySelector('[data-origin="https://github.example.com"]')).not.toBeNull();
+  });
+
+  it("rejects github.com and invalid input without requesting permission", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const io = fakeInstanceIo();
+    await initOptions(document, fakeStorage(), denied(), io);
+    for (const value of ["https://github.com", "not a url"]) {
+      must(document.querySelector<HTMLInputElement>("#instance-origin")).value = value;
+      must(document.querySelector<HTMLButtonElement>("#instance-add-button")).click();
+      await flush();
+      // each rejection explains itself instead of silently doing nothing
+      expect(document.querySelector("#instance-status")?.textContent).not.toBe("");
+    }
+    expect(io.granted).toEqual([]);
+  });
+
+  it("keeps the instance out of storage when the permission is declined", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage();
+    const io = fakeInstanceIo(false);
+    await initOptions(document, storage, denied(), io);
+    must(document.querySelector<HTMLInputElement>("#instance-origin")).value = "https://github.example.com";
+    must(document.querySelector<HTMLButtonElement>("#instance-add-button")).click();
+    await flush();
+    expect(io.registered).toEqual([]);
+    expect(storage.data.instances).toBeUndefined();
+  });
+
+  it("saves a PAT for a listed instance", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage({ instances: { "https://github.example.com": {} } });
+    await initOptions(document, storage, denied(), fakeInstanceIo());
+    const item = must(document.querySelector('[data-origin="https://github.example.com"]'));
+    must(item.querySelector<HTMLInputElement>("input[type=password]")).value = "ghp_x";
+    must(item.querySelector<HTMLButtonElement>("[data-save]")).click();
+    await flush();
+    expect((storage.data.instances as Record<string, { pat?: string }>)["https://github.example.com"]?.pat).toBe(
+      "ghp_x",
+    );
+  });
+
+  it("removes an instance: unregister, permission removal, storage cleanup", async () => {
+    document.body.innerHTML = OPTIONS_BODY;
+    const storage = fakeStorage({ instances: { "https://acme.ghe.com": { pat: "t" } } });
+    const io = fakeInstanceIo();
+    await initOptions(document, storage, denied(), io);
+    const item = must(document.querySelector('[data-origin="https://acme.ghe.com"]'));
+    must(item.querySelector<HTMLButtonElement>("[data-remove]")).click();
+    await flush();
+    expect(io.unregistered).toEqual(["https://acme.ghe.com"]);
+    // ghe.com carries the extra api-subdomain pattern granted at add time
+    expect(io.removed).toEqual([["https://acme.ghe.com/*", "https://api.acme.ghe.com/*"]]);
+    expect(storage.data.instances).toEqual({});
+    expect(document.querySelector('[data-origin="https://acme.ghe.com"]')).toBeNull();
   });
 });

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -1,4 +1,5 @@
 import { type DeviceCode, type PollResult, pollForToken, requestDeviceCode } from "../github/deviceFlow";
+import { GITHUB_ORIGIN, type Instances, permissionPatterns, scriptId } from "../github/hosts";
 import { must } from "../util/must";
 
 // Keep the form body on the TS side: options.html and the jsdom tests share the same markup.
@@ -12,6 +13,17 @@ export const OPTIONS_BODY = `
     <button id="copy-code" type="button">Copy code</button>
   </div>
   <span id="status" role="status"></span>
+  <h2>Enterprise instances</h2>
+  <p>
+    GitHub Enterprise Server or ghe.com: add the instance, then paste a personal access token
+    with repo read access. Sign in with GitHub above covers github.com only.
+  </p>
+  <div>
+    <input id="instance-origin" type="url" placeholder="https://github.example.com" />
+    <button id="instance-add-button" type="button">Add instance</button>
+  </div>
+  <ul id="instance-list"></ul>
+  <span id="instance-status" role="status"></span>
 `;
 
 type StorageLike = {
@@ -31,7 +43,20 @@ export type SignInFlow = {
   clipboard: ClipboardLike;
 };
 
-export async function initOptions(doc: Document, storage: StorageLike, flow: SignInFlow): Promise<void> {
+// Chrome permission/registration side effects, injected so jsdom tests stay chrome-free.
+export type InstanceIo = {
+  requestPermission(patterns: string[]): Promise<boolean>;
+  removePermission(patterns: string[]): Promise<void>;
+  registerScript(origin: string): Promise<void>;
+  unregisterScript(origin: string): Promise<void>;
+};
+
+export async function initOptions(
+  doc: Document,
+  storage: StorageLike,
+  flow: SignInFlow,
+  instanceIo: InstanceIo,
+): Promise<void> {
   const signinState = must(doc.querySelector<HTMLElement>("#signin-state"));
   const signinButton = must(doc.querySelector<HTMLButtonElement>("#signin"));
   const flowArea = must(doc.querySelector<HTMLElement>("#flow"));
@@ -80,14 +105,125 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
   copyButton.addEventListener("click", () => {
     void flow.clipboard.writeText(userCode.textContent ?? "");
   });
+
+  const originInput = must(doc.querySelector<HTMLInputElement>("#instance-origin"));
+  const addButton = must(doc.querySelector<HTMLButtonElement>("#instance-add-button"));
+  const list = must(doc.querySelector<HTMLUListElement>("#instance-list"));
+  const instanceStatus = must(doc.querySelector<HTMLElement>("#instance-status"));
+
+  const loadInstances = async (): Promise<Instances> =>
+    ((await storage.get(["instances"])).instances as Instances | undefined) ?? {};
+
+  // Instance rows are built with createElement/textContent only: origins are user input.
+  const renderInstances = (instances: Instances): void => {
+    list.textContent = "";
+    for (const [origin, entry] of Object.entries(instances)) {
+      const item = doc.createElement("li");
+      item.setAttribute("data-origin", origin);
+      const label = doc.createElement("code");
+      label.textContent = origin;
+      const pat = doc.createElement("input");
+      pat.type = "password";
+      pat.placeholder = "Personal access token";
+      const state = doc.createElement("span");
+      state.textContent = entry.pat ? "Token set" : "No token";
+      const save = doc.createElement("button");
+      save.type = "button";
+      save.setAttribute("data-save", "");
+      save.textContent = "Save token";
+      save.addEventListener("click", () => {
+        void (async () => {
+          const current = await loadInstances();
+          await storage.set({ instances: { ...current, [origin]: { pat: pat.value } } });
+          pat.value = ""; // consumed: never keep the token visible in the form
+          state.textContent = "Token set";
+        })();
+      });
+      const remove = doc.createElement("button");
+      remove.type = "button";
+      remove.setAttribute("data-remove", "");
+      remove.textContent = "Remove";
+      remove.addEventListener("click", () => {
+        void (async () => {
+          await instanceIo.unregisterScript(origin);
+          await instanceIo.removePermission(permissionPatterns(origin));
+          const { [origin]: _gone, ...rest } = await loadInstances();
+          await storage.set({ instances: rest });
+          renderInstances(rest);
+        })();
+      });
+      item.append(label, pat, save, remove, state);
+      list.append(item);
+    }
+  };
+
+  addButton.addEventListener("click", () => {
+    void (async () => {
+      instanceStatus.textContent = "";
+      // Everything before requestPermission stays synchronous: the permission prompt
+      // must be reachable from the click's transient user gesture.
+      let origin: string;
+      try {
+        const url = new URL(originInput.value.trim());
+        if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error("scheme");
+        origin = url.origin;
+      } catch {
+        instanceStatus.textContent = "Enter the instance URL, like https://github.example.com";
+        return;
+      }
+      if (origin === GITHUB_ORIGIN) {
+        instanceStatus.textContent = "github.com works out of the box — use Sign in with GitHub above";
+        return;
+      }
+      const granted = await instanceIo.requestPermission(permissionPatterns(origin));
+      if (!granted) {
+        instanceStatus.textContent = "Permission was not granted";
+        return;
+      }
+      await instanceIo.registerScript(origin);
+      const current = await loadInstances();
+      const next = { ...current, [origin]: current[origin] ?? {} };
+      await storage.set({ instances: next });
+      originInput.value = "";
+      renderInstances(next);
+    })();
+  });
+
+  renderInstances(await loadInstances());
 }
 
 if (typeof chrome !== "undefined" && chrome.storage) {
   document.body.innerHTML = OPTIONS_BODY;
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-  void initOptions(document, chrome.storage.local, {
-    requestDeviceCode: () => requestDeviceCode(fetch),
-    pollForToken: (code) => pollForToken(fetch, sleep, code),
-    clipboard: navigator.clipboard,
-  });
+  void initOptions(
+    document,
+    chrome.storage.local,
+    {
+      requestDeviceCode: () => requestDeviceCode(fetch),
+      pollForToken: (code) => pollForToken(fetch, sleep, code),
+      clipboard: navigator.clipboard,
+    },
+    {
+      requestPermission: (patterns) => chrome.permissions.request({ origins: patterns }),
+      removePermission: async (patterns) => {
+        await chrome.permissions.remove({ origins: patterns }).catch(() => {});
+      },
+      registerScript: async (origin) => {
+        const existing = await chrome.scripting.getRegisteredContentScripts({ ids: [scriptId(origin)] });
+        if (existing.length) return; // re-adding an instance must not double-register
+        await chrome.scripting.registerContentScripts([
+          {
+            id: scriptId(origin),
+            matches: [`${origin}/*`],
+            js: ["content.js"],
+            runAt: "document_idle",
+            persistAcrossSessions: true,
+          },
+        ]);
+      },
+      unregisterScript: async (origin) => {
+        await chrome.scripting.unregisterContentScripts({ ids: [scriptId(origin)] }).catch(() => {});
+      },
+    },
+  );
 }

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -7,6 +7,7 @@ import {
   render,
   renderError,
   renderLoading,
+  renderPatNeeded,
   renderSignIn,
   renderSignInPending,
   renderTooLarge,
@@ -596,6 +597,20 @@ describe("renderSignIn", () => {
     expect(button?.textContent).toBe("Sign in with GitHub");
     button?.click();
     expect(clicks).toBe(1);
+  });
+});
+
+describe("renderPatNeeded", () => {
+  it("renders the PAT instruction and an options button that invokes the callback", () => {
+    const root = freshRoot();
+    let opened = 0;
+    renderPatNeeded(root, () => opened++);
+    // Non-github.com instances cannot run the device flow: the panel points at the options page instead
+    expect(root.querySelector(".pl-error")?.textContent).toContain("personal access token");
+    const button = root.querySelector<HTMLButtonElement>("button.pl-render");
+    expect(button?.textContent).toBe("Open extension options");
+    button?.click();
+    expect(opened).toBe(1);
   });
 });
 

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -101,6 +101,20 @@ export function renderSignIn(root: ShadowRoot, message: string, onSignIn: () => 
   container.append(note("pl-error", message, ALERT), button);
 }
 
+/** Non-github.com instances: the device flow cannot run there, so point at the options page instead. */
+export function renderPatNeeded(root: ShadowRoot, onOpenOptions: () => void): void {
+  const container = mount(root);
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "pl-render";
+  button.textContent = "Open extension options";
+  button.addEventListener("click", onOpenOptions);
+  container.append(
+    note("pl-error", "Set a personal access token for this GitHub instance in the extension options.", ALERT),
+    button,
+  );
+}
+
 /** Device-flow pending state: keeps the user code visible while the user authorizes on GitHub. */
 export function renderSignInPending(
   root: ShadowRoot,

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -83,6 +83,7 @@ export function targetKey(owner: string, repo: string, target: DiffTarget): stri
 // content ↔ background messages (chrome.runtime only serializes JSON)
 export type SemanticDiffRequest = {
   type: "semanticDiff";
+  origin: string; // page origin — selects the GitHub instance (API base + credentials)
   owner: string;
   repo: string;
   target: DiffTarget;
@@ -90,8 +91,10 @@ export type SemanticDiffRequest = {
   force?: boolean; // render past the 25MB guard ("Render anyway" click)
 };
 
-export type PrefetchRequest = { type: "prefetch"; owner: string; repo: string; prNumber: number };
-export type BackgroundRequest = SemanticDiffRequest | PrefetchRequest;
+export type PrefetchRequest = { type: "prefetch"; origin: string; owner: string; repo: string; prNumber: number };
+// Sent by content scripts on non-github.com instances, where the device flow cannot run.
+export type OpenOptionsRequest = { type: "openOptions" };
+export type BackgroundRequest = SemanticDiffRequest | PrefetchRequest | OpenOptionsRequest;
 
 export type BackgroundError =
   | "pat-missing"

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  define: { __API_BASE__: '"https://api.github.com"' },
   test: { include: ["src/**/*.test.ts"] },
 });


### PR DESCRIPTION
## Summary

Makes the Chrome extension work on GitHub Enterprise Server and ghe.com (Enterprise Cloud with data residency): the API base and GraphQL endpoint are resolved at runtime from the page origin, enterprise instances are added from the options page via optional host permissions and dynamic content-script registration, and non-github.com instances authenticate with a manually entered PAT.

## Motivation

The extension was hard-coded to github.com in five places (static `content_scripts` matches, `host_permissions`, the build-time `__API_BASE__` define, github.com-only device flow endpoints, and a GraphQL URL derived as `${restBase}/graphql`), so enterprise users could not use PrefabLens at all.

Closes #120

## Changes

- New `src/github/hosts.ts` resolves a page origin to its `HostApi` (REST base, GraphQL URL, version-header policy): `https://api.github.com` for github.com, `https://api.<host>` for `*.ghe.com`, `<origin>/api/v3` for GHES — with GraphQL at `/graphql`, `/graphql`, and `/api/graphql` respectively. `x-github-api-version` is omitted on GHES (each release accepts only its own date value).
- `GithubClient` consumes a `HostApi` instead of a base string; the `__API_BASE__` build-time define is gone from `build.mjs`, `vitest.config.ts`, and `globals.d.ts`.
- `semanticDiff`/`prefetch` messages carry the page origin (overridden by `sender.origin` in the background as the trusted source); settings, clients, and the PR-context cache are resolved per origin. Repo caches stay keyed by `<restBase>/<owner>/<repo>`, so github.com keys are unchanged and instances never collide.
- Options page gains an "Enterprise instances" section: adding an instance requests host permission in the click's user gesture, registers the content script via `chrome.scripting.registerContentScripts`, and offers per-instance PAT entry/removal. The background reconciles registrations on every service-worker start (registrations are cleared on extension update; permissions can be revoked).
- On non-github.com instances the auth panel steers to the options page (`renderPatNeeded` + `openOptions` message) instead of the github.com-only device flow, and the `/login/device` autofill is gated to github.com. A PAT saved for the instance auto-retries blocked panels.
- `manifest.json`: `optional_host_permissions: ["*://*/*"]` and the `scripting` permission (no new install-time warning; effective access is granted per instance at runtime — the Refined GitHub precedent).
- The e2e fake server now serves the GHES path shape (`/api/v3` REST, `/api/graphql` GraphQL) with a per-instance PAT, so the Playwright suite exercises the Enterprise layout end-to-end; the device-flow smoke tests run on an intercepted `https://github.com` origin.

## Testing

```
$ pnpm typecheck && pnpm lint && pnpm test
Checked 63 files in 42ms. No fixes applied.
Test Files  25 passed (25)
     Tests  283 passed (283)

$ pnpm e2e
19 passed (1.9s)
```

Not verified against a live GHES/ghe.com instance (none available); the GHES API path shape is covered end-to-end by the reworked e2e suite, and github.com behavior is pinned by unit tests. Real-instance smoke remains a follow-up. The ghe.com API shape (`api.<sub>.ghe.com`) follows the data-residency docs and shares all mechanics with the unit-tested GHES path.