### PR TITLE
chore: widen renovate schedule to all of monday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "timezone": "Asia/Tokyo",
   "schedule": [
-    "before 9am on monday"
+    "on monday"
   ],
   "labels": [
     "dependencies"


### PR DESCRIPTION
## Summary

Widen the Renovate schedule window from `before 9am on monday` to all of Monday (JST).

## Motivation

The previous window was only 9 hours per week (Monday 00:00-09:00 JST). The Mend-hosted Renovate app runs at irregular times for this repository (roughly 1-3 runs per day, sometimes skipping a day), so it can miss the window entirely. On 2026-07-20 no run landed inside the window and every pending update stayed in "Awaiting Schedule" for another week. A full-day Monday window keeps the weekly cadence while making misses unlikely.

## Changes

- Change `schedule` in `renovate.json` from `before 9am on monday` to `on monday`

## Testing

- `npx --yes --package renovate -- renovate-config-validator renovate.json`

  ```
  INFO: Validating renovate.json as global config
  INFO: Config validated successfully against 1 file(s)
  ```