### PR TITLE
refactor: tidy diff-split leftovers

### DIFF
--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const model = @import("model.zig");
 const testing = std.testing;
 
-fn findDoc(fd: FlatDiff, file_id: i64) ?DocDiff {
+// Test-only lookup of one document's diff by fileID.
+// pub: diff_overrides' tests use it too.
+pub fn findDoc(fd: FlatDiff, file_id: i64) ?DocDiff {
     for (fd.docs) |d| if (d.file_id == file_id) return d;
     return null;
 }
@@ -383,10 +385,6 @@ const diff_overrides = @import("diff_overrides.zig");
 const Node = model.Node;
 const Status = model.Status;
 const FieldDiff = model.FieldDiff;
-
-// Re-exported for instantiate, which reaches the override helpers through this module.
-pub const modKeyOf = diff_overrides.modKeyOf;
-pub const soleInstanceOverridesSkipping = diff_overrides.soleInstanceOverridesSkipping;
 
 pub const DocDiff = struct {
     file_id: i64,

--- a/core/src/diff_overrides.zig
+++ b/core/src/diff_overrides.zig
@@ -9,10 +9,7 @@ const testing = std.testing;
 const Node = model.Node;
 const Status = model.Status;
 
-fn findDoc(fd: diffmod.FlatDiff, file_id: i64) ?diffmod.DocDiff {
-    for (fd.docs) |d| if (d.file_id == file_id) return d;
-    return null;
-}
+const findDoc = diffmod.findDoc;
 
 test "diff: sortByGroup keeps same-group rows contiguous beyond known ranks" {
     // The renderer relies on "rows of the same group are contiguous" as a core invariant.

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -6,12 +6,10 @@ const std = @import("std");
 const model = @import("model.zig");
 const parser = @import("parser.zig");
 const diffmod = @import("diff.zig");
+const diff_overrides = @import("diff_overrides.zig");
 const tree = @import("tree.zig");
 
 pub const Assets = std.StringHashMapUnmanaged([]const u8);
-
-// Depth limit for nested expansion (same idea as tree.zig's max_instance_hops).
-const max_depth = 8;
 
 const Ctx = struct {
     arena: std.mem.Allocator,
@@ -54,7 +52,7 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     if (node.kind != .prefab_instance) return;
     if (node.status != .added and node.status != .removed) return;
     const guid = node.source_guid orelse return;
-    if (depth >= max_depth or inChain(ctx, guid)) return;
+    if (depth >= model.max_prefab_nesting or inChain(ctx, guid)) return;
     const side: model.SourceSide = if (node.status == .added) .after else .before;
     const bytes = ctx.assets.get(guid) orelse {
         try ctx.needed.put(ctx.arena, guid, side);
@@ -99,7 +97,7 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
         node.children = try concatObjects(ctx.arena, node.children, sub.roots);
     }
     // Keep unapplied mods as rows (don't drop them silently).
-    const leftover = try diffmod.soleInstanceOverridesSkipping(ctx.arena, inst_doc, node.status, &applied);
+    const leftover = try diff_overrides.soleInstanceOverridesSkipping(ctx.arena, inst_doc, node.status, &applied);
     node.overrides = try concatOverrides(ctx.arena, leftover, inner_overrides);
 }
 
@@ -179,7 +177,7 @@ fn applyModifications(arena: std.mem.Allocator, inst_doc: *const model.Document,
             break;
         }
         if (!handled) handled = try pushDown(arena, src_docs, target.ref.file_id, pp, value, obj_ref);
-        if (handled) try applied.put(arena, try diffmod.modKeyOf(arena, target.ref.file_id, pp.scalar), {});
+        if (handled) try applied.put(arena, try diff_overrides.modKeyOf(arena, target.ref.file_id, pp.scalar), {});
     }
     return applied;
 }

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -73,6 +73,12 @@ pub const Status = enum { added, removed, modified, unchanged };
 
 pub const ObjectKind = enum { game_object, prefab_instance };
 
+// Bound on prefab nesting, shared by tree building (instance-chain hops) and
+// source expansion (recursion depth). Real projects nest a few levels; the
+// bound also stops cycles in broken files where stripped PrefabInstances
+// reference each other.
+pub const max_prefab_nesting = 8;
+
 // Per-(target, propertyPath) override diff for a PrefabInstance.
 pub const OverrideDiff = struct {
     group: []const u8, // "Transform" | "GameObject" | "Overrides"

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -84,16 +84,12 @@ fn instanceName(idx: *Index, pi_id: i64) []const u8 {
     return modificationValue(idx, pi_id, "m_Name") orelse "";
 }
 
-// Hop limit for walking the nesting chain. Stops even if stripped PrefabInstances
-// reference each other cyclically in a broken file (real projects nest a few levels).
-const max_instance_hops = 8;
-
 // Walk the m_PrefabInstance chain of a stripped PrefabInstance outward and
 // return the file_id of the real (non-stripped) PrefabInstance.
 fn resolveInstanceChain(idx: *Index, start_id: i64) ?i64 {
     var id = start_id;
     var hops: usize = 0;
-    while (hops < max_instance_hops) : (hops += 1) {
+    while (hops < model.max_prefab_nesting) : (hops += 1) {
         const doc = idx.structuralDoc(id) orelse return null;
         if (doc.class_id != 1001) return null;
         if (!doc.stripped) return id;


### PR DESCRIPTION
## Summary

Cleans up the three seams left behind by the diff-split in PR #186: the duplicated `findDoc` test helper, the re-export shim in `diff.zig`, and the two independent magic values bounding prefab nesting.

## Motivation

PR #186 split the override diff into `diff_overrides.zig` but left mechanical leftovers that blur module boundaries. Removing them now also keeps `tree.zig` internals free of shared constants ahead of the planned tree split (#199).

Closes #202

## Changes

- `findDoc` now has one canonical definition in `diff.zig` (made `pub` with the repo's `// pub:` consumer comment, same pattern as `parenJoinNode`); `diff_overrides.zig` aliases it instead of duplicating it.
- `instantiate.zig` imports `diff_overrides.zig` directly for `modKeyOf` / `soleInstanceOverridesSkipping`; the re-export shim in `diff.zig` is removed.
- `max_depth` (instantiate.zig) and `max_instance_hops` (tree.zig) are replaced by a single shared constant `model.max_prefab_nesting = 8`, used directly at both call sites. `model.zig` is a neutral module both files already import, so no import cycles and nothing new lands inside `tree.zig` internals. The value is unchanged.

## Testing

```
$ zig build test --summary all
Build Summary: 6/6 steps succeeded; 181/181 tests passed
test success
+- run test 97 pass (97 total) 258ms MaxRSS:5M
|  +- compile test Debug native success 1s MaxRSS:362M
+- run test 84 pass (84 total) 1s MaxRSS:7M
   +- compile test Debug native success 1s MaxRSS:381M
      +- options cached

$ zig build lint --summary all
Build Summary: 2/2 steps succeeded
lint success
+- zig fmt --check success
```

Test totals are unchanged from `main` (181/181 before and after).