### PR TITLE
ci: tune concurrency, cache reuse, and packaging

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -7,23 +7,9 @@ runs:
     - name: Install tools
       uses: jdx/mise-action@v4
     - name: Restore Zig global cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/zig
-        key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
-        restore-keys: |
-          ${{ runner.os }}-zig-
-    - name: Resolve pnpm store directory
-      id: pnpm-store
-      shell: bash
-      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      uses: ./.github/actions/setup-zig-cache
     - name: Restore pnpm store cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ steps.pnpm-store.outputs.path }}
-        key: ${{ runner.os }}-pnpm-${{ hashFiles('extension/pnpm-lock.yaml') }}
-        restore-keys: |
-          ${{ runner.os }}-pnpm-
+      uses: ./.github/actions/setup-pnpm-store
     - name: Build CLI and WASM
       shell: bash
       run: |

--- a/.github/actions/setup-pnpm-store/action.yml
+++ b/.github/actions/setup-pnpm-store/action.yml
@@ -1,0 +1,17 @@
+name: Restore pnpm store cache
+description: Resolve the pnpm store path and restore its cache keyed on the extension lockfile; requires pnpm to be installed first
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve pnpm store directory
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+    - name: Restore pnpm store cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('extension/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-

--- a/.github/actions/setup-zig-cache/action.yml
+++ b/.github/actions/setup-zig-cache/action.yml
@@ -1,0 +1,13 @@
+name: Restore Zig global cache
+description: Restore the Zig global cache keyed on build.zig.zon, shared by every job that runs zig build
+
+runs:
+  using: composite
+  steps:
+    - name: Restore Zig global cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/zig
+        key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
+        restore-keys: |
+          ${{ runner.os }}-zig-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+# One run per ref at a time; a superseded push cancels the in-flight run
+# instead of queueing a redundant full matrix behind it.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   core:
     strategy:
@@ -18,17 +24,16 @@ jobs:
       - name: Version sync guard
         if: matrix.os == 'ubuntu-latest'
         run: .github/scripts/check-version-sync.sh
+      - name: Packaging render test
+        # Plain bash + coreutils; folded here so it does not need its own runner
+        if: matrix.os == 'ubuntu-latest'
+        run: cli/pkg/render_test.sh
       - name: Install tools
         uses: jdx/mise-action@v4
       - name: Restore Zig global cache
         # Windows Zig caching was measured as not worth it (see PR #36 context)
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
-          restore-keys: |
-            ${{ runner.os }}-zig-
+        uses: ./.github/actions/setup-zig-cache
       - name: Lint
         run: zig build lint
       - name: Test
@@ -45,28 +50,16 @@ jobs:
       - name: Install tools
         uses: jdx/mise-action@v4
       - name: Restore Zig global cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/zig
-          key: ${{ runner.os }}-zig-${{ hashFiles('build.zig.zon') }}
-          restore-keys: |
-            ${{ runner.os }}-zig-
-      - name: Resolve pnpm store directory
-        id: pnpm-store
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/setup-zig-cache
       - name: Restore pnpm store cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('extension/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+        uses: ./.github/actions/setup-pnpm-store
       - name: Resolve Playwright version
         id: playwright-version
         run: |
           version=$(grep -oE '@playwright/test@[0-9]+\.[0-9]+\.[0-9]+' extension/pnpm-lock.yaml | head -n 1 | cut -d '@' -f 3)
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Restore Playwright browser cache
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
@@ -84,11 +77,20 @@ jobs:
           pnpm run typecheck
           pnpm test
           pnpm run build
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: extension
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Install Playwright OS dependencies
+        # A cache hit restores the browser binaries but not the runner's OS
+        # packages; the E2E launches full Chromium (channel "chromium" with
+        # the extension loaded), so the shared libraries must still exist.
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: extension
+        run: pnpm exec playwright install-deps chromium
       - name: Extension E2E
         working-directory: extension
-        run: |
-          pnpm exec playwright install --with-deps chromium
-          pnpm run e2e
+        run: pnpm run e2e
 
   editor:
     runs-on: ubuntu-latest
@@ -111,13 +113,6 @@ jobs:
       - name: Test
         working-directory: editor
         run: dotnet test DotNetTests~/Tests
-
-  packaging:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Render test
-        run: cli/pkg/render_test.sh
 
   site:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Tunes `ci.yml`: adds a concurrency group so superseded pushes cancel in-flight runs, extracts the copy-pasted zig-cache and pnpm-store blocks into composite actions, gates the Playwright browser download on the cache-hit output, and folds the `packaging` job into the core ubuntu leg.

## Motivation

Rapid pushes and PR force-pushes queued redundant full-matrix runs, the zig-cache restore was copy-pasted three times (core, extension, build-site) and the pnpm-store block twice, `playwright install --with-deps` re-ran its download/apt work on every build even on a browser cache hit, and the `packaging` job spun up a dedicated runner for one bash script.

Closes #205

## Changes

- Add `concurrency: {group: ci-${{ github.ref }}, cancel-in-progress: true}` to `ci.yml`.
- New `.github/actions/setup-zig-cache` composite action; consumed by the `core` job (still gated to ubuntu per the PR #36 measurement), the `extension` job, and `build-site`.
- New `.github/actions/setup-pnpm-store` composite action; consumed by the `extension` job and `build-site`. `build-site` now nests both composites, so `pages.yml` and the `site` job pick the dedup up transitively with no behavior change.
- Give the Playwright browser cache step an `id` and split the install out of the E2E step:
  - cache miss: `pnpm exec playwright install --with-deps chromium` (unchanged behavior);
  - cache hit: `pnpm exec playwright install-deps chromium` only — the browser download is skipped. The OS-deps step is kept on the hit path rather than dropped because `e2e/full.spec.ts` launches a persistent context with `channel: "chromium"` to load the extension headlessly, i.e. full Chromium (not just the headless shell), and the runner image is not guaranteed to carry Chromium's shared-library set across image updates. `install-deps` on a warm image is a near-no-op apt run, far cheaper than the browser download.
  - The cache step has no `restore-keys`, so `cache-hit == 'true'` means an exact per-version hit; a Playwright version bump falls back to the full `--with-deps` install.
- Fold `cli/pkg/render_test.sh` into the `core` job as a `Packaging render test` step (ubuntu leg only) and delete the `packaging` job. The script needs only bash, coreutils, sed, grep, and shasum — same plain-checkout assumptions it had on its dedicated runner — and it now runs under a required status check (`core (ubuntu-latest)`), whereas `packaging` was not in the ruleset's required checks.
- Keeps the version sync guard from #220 as the first ubuntu-gated step; the render test slots in right after it, before toolchain install.

## Testing

YAML syntax of all four touched/added files (system python lacks PyYAML, so Psych):

```
$ ruby -ryaml -e '...YAML.load_file(f)...'
OK .github/workflows/ci.yml
OK .github/actions/build-site/action.yml
OK .github/actions/setup-zig-cache/action.yml
OK .github/actions/setup-pnpm-store/action.yml
```

actionlint (also type-checks the `steps.playwright-cache.outputs.cache-hit` references and local `uses:` paths):

```
$ actionlint .github/workflows/ci.yml .github/workflows/pages.yml
(no findings)
```

Folded packaging script from a plain checkout:

```
$ bash cli/pkg/render_test.sh
PASS
```

Ruleset check: `gh api repos/hashiiiii/PrefabLens/rules/branches/main` lists required checks `core (ubuntu-latest)`, `core (windows-latest)`, `extension`, `editor` — `packaging` is not required, so deleting the job cannot strand PRs.

Only provable on CI (please watch the first run):
- The nested composite resolution (`build-site` -> `setup-zig-cache`/`setup-pnpm-store` via workspace-relative `uses:`) in the `site` job and `pages.yml`.
- The Playwright gate branches: first run after this PR is a cache miss (`--with-deps` path); a re-run or follow-up push exercises the hit path (`install-deps` only) and must keep e2e green.
- Concurrency: push twice quickly to the PR branch and confirm the first run is cancelled.