### PR TITLE
refactor: dedupe helpers, extract state machine

### DIFF
--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -16,6 +16,7 @@ import {
   type SemanticDiffRequest,
   type SemanticDiffResponse,
   targetKey,
+  unresolvedRemaining,
 } from "../types";
 import { isUnityPath } from "../unity";
 import { DiffError, type Differ } from "../wasm/differ";
@@ -238,7 +239,7 @@ export function createHandler(deps: Deps): Handler {
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
 
       // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push
-      const remaining = withPr.unresolvedGuids.filter((g) => !Object.hasOwn(withPr.resolved ?? {}, g));
+      const remaining = unresolvedRemaining(withPr);
       if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
       void resolution.resolveRemaining(withPr, remaining, client, req, base, ctx, push);
       return { ok: true, json: withPr, pending: true };

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -3,6 +3,7 @@ import type { BackgroundRequest, GuidResolvedPush } from "../types";
 import { createDiffer, type Differ } from "../wasm/differ";
 import { createSessionDiffStore } from "./diffStore";
 import { createHandler } from "./handler";
+import { createMergeStore } from "./mergeStore";
 import { createQueue } from "./queue";
 
 let differ: Promise<Differ> | undefined;
@@ -14,6 +15,9 @@ const queuedFetch =
   (front: boolean): typeof fetch =>
   (input, init) =>
     queue(() => fetch(input, init), { front });
+
+// Whole-repo .meta guid records, shared by repoIndexStore.loadGuids/saveGuids below
+const metaGuids = createMergeStore(chrome.storage.local, "metaGuids");
 
 const handler = createHandler({
   async getSettings() {
@@ -28,32 +32,12 @@ const handler = createHandler({
       .then(createDiffer);
     return differ;
   },
-  guidCache: {
-    async load(repo) {
-      const key = `guids:${repo}`;
-      const stored = await chrome.storage.local.get([key]);
-      return (stored[key] as Record<string, string> | undefined) ?? {};
-    },
-    async save(repo, entries) {
-      const key = `guids:${repo}`;
-      const stored = await chrome.storage.local.get([key]);
-      await chrome.storage.local.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
-    },
-  },
+  // Both guid caches are the same merge-on-save record slot, just under different prefixes
+  guidCache: createMergeStore(chrome.storage.local, "guids"),
   diffStore: createSessionDiffStore(chrome.storage.session),
   repoIndexStore: {
-    async loadGuids(repo) {
-      const key = `metaGuids:${repo}`;
-      const stored = await chrome.storage.local.get([key]);
-      return (stored[key] as Record<string, string> | undefined) ?? {};
-    },
-    async saveGuids(repo, entries) {
-      const key = `metaGuids:${repo}`;
-      const stored = await chrome.storage.local.get([key]);
-      await chrome.storage.local
-        .set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } })
-        .catch(() => {}); // on quota overflow, continue in memory only
-    },
+    loadGuids: (repo) => metaGuids.load(repo),
+    saveGuids: (repo, entries) => metaGuids.save(repo, entries).catch(() => {}), // on quota overflow, continue in memory only
     async loadIndex(repo) {
       const key = `guidIndex:${repo}`;
       const stored = await chrome.storage.local.get([key]);

--- a/extension/src/background/mergeStore.test.ts
+++ b/extension/src/background/mergeStore.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { createMergeStore } from "./mergeStore";
+
+/** Real in-memory stand-in for chrome.storage.local: get/set operate on a plain record. */
+function makeArea() {
+  const data: Record<string, unknown> = {};
+  return {
+    data,
+    async get(keys: string[]) {
+      const out: Record<string, unknown> = {};
+      for (const key of keys) if (Object.hasOwn(data, key)) out[key] = data[key];
+      return out;
+    },
+    async set(items: Record<string, unknown>) {
+      Object.assign(data, items);
+    },
+  };
+}
+
+describe("createMergeStore", () => {
+  it("loads an empty record for a slot never written", async () => {
+    const store = createMergeStore(makeArea(), "guids");
+    expect(await store.load("api/o/r")).toEqual({});
+  });
+
+  it("round-trips entries under the prefixed key", async () => {
+    const area = makeArea();
+    const store = createMergeStore(area, "guids");
+    await store.save("api/o/r", { g1: "Assets/A.cs" });
+    expect(await store.load("api/o/r")).toEqual({ g1: "Assets/A.cs" });
+    // The storage key is `prefix:id`, matching what background/index.ts stored before extraction.
+    expect(area.data["guids:api/o/r"]).toEqual({ g1: "Assets/A.cs" });
+  });
+
+  it("save merges into the stored record instead of replacing it", async () => {
+    const store = createMergeStore(makeArea(), "guids");
+    await store.save("api/o/r", { g1: "Assets/A.cs" });
+    await store.save("api/o/r", { g2: "Assets/B.mat" });
+    // Both writes survive: the second save read the slot and spread the new entries over it.
+    expect(await store.load("api/o/r")).toEqual({ g1: "Assets/A.cs", g2: "Assets/B.mat" });
+  });
+
+  it("a later save wins for the same guid", async () => {
+    const store = createMergeStore(makeArea(), "guids");
+    await store.save("api/o/r", { g1: "Assets/Old.cs" });
+    await store.save("api/o/r", { g1: "Assets/New.cs" });
+    expect(await store.load("api/o/r")).toEqual({ g1: "Assets/New.cs" });
+  });
+
+  it("keeps slots independent across prefixes and ids", async () => {
+    const area = makeArea();
+    // The two background stores (Code Search cache, whole-repo meta guids) share one area.
+    const guids = createMergeStore(area, "guids");
+    const metaGuids = createMergeStore(area, "metaGuids");
+    await guids.save("api/o/r", { g1: "Assets/A.cs" });
+    await metaGuids.save("api/o/r", { sha1: "g9" });
+    await guids.save("api/o/other", { g2: "Assets/B.mat" });
+    expect(await guids.load("api/o/r")).toEqual({ g1: "Assets/A.cs" });
+    expect(await metaGuids.load("api/o/r")).toEqual({ sha1: "g9" });
+    expect(await guids.load("api/o/other")).toEqual({ g2: "Assets/B.mat" });
+  });
+
+  it("propagates set failures so each call site chooses its own quota policy", async () => {
+    // Real area whose writes always fail (quota overflow): save must not swallow it,
+    // because repoIndexStore continues in memory while guidCache lets it propagate.
+    const store = createMergeStore(
+      {
+        get: async () => ({}),
+        set: async () => {
+          throw new Error("quota");
+        },
+      },
+      "guids",
+    );
+    await expect(store.save("api/o/r", { g1: "x" })).rejects.toThrow("quota");
+  });
+});

--- a/extension/src/background/mergeStore.ts
+++ b/extension/src/background/mergeStore.ts
@@ -1,0 +1,30 @@
+// Accepts only the needed subset of chrome.storage.local (so tests can swap in a fake)
+type Area = {
+  get(keys: string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+};
+
+export type MergeStore = {
+  load(id: string): Promise<Record<string, string>>;
+  save(id: string, entries: Record<string, string>): Promise<void>;
+};
+
+/** A `prefix:id` storage slot holding a string record, where save merges entries into
+ *  what is stored instead of replacing it (writers only ever add keys, so a stale read
+ *  loses nothing but the other writer's additions). Failures propagate: each call site
+ *  decides whether a lost write is fatal or a quota overflow to continue past. */
+export function createMergeStore(area: Area, prefix: string): MergeStore {
+  const keyOf = (id: string): string => `${prefix}:${id}`;
+  return {
+    async load(id) {
+      const key = keyOf(id);
+      const stored = await area.get([key]);
+      return (stored[key] as Record<string, string> | undefined) ?? {};
+    },
+    async save(id, entries) {
+      const key = keyOf(id);
+      const stored = await area.get([key]);
+      await area.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
+    },
+  };
+}

--- a/extension/src/background/resolution.ts
+++ b/extension/src/background/resolution.ts
@@ -1,7 +1,13 @@
 import { type ChangedFile, type GithubClient, RateLimitError, type RefPair } from "../github/client";
 import { applyResolved, type GuidCache } from "../github/guids";
 import { type RepoIndexStore, syncRepoIndex } from "../github/repoIndex";
-import type { DiffV2, GuidResolvedPush, ResolutionStatus, SemanticDiffRequest } from "../types";
+import {
+  type DiffV2,
+  type GuidResolvedPush,
+  type ResolutionStatus,
+  type SemanticDiffRequest,
+  unresolvedRemaining,
+} from "../types";
 import type { Differ } from "../wasm/differ";
 import { createPromiseCache } from "./promiseCache";
 
@@ -142,7 +148,7 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     repoKey: string,
   ): Promise<{ json: DiffV2; rateLimited: boolean }> {
     const resolved = { ...json.resolved };
-    const pending = json.unresolvedGuids.filter((g) => !Object.hasOwn(resolved, g));
+    const pending = unresolvedRemaining(json);
     const found = await searchGuids(pending, client, owner, repo, repoKey);
     return { json: { ...json, resolved: { ...resolved, ...found.resolved } }, rateLimited: found.rateLimited };
   }

--- a/extension/src/content/fileView.test.ts
+++ b/extension/src/content/fileView.test.ts
@@ -1,0 +1,335 @@
+import { describe, expect, it } from "vitest";
+import type { DiffV2, SemanticDiffResponse } from "../types";
+import { must } from "../util/must";
+import { createFileView, type FileResult } from "./fileView";
+import type { View } from "./toggle";
+
+const DIFF: DiffV2 = { schema: "prefablens.diff.v2", unresolvedGuids: [], roots: [], loose: [] };
+
+/** What the panel last drew, as plain data (a real sink, not a spy). */
+type Screen =
+  | { kind: "loading" }
+  | { kind: "diff"; json: DiffV2; resolving: number }
+  | { kind: "incomplete"; json: DiffV2; onRetry(): void }
+  | { kind: "tooLarge"; bytes: number; onForce(): void }
+  | { kind: "authError"; error: string }
+  | { kind: "error"; error: string };
+
+/** requestDiff resolves on the microtask queue; a macrotask flushes every chained then. */
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** In-memory implementations of every FileViewDeps interface: each object really stores
+ *  the state the machine drives, so assertions read state instead of call recordings. */
+function makeHarness() {
+  const file = {
+    rawHidden: false,
+    isCollapsed: false,
+    setRawHidden(hidden: boolean) {
+      file.rawHidden = hidden;
+    },
+    collapsed: () => file.isCollapsed,
+  };
+  const host = {
+    created: false,
+    attachCount: 0,
+    connected: false,
+    visible: undefined as boolean | undefined,
+    screens: [] as Screen[],
+  };
+  // Responses are consumed in order; requests records the force flag of each round-trip.
+  const responses: SemanticDiffResponse[] = [];
+  const requests: Array<boolean | undefined> = [];
+  const results = {
+    current: undefined as FileResult | undefined,
+    watchdogArmed: 0,
+  };
+  const authRetries: Array<() => void> = [];
+  const state = { effective: "semantic" as View };
+
+  const view = createFileView({
+    file,
+    createHost() {
+      host.created = true;
+      return {
+        attach() {
+          host.attachCount++;
+          host.connected = true;
+        },
+        attached: () => host.connected,
+        setVisible(visible) {
+          host.visible = visible;
+        },
+        panel: {
+          loading: () => void host.screens.push({ kind: "loading" }),
+          diff: (json, resolving) => void host.screens.push({ kind: "diff", json, resolving }),
+          incomplete: (json, onRetry) => void host.screens.push({ kind: "incomplete", json, onRetry }),
+          tooLarge: (bytes, onForce) => void host.screens.push({ kind: "tooLarge", bytes, onForce }),
+          authError: (error) => void host.screens.push({ kind: "authError", error }),
+          error: (error) => void host.screens.push({ kind: "error", error }),
+        },
+      };
+    },
+    requestDiff(force) {
+      requests.push(force);
+      return Promise.resolve(must(responses.shift()));
+    },
+    results: {
+      set: (result) => {
+        results.current = result;
+      },
+      get: () => results.current,
+      armWatchdog: () => void results.watchdogArmed++,
+    },
+    onAuthRetry: (retry) => void authRetries.push(retry),
+    effectiveView: () => state.effective,
+  });
+
+  const screen = (): Screen => must(host.screens.at(-1));
+  return { view, file, host, responses, requests, results, authRetries, state, screen };
+}
+
+describe("createFileView show", () => {
+  it("show(semantic) creates and attaches the host, hides raw, and renders the fetched diff", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: true, json: DIFF });
+
+    h.view.show("semantic");
+    // Transition: no-host + semantic → host created and attached, raw hidden, loading
+    // shown synchronously while the request is in flight.
+    expect(h.host.created).toBe(true);
+    expect(h.host.attachCount).toBe(1);
+    expect(h.file.rawHidden).toBe(true);
+    expect(h.host.visible).toBe(true);
+    expect(h.screen()).toEqual({ kind: "loading" });
+
+    await flush();
+    // Transition: success response → diff rendered without the resolving indicator (not
+    // pending), and the result registered as a push target.
+    expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF, resolving: 0 });
+    expect(h.results.current?.json).toBe(DIFF);
+    expect(h.results.watchdogArmed).toBe(0);
+  });
+
+  it("show(raw) leaves the raw diff alone and never creates a host or fetches", () => {
+    const h = makeHarness();
+    h.view.show("raw");
+    // Transition: raw is the passive state — nothing to build, nothing to request.
+    expect(h.host.created).toBe(false);
+    expect(h.requests).toHaveLength(0);
+    expect(h.file.rawHidden).toBe(false);
+  });
+
+  it("toggling back to semantic reuses the cached result instead of re-fetching", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: true, json: DIFF });
+    h.view.show("semantic");
+    await flush();
+
+    h.view.show("raw");
+    // Transition: semantic-shown → raw restores the raw diff and hides (not destroys) the host.
+    expect(h.file.rawHidden).toBe(false);
+    expect(h.host.visible).toBe(false);
+
+    h.view.show("semantic");
+    // Transition: requested stays latched after success, so re-showing only re-asserts
+    // display — exactly one round-trip ever happened.
+    expect(h.requests).toHaveLength(1);
+    expect(h.file.rawHidden).toBe(true);
+    expect(h.host.visible).toBe(true);
+  });
+
+  it("keeps the resolving indicator up while pending, even when every guid already has a name", async () => {
+    const h = makeHarness();
+    // All names resolved but pending: source merging may still be running in background.
+    h.responses.push({
+      ok: true,
+      json: { ...DIFF, unresolvedGuids: ["g1"], resolved: { g1: "Assets/A.cs" } },
+      pending: true,
+    });
+    h.view.show("semantic");
+    await flush();
+    // Transition: pending success → indicator floor of 1 and the watchdog armed to catch a lost final push.
+    expect(h.screen()).toMatchObject({ kind: "diff", resolving: 1 });
+    expect(h.results.watchdogArmed).toBe(1);
+  });
+
+  it("counts only guids without a resolved name for the indicator", async () => {
+    const h = makeHarness();
+    h.responses.push({
+      ok: true,
+      json: { ...DIFF, unresolvedGuids: ["g1", "g2", "g3"], resolved: { g2: "Assets/B.mat" } },
+      pending: true,
+    });
+    h.view.show("semantic");
+    await flush();
+    // g2 already resolved via the in-PR meta index: 2 remain (the shared unresolvedRemaining filter).
+    expect(h.screen()).toMatchObject({ kind: "diff", resolving: 2 });
+  });
+});
+
+describe("createFileView sync", () => {
+  it("sync(semantic) before any semantic render leaves the raw diff alone", () => {
+    const h = makeHarness();
+    h.view.sync("semantic");
+    // Transition: no host yet → sync must not hide raw (the user would see nothing) and
+    // must not fetch (a fetching sync would hammer retries on rate limits).
+    expect(h.file.rawHidden).toBe(false);
+    expect(h.requests).toHaveLength(0);
+  });
+
+  it("sync re-attaches a host dropped by a react remount without re-fetching", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: true, json: DIFF });
+    h.view.show("semantic");
+    await flush();
+
+    // A react remount discards the diff body together with our host...
+    h.host.connected = false;
+    h.file.rawHidden = false;
+    h.view.sync("semantic");
+    // Transition: display-only re-assert — host re-attached, raw re-hidden, and still
+    // exactly one request (sync never fetches).
+    expect(h.host.attachCount).toBe(2);
+    expect(h.file.rawHidden).toBe(true);
+    expect(h.requests).toHaveLength(1);
+  });
+
+  it("sync follows github's collapse state for the semantic host", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: true, json: DIFF });
+    h.view.show("semantic");
+    await flush();
+
+    h.file.isCollapsed = true;
+    h.view.sync("semantic");
+    // Transition: collapsed file → semantic host hidden along with github's own body.
+    expect(h.host.visible).toBe(false);
+
+    h.file.isCollapsed = false;
+    h.view.sync("semantic");
+    expect(h.host.visible).toBe(true);
+  });
+
+  it("sync(raw) restores the raw diff and hides the semantic host", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: true, json: DIFF });
+    h.view.show("semantic");
+    await flush();
+
+    h.view.sync("raw");
+    expect(h.file.rawHidden).toBe(false);
+    expect(h.host.visible).toBe(false);
+  });
+});
+
+describe("createFileView request", () => {
+  it("does not cache errors: the next semantic show re-fetches", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: false, error: "fetch-failed" });
+    h.view.show("semantic");
+    await flush();
+    // Transition: failure with no prior result → plain error panel, requested reset.
+    expect(h.screen()).toEqual({ kind: "error", error: "fetch-failed" });
+
+    h.responses.push({ ok: true, json: DIFF });
+    h.view.show("semantic");
+    await flush();
+    // Transition: error was not latched → the second show issues a second request.
+    expect(h.requests).toHaveLength(2);
+    expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF });
+  });
+
+  it("a failed retry keeps the diff on screen and re-offers retry instead of a bare error", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: true, json: DIFF, pending: true });
+    h.view.show("semantic");
+    await flush();
+
+    // Retry after an incomplete resolution, but the request fails this time.
+    h.responses.push({ ok: false, error: "rate-limited" });
+    must(h.results.current).retry();
+    expect(h.screen()).toEqual({ kind: "loading" });
+    await flush();
+    // Transition: failure with a prior result → the kept diff plus the retry affordance
+    // (never wipe the tree the user is reading).
+    expect(h.screen()).toMatchObject({ kind: "incomplete", json: DIFF });
+
+    // The offered retry works: a success replaces the incomplete bar with the diff again.
+    h.responses.push({ ok: true, json: DIFF });
+    const incomplete = h.screen();
+    if (incomplete.kind !== "incomplete") throw new Error("expected incomplete screen");
+    incomplete.onRetry();
+    await flush();
+    expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF });
+    expect(h.requests).toHaveLength(3);
+  });
+
+  it("too-large offers force rendering, and retry afterwards keeps the force flag", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: false, error: "too-large", bytes: 123 });
+    h.view.show("semantic");
+    await flush();
+    // Transition: too-large → the render-anyway affordance instead of a diff.
+    expect(h.screen()).toMatchObject({ kind: "tooLarge", bytes: 123 });
+
+    h.responses.push({ ok: true, json: DIFF, pending: true });
+    const tooLarge = h.screen();
+    if (tooLarge.kind !== "tooLarge") throw new Error("expected tooLarge screen");
+    tooLarge.onForce();
+    await flush();
+    // Transition: force render → the request repeats with force, bypassing the size guard.
+    expect(h.requests).toEqual([undefined, true]);
+    expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF });
+
+    // The registered retry re-runs the whole request with the same force flag: without it
+    // the retried request would bounce off the size guard again.
+    h.responses.push({ ok: true, json: DIFF });
+    must(h.results.current).retry();
+    await flush();
+    expect(h.requests).toEqual([undefined, true, true]);
+  });
+
+  it("an auth error registers a retry that fires only while the file still shows semantic", async () => {
+    const h = makeHarness();
+    h.responses.push({ ok: false, error: "pat-missing" });
+    h.view.show("semantic");
+    await flush();
+    // Transition: auth failure → sign-in panel plus a retry parked until a token lands.
+    expect(h.screen()).toEqual({ kind: "authError", error: "pat-missing" });
+    expect(h.authRetries).toHaveLength(1);
+
+    // The user flipped this file to raw before signing in: the token retry must not fetch
+    // for a file that no longer shows the semantic view.
+    h.state.effective = "raw";
+    must(h.authRetries[0])();
+    expect(h.requests).toHaveLength(1);
+
+    // Back on semantic, the same parked retry re-requests.
+    h.state.effective = "semantic";
+    h.responses.push({ ok: true, json: DIFF });
+    must(h.authRetries[0])();
+    await flush();
+    expect(h.requests).toHaveLength(2);
+    expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF });
+  });
+
+  it("duplicate auth retries no-op after the first one flips requested back on", async () => {
+    const h = makeHarness();
+    // Two auth failures in a row (show → error → show again) park two retries.
+    h.responses.push({ ok: false, error: "auth-failed" });
+    h.view.show("semantic");
+    await flush();
+    h.responses.push({ ok: false, error: "auth-failed" });
+    h.view.show("semantic");
+    await flush();
+    expect(h.authRetries).toHaveLength(2);
+
+    // A token lands and the flush runs every parked retry: the first re-requests and sets
+    // requested, so the second must see requested === true and stay idle (one fetch, not two).
+    h.responses.push({ ok: true, json: DIFF });
+    for (const retry of h.authRetries) retry();
+    await flush();
+    expect(h.requests).toHaveLength(3);
+    expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF });
+  });
+});

