### PR TITLE
feat: show GameObject properties as overrides

### DIFF
--- a/cli/src/render_html.zig
+++ b/cli/src/render_html.zig
@@ -231,6 +231,8 @@ test "html: nested child GameObject nests inside the parent's pl-kids" {
     try testing.expect(parent_at < kids_at and kids_at < child_at);
     // The renamed child is a modified GameObject card.
     try testing.expect(std.mem.indexOf(u8, html, "<details open class=\"pl-go pl-modified\">") != null);
+    // Rename surfaces as a GameObject Name override row, not only in the summary label.
+    try testing.expect(std.mem.indexOf(u8, html, "<span class=\"pl-path\">Name</span><span class=\"pl-before\">Child</span><span class=\"pl-arrow\">→</span><span class=\"pl-after\">ChildRenamed</span>") != null);
 }
 
 test "html: added and removed fields render only their one side" {

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -277,6 +277,8 @@ test "render: child object hangs off the parent spine after components" {
     const text = aw.toArrayList().items;
     // The child is the parent's last spine node.
     try testing.expect(std.mem.indexOf(u8, text, "└─ ◆ ~ ChildRenamed") != null);
+    // Name override row shows before → after under the child's components group.
+    try testing.expect(std.mem.indexOf(u8, text, "Name: Child → ChildRenamed") != null);
 }
 
 test "render: component shows editor class name when script is unresolved" {

--- a/core/src/diff_overrides.zig
+++ b/core/src/diff_overrides.zig
@@ -208,14 +208,17 @@ test "diff: added prefab instance emits placement summary rows" {
     const d = findDoc(fd, 1001).?;
     try testing.expectEqual(model.Status.added, d.status);
     // Recorded placement is emitted as a single synthesized row even at default values (identity Rotation).
-    // EulerAnglesHint (hidden in Inspector) is not emitted; m_Name stays absent on added instances.
-    try testing.expectEqual(@as(usize, 2), d.overrides.len);
+    // EulerAnglesHint (hidden in Inspector) is not emitted; m_Name appears as a GameObject row.
+    try testing.expectEqual(@as(usize, 3), d.overrides.len);
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Position", d.overrides[0].label);
     try testing.expectEqualStrings("(2.03, 3.63, 1.11797)", d.overrides[0].after.?.scalar);
     try testing.expectEqualStrings("Transform", d.overrides[1].group);
     try testing.expectEqualStrings("Rotation", d.overrides[1].label);
     try testing.expectEqualStrings("(0, 0, 0, 1)", d.overrides[1].after.?.scalar);
+    try testing.expectEqualStrings("GameObject", d.overrides[2].group);
+    try testing.expectEqualStrings("Name", d.overrides[2].label);
+    try testing.expectEqualStrings("Cylinder Variant", d.overrides[2].after.?.scalar);
 }
 
 test "diff: added prefab instance keeps partial scale override" {

--- a/core/src/diff_overrides.zig
+++ b/core/src/diff_overrides.zig
@@ -74,6 +74,43 @@ test "diff: prefab instance override keyed by target+propertyPath" {
     try testing.expectEqualStrings("1", d.overrides[0].after.?.scalar);
 }
 
+test "diff: prefab instance name rename emits GameObject override" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 7, guid: aaa, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Head
+        \\      objectReference: {fileID: 0}
+        \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
+    ;
+    const after =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 7, guid: aaa, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Sensor
+        \\      objectReference: {fileID: 0}
+        \\  m_SourcePrefab: {fileID: 100100000, guid: aaa, type: 3}
+    ;
+    const fd = try diffmod.compute(arena, before, after);
+    const d = findDoc(fd, 1001).?;
+    try testing.expectEqual(model.Status.modified, d.status);
+    try testing.expectEqual(@as(usize, 1), d.overrides.len);
+    try testing.expectEqualStrings("GameObject", d.overrides[0].group);
+    try testing.expectEqualStrings("Name", d.overrides[0].label);
+    try testing.expectEqual(model.Status.modified, d.overrides[0].status);
+    try testing.expectEqualStrings("Head", d.overrides[0].before.?.scalar);
+    try testing.expectEqualStrings("Sensor", d.overrides[0].after.?.scalar);
+}
+
 test "diff: modified instance overrides are sorted group-contiguous, Transform first" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -171,7 +208,7 @@ test "diff: added prefab instance emits placement summary rows" {
     const d = findDoc(fd, 1001).?;
     try testing.expectEqual(model.Status.added, d.status);
     // Recorded placement is emitted as a single synthesized row even at default values (identity Rotation).
-    // EulerAnglesHint (hidden in Inspector) and m_Name (absorbed into the node name) are not emitted.
+    // EulerAnglesHint (hidden in Inspector) is not emitted; m_Name stays absent on added instances.
     try testing.expectEqual(@as(usize, 2), d.overrides.len);
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Position", d.overrides[0].label);
@@ -347,8 +384,10 @@ pub fn diffOverrides(arena: std.mem.Allocator, before_doc: ?*const model.Documen
         if (before_map.get(key)) |bm| {
             const bv: ?*const Node = modValue(bm);
             if (nodeEqlOpt(bv, av)) continue;
+            if (std.mem.eql(u8, am.path, "m_Name") and !inspector.shouldEmitNameOverride(.modified, bv, av)) continue;
             try out.append(arena, try makeOverride(arena, am.path, .modified, bv, av));
         } else {
+            if (std.mem.eql(u8, am.path, "m_Name") and !inspector.shouldEmitNameOverride(.added, null, av)) continue;
             try out.append(arena, try makeOverride(arena, am.path, .added, null, av));
         }
     }
@@ -356,7 +395,9 @@ pub fn diffOverrides(arena: std.mem.Allocator, before_doc: ?*const model.Documen
     for (before_mods) |bm| {
         if (seen.contains(try modKey(arena, bm))) continue;
         if (inspector.isHidden(bm.path)) continue;
-        try out.append(arena, try makeOverride(arena, bm.path, .removed, modValue(bm), null));
+        const bv = modValue(bm);
+        if (std.mem.eql(u8, bm.path, "m_Name") and !inspector.shouldEmitNameOverride(.removed, bv, null)) continue;
+        try out.append(arena, try makeOverride(arena, bm.path, .removed, bv, null));
     }
     try appendStructuralSummaries(arena, &out, before_doc, after_doc);
     sortByGroup(out.items);
@@ -469,7 +510,12 @@ fn soleOverridesFromMods(arena: std.mem.Allocator, doc: *const model.Document, m
 
     for (mods) |m| {
         if (inspector.isHidden(m.path)) continue;
-        if (std.mem.eql(u8, m.path, "m_Name")) continue; // absorbed into the node name
+        const v = modValue(m);
+        if (std.mem.eql(u8, m.path, "m_Name") and !inspector.shouldEmitNameOverride(
+            status,
+            if (status == .removed) v else null,
+            if (status == .added) v else null,
+        )) continue;
         const in_consumed = blk: {
             for (placements, 0..) |p, pi| {
                 if (consumed[pi] and std.mem.startsWith(u8, m.path, p.prefix) and
@@ -478,7 +524,6 @@ fn soleOverridesFromMods(arena: std.mem.Allocator, doc: *const model.Document, m
             break :blk false;
         };
         if (in_consumed) continue;
-        const v = modValue(m);
         try out.append(arena, try makeOverride(
             arena,
             m.path,

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -32,12 +32,15 @@ test "fixture: Plane.prefab shows both cylinder instances under Plane" {
     const variant = childByName(plane, "Cylinder Variant").?;
     try testing.expectEqual(model.ObjectKind.prefab_instance, variant.kind);
     try testing.expectEqual(model.Status.added, variant.status);
-    try testing.expectEqual(@as(usize, 2), variant.overrides.len);
+    try testing.expectEqual(@as(usize, 3), variant.overrides.len);
     try testing.expectEqualStrings("Transform", variant.overrides[0].group);
     try testing.expectEqualStrings("Position", variant.overrides[0].label);
     try testing.expectEqualStrings("(2.03, 3.63, 1.11797)", variant.overrides[0].after.?.scalar);
     try testing.expectEqualStrings("Rotation", variant.overrides[1].label);
     try testing.expectEqualStrings("(0, 0, 0, 1)", variant.overrides[1].after.?.scalar);
+    try testing.expectEqualStrings("GameObject", variant.overrides[2].group);
+    try testing.expectEqualStrings("Name", variant.overrides[2].label);
+    try testing.expectEqualStrings("Cylinder Variant", variant.overrides[2].after.?.scalar);
 
     // Modified Cylinder: only the single Position.x override.
     const cylinder = childByName(plane, "Cylinder").?;
@@ -91,14 +94,17 @@ test "fixture: new Cylinder Variant.prefab shows all recorded placement values" 
     try testing.expectEqualStrings("Cylinder Variant", inst.name);
     try testing.expectEqual(model.Status.added, inst.status);
     // Placement recorded in the file is all emitted, even at defaults.
-    // The only omissions are EulerAnglesHint (hidden) and m_Name (absorbed into the node name).
-    try testing.expectEqual(@as(usize, 3), inst.overrides.len);
+    // The only omission is EulerAnglesHint (hidden); m_Name appears as a GameObject row.
+    try testing.expectEqual(@as(usize, 4), inst.overrides.len);
     try testing.expectEqualStrings("Position", inst.overrides[0].label);
     try testing.expectEqualStrings("(0, 0, 0)", inst.overrides[0].after.?.scalar);
     try testing.expectEqualStrings("Rotation", inst.overrides[1].label);
     try testing.expectEqualStrings("(0, 0, 0, 1)", inst.overrides[1].after.?.scalar);
     try testing.expectEqualStrings("Scale.y", inst.overrides[2].label);
     try testing.expectEqualStrings("2", inst.overrides[2].after.?.scalar);
+    try testing.expectEqualStrings("GameObject", inst.overrides[3].group);
+    try testing.expectEqualStrings("Name", inst.overrides[3].label);
+    try testing.expectEqualStrings("Cylinder Variant", inst.overrides[3].after.?.scalar);
 }
 
 test "fixture: deleted Cylinder Variant.prefab mirrors the added enumeration" {

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -111,7 +111,7 @@ test "fixture: deleted Cylinder Variant.prefab mirrors the added enumeration" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
-    // Mirror of added (the previous test): the same 3 rows appear with before values and removed.
+    // Mirror of added (the previous test) minus the Name row: removed omits Name via shouldEmitNameOverride.
     const res = try root.diffBytes(arena, cylinder_variant_after, "");
     try testing.expectEqual(@as(usize, 1), res.roots.len);
     const inst = res.roots[0];

--- a/core/src/inspector.zig
+++ b/core/src/inspector.zig
@@ -1,5 +1,15 @@
 const std = @import("std");
+const model = @import("model.zig");
 const testing = std.testing;
+
+test "inspector: shouldEmitNameOverride only for modified renames" {
+    var before_n = model.Node{ .scalar = "Head" };
+    var after_n = model.Node{ .scalar = "Sensor" };
+    try testing.expect(shouldEmitNameOverride(.modified, &before_n, &after_n));
+    try testing.expect(!shouldEmitNameOverride(.added, null, &after_n));
+    try testing.expect(!shouldEmitNameOverride(.removed, &before_n, null));
+    try testing.expect(!shouldEmitNameOverride(.modified, &before_n, &before_n));
+}
 
 test "inspector: hidden fields are hidden by first path segment" {
     try testing.expect(isHidden("m_ObjectHideFlags"));
@@ -136,4 +146,11 @@ pub fn groupOf(property_path: []const u8) []const u8 {
     for (transform_props) |t| if (std.mem.eql(u8, head, t)) return "Transform";
     for (game_object_props) |g| if (std.mem.eql(u8, head, g)) return "GameObject";
     return "Overrides";
+}
+
+pub fn shouldEmitNameOverride(status: model.Status, before: ?*const model.Node, after: ?*const model.Node) bool {
+    if (status != .modified) return false;
+    const b = before orelse return false;
+    const a = after orelse return false;
+    return !model.Node.eql(b, a);
 }

--- a/core/src/inspector.zig
+++ b/core/src/inspector.zig
@@ -2,13 +2,14 @@ const std = @import("std");
 const model = @import("model.zig");
 const testing = std.testing;
 
-test "inspector: shouldEmitNameOverride only for modified renames" {
+test "inspector: shouldEmitNameOverride for added and modified renames" {
     var before_n = model.Node{ .scalar = "Head" };
     var after_n = model.Node{ .scalar = "Sensor" };
     try testing.expect(shouldEmitNameOverride(.modified, &before_n, &after_n));
-    try testing.expect(!shouldEmitNameOverride(.added, null, &after_n));
+    try testing.expect(shouldEmitNameOverride(.added, null, &after_n));
     try testing.expect(!shouldEmitNameOverride(.removed, &before_n, null));
     try testing.expect(!shouldEmitNameOverride(.modified, &before_n, &before_n));
+    try testing.expect(!shouldEmitNameOverride(.added, null, null));
 }
 
 test "inspector: hidden fields are hidden by first path segment" {
@@ -149,8 +150,13 @@ pub fn groupOf(property_path: []const u8) []const u8 {
 }
 
 pub fn shouldEmitNameOverride(status: model.Status, before: ?*const model.Node, after: ?*const model.Node) bool {
-    if (status != .modified) return false;
-    const b = before orelse return false;
-    const a = after orelse return false;
-    return !model.Node.eql(b, a);
+    return switch (status) {
+        .added => after != null,
+        .modified => blk: {
+            const b = before orelse return false;
+            const a = after orelse return false;
+            break :blk !model.Node.eql(b, a);
+        },
+        else => false,
+    };
 }

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -91,7 +91,8 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     if (sub.roots.len == 1) {
         node.components = try concatComponents(ctx.arena, node.components, sub.roots[0].components, sub.loose);
         node.children = try concatObjects(ctx.arena, node.children, sub.roots[0].children);
-        inner_overrides = sub.roots[0].overrides;
+        // Variant PrefabInstance roots may carry nested override rows; GameObject roots must not.
+        inner_overrides = if (sub.roots[0].kind == .prefab_instance) sub.roots[0].overrides else &.{};
     } else {
         node.components = try concatComponents(ctx.arena, node.components, &.{}, sub.loose);
         node.children = try concatObjects(ctx.arena, node.children, sub.roots);

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -78,13 +78,13 @@ fn writeObject(w: *std.Io.Writer, o: model.ObjectDiff, resolved: ?*const Resolve
     if (o.kind == .prefab_instance) {
         try w.writeAll(",\"sourceGuid\":");
         if (o.source_guid) |g| try writeJsonString(w, g) else try w.writeAll("null");
-        try w.writeAll(",\"overrides\":[");
-        for (o.overrides, 0..) |ov, i| {
-            if (i != 0) try w.writeByte(',');
-            try writeOverride(w, ov);
-        }
-        try w.writeByte(']');
     }
+    try w.writeAll(",\"overrides\":[");
+    for (o.overrides, 0..) |ov, i| {
+        if (i != 0) try w.writeByte(',');
+        try writeOverride(w, ov);
+    }
+    try w.writeByte(']');
     try w.writeAll(",\"components\":[");
     for (o.components, 0..) |c, i| {
         if (i != 0) try w.writeByte(',');
@@ -314,9 +314,41 @@ test "json: v2 root node shape matches golden" {
     // Regression pin fixing the full node shape on the roots side (gameObject + components + child
     // prefabInstance + overrides + structural summary) byte-for-byte.
     const golden =
-        \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"neededSources":[{"guid":"aaa","side":"after"}],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"GameObject","label":"Name","status":"added","before":null,"after":"Cylinder"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
+        \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"neededSources":[{"guid":"aaa","side":"after"}],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","overrides":[],"components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"GameObject","label":"Name","status":"added","before":null,"after":"Cylinder"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
     ;
     try testing.expectEqualStrings(golden, out);
+}
+
+test "json: gameObject rename emits Name override" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Head
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    const after =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Sensor
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    const out = try root.diffToJson(arena, before, after);
+    try testing.expect(std.mem.indexOf(u8, out, "\"label\":\"Name\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"before\":\"Head\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"after\":\"Sensor\"") != null);
 }
 
 test "json: component carries className" {

--- a/core/src/json.zig
+++ b/core/src/json.zig
@@ -231,7 +231,7 @@ test "json: v2 prefab instance node with overrides" {
     try testing.expect(std.mem.indexOf(u8, out, "\"kind\":\"prefabInstance\"") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"name\":\"Cylinder Variant\"") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"sourceGuid\":\"aaa\"") != null);
-    try testing.expect(std.mem.indexOf(u8, out, "\"overrides\":[{\"group\":\"Transform\",\"label\":\"Scale.y\",\"status\":\"added\",\"before\":null,\"after\":\"2\"}]") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"overrides\":[{\"group\":\"Transform\",\"label\":\"Scale.y\",\"status\":\"added\",\"before\":null,\"after\":\"2\"},{\"group\":\"GameObject\",\"label\":\"Name\",\"status\":\"added\",\"before\":null,\"after\":\"Cylinder Variant\"}]") != null);
 }
 
 test "json: needed sources are emitted only when unresolved" {
@@ -314,7 +314,7 @@ test "json: v2 root node shape matches golden" {
     // Regression pin fixing the full node shape on the roots side (gameObject + components + child
     // prefabInstance + overrides + structural summary) byte-for-byte.
     const golden =
-        \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"neededSources":[{"guid":"aaa","side":"after"}],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
+        \\{"schema":"prefablens.diff.v2","unresolvedGuids":["def","aaa"],"neededSources":[{"guid":"aaa","side":"after"}],"roots":[{"kind":"gameObject","fileId":"1","name":"Plane","status":"unchanged","components":[{"kind":"component","fileId":"5","classId":114,"typeName":"MonoBehaviour","scriptGuid":"def","className":null,"status":"modified","fields":[{"path":"Hp","status":"modified","before":"1","after":"2"}]}],"children":[{"kind":"prefabInstance","fileId":"1001","name":"Cylinder","status":"added","sourceGuid":"aaa","overrides":[{"group":"Transform","label":"Scale.y","status":"added","before":null,"after":"2"},{"group":"GameObject","label":"Name","status":"added","before":null,"after":"Cylinder"},{"group":"Overrides","label":"Added Components (1)","status":"added","before":null,"after":null}],"components":[],"children":[]}]}],"loose":[]}
     ;
     try testing.expectEqualStrings(golden, out);
 }

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -133,7 +133,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
             .file_id = go_id,
             .name = goName(&idx, go_id),
             .status = gd.status,
-            .overrides = if (gd.status == .added) &.{} else try goFieldsToOverrides(arena, gd.fields),
+            .overrides = try goFieldsToOverrides(arena, gd.fields),
             .components = comps,
             .children = &.{},
         });
@@ -270,7 +270,7 @@ test "tree: GameObject rename appears as GameObject Name override" {
     try testing.expectEqualStrings("Sensor", go.overrides[0].after.?.scalar);
 }
 
-test "tree: GameObject Active change is an override; added GO omits Name" {
+test "tree: GameObject Active change is an override; added GO includes Name and Active" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -321,9 +321,21 @@ test "tree: GameObject Active change is an override; added GO omits Name" {
     const go_added = res_added.roots[0];
     try testing.expectEqualStrings("Widget", go_added.name);
     try testing.expectEqual(model.Status.added, go_added.status);
+    var saw_name = false;
+    var saw_active = false;
     for (go_added.overrides) |o| {
-        try testing.expect(!std.mem.eql(u8, o.label, "Name"));
+        if (std.mem.eql(u8, o.label, "Name")) {
+            saw_name = true;
+            try testing.expectEqualStrings("GameObject", o.group);
+            try testing.expectEqualStrings("Widget", o.after.?.scalar);
+        }
+        if (std.mem.eql(u8, o.label, "Active")) {
+            saw_active = true;
+            try testing.expectEqualStrings("GameObject", o.group);
+            try testing.expectEqualStrings("1", o.after.?.scalar);
+        }
     }
+    try testing.expect(saw_name and saw_active);
 }
 
 test "tree: GameObject groups its components; modified component bubbles up" {

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -8,6 +8,7 @@ const root = @import("root.zig");
 const testing = std.testing;
 
 const diffmod = @import("diff.zig");
+const inspector = @import("inspector.zig");
 const tree_chain = @import("tree_chain.zig");
 const tree_order = @import("tree_order.zig");
 
@@ -47,6 +48,22 @@ fn makeComponent(dd: diffmod.DocDiff) ComponentDiff {
         .status = dd.status,
         .fields = dd.fields,
     };
+}
+
+fn goFieldsToOverrides(arena: std.mem.Allocator, fields: []const model.FieldDiff) ![]model.OverrideDiff {
+    var out: std.ArrayList(model.OverrideDiff) = .empty;
+    for (fields) |f| {
+        if (std.mem.eql(u8, f.path, "Name") and !inspector.shouldEmitNameOverride(f.status, f.before, f.after))
+            continue;
+        try out.append(arena, .{
+            .group = "GameObject",
+            .label = f.path,
+            .status = f.status,
+            .before = f.before,
+            .after = f.after,
+        });
+    }
+    return out.toOwnedSlice(arena);
 }
 
 pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
@@ -116,6 +133,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
             .file_id = go_id,
             .name = goName(&idx, go_id),
             .status = gd.status,
+            .overrides = if (gd.status == .added) &.{} else try goFieldsToOverrides(arena, gd.fields),
             .components = comps,
             .children = &.{},
         });
@@ -213,6 +231,99 @@ fn materialize(
 pub fn findRoot(res: model.DiffResult, file_id: i64) ?model.ObjectDiff {
     for (res.roots) |o| if (o.file_id == file_id) return o;
     return null;
+}
+
+test "tree: GameObject rename appears as GameObject Name override" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Head
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    const after =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Sensor
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    const res = try root.diffBytes(arena, before, after);
+    const go = res.roots[0];
+    try testing.expectEqualStrings("Sensor", go.name);
+    try testing.expectEqual(model.Status.modified, go.status);
+    try testing.expectEqual(@as(usize, 1), go.overrides.len);
+    try testing.expectEqualStrings("GameObject", go.overrides[0].group);
+    try testing.expectEqualStrings("Name", go.overrides[0].label);
+    try testing.expectEqualStrings("Head", go.overrides[0].before.?.scalar);
+    try testing.expectEqualStrings("Sensor", go.overrides[0].after.?.scalar);
+}
+
+test "tree: GameObject Active change is an override; added GO omits Name" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before_active =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Lamp
+        \\  m_IsActive: 1
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    const after_active =
+        \\--- !u!1 &1
+        \\GameObject:
+        \\  m_Name: Lamp
+        \\  m_IsActive: 0
+        \\  m_Component:
+        \\  - component: {fileID: 4}
+        \\--- !u!4 &4
+        \\Transform:
+        \\  m_GameObject: {fileID: 1}
+        \\  m_Father: {fileID: 0}
+    ;
+    const res_active = try root.diffBytes(arena, before_active, after_active);
+    const go_active = res_active.roots[0];
+    try testing.expectEqual(@as(usize, 1), go_active.overrides.len);
+    try testing.expectEqualStrings("Active", go_active.overrides[0].label);
+    try testing.expectEqualStrings("1", go_active.overrides[0].before.?.scalar);
+    try testing.expectEqualStrings("0", go_active.overrides[0].after.?.scalar);
+
+    const after_added =
+        \\--- !u!1 &2
+        \\GameObject:
+        \\  m_Name: Widget
+        \\  m_IsActive: 1
+        \\  m_Component:
+        \\  - component: {fileID: 5}
+        \\--- !u!4 &5
+        \\Transform:
+        \\  m_GameObject: {fileID: 2}
+        \\  m_Father: {fileID: 0}
+    ;
+    const res_added = try root.diffBytes(arena, "", after_added);
+    const go_added = res_added.roots[0];
+    try testing.expectEqualStrings("Widget", go_added.name);
+    try testing.expectEqual(model.Status.added, go_added.status);
+    for (go_added.overrides) |o| {
+        try testing.expect(!std.mem.eql(u8, o.label, "Name"));
+    }
 }
 
 test "tree: GameObject groups its components; modified component bubbles up" {

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -321,6 +321,7 @@ test "tree: GameObject Active change is an override; added GO includes Name and 
     const go_added = res_added.roots[0];
     try testing.expectEqualStrings("Widget", go_added.name);
     try testing.expectEqual(model.Status.added, go_added.status);
+    // Added GameObjects emit all visible presentFields (not only Name/Active); spot-check the two we care about here.
     var saw_name = false;
     var saw_active = false;
     for (go_added.overrides) |o| {

--- a/editor/Editor/DiffModel.cs
+++ b/editor/Editor/DiffModel.cs
@@ -58,6 +58,7 @@ namespace PrefabLens
         public string FileId;
         public string Name;
         public DiffStatus Status;
+        public List<OverrideDiff> Overrides = new();
         public List<ComponentDiff> Components = new();
         public List<NodeDiff> Children = new();
     }
@@ -67,7 +68,6 @@ namespace PrefabLens
     public sealed class PrefabInstanceDiff : NodeDiff
     {
         public string SourceGuid;
-        public List<OverrideDiff> Overrides = new();
     }
 
     /// Reader-side model for prefablens.diff.v2 (the output of core/src/json.zig).
@@ -137,6 +137,9 @@ namespace PrefabLens
             n.FileId = Str(o, "fileId") ?? "";
             n.Name = Str(o, "name") ?? "";
             n.Status = ParseStatus(Str(o, "status"));
+            foreach (var ov in Items(o, "overrides"))
+                if (ov is Dictionary<string, object> ovo)
+                    n.Overrides.Add(ParseOverride(ovo));
             foreach (var c in Items(o, "components"))
                 if (c is Dictionary<string, object> co)
                     n.Components.Add(ParseComponent(co));
@@ -146,23 +149,18 @@ namespace PrefabLens
             return n;
         }
 
-        static PrefabInstanceDiff ParsePrefabInstance(Dictionary<string, object> o)
-        {
-            var pi = new PrefabInstanceDiff { SourceGuid = Str(o, "sourceGuid") };
-            foreach (var ov in Items(o, "overrides"))
-                if (ov is Dictionary<string, object> ovo)
-                    pi.Overrides.Add(
-                        new OverrideDiff
-                        {
-                            Group = Str(ovo, "group") ?? "",
-                            Label = Str(ovo, "label") ?? "",
-                            Status = ParseStatus(Str(ovo, "status")),
-                            Before = ParseValue(Val(ovo, "before")),
-                            After = ParseValue(Val(ovo, "after")),
-                        }
-                    );
-            return pi;
-        }
+        static PrefabInstanceDiff ParsePrefabInstance(Dictionary<string, object> o) =>
+            new() { SourceGuid = Str(o, "sourceGuid") };
+
+        static OverrideDiff ParseOverride(Dictionary<string, object> ovo) =>
+            new()
+            {
+                Group = Str(ovo, "group") ?? "",
+                Label = Str(ovo, "label") ?? "",
+                Status = ParseStatus(Str(ovo, "status")),
+                Before = ParseValue(Val(ovo, "before")),
+                After = ParseValue(Val(ovo, "after")),
+            };
 
         static ComponentDiff ParseComponent(Dictionary<string, object> o)
         {

--- a/editor/Editor/DiffTree.cs
+++ b/editor/Editor/DiffTree.cs
@@ -95,9 +95,8 @@ namespace PrefabLens
                     Palette.Muted
                 );
             var item = new Item(row);
-            if (pi != null)
-                foreach (var ov in pi.Overrides)
-                    item.Children.Add(new Item(OverrideRow(ov, m)));
+            foreach (var ov in n.Overrides)
+                item.Children.Add(new Item(OverrideRow(ov, m)));
             if (n.Components.Count > 0)
             {
                 // Components fold as their own group one level below the object row (extension parity).

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -62,6 +62,26 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void ParsesGameObjectOverrides()
+        {
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[{""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""modified"",
+                    ""overrides"":[{""group"":"""",""label"":""Name"",""status"":""modified"",""before"":""Old"",""after"":""New""}],
+                    ""components"":[],""children"":[]}],
+                ""loose"":[]
+            }";
+            var m = DiffModel.Parse(json);
+            var go = (GameObjectDiff)m.Roots[0];
+            Assert.AreEqual(1, go.Overrides.Count);
+            Assert.AreEqual("Name", go.Overrides[0].Label);
+            Assert.AreEqual(DiffStatus.Modified, go.Overrides[0].Status);
+            Assert.AreEqual("Old", go.Overrides[0].Before.Scalar);
+            Assert.AreEqual("New", go.Overrides[0].After.Scalar);
+        }
+
+        [Test]
         public void SkipsUnknownNodeKindsAndToleratesMissingFields()
         {
             const string json =

--- a/editor/Tests/Editor/DiffTreeTests.cs
+++ b/editor/Tests/Editor/DiffTreeTests.cs
@@ -191,6 +191,25 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void GameObjectOverridesRenderAsChildRows()
+        {
+            const string json =
+                @"{
+                ""unresolvedGuids"":[],
+                ""roots"":[{""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""modified"",
+                    ""overrides"":[{""group"":"""",""label"":""Name"",""status"":""modified"",""before"":""Old"",""after"":""New""}],
+                    ""components"":[],""children"":[]}],
+                ""loose"":[]
+            }";
+            var children = Build(json)[0].Children;
+            Assert.AreEqual(1, children.Count);
+            AssertSpan(children[0].Row.Spans[1], "Name ", Palette.Muted);
+            AssertSpan(children[0].Row.Spans[2], "Old", Palette.Removed);
+            AssertSpan(children[0].Row.Spans[3], " → ", Palette.Muted);
+            AssertSpan(children[0].Row.Spans[4], "New", Palette.Added);
+        }
+
+        [Test]
         public void NodeChildrenOrderIsOverridesThenComponentsThenChildNodes()
         {
             // Mirrors the Inspector's mental model: instance overrides at the top,

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -45,7 +45,15 @@ const DIFF: DiffV2 = {
         },
       ],
       children: [
-        { kind: "gameObject", fileId: "3", name: "Weapon", status: "added", overrides: [], components: [], children: [] },
+        {
+          kind: "gameObject",
+          fileId: "3",
+          name: "Weapon",
+          status: "added",
+          overrides: [],
+          components: [],
+          children: [],
+        },
       ],
     },
   ],
@@ -259,9 +267,7 @@ describe("render", () => {
           fileId: "1",
           name: "Sensor",
           status: "modified",
-          overrides: [
-            { group: "GameObject", label: "Name", status: "modified", before: "Head", after: "Sensor" },
-          ],
+          overrides: [{ group: "GameObject", label: "Name", status: "modified", before: "Head", after: "Sensor" }],
           components: [],
           children: [],
         },

--- a/extension/src/renderer/render.test.ts
+++ b/extension/src/renderer/render.test.ts
@@ -22,6 +22,7 @@ const DIFF: DiffV2 = {
       fileId: "1",
       name: "Player",
       status: "modified",
+      overrides: [],
       components: [
         {
           kind: "component",
@@ -43,7 +44,9 @@ const DIFF: DiffV2 = {
           ],
         },
       ],
-      children: [{ kind: "gameObject", fileId: "3", name: "Weapon", status: "added", components: [], children: [] }],
+      children: [
+        { kind: "gameObject", fileId: "3", name: "Weapon", status: "added", overrides: [], components: [], children: [] },
+      ],
     },
   ],
   loose: [],
@@ -59,6 +62,7 @@ const INSTANCE: DiffV2 = {
       fileId: "1",
       name: "Plane",
       status: "unchanged",
+      overrides: [],
       components: [],
       children: [
         {
@@ -208,6 +212,7 @@ describe("render", () => {
           fileId: "1",
           name: "<img src=x onerror=alert(1)>",
           status: "added",
+          overrides: [],
           components: [],
           children: [],
         },
@@ -242,6 +247,33 @@ describe("render", () => {
     const root = freshRoot();
     renderError(root, "Set a GitHub token in the PrefabLens options page.");
     expect(root.textContent).toContain("Set a GitHub token");
+  });
+
+  it("renders game object overrides in the components section", () => {
+    const diff: DiffV2 = {
+      schema: "prefablens.diff.v2",
+      unresolvedGuids: [],
+      roots: [
+        {
+          kind: "gameObject",
+          fileId: "1",
+          name: "Sensor",
+          status: "modified",
+          overrides: [
+            { group: "GameObject", label: "Name", status: "modified", before: "Head", after: "Sensor" },
+          ],
+          components: [],
+          children: [],
+        },
+      ],
+      loose: [],
+    };
+    const root = freshRoot();
+    render(root, diff);
+    const row = root.querySelector(".pl-components .pl-field.pl-modified");
+    expect(row?.textContent).toContain("Name");
+    expect(row?.textContent).toContain("Head");
+    expect(row?.textContent).toContain("Sensor");
   });
 
   it("renders prefab instance with badge, components section and open override card", () => {
@@ -326,6 +358,7 @@ describe("render", () => {
           fileId: "1",
           name: "Cylinder",
           status: "modified",
+          overrides: [],
           components: [
             {
               kind: "component",

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -230,7 +230,7 @@ function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
   const kids = kidsBox();
   // Display-hierarchy rule: component/override cards live only under the components section.
   const cards: HTMLElement[] = [];
-  if (node.kind === "prefabInstance") cards.push(...renderOverrideGroups(node.overrides, diff));
+  cards.push(...renderOverrideGroups(node.overrides, diff));
   cards.push(...node.components.map((c) => renderComponent(c, diff)));
   if (cards.length) kids.append(componentsSection(cards));
   for (const child of node.children) kids.append(renderNode(child, diff));

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -30,6 +30,7 @@ export type GameObjectDiff = {
   fileId: string;
   name: string;
   status: Status;
+  overrides: OverrideDiff[];
   components: ComponentDiff[];
   children: NodeDiff[];
 };

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -208,6 +208,9 @@ try {
   // not ship a silently broken page.
   if (!report.includes("pl-")) throw new Error("CLI report lost its pl- classes");
   if (!heroReport.includes("Rigidbody")) throw new Error("hero report is missing the Robot diff");
+  if (!heroReport.includes("Head") || !heroReport.includes("Sensor")) {
+    throw new Error("hero report is missing the Head → Sensor rename");
+  }
   if (!heroReport.includes("Assets/Scripts/FixtureBehaviour.cs")) throw new Error("hero report lost guid resolution");
   if (tree.includes("unresolved")) throw new Error("tree output has unresolved guid references");
   // Playground.unity references built-in meshes and Default-Material: those


### PR DESCRIPTION
## Summary

Surface GameObject Inspector properties (Name, Active, Tag, Layer, …) and PrefabInstance renames as `overrides` with `group: "GameObject"`, matching the existing PrefabInstance override UI across CLI, extension, and editor.

## Motivation

`Robot.prefab`'s Head → Sensor rename appeared in raw git diffs but not in PrefabLens: GameObject `fields` were dropped when building the tree, and PrefabInstance `m_Name` was absorbed into the after-only hierarchy label. Reviewers could not see the rename (or Active/Tag/Layer changes) as semantic field diffs.

Closes #234

## Changes

- Attach GameObject `fields` to `ObjectDiff.overrides`; centralize Name emit in `shouldEmitNameOverride` (modified rename or added; omit on removed)
- Stop PrefabInstance `m_Name` blanket absorb; emit Name under GameObject overrides
- Instantiate graft: lift overrides only from PrefabInstance source roots (not GameObject roots)
- Always emit `overrides` in `prefablens.diff.v2` JSON for every object kind
- Extension / editor: read and render GO overrides; move `Overrides` onto `NodeDiff`
- CLI tests assert Name override on rename; site hero smoke requires Head and Sensor

## Testing

```
mise exec -- zig build test
# exit 0

cd extension && mise exec -- pnpm test
# 291 tests pass

cd editor && dotnet test DotNetTests~/Tests
# 75 tests pass

mise exec -- zig build && mise exec -- zig build wasm
cd extension && mise exec -- pnpm run demo
cd ../site && mise exec -- pnpm run build
# hero smoke includes Head → Sensor rename assert
```