### PR TITLE
build: block esbuild build script in site

### DIFF
--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  esbuild: true
+  esbuild: false
   workerd: false
 minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary

Flip `esbuild` from `true` to `false` in `site/pnpm-workspace.yaml` `allowBuilds`, so neither esbuild nor workerd runs an install-time build script.

## Motivation

esbuild's postinstall is an optimization only: the native binary ships as the `@esbuild/*` optionalDependency and the JS shim resolves it at runtime, so blocking the script changes nothing functionally. The entry itself cannot be removed — pnpm 11 regenerates a placeholder and fails install with `ERR_PNPM_IGNORED_BUILDS`.

Closes #239

## Changes

- `site/pnpm-workspace.yaml`: `allowBuilds.esbuild` `true` → `false`

## Testing

Clean install and deploy dry-run in `site/` with both build scripts blocked:

```
$ rm -rf node_modules && pnpm install --frozen-lockfile
Done in 335ms using pnpm v11.13.0

$ pnpm exec wrangler deploy --dry-run
✨ Read 56 files from the assets directory .../site/dist
Total Upload: 0.34 KiB / gzip: 0.24 KiB
--dry-run: exiting now.
```

`wrangler dev` was also verified against an isolated copy: serves the built site with HTTP 200 (the blocked postinstalls only skip the native-binary swap; `@esbuild/darwin-arm64` / `@cloudflare/workerd-darwin-arm64` resolve via the JS shims).