--- a/extension/src/content/fileView.ts
+++ b/extension/src/content/fileView.ts
@@ -1,0 +1,132 @@
+import { type BackgroundError, type DiffV2, type SemanticDiffResponse, unresolvedRemaining } from "../types";
+import { must } from "../util/must";
+import type { View } from "./toggle";
+
+/** Rendering surface inside the host's shadow root: the machine picks the screen,
+ *  the caller draws it (render/renderLoading/... in content/index.ts). */
+export type FilePanel = {
+  loading(): void;
+  /** The diff tree, with the resolving indicator while `resolving` > 0. */
+  diff(json: DiffV2, resolving: number): void;
+  /** A kept diff plus the incomplete-resolution bar (manual retry affordance). */
+  incomplete(json: DiffV2, onRetry: () => void): void;
+  tooLarge(bytes: number, onForce: () => void): void;
+  /** Auth-error panel driving the device flow. */
+  authError(error: "pat-missing" | "auth-failed"): void;
+  error(error: BackgroundError): void;
+};
+
+/** The semantic-view host as the machine sees it: layout attach, visibility, its panel. */
+export type FileHost = {
+  attach(): void;
+  attached(): boolean;
+  setVisible(visible: boolean): void;
+  panel: FilePanel;
+};
+
+/** A successful diff registered as a push target (content/index.ts adapts this onto the
+ *  view registry, where guidResolved pushes and the watchdog find it). */
+export type FileResult = { json: DiffV2; retry(): void };
+
+export type FileViewDeps = {
+  /** The pieces of FileEntry the machine drives: raw-diff visibility and collapse state. */
+  file: { setRawHidden(hidden: boolean): void; collapsed(): boolean };
+  /** Creates the semantic-view host; called once, on the first semantic show. */
+  createHost(): FileHost;
+  /** Background round-trip for this file's semantic diff (never rejects: the caller maps
+   *  channel loss to a fetch-failed response). */
+  requestDiff(force?: boolean): Promise<SemanticDiffResponse>;
+  /** This file's push-target slot; armWatchdog guards the pending final push. */
+  results: { set(result: FileResult): void; get(): FileResult | undefined; armWatchdog(): void };
+  /** Registers a retry to run when a token lands in storage (auth-blocked panels). */
+  onAuthRetry(retry: () => void): void;
+  /** The view currently effective for this file (global default + per-file override). */
+  effectiveView(): View;
+};
+
+export type FileView = {
+  /** User-intent transition: may create the host and fetch the diff. */
+  show(view: View): void;
+  /** Display-only re-assert of the current view; never fetches. */
+  sync(view: View): void;
+};
+
+/** Per-file attach/show state machine: which of raw/semantic is displayed, whether the
+ *  semantic host exists, and whether a diff request is in flight or cached. Extracted
+ *  from content/index.ts so the transitions are unit-testable without a browser. */
+export function createFileView(deps: FileViewDeps): FileView {
+  let host: FileHost | undefined;
+  // A successful request stays latched (re-toggle doesn't re-fetch); failures reset it.
+  let requested = false;
+
+  // Display-only re-assert, never fetches: safe to run on every scan even while a panel
+  // sits on an error (a fetching sync would silently hammer retries on rate limits).
+  const sync = (view: View): void => {
+    if (view === "raw") {
+      deps.file.setRawHidden(false);
+      host?.setVisible(false);
+      return;
+    }
+    if (!host) return; // semantic never rendered here: leave the raw diff alone
+    deps.file.setRawHidden(true);
+    if (!host.attached()) host.attach(); // a react remount can drop the host together with the old body
+    // Follow github's own collapse (react ui): the classic layout handles this via the
+    // Details CSS class added in attachHost instead, where collapsed() is always false.
+    host.setVisible(!deps.file.collapsed());
+  };
+
+  const request = (force?: boolean): void => {
+    requested = true;
+    const panel = must(host).panel; // request is only reachable after show created the host
+    panel.loading();
+    void deps.requestDiff(force).then((res) => {
+      if (res.ok) {
+        deps.results.set({
+          json: res.json,
+          // Retry re-runs the whole request: the diff itself is cached, so this only
+          // re-enters background resolution (requested must reset or request() no-ops).
+          retry: () => {
+            requested = false;
+            request(force);
+          },
+        });
+        if (res.pending) deps.results.armWatchdog();
+        // Always show it while pending: even if all names are resolved, source merging may remain
+        panel.diff(res.json, res.pending ? Math.max(unresolvedRemaining(res.json).length, 1) : 0);
+        return;
+      }
+      requested = false; // don't cache errors: let the next toggle re-fetch
+      const prior = deps.results.get();
+      if (prior) {
+        // A failed retry must not wipe the diff the user is reading: keep the
+        // tree and re-offer the retry affordance instead of a bare error panel.
+        panel.incomplete(prior.json, prior.retry);
+        return;
+      }
+      if (res.error === "too-large") panel.tooLarge(res.bytes, () => request(true));
+      else if (res.error === "pat-missing" || res.error === "auth-failed") {
+        deps.onAuthRetry(() => {
+          // requested flips true on the first retry, so duplicate registrations no-op.
+          if (!requested && deps.effectiveView() === "semantic") request();
+        });
+        panel.authError(res.error);
+      } else panel.error(res.error);
+    });
+  };
+
+  const show = (view: View): void => {
+    if (view === "raw") {
+      sync(view);
+      return;
+    }
+    if (!host) {
+      host = deps.createHost();
+      host.attach();
+    }
+    sync(view);
+    if (requested) return; // cache only successful results per file (re-toggle doesn't re-fetch)
+    request();
+  };
+
+  return { show, sync };
+}

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -9,17 +9,18 @@ import {
 } from "../renderer/render";
 import {
   type BackgroundError,
-  type DiffV2,
   type GuidResolvedPush,
   type PrefetchRequest,
   type SemanticDiffRequest,
   type SemanticDiffResponse,
   targetKey,
+  unresolvedRemaining,
 } from "../types";
 import { must } from "../util/must";
 import { createAuthRetries } from "./authRetries";
 import { type DiffPage, type FileEntry, parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 import { fillDeviceCode } from "./devicePage";
+import { createFileView } from "./fileView";
 import { createSignIn, type PendingSignIn } from "./signin";
 import { createToggle, type Toggle, type View } from "./toggle";
 import { createViewRegistry, type ViewEntry } from "./views";
@@ -36,10 +37,6 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
 
 // path → render target. When a push (guidResolved) arrives, merge resolved and re-render
 const views = createViewRegistry();
-
-function countUnresolved(json: DiffV2): number {
-  return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g)).length;
-}
 
 // If the final push is lost (dropped tab message, killed service worker), flip the
 // indicator to the retryable incomplete state instead of spinning forever.
