### PR TITLE
build: bump postcss to 8.5.18 in lockfile

### DIFF
--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -814,8 +814,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   punycode@2.3.1:
@@ -1577,7 +1577,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.16:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -1681,7 +1681,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.18
       rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary

Bump transitive postcss from 8.5.16 to 8.5.18 in the extension lockfile to fix a high-severity path traversal advisory.

## Motivation

[Dependabot alert #1](https://github.com/hashiiiii/PrefabLens/security/dependabot/1) flags postcss <= 8.5.17 (path traversal in source map auto-loading, GHSA high severity). postcss is a transitive devDependency (`vite -> postcss`), so Renovate cannot remediate it: its vulnerability alerts only cover direct dependencies listed in package files.

## Changes

- Bump postcss 8.5.16 -> 8.5.18 in `extension/pnpm-lock.yaml` (lockfile-only; within vite's `^8.5.16` range, no `package.json` change)

## Testing

- `pnpm test`: 27 files / 291 tests passed
- `pnpm build`: succeeded