### PR TITLE
test: add unit tests for wasm asset tlv parser

### DIFF
--- a/core/src/assets_tlv.zig
+++ b/core/src/assets_tlv.zig
@@ -1,0 +1,117 @@
+// Decoder for the wasm asset buffer, a binary TLV (LE):
+// [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }.
+// Factored out of wasm.zig so the native test build can compile it:
+// wasm.zig pins std.heap.wasm_allocator and only builds for wasm targets.
+const std = @import("std");
+const testing = std.testing;
+
+const Assets = @import("instantiate.zig").Assets;
+
+// A broken TLV returns error.TruncatedAssets; the wasm wrapper turns it
+// into the error.v1 payload (no trap).
+pub fn parseAssets(arena: std.mem.Allocator, bytes: []const u8) !Assets {
+    var assets: Assets = .empty;
+    if (bytes.len == 0) return assets;
+    var off: usize = 0;
+    const count = try readU32(bytes, &off);
+    var i: u32 = 0;
+    while (i < count) : (i += 1) {
+        const guid = try readChunk(bytes, &off);
+        const data = try readChunk(bytes, &off);
+        try assets.put(arena, guid, data);
+    }
+    return assets;
+}
+
+fn readU32(bytes: []const u8, off: *usize) !u32 {
+    if (bytes.len - off.* < 4) return error.TruncatedAssets;
+    const v = std.mem.readInt(u32, bytes[off.*..][0..4], .little);
+    off.* += 4;
+    return v;
+}
+
+fn readChunk(bytes: []const u8, off: *usize) ![]const u8 {
+    const len = try readU32(bytes, off);
+    if (bytes.len - off.* < len) return error.TruncatedAssets;
+    const s = bytes[off.*..][0..len];
+    off.* += len;
+    return s;
+}
+
+test "parseAssets: valid two-entry buffer round-trips" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Well-formed buffer: count=2 followed by two {guid, data} chunk pairs.
+    // Every u32 is little-endian and every payload matches its length prefix,
+    // so both entries must land in the map with their exact bytes.
+    const bytes = [_]u8{
+        2, 0, 0, 0, // count = 2
+        2, 0, 0, 0, 'a', 'a', // guid "aa" (len 2 + payload)
+        3, 0, 0, 0, 'A', 'A', 'A', // data "AAA" (len 3 + payload)
+        2, 0, 0, 0, 'b', 'b', // guid "bb" (len 2 + payload)
+        1, 0, 0, 0, 'B', // data "B" (len 1 + payload)
+    };
+    const assets = try parseAssets(arena, &bytes);
+    try testing.expectEqual(2, assets.count());
+    try testing.expectEqualStrings("AAA", assets.get("aa").?);
+    try testing.expectEqualStrings("B", assets.get("bb").?);
+}
+
+test "parseAssets: empty buffer yields empty assets" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // A zero-length buffer is the "no assets supplied" fast path: it must
+    // succeed with an empty map, not be rejected as a truncated count prefix.
+    const assets = try parseAssets(arena, "");
+    try testing.expectEqual(0, assets.count());
+}
+
+test "parseAssets: count-only buffer with zero entries yields empty assets" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Well-formed 4-byte buffer holding count=0: the count prefix parses,
+    // the entry loop runs zero times, and the result is an empty map.
+    const bytes = [_]u8{ 0, 0, 0, 0 };
+    const assets = try parseAssets(arena, &bytes);
+    try testing.expectEqual(0, assets.count());
+}
+
+test "parseAssets: truncated count prefix fails" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // Only 2 of the 4 bytes of the leading u32 count are present, so the
+    // very first length-prefix read must fail with TruncatedAssets.
+    const bytes = [_]u8{ 2, 0 };
+    try testing.expectError(error.TruncatedAssets, parseAssets(arena, &bytes));
+}
+
+test "parseAssets: truncated chunk length prefix fails" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // count=1 announces one {guid, data} pair, but the stream ends after
+    // only 2 of the 4 bytes of the guid length prefix, so the mid-stream
+    // length-prefix read must fail with TruncatedAssets.
+    const bytes = [_]u8{ 1, 0, 0, 0, 4, 0 };
+    try testing.expectError(error.TruncatedAssets, parseAssets(arena, &bytes));
+}
+
+test "parseAssets: truncated chunk payload fails" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    // count=1 and the guid length prefix parses as 4, but only 2 payload
+    // bytes follow, so the payload read must fail with TruncatedAssets.
+    const bytes = [_]u8{ 1, 0, 0, 0, 4, 0, 0, 0, 'a', 'b' };
+    try testing.expectError(error.TruncatedAssets, parseAssets(arena, &bytes));
+}

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 pub const model = @import("model.zig");
 pub const json = @import("json.zig");
 
+const assets_tlv = @import("assets_tlv.zig");
 const classid = @import("classid.zig");
 const parser = @import("parser.zig");
 const diff = @import("diff.zig");