@@ -141,103 +138,70 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
   entry.header.setAttribute("data-prefablens", "");
   const viewKey = `${targetKey(page.owner, page.repo, page.target)}:${entry.path}`;
 
-  let host: HTMLElement | undefined;
-  let requested = false;
+  // Set by createHost; results.set only runs after the machine created the host, so the
+  // registry (whose push listener renders into it) always sees a real shadow root.
+  let shadow: ShadowRoot | undefined;
 
-  // Display-only re-assert, never fetches: safe to run on every scan even while a panel
-  // sits on an error (a fetching sync would silently hammer retries on rate limits).
-  const sync = (view: View): void => {
-    if (view === "raw") {
-      entry.setRawHidden(false);
-      if (host) host.style.display = "none";
-      return;
-    }
-    if (!host) return; // semantic never rendered here: leave the raw diff alone
-    entry.setRawHidden(true);
-    if (!host.isConnected) entry.attachHost(host); // a react remount can drop the host together with the old body
-    // Follow github's own collapse (react ui): the classic layout handles this via the
-    // Details CSS class added in attachHost instead, where collapsed() is always false.
-    host.style.display = entry.collapsed() ? "none" : "";
-  };
-
-  const show = (view: View): void => {
-    if (view === "raw") {
-      sync(view);
-      return;
-    }
-    if (!host) {
-      host = document.createElement("div");
+  // The transitions live in fileView.ts; this block only binds them to the real DOM,
+  // the runtime channel, and the shared registries.
+  const fileView = createFileView({
+    file: entry,
+    createHost() {
+      const host = document.createElement("div");
       host.setAttribute("data-prefablens-view", "");
-      host.attachShadow({ mode: "open" });
-      entry.attachHost(host);
-    }
-    sync(view);
-    if (requested) return; // cache only successful results per file (re-toggle doesn't re-fetch)
-    const root = must(host.shadowRoot);
-    const request = (force?: boolean): void => {
-      requested = true;
-      renderLoading(root);
-      void requestDiff({
+      const root = host.attachShadow({ mode: "open" });
+      shadow = root;
+      return {
+        attach: () => entry.attachHost(host),
+        attached: () => host.isConnected,
+        setVisible: (visible) => {
+          host.style.display = visible ? "" : "none";
+        },
+        panel: {
+          loading: () => renderLoading(root),
+          diff: (json, resolving) => render(root, json, { resolving }),
+          incomplete: (json, onRetry) => render(root, json, { incomplete: { onRetry } }),
+          tooLarge: (bytes, onForce) => renderTooLarge(root, bytes, onForce),
+          authError: (error) => signInPanel(root, ERROR_TEXT[error]),
+          error: (error) => renderError(root, ERROR_TEXT[error]),
+        },
+      };
+    },
+    requestDiff: (force) =>
+      requestDiff({
         type: "semanticDiff",
         owner: page.owner,
         repo: page.repo,
         target: page.target,
         path: entry.path,
         force,
-      }).then((res) => {
-        if (res.ok) {
-          views.set(viewKey, {
-            root,
-            json: res.json,
-            // Retry re-runs the whole request: the diff itself is cached, so this only
-            // re-enters background resolution (requested must reset or request() no-ops).
-            retry: () => {
-              requested = false;
-              request(force);
-            },
-          });
-          if (res.pending) armWatchdog(must(views.get(viewKey)));
-          // Always show it while pending: even if all names are resolved, source merging may remain
-          return render(root, res.json, { resolving: res.pending ? Math.max(countUnresolved(res.json), 1) : 0 });
-        }
-        requested = false; // don't cache errors: let the next toggle re-fetch
-        const view = views.get(viewKey);
-        if (view) {
-          // A failed retry must not wipe the diff the user is reading: keep the
-          // tree and re-offer the retry affordance instead of a bare error panel.
-          render(root, view.json, { incomplete: { onRetry: view.retry } });
-          return;
-        }
-        if (res.error === "too-large") renderTooLarge(root, res.bytes, () => request(true));
-        else if (res.error === "pat-missing" || res.error === "auth-failed") {
-          authRetries.add(() => {
-            // requested flips true on the first retry, so duplicate registrations no-op.
-            if (!requested && state.effective(entry.path) === "semantic") request();
-          });
-          signInPanel(root, ERROR_TEXT[res.error]);
-        } else renderError(root, ERROR_TEXT[res.error]);
-      });
-    };
-    request();
-  };
+      }),
+    results: {
+      set: ({ json, retry }) => views.set(viewKey, { root: must(shadow), json, retry }),
+      get: () => views.get(viewKey),
+      armWatchdog: () => armWatchdog(must(views.get(viewKey))),
+    },
+    onAuthRetry: (retry) => authRetries.add(retry),
+    effectiveView: () => state.effective(entry.path),
+  });
 
   const toggle = createToggle((view) => {
     state.setOverride(entry.path, view); // a click overrides just this file
-    show(view);
+    fileView.show(view);
   }, state.effective(entry.path));
   entry.header.append(toggle.element);
   appliers.add({
     header: entry.header,
     apply: (view) => {
       toggle.set(view);
-      show(view);
+      fileView.show(view);
     },
-    sync: () => sync(state.effective(entry.path)),
+    sync: () => fileView.sync(state.effective(entry.path)),
   });
 
   // If the default is semantic, start rendering at attach time: lazy-loaded files also pass through here, so
   // "the global is semantic but a later-arriving file is raw" doesn't happen
