### PR TITLE
refactor: share override group walk in display

### DIFF
--- a/cli/src/display.zig
+++ b/cli/src/display.zig
@@ -51,27 +51,44 @@ pub fn refDisplay(r: model.Ref, resolved: ?*const core.json.Resolver) RefDisplay
     return .{ .file_id = r.file_id };
 }
 
-/// Heading status for the override group starting at `start`: that status if
-/// uniform within the group, modified if mixed.
-pub fn groupHeadingStatus(overrides: []const model.OverrideDiff, start: usize) model.Status {
-    const first = overrides[start];
-    for (overrides[start + 1 ..]) |ov| {
-        if (!std.mem.eql(u8, ov.group, first.group)) break;
-        if (ov.status != first.status) return .modified;
+/// Iterator over the consecutive same-group runs of an override list; each
+/// run renders as one card. The single place that derives group boundaries
+/// from `.group`, relying on the core invariant that same-group rows are
+/// contiguous (pinned by a test in core/src/diff_overrides.zig).
+pub const OverrideGroups = struct {
+    rest: []const model.OverrideDiff,
+
+    /// Rows of the next group, or null when exhausted. Never empty:
+    /// `group[0].group` is the group's heading name.
+    pub fn next(it: *OverrideGroups) ?[]const model.OverrideDiff {
+        if (it.rest.len == 0) return null;
+        var end: usize = 1;
+        while (end < it.rest.len and std.mem.eql(u8, it.rest[end].group, it.rest[0].group)) end += 1;
+        const group = it.rest[0..end];
+        it.rest = it.rest[end..];
+        return group;
     }
-    return first.status;
+};
+
+pub fn overrideGroups(overrides: []const model.OverrideDiff) OverrideGroups {
+    return .{ .rest = overrides };
+}
+
+/// Heading status for one group slice yielded by `overrideGroups`: the rows'
+/// shared status if uniform, modified if mixed.
+pub fn groupHeadingStatus(group: []const model.OverrideDiff) model.Status {
+    const first = group[0].status;
+    for (group[1..]) |ov| {
+        if (ov.status != first) return .modified;
+    }
+    return first;
 }
 
 /// Number of consecutive-group cards the overrides collapse into.
 pub fn overrideGroupCount(overrides: []const model.OverrideDiff) usize {
+    var groups = overrideGroups(overrides);
     var n: usize = 0;
-    var current: []const u8 = "";
-    for (overrides) |ov| {
-        if (!std.mem.eql(u8, current, ov.group)) {
-            current = ov.group;
-            n += 1;
-        }
-    }
+    while (groups.next() != null) n += 1;
     return n;
 }
 
@@ -86,6 +103,38 @@ pub fn unresolvedCount(res: model.DiffResult) usize {
 }
 
 const builtin_refs = @import("builtin_refs.zig");
+
+test "overrideGroups splits contiguous rows at each group-name change" {
+    const rows = [_]model.OverrideDiff{
+        .{ .group = "Transform", .label = "m_LocalPosition.x", .status = .modified, .before = null, .after = null },
+        .{ .group = "Transform", .label = "m_LocalPosition.y", .status = .added, .before = null, .after = null },
+        .{ .group = "Overrides", .label = "maxHp", .status = .added, .before = null, .after = null },
+    };
+    var groups = overrideGroups(&rows);
+
+    // First run: both Transform rows in input order.
+    const transform = groups.next().?;
+    try std.testing.expectEqual(@as(usize, 2), transform.len);
+    try std.testing.expectEqualStrings("m_LocalPosition.x", transform[0].label);
+    try std.testing.expectEqualStrings("m_LocalPosition.y", transform[1].label);
+    // Mixed statuses within the group read as modified on the heading.
+    try std.testing.expectEqual(model.Status.modified, groupHeadingStatus(transform));
+
+    // Second run: the single Overrides row; a uniform group keeps its status.
+    const overrides = groups.next().?;
+    try std.testing.expectEqual(@as(usize, 1), overrides.len);
+    try std.testing.expectEqualStrings("Overrides", overrides[0].group);
+    try std.testing.expectEqual(model.Status.added, groupHeadingStatus(overrides));
+
+    try std.testing.expectEqual(@as(?[]const model.OverrideDiff, null), groups.next());
+    // The card count is exactly the number of runs the iterator yields.
+    try std.testing.expectEqual(@as(usize, 2), overrideGroupCount(&rows));
+}
+
+test "overrideGroups yields nothing for an empty override list" {
+    var groups = overrideGroups(&.{});
+    try std.testing.expectEqual(@as(?[]const model.OverrideDiff, null), groups.next());
+}
 
 test "unresolvedCount ignores built-in guids" {
     var guids = [_][]const u8{ "abc123", builtin_refs.builtin_extra_guid };

--- a/cli/src/render_html.zig
+++ b/cli/src/render_html.zig
@@ -484,24 +484,17 @@ fn renderObject(w: *std.Io.Writer, o: model.ObjectDiff, resolved: ?*const core.j
 }
 
 fn renderOverrideGroups(w: *std.Io.Writer, overrides: []const model.OverrideDiff, resolved: ?*const core.json.Resolver) !void {
-    var current: []const u8 = "";
-    var i: usize = 0;
-    while (i < overrides.len) {
-        if (!std.mem.eql(u8, current, overrides[i].group)) {
-            if (current.len != 0) try w.writeAll("</div></details>");
-            current = overrides[i].group;
-            const hs = display.groupHeadingStatus(overrides, i);
-            try w.writeAll("<details open class=\"pl-comp");
-            try w.writeAll(statusClass(hs));
-            try w.writeAll("\">");
-            try writeSummary(w, hs, gear_svg, "pl-icon", current, .none, false);
-            try w.writeAll("<div class=\"pl-kids\">");
-        }
-        const ov = overrides[i];
-        try renderField(w, ov.label, ov.status, ov.before, ov.after, resolved);
-        i += 1;
+    var groups = display.overrideGroups(overrides);
+    while (groups.next()) |group| {
+        const hs = display.groupHeadingStatus(group);
+        try w.writeAll("<details open class=\"pl-comp");
+        try w.writeAll(statusClass(hs));
+        try w.writeAll("\">");
+        try writeSummary(w, hs, gear_svg, "pl-icon", group[0].group, .none, false);
+        try w.writeAll("<div class=\"pl-kids\">");
+        for (group) |ov| try renderField(w, ov.label, ov.status, ov.before, ov.after, resolved);
+        try w.writeAll("</div></details>");
     }
-    if (current.len != 0) try w.writeAll("</div></details>");
 }
 
 fn renderComponent(w: *std.Io.Writer, c: model.ComponentDiff, resolved: ?*const core.json.Resolver) !void {

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -502,14 +502,10 @@ fn renderObject(
         defer prefix.shrinkRetainingCapacity(inner_mark);
 
         var idx: usize = 0;
-        var current: []const u8 = "";
-        var i: usize = 0;
-        while (i < o.overrides.len) : (i += 1) {
-            if (!std.mem.eql(u8, current, o.overrides[i].group)) {
-                current = o.overrides[i].group;
-                idx += 1;
-                try renderCard(arena, w, .{ .group = .{ .overrides = o.overrides, .start = i } }, resolved, color, prefix, idx == card_count);
-            }
+        var groups = display.overrideGroups(o.overrides);
+        while (groups.next()) |group| {
+            idx += 1;
+            try renderCard(arena, w, .{ .group = group }, resolved, color, prefix, idx == card_count);
         }
         for (o.components) |c| {
             idx += 1;
@@ -529,7 +525,8 @@ fn continuation(branch: []const u8) []const u8 {
 
 const Card = union(enum) {
     component: model.ComponentDiff,
-    group: struct { overrides: []const model.OverrideDiff, start: usize },
+    /// One group slice yielded by display.overrideGroups.
+    group: []const model.OverrideDiff,
 };
 
 fn renderCard(
@@ -545,7 +542,7 @@ fn renderCard(
     try w.writeAll(if (last) "└─ " else "├─ ");
     const status: model.Status = switch (card) {
         .component => |c| c.status,
-        .group => |g| display.groupHeadingStatus(g.overrides, g.start),
+        .group => |g| display.groupHeadingStatus(g),
     };
     try signed(w, color, status);
     switch (card) {
@@ -559,7 +556,7 @@ fn renderCard(
                 if (color) try w.writeAll(Color.reset);
             }
         },
-        .group => |g| try w.writeAll(g.overrides[g.start].group),
+        .group => |g| try w.writeAll(g[0].group),
     }
     try w.writeByte('\n');
 
@@ -572,12 +569,8 @@ fn renderCard(
         .component => |c| for (c.fields) |f| {
             try renderFieldRow(w, f.path, f.status, status, f.before, f.after, resolved, color, prefix);
         },
-        .group => |g| {
-            const group_name = g.overrides[g.start].group;
-            for (g.overrides[g.start..]) |ov| {
-                if (!std.mem.eql(u8, ov.group, group_name)) break;
-                try renderFieldRow(w, ov.label, ov.status, status, ov.before, ov.after, resolved, color, prefix);
-            }
+        .group => |g| for (g) |ov| {
+            try renderFieldRow(w, ov.label, ov.status, status, ov.before, ov.after, resolved, color, prefix);
         },
     }
 }


### PR DESCRIPTION
## Summary

Hoist the override-group boundary walk into a single `OverrideGroups` iterator in `cli/src/display.zig` and have both CLI renderers (tree and HTML) plus display.zig's own `overrideGroupCount` consume group slices instead of re-deriving boundaries. Pure refactor: rendered output is byte-identical.

## Motivation

PR #185 shared the ref-display ladder, `overrideGroupCount`, and `groupHeadingStatus` across the renderers, but the actual boundary walk (comparing each row's `.group` to the previous one) was still hand-rolled in three places: `display.zig`, `render_tree.zig`, and `render_html.zig` — all leaning on the same-group-contiguity invariant pinned in `core/src/diff_overrides.zig`. Three independent copies can drift without the others noticing.

Closes #198

## Changes

- `display.zig`: new `OverrideGroups` iterator (`overrideGroups(overrides)`); `next()` yields each consecutive same-group run as a `[]const model.OverrideDiff` slice. This is now the only place that derives group boundaries from `.group`.
- `display.zig`: `groupHeadingStatus` now takes one group slice instead of `(overrides, start)` — its own boundary scan is gone. `overrideGroupCount` counts iterator runs.
- `render_tree.zig`: `renderObject` walks `display.overrideGroups`; `Card.group` becomes a plain group slice, which also removes the second hand-rolled boundary break-loop inside `renderCard`'s field emission.
- `render_html.zig`: `renderOverrideGroups` iterates groups and opens/closes each `<details>` card per group, replacing the `current`-sentinel open/close bookkeeping.
- New tests in `display.zig` pin the iterator's splitting behavior (multi-group run, heading status, count agreement, empty input).

## Testing

All 183 tests pass (181 existing unchanged — including the exact-output render snapshot tests in `render_tree.zig` / `render_html.zig`, which pin byte-identical output — plus 2 new iterator tests; main's baseline is 181/181):

```
$ zig build test --summary all
Build Summary: 6/6 steps succeeded; 183/183 tests passed
test success
+- run test 97 pass (97 total) 113ms MaxRSS:5M
|  +- compile test Debug native cached 43ms MaxRSS:39M
+- run test 86 pass (86 total) 1s MaxRSS:6M
   +- compile test Debug native cached 43ms MaxRSS:39M
      +- options cached

$ zig build lint --summary all
Build Summary: 2/2 steps succeeded
lint success
+- zig fmt --check success
```

End-to-end byte comparison of real CLI output between main and this branch — `--color` tree and `--html` for four fixture pairs (site RobotVariant, core plane/cylinder testdata, plus a crafted RobotVariant variant whose diff spans three groups: Transform, GameObject, and a mixed-status Overrides group) — all identical via `cmp`:

```
IDENTICAL: multi_tree
IDENTICAL: multi_html
IDENTICAL: variant_tree
IDENTICAL: variant_html
IDENTICAL: plane_tree
IDENTICAL: plane_html
IDENTICAL: cyl_tree
IDENTICAL: cyl_html
```
