### PR TITLE
ci: unify lint reporting to fail-only

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -8,7 +8,7 @@
     "build": "node build.mjs",
     "demo": "node build.mjs --demo",
     "typecheck": "tsc --noEmit",
-    "lint": "biome ci .",
+    "lint": "biome ci --reporter=default .",
     "fmt": "biome check --write .",
     "pretest": "zig build wasm",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

Suppress Biome's GitHub annotations in CI so that all three lint gates (Zig, C#, TS) report violations identically: a failing CI step with plain console output.

## Motivation

`biome ci` auto-detects `GITHUB_ACTIONS` and emits `::error` workflow commands, so the extension gate decorated PRs with annotations while the Zig (`zig fmt --check`) and C# (`csharpier check`) gates stayed silent. The desired unified behavior is fail-only.

Closes #218

## Changes

- `extension/package.json`: `"lint": "biome ci ."` → `"lint": "biome ci --reporter=default ."` — an explicit reporter overrides Biome's GitHub Actions auto-detection.

## Testing

Clean tree (`extension/`):

```
$ pnpm run lint
$ biome ci --reporter=default .
Checked 62 files in 46ms. No fixes applied.
clean exit=0
```

Deliberately misformatted file with `GITHUB_ACTIONS=true` (old vs new):

```
$ GITHUB_ACTIONS=true pnpm exec biome ci bad.ts
old exit=1
old :: lines: 2
$ GITHUB_ACTIONS=true pnpm exec biome ci --reporter=default bad.ts
new exit=1
new :: lines: 0
```

Exit codes stay non-zero in both cases, so CI still fails on violations; only the annotation output is gone.