-  if (state.effective(entry.path) === "semantic") show("semantic");
+  if (state.effective(entry.path) === "semantic") fileView.show("semantic");
 }
 
 function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
@@ -294,7 +258,7 @@ async function init(): Promise<void> {
       return;
     }
     if (!msg.done) armWatchdog(view);
-    render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(countUnresolved(view.json), 1) });
+    render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(unresolvedRemaining(view.json).length, 1) });
   });
 
   // GitHub is an SPA: an initial scan + MutationObserver follows lazy loading and tab navigation.

--- a/extension/src/types.test.ts
+++ b/extension/src/types.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { unresolvedRemaining } from "./types";
+
+describe("unresolvedRemaining", () => {
+  it("returns the guids without a resolved name, in order", () => {
+    expect(unresolvedRemaining({ unresolvedGuids: ["g1", "g2", "g3"], resolved: { g2: "Assets/B.mat" } })).toEqual([
+      "g1",
+      "g3",
+    ]);
+  });
+
+  it("treats a missing resolved map as nothing resolved", () => {
+    // resolved is optional on DiffV2 (attached later by applyResolved): absent means every guid remains.
+    expect(unresolvedRemaining({ unresolvedGuids: ["g1"] })).toEqual(["g1"]);
+  });
+
+  it("returns empty when everything is resolved", () => {
+    expect(unresolvedRemaining({ unresolvedGuids: ["g1"], resolved: { g1: "Assets/A.cs" } })).toEqual([]);
+  });
+
+  it("does not let Object.prototype keys count as resolved", () => {
+    // Guids are arbitrary strings: with `in` or property access, "constructor" would hit
+    // Object.prototype and silently drop out of the unresolved list. Object.hasOwn keeps it.
+    expect(unresolvedRemaining({ unresolvedGuids: ["constructor", "hasOwnProperty"], resolved: {} })).toEqual([
+      "constructor",
+      "hasOwnProperty",
+    ]);
+  });
+});

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -62,6 +62,14 @@ export type DiffV2 = {
 
 export type DiffErrorV1 = { schema: "prefablens.error.v1"; error: string };
 
+/** Guids still lacking a name after resolution so far — the single definition of
+ *  "unresolved" shared by handler, resolution, and the content indicator. Object.hasOwn
+ *  is a prototype-pollution guard: guids are arbitrary strings, so "constructor" and
+ *  friends must not falsely hit Object.prototype and count as resolved. */
+export function unresolvedRemaining(json: Pick<DiffV2, "unresolvedGuids" | "resolved">): string[] {
+  return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g));
+}
+
 // Which diff page a request is for. Every kind shares the blob/diff pipeline; only
 // the refs + changed-file discovery differs (PR API / commit API / compare API).
 export type DiffTarget =