@@ -41,6 +42,7 @@ test {
     std.testing.refAllDecls(@This());
     // refAllDecls only references pub decls; reference the internal modules
     // explicitly so their tests are still discovered.
+    _ = assets_tlv;
     _ = classid;
     _ = parser;
     _ = diff;

--- a/core/src/wasm.zig
+++ b/core/src/wasm.zig
@@ -2,6 +2,7 @@
 // Returns a JSON byte string prefixed with a u32 (LE) length. The caller frees it with free(ptr, 4 + len).
 const std = @import("std");
 const core = @import("root.zig");
+const assets_tlv = @import("assets_tlv.zig");
 
 const gpa = std.heap.wasm_allocator;
 
@@ -65,38 +66,9 @@ fn run(before: []const u8, after: []const u8, assets_bytes: ?[]const u8) ?[*]u8 
 
 fn computeJson(arena: std.mem.Allocator, before: []const u8, after: []const u8, assets_bytes: ?[]const u8) ![]u8 {
     const ab = assets_bytes orelse return core.diffToJson(arena, before, after);
-    var assets = try parseAssets(arena, ab);
+    // A broken TLV returns an error and falls through to the error.v1 payload (no trap).
+    var assets = try assets_tlv.parseAssets(arena, ab);
     return core.diffToJsonWithAssets(arena, before, after, &assets);
-}
-
-// A broken TLV returns an error and falls through to the error.v1 payload (no trap).
-fn parseAssets(arena: std.mem.Allocator, bytes: []const u8) !core.Assets {
-    var assets: core.Assets = .empty;
-    if (bytes.len == 0) return assets;
-    var off: usize = 0;
-    const count = try readU32(bytes, &off);
-    var i: u32 = 0;
-    while (i < count) : (i += 1) {
-        const guid = try readChunk(bytes, &off);
-        const data = try readChunk(bytes, &off);
-        try assets.put(arena, guid, data);
-    }
-    return assets;
-}
-
-fn readU32(bytes: []const u8, off: *usize) !u32 {
-    if (bytes.len - off.* < 4) return error.TruncatedAssets;
-    const v = std.mem.readInt(u32, bytes[off.*..][0..4], .little);
-    off.* += 4;
-    return v;
-}
-
-fn readChunk(bytes: []const u8, off: *usize) ![]const u8 {
-    const len = try readU32(bytes, off);
-    if (bytes.len - off.* < len) return error.TruncatedAssets;
-    const s = bytes[off.*..][0..len];
-    off.* += len;
-    return s;
 }
 
 // Copy outside the arena (caller-owned) and prefix the length.


### PR DESCRIPTION
## Summary

Add direct Zig unit tests for the wasm asset TLV parser (`parseAssets` / `readChunk` / `readU32`), covering valid, empty, and truncated inputs.

## Motivation

The TLV parser was exercised only end-to-end through `core/tests/wasm_golden.test.mjs`, and no golden fixture is malformed, so the `error.TruncatedAssets` branches were effectively untested.

Closes #204

## Changes

- Factor `parseAssets` / `readU32` / `readChunk` out of `core/src/wasm.zig` into a new `core/src/assets_tlv.zig`, byte-for-byte unchanged (no behavior change). This factoring was required: `wasm.zig` cannot be compiled into the native test build. Its `export` fns are analyzed eagerly on import and reference `std.heap.wasm_allocator`, which is `@compileError("unimplemented")` on native targets in Zig 0.16:

  ```
  /Users/.../zig/0.16.0/lib/std/heap.zig:16:74: error: unimplemented
  pub const WasmAllocator = if (builtin.single_threaded) BrkAllocator else @compileError("unimplemented");
  referenced by:
      wasm_allocator: .../lib/std/heap.zig:361:16
      gpa: core/src/wasm.zig:6:21
  ```

- Add 6 in-file test blocks in `assets_tlv.zig` with inline byte buffers; each test comments the exact TLV shape it constructs and why it must pass or fail:
  - valid two-entry buffer round-trips (both guids map to their exact data bytes)
  - zero-length buffer yields empty assets (the "no assets supplied" fast path)
  - count-only buffer with count=0 yields empty assets
  - truncated count prefix (2 of 4 bytes) asserts `error.TruncatedAssets`
  - truncated chunk length prefix mid-stream (count=1, 2 of 4 guid-length bytes) asserts `error.TruncatedAssets`
  - truncated chunk payload (guid length says 4, only 2 payload bytes follow) asserts `error.TruncatedAssets`
- Wire `assets_tlv` into the root test block in `core/src/root.zig` (`refAllDecls` is pub-only, so internal modules need an explicit reference).
- The JS golden tests stay untouched as integration coverage.

## Testing

`zig build test --summary all` — test count goes 181 -> 187 (core 97 -> 103, exactly the 6 new tests):

```
Build Summary: 6/6 steps succeeded; 187/187 tests passed
test success
+- run test 103 pass (103 total) 259ms MaxRSS:6M
|  +- compile test Debug native success 1s MaxRSS:369M
+- run test 84 pass (84 total) 1s MaxRSS:6M
   +- compile test Debug native success 1s MaxRSS:378M
```

Proof the new tests actually execute (temporarily broke the round-trip assertion `"AAA"` -> `"XXX"`, then restored it):

```
+- run test 102 pass, 1 fail (103 total)
error: 'assets_tlv.test.parseAssets: valid two-entry buffer round-trips' failed:
```

`zig build lint` — pass (no output, exit 0).

`zig build wasm` + `node --test core/tests/wasm_golden.test.mjs` — the refactored wasm build behaves identically, including the malformed-TLV integration path:

```
✔ broken assets TLV yields a clean error.v1 payload (0.055833ms)
ℹ tests 7
ℹ pass 7
ℹ fail 0
```
