### PR TITLE
ci: guard version sync across pinned files

### DIFF
--- a/.github/scripts/check-version-sync.sh
+++ b/.github/scripts/check-version-sync.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Guard that the release version stays in sync across the five version-pinned
+# files fanned out by .bumpversion.toml. Each extraction below mirrors that
+# file's search pattern in .bumpversion.toml, so this guard and the release
+# tooling agree on what "the version" is.
+set -eu
+
+cd "$(dirname "$0")/../.."
+
+status=0
+reference=""
+
+# $1: file path, $2: extracted version (empty when the marker is missing)
+check() {
+  file=$1
+  version=$2
+  if [ -z "$version" ]; then
+    version="(version marker not found)"
+    status=1
+  fi
+  printf '%s: %s\n' "$file" "$version"
+  if [ -z "$reference" ]; then
+    reference=$version
+  elif [ "$version" != "$reference" ]; then
+    status=1
+  fi
+}
+
+check build.zig.zon \
+  "$(sed -n 's/.*\.version = "\([^"]*\)".*/\1/p' build.zig.zon | head -n 1)"
+check extension/manifest.json \
+  "$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' extension/manifest.json | head -n 1)"
+check editor/package.json \
+  "$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' editor/package.json | head -n 1)"
+check editor/Editor/Cli.cs \
+  "$(sed -n 's/.*public const string Version = "\([^"]*\)".*/\1/p' editor/Editor/Cli.cs | head -n 1)"
+check extension/package.json \
+  "$(sed -n 's/.*"version": "\([^"]*\)".*/\1/p' extension/package.json | head -n 1)"
+
+if [ "$status" -ne 0 ]; then
+  echo "Version mismatch: the files above must all carry the same version." >&2
+  exit 1
+fi
+echo "Version sync OK: $reference"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
+      - name: Version sync guard
+        if: matrix.os == 'ubuntu-latest'
+        run: .github/scripts/check-version-sync.sh
       - name: Install tools
         uses: jdx/mise-action@v4
       - name: Restore Zig global cache


### PR DESCRIPTION
## Summary

Adds a CI guard that fails when the five version-pinned files fanned out by `.bumpversion.toml` no longer carry the same version.

## Motivation

The release version lives in five files (`build.zig.zon`, `extension/manifest.json`, `editor/package.json`, `editor/Editor/Cli.cs`, `extension/package.json`), but nothing checked between releases that they still agree. Drift only surfaced at release time when bump-my-version's search failed.

Closes #192

## Changes

- Add `.github/scripts/check-version-sync.sh`, a POSIX shell script that extracts each file's version by mirroring its search pattern in `.bumpversion.toml`, prints every file's value, and exits non-zero when any value diverges or a version marker is missing
- Add one `Version sync guard` step to the existing `core` job in `.github/workflows/ci.yml`, right after checkout (needs no toolchain), gated to `ubuntu-latest` since the matrix also runs Windows

## Testing

Current tree passes:

```
$ .github/scripts/check-version-sync.sh
build.zig.zon: 0.8.0
extension/manifest.json: 0.8.0
editor/package.json: 0.8.0
editor/Editor/Cli.cs: 0.8.0
extension/package.json: 0.8.0
Version sync OK: 0.8.0
(exit 0)
```

Induced drift (`editor/package.json` set to 0.7.9) fails and names each file and value:

```
build.zig.zon: 0.8.0
extension/manifest.json: 0.8.0
editor/package.json: 0.7.9
editor/Editor/Cli.cs: 0.8.0
extension/package.json: 0.8.0
Version mismatch: the files above must all carry the same version.
(exit 1)
```

Missing marker (`Version =` renamed in `editor/Editor/Cli.cs`) also fails:

```
editor/Editor/Cli.cs: (version marker not found)
Version mismatch: the files above must all carry the same version.
(exit 1)
```

After restoring both files the guard passes again with exit 0.