### PR DESCRIPTION
## Summary

Deduplicates two copy-pasted extension helpers (the storage merge-on-save pattern and the unresolved-guid filter) into single definitions, and extracts the per-file attach/show state machine from the content script into a unit-testable module with vitest coverage of the show/sync/request transitions. No UI-visible behavior change.

## Motivation

The `chrome.storage.local.get` → spread-merge → `set` pattern existed three times in `background/index.ts`, and the "unresolved guids remaining" filter was repeated in three modules with nothing enforcing they agree on what "resolved" means. Meanwhile `content/index.ts` orchestrated the whole per-file show/sync/request state machine inline — the largest branch-heavy module with only e2e coverage.

Closes #201

## Changes

- `background/mergeStore.ts` (new): `createMergeStore(area, prefix)` — the single merge-on-save record slot. `background/index.ts` now builds `guidCache` and the repo-index `metaGuids` store from it; the repoIndexStore call site keeps its own quota policy (`.catch(() => {})`).
- `types.ts`: `unresolvedRemaining(json)` — the single definition of "unresolved guids without a resolved name", keeping the `Object.hasOwn` prototype-pollution guard. Used by `background/handler.ts`, `background/resolution.ts` (searchUnresolved), and the content resolving indicator (initial render and the guidResolved push listener).
- `content/fileView.ts` (new): the per-file attach/show state machine extracted from `content/index.ts` — host creation/attach, raw/semantic visibility sync, request latching, pending indicator + watchdog arming, and the error paths (kept-diff retry, too-large force, auth retry registration). All DOM/channel dependencies are parameters (`file`, `createHost`/`FilePanel`, `requestDiff`, `results`, `onAuthRetry`, `effectiveView`); `content/index.ts` now only binds them to the real DOM, the runtime channel, and the shared registries.
- Tests (+24, all with real in-memory dependency implementations, no mocks): `content/fileView.test.ts` (12 — show/sync/request transitions), `background/mergeStore.test.ts` (6), `types.test.ts` (4 — including the prototype-key guard).

## Testing

All inside `extension/` (`pnpm install` done first).

`pnpm typecheck`

```
$ tsc --noEmit
(exit 0)
```

`pnpm lint`

```
$ biome ci --reporter=default .
Checked 67 files in 26ms. No fixes applied.
```

`pnpm test` (266 tests / 24 files on main → 290 / 27 here)

```
$ zig build wasm
$ vitest run
 Test Files  27 passed (27)
      Tests  290 passed (290)
   Duration  2.64s
```

`pnpm e2e`

```
$ node build.mjs --e2e && playwright test
Running 19 tests using 3 workers
  19 passed (3.5s)
```