### PR TITLE
refactor: clarify extension comments and names

### DIFF
--- a/extension/src/background/diffStore.ts
+++ b/extension/src/background/diffStore.ts
@@ -1,9 +1,9 @@
 import type { DiffV2 } from "../types";
 
 const PREFIX = "diff:";
-const MAX_BYTES = 512 * 1024; // storage.session is 10MB: leave large ones to the memory cache only (recompute if the SW dies)
+const MAX_BYTES = 512 * 1024; // storage.session is 10MB: leave large ones to memory cache only
 
-// Accepts only the needed subset of chrome.storage.session (so tests can swap in a fake)
+// Needed subset of chrome.storage.session (tests swap in a fake)
 type Area = {
   get(keys: string | string[] | null): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
@@ -15,9 +15,8 @@ export type DiffStore = {
   save(key: string, json: DiffV2): Promise<void>;
 };
 
-/** Stores raw diffs in storage.session under a sha key, reusing them across SW restarts.
- *  On quota overflow, wipe the accumulated diffs and rewrite once: without this, once it fills up
- *  every SW restart thereafter recomputes everything and it silently degrades permanently (content is recomputable from the sha key). */
+// Raw diffs in storage.session under a sha key across SW restarts.
+// Quota overflow → wipe diffs and rewrite once; without this every SW restart recomputes forever.
 export function createSessionDiffStore(area: Area): DiffStore {
   return {
     async load(key) {
@@ -31,14 +30,14 @@ export function createSessionDiffStore(area: Area): DiffStore {
       } catch {
         await flushDiffs(area);
         await area.set({ [PREFIX + key]: json }).catch(() => {
-          // Still unwritable after flush (a single diff over quota, etc.): continue with the memory cache
+          // Still unwritable after flush: continue with the memory cache
         });
       }
     },
   };
 }
 
-/** Wipes only keys with the diff: prefix (keeps unrelated session keys like viewMode). */
+// Wipe only diff: keys (keeps unrelated session keys like viewMode)
 async function flushDiffs(area: Area): Promise<void> {
   const all = await area.get(null).catch(() => ({}));
   const keys = Object.keys(all).filter((k) => k.startsWith(PREFIX));

--- a/extension/src/background/handler.ts
+++ b/extension/src/background/handler.ts
@@ -52,7 +52,7 @@ export type Handler = {
   prefetch(req: PrefetchRequest): Promise<void>;
 };
 
-/** The only per-kind logic: refs + changed-file discovery. Everything downstream is target-agnostic. */
+// Per-kind: refs + changed-file discovery; everything downstream is target-agnostic
 async function loadRefsAndFiles(
   client: ClientLike,
   owner: string,
@@ -68,24 +68,22 @@ async function loadRefsAndFiles(
   }
   if (target.kind === "commit") {
     const commit = await client.getCommit(owner, repo, target.sha);
-    // Root commit: every file is added, so the before side is never fetched; using the commit's
-    // own sha as baseSha keeps downstream tree lookups harmless.
+    // Root commit: before side is never fetched; own sha as baseSha keeps tree lookups harmless
     return { refs: { baseSha: commit.parentSha ?? commit.sha, headSha: commit.sha }, files: commit.files };
   }
   const [cmp, headSha] = await Promise.all([
     client.compareRefs(owner, repo, target.base, target.head),
-    // Cache keys need an immutable sha, not a branch name. The compare body can't supply it:
-    // its commits array truncates at 250, so the last entry isn't always the head.
+    // Cache keys need an immutable sha; compare commits truncate at 250 so last ≠ always head
     client.resolveRefSha(owner, repo, target.head),
   ]);
   return { refs: { baseSha: cmp.mergeBaseSha, headSha }, files: cmp.files };
 }
 
 const EMPTY = new Uint8Array(0);
-const CONTEXT_TTL_MS = 60_000; // PR context is short-lived because a push changes headSha
+const CONTEXT_TTL_MS = 60_000; // push moves headSha
 const BLOB_CACHE_MAX = 32;
 const TOO_LARGE_BYTES = 25 * 1024 * 1024; // over 25MB renders on click
-const PREFETCH_MAX = 100; // prefetch cap per PR (bounds API usage)
+const PREFETCH_MAX = 100; // bounds API usage per PR
 const PREFETCH_CONCURRENCY = 4;
 
 type DiffOutcome =
@@ -94,16 +92,14 @@ type DiffOutcome =
   | { ok: false; error: "not-unity-yaml" };
 
 export function createHandler(deps: Deps): Handler {
-  // Per-PR context cache (60s ttl: a push moves headSha). The SW may be killed at any time; then we just re-fetch.
+  // Per-PR context; SW kill → re-fetch
   const contexts = createPromiseCache<DiffContext>({ ttlMs: CONTEXT_TTL_MS });
-  // sha+path → bytes. The promise fold shares one fetch between concurrent prefetch and manual-toggle requests.
+  // sha+path → bytes; promise fold shares prefetch + toggle fetches
   const blobs = createPromiseCache<Uint8Array | null>({ max: BLOB_CACHE_MAX });
-  // baseSha:headSha:path → raw diff computation. too-large is dropped so force can recompute; not-unity-yaml
-  // is deterministic for the sha pair, so it stays cached alongside successes.
+  // too-large dropped so force can recompute; not-unity-yaml stays cached
   const diffs = createPromiseCache<DiffOutcome>({ retain: (o) => o.ok || o.error !== "too-large" });
 
-  /** blobSha rides along when known (files API / merge-base tree): blob-by-sha latency is flat where
-   *  contents-by-path stalls for seconds (#110). A 404 on the sha (force push) falls back to path+ref. */
+  // Prefer blob-sha when known (#110); 404 (force push) falls back to path+ref
   function fetchBlob(
     client: ClientLike,
     owner: string,
@@ -112,7 +108,7 @@ export function createHandler(deps: Deps): Handler {
     sha: string,
     blobSha?: string,
   ): Promise<Uint8Array | null> {
-    // a blob sha never collides with the `${sha}:${path}` form
+    // blob sha never collides with `${sha}:${path}`
     return blobs.get(blobSha ?? `${sha}:${path}`, () =>
       blobSha
         ? client.getBlobRaw(owner, repo, blobSha).then((bytes) => bytes ?? client.getFileAtRef(owner, repo, path, sha))
@@ -120,7 +116,7 @@ export function createHandler(deps: Deps): Handler {
     );
   }
 
-  /** Retrieves the before/after blobs (status/previousPath rules follow the files API). */
+  // Before/after blobs; status/previousPath follow the files API
   async function fetchPair(
     client: ClientLike,
     ctx: DiffContext,
@@ -131,7 +127,7 @@ export function createHandler(deps: Deps): Handler {
     const file = ctx.files.find((f) => f.path === path);
     const status = file?.status ?? "modified";
     const beforePath = file?.previousPath ?? path;
-    // files API sha is the head blob, except for removed files where it is the base blob
+    // files API sha is head blob, except removed where it is the base blob
     const beforeBlob = status === "removed" ? file?.sha : ctx.baseShas?.get(beforePath);
     const afterBlob = status === "removed" ? undefined : file?.sha;
     const fetchSide = (p: string, sha: string, blobSha?: string): Promise<Uint8Array> =>
@@ -142,7 +138,6 @@ export function createHandler(deps: Deps): Handler {
     ]);
   }
 
-  // Repo-index and Code Search resolution plus source re-merge, sharing the handler's cached fetchers.
   const resolution = createResolution({
     guidCache: deps.guidCache,
     repoIndexStore: deps.repoIndexStore,
@@ -157,7 +152,7 @@ export function createHandler(deps: Deps): Handler {
       const bySha = new Map(files.map((f) => [f.path, f.sha]));
       const [guidIndex, baseShas] = await Promise.all([
         buildGuidIndex(files, async (path, side) => {
-          // the files API sha matches the side buildGuidIndex reads: head, or base exactly for removed metas
+          // files API sha matches the side buildGuidIndex reads (head, or base for removed metas)
           const bytes = await fetchBlob(
             client,
             owner,
@@ -168,7 +163,7 @@ export function createHandler(deps: Deps): Handler {
           );
           return bytes ? new TextDecoder().decode(bytes) : null;
         }),
-        // like buildGuidIndex, only rate limits propagate; anything else degrades to the contents-api fallback
+        // Only rate limits propagate; anything else → null → contents-api fallback
         client.listBlobShas(owner, repo, refs.baseSha).then(
           (tree) => (tree.truncated ? null : tree.byPath),
           (err: unknown) => {
@@ -181,8 +176,7 @@ export function createHandler(deps: Deps): Handler {
     });
   }
 
-  /** blob fetch → 25MB guard → plain diff, no further. Don't put resolution or mergeSources here
-   *  (resolved improves later via Code Search, so the raw diff determined by sha alone is the cache unit). */
+  // Raw sha-keyed diff only; resolution/mergeSources stay out (Code Search improves later)
   async function computeDiff(
     client: ClientLike,
     ctx: DiffContext,
@@ -191,21 +185,20 @@ export function createHandler(deps: Deps): Handler {
     path: string,
     force: boolean,
   ): Promise<DiffOutcome> {
-    // If not in the listing (the files API cuts off at 3000 entries), treat as modified: the missing side just 404s → EMPTY (fetchPair's rule)
+    // Missing from listing (files API caps at 3000) → treat as modified; 404 side → EMPTY
     const [before, after] = await fetchPair(client, ctx, owner, repo, path);
     if (!force && before.length + after.length > TOO_LARGE_BYTES) {
       return { ok: false, error: "too-large", bytes: before.length + after.length };
     }
     const differ = await deps.getDiffer();
-    // Path passed the extension prefilter, but some .asset files are binary
-    // regardless of Force Text: content is the ground truth.
+    // Prefilter passed, but some .asset files are binary regardless of ForceText
     if (!differ.isUnityYaml(before) && !differ.isUnityYaml(after)) {
       return { ok: false, error: "not-unity-yaml" };
     }
     return { ok: true, json: differ.diff(before, after) };
   }
 
-  /** sha-keyed, so a push naturally produces a different key (no invalidation needed). */
+  // Sha-keyed: a push produces a new key (no invalidation)
   function getDiff(
     client: ClientLike,
     ctx: DiffContext,
@@ -216,7 +209,7 @@ export function createHandler(deps: Deps): Handler {
   ): Promise<DiffOutcome> {
     const key = `${ctx.refs.baseSha}:${ctx.refs.headSha}:${path}`;
     return diffs.get(key, async (): Promise<DiffOutcome> => {
-      const stored = await deps.diffStore.load(key); // a result left by a prior SW life
+      const stored = await deps.diffStore.load(key); // prior SW life
       if (stored) return { ok: true, json: stored };
       const outcome = await computeDiff(client, ctx, owner, repo, path, force);
       if (outcome.ok) void deps.diffStore.save(key, outcome.json);
@@ -238,7 +231,7 @@ export function createHandler(deps: Deps): Handler {
       if (!outcome.ok) return outcome;
       const withPr = applyResolved(outcome.json, ctx.guidIndex);
 
-      // Two-stage path: return the diff immediately, continue resolution and source merging in the background, deliver via push
+      // Return immediately; resolution + source merge continue via push
       const remaining = unresolvedRemaining(withPr);
       if (!remaining.length && !withPr.neededSources?.length) return { ok: true, json: withPr };
       void resolution.resolveRemaining(withPr, remaining, client, req, base, ctx, push);
@@ -251,8 +244,7 @@ export function createHandler(deps: Deps): Handler {
     }
   }
 
-  /** Precomputes the raw diff only. No resolve/search/mergeSources
-   *  — Code Search is a scarce 10 req/min resource and mergeSources depends on resolution, so leave them to serve time. */
+  // Raw diff only — leave Code Search / mergeSources to serve time (10 req/min)
   async function prefetch(req: PrefetchRequest): Promise<void> {
     try {
       const settings = await deps.getSettings();
@@ -260,7 +252,7 @@ export function createHandler(deps: Deps): Handler {
       const base = API_BASE;
       const client = deps.makeClient(base, settings.pat, "prefetch");
       const ctx = await loadContext(client, req.owner, req.repo, { kind: "pull", prNumber: req.prNumber });
-      // Run independently of raw-diff prefetch (index sync speeds up the 3-stage resolution at serve time)
+      // Index sync independent of raw-diff prefetch (speeds 3-stage resolution at serve time)
       void resolution.getRepoIndex(client, req.owner, req.repo, `${base}/${req.owner}/${req.repo}`, ctx.refs.headSha);
       const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
       for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
@@ -268,14 +260,14 @@ export function createHandler(deps: Deps): Handler {
         await Promise.all(
           chunk.map((f) =>
             getDiff(client, ctx, req.owner, req.repo, f.path, false).catch((err) => {
-              if (err instanceof RateLimitError) throw err; // only a rate limit stops the whole thing
-              // Swallow per-file failures: the error is shown again on manual toggle
+              if (err instanceof RateLimitError) throw err; // only rate limit stops the whole thing
+              // Swallow per-file failures: shown again on manual toggle
             }),
           ),
         );
       }
     } catch (err) {
-      // Prefetch gives up quietly. Only the user-action path surfaces error UI
+      // Prefetch gives up quietly; only the user-action path surfaces error UI
       console.debug("prefablens: prefetch aborted", err);
     }
   }

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -8,15 +8,14 @@ import { createQueue } from "./queue";
 
 let differ: Promise<Differ> | undefined;
 
-// Six concurrent across all REST/GraphQL. GraphQL also goes through fetchFn, so it shares the same budget.
-// User-action-originated requests jump the queue via front
+// Six concurrent across REST/GraphQL (GraphQL shares fetchFn). User-action jumps via front.
 const queue = createQueue(6);
 const queuedFetch =
   (front: boolean): typeof fetch =>
   (input, init) =>
     queue(() => fetch(input, init), { front });
 
-// Whole-repo .meta guid records, shared by repoIndexStore.loadGuids/saveGuids below
+// Whole-repo .meta guid records for repoIndexStore.loadGuids/saveGuids
 const metaGuids = createMergeStore(chrome.storage.local, "metaGuids");
 
 const handler = createHandler({
@@ -26,18 +25,18 @@ const handler = createHandler({
   },
   makeClient: (base, token, lane) => new GithubClient(base, token, queuedFetch(lane === "user")),
   getDiffer() {
-    // Lazy singleton. If the SW restarts, just re-fetch.
+    // Lazy singleton; SW restart → re-fetch
     differ ??= fetch(chrome.runtime.getURL("prefablens.wasm"))
       .then((r) => r.arrayBuffer())
       .then(createDiffer);
     return differ;
   },
-  // Both guid caches are the same merge-on-save record slot, just under different prefixes
+  // Same merge-on-save slot under different prefixes
   guidCache: createMergeStore(chrome.storage.local, "guids"),
   diffStore: createSessionDiffStore(chrome.storage.session),
   repoIndexStore: {
     loadGuids: (repo) => metaGuids.load(repo),
-    saveGuids: (repo, entries) => metaGuids.save(repo, entries).catch(() => {}), // on quota overflow, continue in memory only
+    saveGuids: (repo, entries) => metaGuids.save(repo, entries).catch(() => {}), // quota overflow → memory only
     async loadIndex(repo) {
       const key = `guidIndex:${repo}`;
       const stored = await chrome.storage.local.get([key]);
@@ -52,12 +51,11 @@ const handler = createHandler({
 chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendResponse) => {
   if (msg?.type === "semanticDiff") {
     const tabId = sender.tab?.id;
-    // semanticDiff requests always originate in a tab content script; guard defensively so a non-tab sender no-ops.
+    // semanticDiff always originates in a tab content script; non-tab sender no-ops
     const push = (m: GuidResolvedPush) => {
       if (tabId === undefined) return;
-      // The final push releases the content-side indicator: retry a dropped tab message
-      // (SPA navigation races, transient port loss) before giving up. Intermediate pushes
-      // stay fire-and-forget — losing one only delays names until the final push.
+      // Final push releases the indicator: retry a dropped tab message before giving up.
+      // Intermediate pushes stay fire-and-forget — losing one only delays names until final.
       const attempt = (left: number): void => {
         void chrome.tabs.sendMessage(tabId, m).catch(() => {
           if (m.done && left > 0) setTimeout(() => attempt(left - 1), 1000);
@@ -69,5 +67,5 @@ chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendRespon
     return true; // async response
   }
   if (msg?.type === "prefetch") void handler.prefetch(msg);
-  return undefined; // prefetch doesn't respond (fire-and-forget)
+  return undefined; // prefetch is fire-and-forget
 });

--- a/extension/src/background/mergeStore.ts
+++ b/extension/src/background/mergeStore.ts
@@ -1,4 +1,4 @@
-// Accepts only the needed subset of chrome.storage.local (so tests can swap in a fake)
+// Needed subset of chrome.storage.local (tests swap in a fake)
 type Area = {
   get(keys: string[]): Promise<Record<string, unknown>>;
   set(items: Record<string, unknown>): Promise<void>;
@@ -9,10 +9,8 @@ export type MergeStore = {
   save(id: string, entries: Record<string, string>): Promise<void>;
 };
 
-/** A `prefix:id` storage slot holding a string record, where save merges entries into
- *  what is stored instead of replacing it (writers only ever add keys, so a stale read
- *  loses nothing but the other writer's additions). Failures propagate: each call site
- *  decides whether a lost write is fatal or a quota overflow to continue past. */
+// `prefix:id` slot: save merges into stored instead of replacing (writers only add keys).
+// Failures propagate — each call site decides if a lost write is fatal or quota to continue past.
 export function createMergeStore(area: Area, prefix: string): MergeStore {
   const keyOf = (id: string): string => `${prefix}:${id}`;
   return {

--- a/extension/src/background/promiseCache.ts
+++ b/extension/src/background/promiseCache.ts
@@ -1,7 +1,6 @@
 import { must } from "../util/must";
 
 export type PromiseCache<V> = {
-  /** Returns the cached promise for the key, computing (and caching) it on a miss. */
   get(key: string, compute: () => Promise<V>): Promise<V>;
 };
 
@@ -14,9 +13,7 @@ export type PromiseCacheOptions<V> = {
   retain?: (value: V) => boolean;
 };
 
-/** Keyed memoization of async computations for the background handler's caches.
- *  Storing the Promise itself folds concurrent requests for the same key into one
- *  computation; rejections are always dropped so the next get can retry. */
+// Keyed async memoization: storing the Promise folds concurrent gets; rejections always drop for retry.
 export function createPromiseCache<V>(options: PromiseCacheOptions<V> = {}): PromiseCache<V> {
   const { ttlMs, max, retain } = options;
   const entries = new Map<string, { at: number; promise: Promise<V> }>();

--- a/extension/src/background/queue.ts
+++ b/extension/src/background/queue.ts
@@ -12,13 +12,11 @@ type Job = {
 export type Queue = <T>(task: () => Promise<T>, opts?: { front?: boolean }) => Promise<T>;
 
 const MAX_RATE_LIMIT_RETRIES = 2; // per job, on top of the initial attempt
-const BACKOFF_CAP_MS = 60_000; // a primary-limit reset can be an hour away: fail into the manual message instead
-const BACKOFF_FALLBACK_MS = 30_000; // secondary limits sometimes advise nothing; they clear within a minute
+const BACKOFF_CAP_MS = 60_000; // primary-limit reset can be an hour: fail into the manual message instead
+const BACKOFF_FALLBACK_MS = 30_000; // secondary limits sometimes advise nothing; clear within a minute
 
-/** Throttles REST concurrency (GitHub secondary rate limits trigger on bursts).
- *  front is for user-action interrupts: it jumps the prefetch queue.
- *  A RateLimitError pauses the whole queue for the advised (capped) duration and re-enqueues
- *  the failed job by lane — front jobs re-enter at the front so prefetch never starves them. */
+// Throttles REST concurrency. front jumps the prefetch queue for user actions.
+// RateLimitError pauses the whole queue and re-enqueues by lane so prefetch never starves front.
 export function createQueue(
   limit: number,
   sleep: (ms: number) => Promise<void> = (ms) => new Promise((r) => setTimeout(r, ms)),
@@ -40,7 +38,7 @@ export function createQueue(
     while (!paused && active < limit && pending.length) {
       const job = must(pending.shift());
       active++;
-      // Normalize even a synchronous throw into a rejection: a leak here leaves active undecremented and jams the queue forever
+      // Normalize sync throws into rejections: a leak here jams the queue forever
       Promise.resolve()
         .then(job.run)
         .then(

--- a/extension/src/background/resolution.ts
+++ b/extension/src/background/resolution.ts
@@ -11,11 +11,10 @@ import {
 import type { Differ } from "../wasm/differ";
 import { createPromiseCache } from "./promiseCache";
 
-/** What the pipeline itself calls on the GitHub client. Callers thread their richer
- *  client through the generic C, so the injected fetchers keep their own view of it. */
+// Pipeline's GitHub surface; callers thread a richer client through C so injected fetchers keep their view
 export type SearchClient = Pick<GithubClient, "searchMetaByGuid" | "listMetaTree" | "batchBlobTexts">;
 
-// baseShas: path → blob sha at the base ref. null = tree unavailable (truncated/failed) → contents-api fallback
+// baseShas: path → blob sha at base. null = tree unavailable → contents-api fallback
 export type DiffContext = {
   refs: RefPair;
   files: ChangedFile[];
@@ -30,7 +29,7 @@ export type ResolutionDeps<C extends SearchClient> = {
   guidCache: GuidCache;
   repoIndexStore: RepoIndexStore;
   getDiffer(): Promise<Differ>;
-  /** The handler's cached blob fetcher (sha+path keyed, blob-sha fast path). */
+  // Handler's cached blob fetcher (sha+path keyed, blob-sha fast path)
   fetchBlob(
     client: C,
     owner: string,
@@ -39,7 +38,7 @@ export type ResolutionDeps<C extends SearchClient> = {
     sha: string,
     blobSha?: string,
   ): Promise<Uint8Array | null>;
-  /** The handler's before/after pair fetcher (status/previousPath rules follow the files API). */
+  // Handler's before/after pair fetcher (status/previousPath follow the files API)
   fetchPair(client: C, ctx: DiffContext, owner: string, repo: string, path: string): Promise<[Uint8Array, Uint8Array]>;
 };
 
@@ -80,22 +79,18 @@ export type Resolution<C extends SearchClient> = {
   ): Promise<void>;
 };
 
-/** Guid resolution beyond the in-PR .meta index: whole-repo index → Code Search, plus the
- *  source prefab re-merge that resolution unlocks. Owns the search/index caches; blob and
- *  diff caching stay with the handler, injected through fetchBlob/fetchPair. */
+// Beyond in-PR .meta: repo index → Code Search + source re-merge. Blob/diff caches stay in the handler.
 export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>): Resolution<C> {
-  // guids that missed in Code Search. Indexing lag means we don't persist these — SW lifetime only
+  // Code Search misses; indexing lag → SW lifetime only (not persisted)
   const misses = new Set<string>();
-  // repoKey:guid → in-flight search, folding concurrent searches for the same guid into one (protects the
-  // 10 req/min). Nothing is retained after settling: guidCache/misses take over from there.
+  // Fold concurrent searches for the same guid (protects 10 req/min); nothing retained after settle
   const searches = createPromiseCache<string | null>({ retain: () => false });
-  // repoKey@ref → whole-repo index. null means not indexable (truncated/over the cap)
+  // repoKey@ref → whole-repo index; null = not indexable (truncated/over the cap)
   const indexes = createPromiseCache<Record<string, string> | null>();
-  // A repo that hit a rate limit falls back for the SW lifetime (gives up on the index and defers to Code Search only)
+  // Rate-limited repos skip the index for the SW lifetime (Code Search only)
   const indexFallback = new Set<string>();
 
-  /** Resolves guid[] in cache → Code Search order (the body of searchUnresolved itself).
-   *  A search failure (including rate limits) doesn't drop the diff: returns only what was resolved. */
+  // cache → Code Search; failures (incl. rate limits) don't drop the diff — return what resolved
   async function searchGuids(
     guids: string[],
     client: C,
@@ -104,9 +99,8 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     repoKey: string,
   ): Promise<{ resolved: Record<string, string>; rateLimited: boolean }> {
     if (!guids.length) return { resolved: {}, rateLimited: false };
-    // hasOwn: guids are arbitrary strings, so 'constructor' etc. don't falsely hit Object.prototype
-    // The cached lookup covers all guids without going through misses: since index resolutions also land in guidCache,
-    // a cached name is always emitted even if it's in misses (the search gatekeeper)
+    // hasOwn: guids are arbitrary strings, so 'constructor' etc. don't hit Object.prototype
+    // Index hits also land in guidCache, so emit cached names even when listed in misses
     const cached = await deps.guidCache.load(repoKey);
     const resolved: Record<string, string> = {};
     const unknown: string[] = [];
@@ -125,7 +119,7 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
         if (path) resolved[g] = found[g] = path;
         else misses.add(key);
       } catch (err) {
-        // A rate limit truncates the run: report it instead of degrading silently (#194).
+        // Rate limit truncates the run: report it instead of degrading silently (#194)
         if (err instanceof RateLimitError) {
           rateLimited = true;
           break;
@@ -137,9 +131,7 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     return { resolved, rateLimited };
   }
 
-  /** Thin wrapper that resolves guids unresolved by in-PR .meta in cache → Code Search
-   *  order, reporting whether a rate limit truncated the search (mergeSources folds the
-   *  flag into its own status). */
+  // Unresolved-by-in-PR-.meta → cache → Code Search; rateLimited folds into mergeSources status
   async function searchUnresolved(
     json: DiffV2,
     client: C,
@@ -153,7 +145,7 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     return { json: { ...json, resolved: { ...resolved, ...found.resolved } }, rateLimited: found.rateLimited };
   }
 
-  /** Fetches and memoizes the whole-repo guid index. A repo that hit a rate limit is pinned to fallback for the SW lifetime. */
+  // Memoized whole-repo index; rate-limited repos stay on fallback for the SW lifetime
   function getRepoIndex(
     client: C,
     owner: string,
@@ -165,16 +157,13 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     return indexes
       .get(`${repoKey}@${ref}`, () => syncRepoIndex(client, deps.repoIndexStore, owner, repo, repoKey, ref))
       .catch((err: unknown) => {
-        // the cache has already dropped the failure, so the next visit retries
+        // Cache already dropped the failure, so the next visit retries
         if (err instanceof RateLimitError) indexFallback.add(repoKey);
         return null;
       });
   }
 
-  /** Fetches neededSources (the source prefab of an added/removed instance) via the resolved
-   *  path and re-diffs with assets attached. The source guid rides on unresolvedGuids as an
-   *  m_SourcePrefab reference, so searchUnresolved has already done the path resolution.
-   *  Failure to resolve/fetch/merge degrades to the diff at that point (doesn't drop the whole thing). */
+  // Fetch neededSources via resolved path and re-diff with assets; failure degrades (doesn't drop)
   async function mergeSources(
     first: DiffV2,
     differ: Differ,
@@ -197,18 +186,17 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
         const path = current.resolved?.[s.guid];
         if (path === undefined) continue;
         const sha = s.side === "before" ? ctx.refs.baseSha : ctx.refs.headSha;
-        // sources aren't PR files, so only the base tree can supply a sha; the head side keeps the path fallback
+        // Sources aren't PR files: only base tree can supply a sha; head keeps path fallback
         const blobSha = s.side === "before" ? ctx.baseShas?.get(path) : undefined;
         let bytes: Uint8Array | null = null;
         try {
           bytes = await deps.fetchBlob(client, owner, repo, path, sha, blobSha);
         } catch (err) {
-          // degrade to the first-pass diff, but tell the caller why (#194)
+          // Degrade to first-pass diff, but tell the caller why (#194)
           return { json: current, status: err instanceof RateLimitError ? "rateLimited" : "failed" };
         }
         if (!bytes) continue;
-        // Sources resolved by guid can be binary-serialized too: merging
-        // them is a no-op re-diff, so don't count it as progress.
+        // Binary-serialized sources are a no-op re-diff — don't count as progress
         if (!differ.isUnityYaml(bytes)) continue;
         assets.set(s.guid, bytes);
         progressed = true;
@@ -218,9 +206,9 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
       try {
         merged = differ.diffWithAssets(before, after, assets);
       } catch {
-        return { json: current, status: "failed" }; // a merge failure degrades to the current result
+        return { json: current, status: "failed" }; // merge failure degrades to current result
       }
-      // Merging surfaces new external references (script/material) inside the source, so resolve again.
+      // Merging surfaces new external refs inside the source, so resolve again
       const next = await searchUnresolved(applyResolved(merged, ctx.guidIndex), client, owner, repo, repoKey);
       rateLimited ||= next.rateLimited;
       current = next.json;
@@ -228,15 +216,14 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     return { json: current, status: rateLimited ? "rateLimited" : "complete" };
   }
 
-  /** rateLimited wins over failed: it is the outcome a manual retry is most likely to fix. */
+  // rateLimited wins: most likely to succeed on manual retry
   function combine(a: ResolutionStatus, b: ResolutionStatus): ResolutionStatus {
     if (a === "rateLimited" || b === "rateLimited") return "rateLimited";
     if (a === "failed" || b === "failed") return "failed";
     return "complete";
   }
 
-  /** Runs the rest of the 3-stage resolution (index → Code Search) and source re-merge in the background, delivering results via push.
-   *  On failure it still emits a done push in catch to release waiters. */
+  // Background index → Code Search + source re-merge via push; catch still emits done to release waiters
   async function resolveRemaining(
     first: DiffV2,
     remaining: string[],
@@ -249,7 +236,7 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
     const repoKey = `${base}/${req.owner}/${req.repo}`;
     const at = { owner: req.owner, repo: req.repo, target: req.target, path: req.path };
     try {
-      // If remaining is empty (source re-merge only), don't wait on the index: the first index build can take tens of seconds and doesn't help resolution
+      // Empty remaining (source re-merge only): skip index — first build can take tens of seconds
       const index = remaining.length
         ? await getRepoIndex(client, req.owner, req.repo, repoKey, ctx.refs.headSha)
         : null;
@@ -262,29 +249,27 @@ export function createResolution<C extends SearchClient>(deps: ResolutionDeps<C>
         }
         leftover = remaining.filter((g) => !Object.hasOwn(fromIndex, g));
         if (Object.keys(fromIndex).length) {
-          // Also land it in guidCache: searchUnresolved inside mergeSources rebuilds resolved
-          // from ctx.guidIndex via applyResolved, so without going through guidCache the index-derived
-          // resolutions would vanish after the source re-merge (same reasoning as Code-Search-derived ones already restored this way).
+          // Land in guidCache: mergeSources rebuilds via applyResolved; without this, index hits vanish
           await deps.guidCache.save(repoKey, fromIndex);
-          // Deliver the already-available names first (the structure is finalized by the later final push)
+          // Deliver available names first; structure finalized by the later final push
           push({ type: "guidResolved", ...at, resolved: fromIndex, done: false });
         }
       }
-      // Only guids that aren't indexable or aren't in the index go to Code Search
+      // Only guids missing from the index go to Code Search
       const search = leftover.length
         ? await searchGuids(leftover, client, req.owner, req.repo, repoKey)
         : { resolved: {}, rateLimited: false };
       let status: ResolutionStatus = search.rateLimited ? "rateLimited" : "complete";
       let json: DiffV2 = { ...first, resolved: { ...first.resolved, ...fromIndex, ...search.resolved } };
       if (json.neededSources?.length) {
-        // Resolution advanced, so redo source merging (picks up the case where the source guid resolved this time)
+        // Resolution advanced — redo source merging (source guid may have resolved this time)
         const differ = await deps.getDiffer();
         const [before, after] = await deps.fetchPair(client, ctx, req.owner, req.repo, req.path);
         const merged = await mergeSources(json, differ, before, after, ctx, client, req.owner, req.repo, repoKey);
         json = merged.json;
         status = combine(status, merged.status);
       }
-      push({ type: "guidResolved", ...at, resolved: {}, json, done: true, status }); // the final push replaces json
+      push({ type: "guidResolved", ...at, resolved: {}, json, done: true, status }); // final push replaces json
     } catch (err) {
       console.debug("prefablens: guid resolution aborted", err);
       push({

--- a/extension/src/content/authRetries.ts
+++ b/extension/src/content/authRetries.ts
@@ -3,14 +3,13 @@ export type AuthRetries = {
   flush(): void;
 };
 
-/** Files whose panels are stuck on an auth error register a retry; a token landing
- *  in storage flushes them all at once. */
+// Auth-blocked panels register a retry; a token landing in storage flushes them all
 export function createAuthRetries(): AuthRetries {
   const retries = new Set<() => void>();
   return {
     add: (retry) => void retries.add(retry),
     flush() {
-      // Clear before running: a retry that fails again re-registers itself for the next token.
+      // Clear first: a retry that fails again re-registers for the next token
       const pending = [...retries];
       retries.clear();
       for (const retry of pending) retry();

--- a/extension/src/content/detect.ts
+++ b/extension/src/content/detect.ts
@@ -4,18 +4,16 @@ import { must } from "../util/must";
 
 export type FileEntry = {
   path: string;
-  header: HTMLElement; // toggle mount point + data-prefablens marker
-  attachHost(host: HTMLElement): void; // insert the semantic-view host at the layout's spot
-  setRawHidden(hidden: boolean): void; // idempotent, re-resolves live DOM every call
-  collapsed(): boolean; // github-level file collapse state (react ui chevron)
-  globalAnchor(): Element | null; // element the global bar is inserted before
+  header: HTMLElement; // toggle mount + data-prefablens marker
+  attachHost(host: HTMLElement): void; // insert semantic host at the layout's spot
+  setRawHidden(hidden: boolean): void; // idempotent; re-resolves live DOM each call
+  collapsed(): boolean; // github file collapse (react chevron)
+  globalAnchor(): Element | null; // element the global bar inserts before
 };
 
 export type DiffPage = { owner: string; repo: string; target: DiffTarget };
 
-/** decodeURIComponent that tolerates malformed escapes: a pathname can carry a bare %
- *  (browsers pass invalid sequences through verbatim), and parseDiffUrl runs unguarded
- *  in attach() — throwing here would kill the whole page scan. */
+// Tolerate bare % in pathnames — throwing here would kill the whole page scan
 function decodeRef(s: string): string {
   try {
     return decodeURIComponent(s);
@@ -24,18 +22,15 @@ function decodeRef(s: string): string {
   }
 }
 
-/** Recognizes every diff page the pipeline can serve. Compare is same-repo three-dot only:
- *  fork syntax (owner:branch) would need a second repo's blobs, and GitHub's compare page
- *  itself is three-dot (merge base), which is exactly what the compare API returns. */
+// Diff pages we can serve. Compare is same-repo three-dot only (fork owner:branch needs a second repo).
 export function parseDiffUrl(pathname: string): DiffPage | null {
-  // files: any suffix (ranges render inline). changes (react ui): bare tab or A..B range only.
+  // files: any suffix. changes (react): bare tab or A..B range only.
   const pr =
     /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/(?:files(?:\/|$)|changes(?:\/[\da-f]{7,40}\.\.[\da-f]{7,40})?\/?$)/.exec(
       pathname,
     );
   if (pr) return { owner: must(pr[1]), repo: must(pr[2]), target: { kind: "pull", prNumber: Number(must(pr[3])) } };
-  // Single-commit views: standalone /commit/SHA, plus the in-PR classic /commits/SHA and
-  // react /changes/SHA — all show one commit against its parent
+  // /commit/SHA, classic /commits/SHA, react /changes/SHA — one commit vs parent
   const commit = /^\/([^/]+)\/([^/]+)\/(?:pull\/\d+\/(?:commits|changes)|commit)\/([\da-f]{7,40})\/?$/.exec(pathname);
   if (commit)
     return { owner: must(commit[1]), repo: must(commit[2]), target: { kind: "commit", sha: must(commit[3]) } };
@@ -49,13 +44,13 @@ export function parseDiffUrl(pathname: string): DiffPage | null {
   return null;
 }
 
-/** Matches any PR tab (the prefetch trigger). Different role from the diff-page-only parseDiffUrl. */
+// Any PR tab (prefetch trigger); unlike parseDiffUrl this is not diff-page-only
 export function parsePrPage(pathname: string): { owner: string; repo: string; prNumber: number } | null {
   const m = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)(\/|$)/.exec(pathname);
   return m ? { owner: must(m[1]), repo: must(m[2]), prNumber: Number(must(m[3])) } : null;
 }
 
-// Defensively searches GitHub's Files changed (classic DOM). If it doesn't match, ends harmlessly with an empty array.
+// Classic Files changed DOM; no match → empty array
 function scanClassic(root: ParentNode): FileEntry[] {
   const out: FileEntry[] = [];
   for (const header of root.querySelectorAll<HTMLElement>(".file-header[data-path]")) {
@@ -68,15 +63,14 @@ function scanClassic(root: ParentNode): FileEntry[] {
       path,
       header,
       attachHost(host) {
-        // Same Primer class github puts on .js-file-content: the chevron / Viewed collapse
-        // only toggles Details--on on .file, so the host must opt into that CSS itself
+        // Opt into Details--on CSS the way .js-file-content does
         host.classList.add("Details-content--hidden");
         content.after(host);
       },
       setRawHidden(hidden) {
         content.style.display = hidden ? "none" : "";
       },
-      collapsed: () => false, // the Details--on CSS contract hides collapsed content without our help
+      collapsed: () => false, // Details--on CSS hides collapsed content without our help
       globalAnchor: () => container,
     });
   }
@@ -85,9 +79,8 @@ function scanClassic(root: ParentNode): FileEntry[] {
 
 const BIDI_MARKS = /[‎‏]/g;
 
-/** The react ui has no path attribute: the path only exists as header text wrapped in
- *  LRM marks, and renames add a visually hidden "OLD renamed to NEW" span. */
-function reactPath(header: HTMLElement): string | null {
+// React has no path attribute: header text (+ LRM marks); renames hide "OLD renamed to NEW"
+function filePathFromReactHeader(header: HTMLElement): string | null {
   const code = header.querySelector('[class*="file-name"] code');
   if (!code) return null;
   const renamed = code.querySelector("span.sr-only")?.textContent?.split(" renamed to ", 2)[1];
@@ -95,13 +88,10 @@ function reactPath(header: HTMLElement): string | null {
   return text || null;
 }
 
-/** React remounts diff bodies with no inline styles (collapse/expand, re-renders), and
- *  the debounced rescan re-hides them only ~200ms later — long enough to flash the raw
- *  diff. This document-level rule, keyed on the region marker set by setRawHidden, hides
- *  a fresh body before first paint. It targets the body's own classes rather than
- *  "everything but the header" so github markup drift degrades back to the debounced
- *  flash instead of hiding the file header. */
-function ensureHideRule(doc: Document): void {
+// React remounts strip inline styles; debounced rescan is ~200ms late and flashes raw.
+// Document rule keyed on setRawHidden's marker hides a fresh body before first paint.
+// Targets the body's own classes, not "everything but the header": drift degrades to a flash, never a hidden header.
+function ensureReactRawHideStyle(doc: Document): void {
   if (doc.head.querySelector("style[data-prefablens-hide-rule]")) return;
   const style = doc.createElement("style");
   style.setAttribute("data-prefablens-hide-rule", "");
@@ -109,17 +99,15 @@ function ensureHideRule(doc: Document): void {
   doc.head.append(style);
 }
 
-// GitHub's react diff UI (login-gated rollout). Class names are hashed CSS modules, so
-// anchors are role/id plus class-prefix matches; the body is "any region child that isn't
-// the header block", because its class is unstable and react recreates it constantly.
+// React diff UI: hashed CSS modules → role/id + class-prefix anchors; body class is unstable
 function scanReact(root: ParentNode): FileEntry[] {
   const out: FileEntry[] = [];
   for (const region of root.querySelectorAll<HTMLElement>('div[role="region"][id^="diff-"]')) {
     const header = region.querySelector<HTMLElement>('[class*="diff-file-header"]');
     if (!header) continue;
-    const path = reactPath(header);
+    const path = filePathFromReactHeader(header);
     if (!path || !isUnityPath(path)) continue;
-    // The region child containing the header (normally the diffHeaderWrapper)
+    // Region child that contains the header (normally diffHeaderWrapper)
     const headerBlock = (): Element => {
       let el: Element = header;
       while (el.parentElement && el.parentElement !== region) el = el.parentElement;
@@ -129,25 +117,21 @@ function scanReact(root: ParentNode): FileEntry[] {
       path,
       header,
       attachHost(host) {
-        // The card frame lives on the diff body in this layout, so hiding the body
-        // strips it: recreate the same chrome on the host (theme-following variables,
-        // fallbacks for pages without Primer)
+        // Card frame lives on the body here; recreate chrome on the host when body is hidden
         host.style.cssText =
           "border: 1px solid var(--borderColor-default, #d1d9e0); border-radius: 0 0 6px 6px; background: var(--bgColor-default, #ffffff);";
         headerBlock().after(host);
       },
       setRawHidden(hidden) {
         region.toggleAttribute("data-prefablens-raw-hidden", hidden);
-        if (hidden) ensureHideRule(region.ownerDocument);
-        // Inline fallback for bodies the CSS rule misses (markup drift): the rescan
-        // hides them one debounce late instead of never
+        if (hidden) ensureReactRawHideStyle(region.ownerDocument);
+        // Inline fallback for markup the CSS rule misses
         for (const child of region.children) {
           if (child === headerBlock() || child.hasAttribute("data-prefablens-view")) continue;
           (child as HTMLElement).style.display = hidden ? "none" : "";
         }
       },
-      // Two independent collapse signals: github swaps the chevron octicon per state and
-      // stamps a DiffFileHeader-module__collapsed class on the header row
+      // Chevron octicon swap + DiffFileHeader-module__collapsed class
       collapsed: () =>
         headerBlock().querySelector(".octicon-chevron-right") !== null ||
         headerBlock().querySelector('[class*="DiffFileHeader-module__collapsed"]') !== null,
@@ -157,8 +141,7 @@ function scanReact(root: ParentNode): FileEntry[] {
   return out;
 }
 
-// Both scanners always run: on any given page one matches and the other yields [] harmlessly,
-// so no layout probe is needed (and a mid-rollout A/B flip can't strand us).
+// Always run both: one matches, the other yields []; no layout probe (survives A/B flips)
 export function scanUnityFiles(root: ParentNode): FileEntry[] {
   return [...scanClassic(root), ...scanReact(root)];
 }

--- a/extension/src/content/devicePage.ts
+++ b/extension/src/content/devicePage.ts
@@ -1,9 +1,6 @@
 import type { PendingSignIn } from "./signin";
 
-/** Autofill of GitHub's Device Activation form. The eight fillable boxes are marked with
- *  GitHub's js-user-code-field hook class (a ninth user-code input is a CSS-hidden readonly
- *  hyphen placeholder and must be ignored). If GitHub redesigns the form this no-ops and
- *  the user pastes the code shown on the PR page instead. */
+// Autofill Device Activation boxes (js-user-code-field). Markup drift → no-op; user pastes instead.
 export function fillDeviceCode(doc: Document, pending: PendingSignIn, now: number): boolean {
   if (now > pending.expiresAt) return false;
   const boxes = [...doc.querySelectorAll<HTMLInputElement>("input.js-user-code-field")];
@@ -11,7 +8,7 @@ export function fillDeviceCode(doc: Document, pending: PendingSignIn, now: numbe
   if (boxes.length !== chars.length || boxes.some((box) => box.value)) return false;
   boxes.forEach((box, i) => {
     box.value = chars.charAt(i);
-    // GitHub's auto-advance JS listens per box; keep it in sync with the programmatic fill.
+    // Keep GitHub's per-box auto-advance JS in sync with the programmatic fill
     box.dispatchEvent(new Event("input", { bubbles: true }));
   });
   return true;

--- a/extension/src/content/fileView.ts
+++ b/extension/src/content/fileView.ts
@@ -2,21 +2,17 @@ import { type BackgroundError, type DiffV2, type SemanticDiffResponse, unresolve
 import { must } from "../util/must";
 import type { View } from "./toggle";
 
-/** Rendering surface inside the host's shadow root: the machine picks the screen,
- *  the caller draws it (render/renderLoading/... in content/index.ts). */
+// Per-file raw/semantic state machine (host + fetch latch); unit-testable without a browser.
+
 export type FilePanel = {
   loading(): void;
-  /** The diff tree, with the resolving indicator while `resolving` > 0. */
   diff(json: DiffV2, resolving: number): void;
-  /** A kept diff plus the incomplete-resolution bar (manual retry affordance). */
   incomplete(json: DiffV2, onRetry: () => void): void;
   tooLarge(bytes: number, onForce: () => void): void;
-  /** Auth-error panel driving the device flow. */
   authError(error: "pat-missing" | "auth-failed"): void;
   error(error: BackgroundError): void;
 };
 
-/** The semantic-view host as the machine sees it: layout attach, visibility, its panel. */
 export type FileHost = {
   attach(): void;
   attached(): boolean;
@@ -24,43 +20,29 @@ export type FileHost = {
   panel: FilePanel;
 };
 
-/** A successful diff registered as a push target (content/index.ts adapts this onto the
- *  view registry, where guidResolved pushes and the watchdog find it). */
+// Push-target slot: index.ts adapts onto the view registry (guidResolved + watchdog)
 export type FileResult = { json: DiffV2; retry(): void };
 
 export type FileViewDeps = {
-  /** The pieces of FileEntry the machine drives: raw-diff visibility and collapse state. */
   file: { setRawHidden(hidden: boolean): void; collapsed(): boolean };
-  /** Creates the semantic-view host; called once, on the first semantic show. */
   createHost(): FileHost;
-  /** Background round-trip for this file's semantic diff (never rejects: the caller maps
-   *  channel loss to a fetch-failed response). */
-  requestDiff(force?: boolean): Promise<SemanticDiffResponse>;
-  /** This file's push-target slot; armWatchdog guards the pending final push. */
+  requestDiff(force?: boolean): Promise<SemanticDiffResponse>; // must never reject: callers map channel loss to fetch-failed
   results: { set(result: FileResult): void; get(): FileResult | undefined; armWatchdog(): void };
-  /** Registers a retry to run when a token lands in storage (auth-blocked panels). */
   onAuthRetry(retry: () => void): void;
-  /** The view currently effective for this file (global default + per-file override). */
   effectiveView(): View;
 };
 
 export type FileView = {
-  /** User-intent transition: may create the host and fetch the diff. */
-  show(view: View): void;
-  /** Display-only re-assert of the current view; never fetches. */
-  sync(view: View): void;
+  show(view: View): void; // may create host + fetch
+  sync(view: View): void; // display-only; never fetches
 };
 
-/** Per-file attach/show state machine: which of raw/semantic is displayed, whether the
- *  semantic host exists, and whether a diff request is in flight or cached. Extracted
- *  from content/index.ts so the transitions are unit-testable without a browser. */
 export function createFileView(deps: FileViewDeps): FileView {
   let host: FileHost | undefined;
-  // A successful request stays latched (re-toggle doesn't re-fetch); failures reset it.
+  // Success stays latched (re-toggle doesn't re-fetch); failures reset
   let requested = false;
 
-  // Display-only re-assert, never fetches: safe to run on every scan even while a panel
-  // sits on an error (a fetching sync would silently hammer retries on rate limits).
+  // Display-only: safe on every scan, even while a panel sits on an error
   const sync = (view: View): void => {
     if (view === "raw") {
       deps.file.setRawHidden(false);
@@ -69,44 +51,41 @@ export function createFileView(deps: FileViewDeps): FileView {
     }
     if (!host) return; // semantic never rendered here: leave the raw diff alone
     deps.file.setRawHidden(true);
-    if (!host.attached()) host.attach(); // a react remount can drop the host together with the old body
-    // Follow github's own collapse (react ui): the classic layout handles this via the
-    // Details CSS class added in attachHost instead, where collapsed() is always false.
+    if (!host.attached()) host.attach(); // react remount can drop the host with the old body
+    // Follow github collapse (react); classic uses Details CSS in attachHost instead
     host.setVisible(!deps.file.collapsed());
   };
 
   const request = (force?: boolean): void => {
     requested = true;
-    const panel = must(host).panel; // request is only reachable after show created the host
+    const panel = must(host).panel; // only reachable after show created the host
     panel.loading();
     void deps.requestDiff(force).then((res) => {
       if (res.ok) {
         deps.results.set({
           json: res.json,
-          // Retry re-runs the whole request: the diff itself is cached, so this only
-          // re-enters background resolution (requested must reset or request() no-ops).
+          // Retry re-enters background resolution; reset latch or request() no-ops
           retry: () => {
             requested = false;
             request(force);
           },
         });
         if (res.pending) deps.results.armWatchdog();
-        // Always show it while pending: even if all names are resolved, source merging may remain
+        // Show while pending even if names are resolved (source merging may remain)
         panel.diff(res.json, res.pending ? Math.max(unresolvedRemaining(res.json).length, 1) : 0);
         return;
       }
-      requested = false; // don't cache errors: let the next toggle re-fetch
+      requested = false; // don't cache errors: next toggle re-fetches
       const prior = deps.results.get();
       if (prior) {
-        // A failed retry must not wipe the diff the user is reading: keep the
-        // tree and re-offer the retry affordance instead of a bare error panel.
+        // Failed retry must not wipe the diff the user is reading
         panel.incomplete(prior.json, prior.retry);
         return;
       }
       if (res.error === "too-large") panel.tooLarge(res.bytes, () => request(true));
       else if (res.error === "pat-missing" || res.error === "auth-failed") {
         deps.onAuthRetry(() => {
-          // requested flips true on the first retry, so duplicate registrations no-op.
+          // First retry sets requested; duplicate registrations no-op
           if (!requested && deps.effectiveView() === "semantic") request();
         });
         panel.authError(res.error);
@@ -124,7 +103,7 @@ export function createFileView(deps: FileViewDeps): FileView {
       host.attach();
     }
     sync(view);
-    if (requested) return; // cache only successful results per file (re-toggle doesn't re-fetch)
+    if (requested) return; // cache only successful results (re-toggle doesn't re-fetch)
     request();
   };
 

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -35,11 +35,10 @@ const ERROR_TEXT: Record<BackgroundError, string> = {
   "not-unity-yaml": "This file is not a text-serialized Unity asset.",
 };
 
-// path → render target. When a push (guidResolved) arrives, merge resolved and re-render
+// path → render target for guidResolved pushes
 const views = createViewRegistry();
 
-// If the final push is lost (dropped tab message, killed service worker), flip the
-// indicator to the retryable incomplete state instead of spinning forever.
+// Lost final push → flip to retryable incomplete instead of spinning forever
 const WATCHDOG_MS = 120_000;
 
 function armWatchdog(view: ViewEntry): void {
@@ -50,19 +49,19 @@ function armWatchdog(view: ViewEntry): void {
   );
 }
 
-// Targets of the global switch: drives the toggle + display of already-attached files from outside
+// Global switch targets: toggle + display for already-attached files
 type Applier = { header: HTMLElement; apply(view: View): void; sync(): void };
 const appliers = new Set<Applier>();
 let globalToggle: Toggle | undefined;
-let currentPage = ""; // overrides are valid only while on the diff page: discard when it changes
-let prefetchedPr = ""; // send prefetch just once across all PR tabs, including the conversation tab
+let currentPage = ""; // drop overrides when leaving this diff page
+let prefetchedPr = ""; // prefetch once per PR across conversation + files tabs
 
-// Files whose panels are stuck on an auth error: all retried once a token lands in storage.
+// Auth-blocked panels: retry all when a token lands
 const authRetries = createAuthRetries();
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 const signIn = createSignIn({
-  // Same-origin on github.com: the device flow needs no background relay and no extra permissions.
+  // Same-origin on github.com: no background relay or extra permissions.
   requestDeviceCode: () => requestDeviceCode(fetch),
   pollForToken: (code) => pollForToken(fetch, sleep, code),
   savePending: (pending) => chrome.storage.local.set({ signin: pending }),
@@ -72,7 +71,7 @@ const signIn = createSignIn({
   now: () => Date.now(),
 });
 
-/** Auth-error panel driving the device flow; failures land back here so the user can retry. */
+// Auth-error panel: device flow; failures land back here for retry
 function signInPanel(root: ShadowRoot, message: string): void {
   renderSignIn(root, message, () => {
     void signIn({
@@ -83,13 +82,13 @@ function signInPanel(root: ShadowRoot, message: string): void {
   });
 }
 
-function attach(state: ViewState): void {
+function attach(viewState: ViewState): void {
   const prPage = parsePrPage(location.pathname);
   if (prPage) {
     const prKey = targetKey(prPage.owner, prPage.repo, { kind: "pull", prNumber: prPage.prNumber });
     if (prKey !== prefetchedPr) {
       prefetchedPr = prKey;
-      // fire-and-forget: don't wait on the response, ignore failures (the manual-toggle path is separately alive)
+      // Fire-and-forget; manual toggle stays available if prefetch fails
       void (
         chrome.runtime.sendMessage({ type: "prefetch", ...prPage } satisfies PrefetchRequest) as Promise<unknown>
       ).catch(() => {});
@@ -100,25 +99,21 @@ function attach(state: ViewState): void {
   const key = targetKey(page.owner, page.repo, page.target);
   if (key !== currentPage) {
     currentPage = key;
-    state.clearOverrides();
-    views.pruneDisconnected(); // not only ignore late pushes to views killed by navigation, but also cut the reference
+    viewState.clearOverrides();
+    views.pruneDisconnected(); // drop refs so late pushes can't revive dead views
   }
-  // The react ui virtualizes the list and discards off-screen DOM continuously, so prune
-  // dead appliers every scan, not just on PR change (also plugs the classic soft leak).
+  // React virtualizes and discards off-screen DOM; prune every scan (also plugs classic soft leak)
   for (const a of [...appliers]) if (!a.header.isConnected) appliers.delete(a);
   const entries = scanUnityFiles(document);
   const first = entries[0];
-  if (first) ensureGlobalToggle(state, first);
-  for (const entry of entries) attachToggle(state, page, entry);
-  // Re-assert view state: react remounts diff bodies under still-marked headers, which
-  // silently undoes the inline hide. All sync operations are idempotent and fetch-free.
+  if (first) ensureGlobalToggle(viewState, first);
+  for (const entry of entries) attachToggle(viewState, page, entry);
+  // React remounts can undo inline hide under still-marked headers; sync is idempotent/fetch-free
   for (const a of appliers) a.sync();
 }
 
-/** Injects exactly one global toggle right before the first Unity file's layout anchor:
- *  the .file container on classic, the virtualized list root on the react ui (a bar inside
- *  a recycled list item would be discarded on scroll). */
-function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
+// Global bar must sit outside recycled react list items (classic: before .file; react: list root)
+function ensureGlobalToggle(viewState: ViewState, first: FileEntry): void {
   if (globalToggle?.element.closest("[data-prefablens-global]")?.isConnected) return;
   const anchor = first.globalAnchor();
   if (!anchor?.parentElement) return;
@@ -127,23 +122,21 @@ function ensureGlobalToggle(state: ViewState, first: FileEntry): void {
   const label = document.createElement("span");
   label.className = "prefablens-eyebrow";
   label.textContent = "PrefabLens";
-  const toggle = createToggle((view) => state.setDefault(view), state.defaultView());
+  const toggle = createToggle((view) => viewState.setDefault(view), viewState.defaultView());
   bar.append(label, toggle.element);
   anchor.before(bar);
   globalToggle = toggle;
 }
 
-function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void {
+function attachToggle(viewState: ViewState, page: DiffPage, entry: FileEntry): void {
   if (entry.header.hasAttribute("data-prefablens")) return;
   entry.header.setAttribute("data-prefablens", "");
   const viewKey = `${targetKey(page.owner, page.repo, page.target)}:${entry.path}`;
 
-  // Set by createHost; results.set only runs after the machine created the host, so the
-  // registry (whose push listener renders into it) always sees a real shadow root.
+  // Set by createHost before results.set so the push listener always has a real shadow root
   let shadow: ShadowRoot | undefined;
 
-  // The transitions live in fileView.ts; this block only binds them to the real DOM,
-  // the runtime channel, and the shared registries.
+  // Transitions live in fileView.ts; here we bind them to DOM, runtime, and registries
   const fileView = createFileView({
     file: entry,
     createHost() {
@@ -182,13 +175,13 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
       armWatchdog: () => armWatchdog(must(views.get(viewKey))),
     },
     onAuthRetry: (retry) => authRetries.add(retry),
-    effectiveView: () => state.effective(entry.path),
+    effectiveView: () => viewState.effective(entry.path),
   });
 
   const toggle = createToggle((view) => {
-    state.setOverride(entry.path, view); // a click overrides just this file
+    viewState.setOverride(entry.path, view); // per-file override
     fileView.show(view);
-  }, state.effective(entry.path));
+  }, viewState.effective(entry.path));
   entry.header.append(toggle.element);
   appliers.add({
     header: entry.header,
@@ -196,12 +189,11 @@ function attachToggle(state: ViewState, page: DiffPage, entry: FileEntry): void 
       toggle.set(view);
       fileView.show(view);
     },
-    sync: () => fileView.sync(state.effective(entry.path)),
+    sync: () => fileView.sync(viewState.effective(entry.path)),
   });
 
-  // If the default is semantic, start rendering at attach time: lazy-loaded files also pass through here, so
-  // "the global is semantic but a later-arriving file is raw" doesn't happen
-  if (state.effective(entry.path) === "semantic") fileView.show("semantic");
+  // Start semantic at attach so late-arriving files inherit a semantic global default
+  if (viewState.effective(entry.path) === "semantic") fileView.show("semantic");
 }
 
 function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
@@ -212,7 +204,7 @@ function requestDiff(req: SemanticDiffRequest): Promise<SemanticDiffResponse> {
 }
 
 async function init(): Promise<void> {
-  // On the device-verification page the only job is pre-filling the code the PR page issued.
+  // Device page: only pre-fill the code the PR page issued
   if (location.pathname === "/login/device") {
     const stored = await chrome.storage.local.get(["signin"]).catch(() => ({}) as Record<string, unknown>);
     const pending = stored.signin as PendingSignIn | undefined;
@@ -222,38 +214,41 @@ async function init(): Promise<void> {
 
   const stored = await chrome.storage.local.get(["viewMode"]).catch(() => ({}) as Record<string, unknown>);
   const initial: View = stored.viewMode === "semantic" ? "semantic" : "raw";
-  const state = createViewState(initial, (view) => void chrome.storage.local.set({ viewMode: view }).catch(() => {}));
-  state.onDefaultChange((view) => {
+  const viewState = createViewState(
+    initial,
+    (view) => void chrome.storage.local.set({ viewMode: view }).catch(() => {}),
+  );
+  viewState.onDefaultChange((view) => {
     globalToggle?.set(view);
     for (const a of [...appliers]) {
       if (!a.header.isConnected) {
-        appliers.delete(a); // clean up DOM killed by an SPA navigation
+        appliers.delete(a); // SPA navigation may have killed the DOM
         continue;
       }
       a.apply(view);
     }
   });
-  // Follow default changes in other tabs (the echo to the originating set tab is ignored inside applyExternal)
+  // Cross-tab default sync; applyExternal ignores the originating tab's echo
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area !== "local") return;
     const next = changes.viewMode?.newValue;
-    if (next === "raw" || next === "semantic") state.applyExternal(next);
+    if (next === "raw" || next === "semantic") viewState.applyExternal(next);
     if (typeof changes.pat?.newValue === "string" && changes.pat.newValue) {
-      // A token just landed (this tab's own flow or another surface): retry every auth-blocked panel.
+      // Token landed (this tab or elsewhere): retry every auth-blocked panel
       authRetries.flush();
     }
   });
 
-  // guid resolution push from background (the second stage of the two-stage response): re-render if the matching view exists
+  // guidResolved: second-stage push from background; re-render if this view still exists
   chrome.runtime.onMessage.addListener((msg: GuidResolvedPush) => {
     if (msg?.type !== "guidResolved") return;
     const view = views.get(`${targetKey(msg.owner, msg.repo, msg.target)}:${msg.path}`);
-    if (!view) return; // already navigated to a different diff page, etc.: drop silently
+    if (!view) return; // navigated away: drop silently
     clearTimeout(view.watchdog);
-    // The final push replaces json (mergeSources may change the structure), an intermediate push merges resolved
+    // Final push replaces json (mergeSources can reshape); intermediate merges resolved
     view.json = msg.json ?? { ...view.json, resolved: { ...view.json.resolved, ...msg.resolved } };
     if (msg.done && msg.status !== undefined && msg.status !== "complete") {
-      // The run gave up: keep the names that did arrive, offer a manual retry (#194).
+      // Gave up: keep arrived names, offer manual retry (#194)
       render(view.root, view.json, { incomplete: { onRetry: view.retry } });
       return;
     }
@@ -261,18 +256,16 @@ async function init(): Promise<void> {
     render(view.root, view.json, { resolving: msg.done ? 0 : Math.max(unresolvedRemaining(view.json).length, 1) });
   });
 
-  // GitHub is an SPA: an initial scan + MutationObserver follows lazy loading and tab navigation.
-  // 50ms debounce keeps collapse/expand tracking under the ~100ms sluggishness threshold while
-  // still batching mutation storms: a full scan pass measured ~0.75ms on a 21-file PR, so even
-  // back-to-back rescans are negligible (the scan is fetch-free and idempotent).
-  attach(state);
+  // SPA: MutationObserver + 50ms debounce follows lazy loads without feeling sluggish
+  // (~100ms threshold); scans are fetch-free/~0.75ms so storms stay cheap.
+  attach(viewState);
   let scheduled = false;
   new MutationObserver(() => {
     if (scheduled) return;
     scheduled = true;
     setTimeout(() => {
       scheduled = false;
-      attach(state);
+      attach(viewState);
     }, 50);
   }).observe(document.body, { childList: true, subtree: true });
 }

--- a/extension/src/content/signin.ts
+++ b/extension/src/content/signin.ts
@@ -1,7 +1,6 @@
 import type { DeviceCode, PollResult } from "../github/deviceFlow";
 
-// Written to storage.local before the verification tab opens; the /login/device
-// content script reads it to pre-fill the code.
+// Written before the verification tab opens; /login/device reads it to pre-fill
 export type PendingSignIn = { userCode: string; expiresAt: number };
 
 export type SignInIo = {
@@ -26,7 +25,7 @@ export const FAILURE_TEXT = {
 } as const;
 
 export function createSignIn(io: SignInIo): (ui: SignInUi) => Promise<void> {
-  let inFlight = false; // one flow per page: a second click while polling is a no-op
+  let inFlight = false; // one flow per page; second click while polling is a no-op
   return async (ui) => {
     if (inFlight) return;
     inFlight = true;
@@ -36,8 +35,7 @@ export function createSignIn(io: SignInIo): (ui: SignInUi) => Promise<void> {
       ui.showPending(code.userCode, code.verificationUri);
       io.openTab(code.verificationUri);
       const result = await io.pollForToken(code);
-      // Success needs no ui call: saveToken writes `pat`, and the storage.onChanged
-      // retry in content/index.ts repaints every auth-blocked panel, including this one.
+      // Success: saveToken → storage.onChanged in index.ts retries auth-blocked panels
       if (result.status === "ok") await io.saveToken(result.token);
       else ui.showFailure(FAILURE_TEXT[result.status]);
       await io.clearPending();

--- a/extension/src/content/toggle.ts
+++ b/extension/src/content/toggle.ts
@@ -4,8 +4,7 @@ export type Toggle = { element: HTMLElement; set(view: View): void };
 
 const FONT = `-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif`;
 
-/** Page-level styles for the toggle and global bar. Colors read GitHub's Primer
- *  variables (always defined on github.com); fallbacks cover the e2e fixture. */
+// Primer variables on github.com; fallbacks cover the e2e fixture
 const PAGE_STYLES = `
   [data-prefablens-global] { display: flex; align-items: center; gap: 8px; margin: 0 0 8px; }
   [data-prefablens-global] .prefablens-seg { margin-left: 0; }
@@ -33,7 +32,7 @@ const PAGE_STYLES = `
   }
 `;
 
-/** Injects the page stylesheet once. The toggle lives in GitHub's DOM (not a shadow root). */
+// Toggle lives in GitHub's DOM (not a shadow root)
 export function injectPageStyles(doc: Document = document): void {
   if (doc.head.querySelector("style[data-prefablens-style]")) return;
   const style = doc.createElement("style");
@@ -49,8 +48,7 @@ export function createToggle(onSelect: (view: View) => void, initial: View = "ra
   wrap.className = "prefablens-seg";
 
   const buttons: HTMLButtonElement[] = [];
-  // set updates only the display: to avoid pulling in onSelect (the re-fetch side) during a global apply.
-  // The selected look is keyed entirely off aria-pressed in the injected CSS.
+  // set updates display only — avoids onSelect (re-fetch) during a global apply
   const select = (view: View): void => {
     for (const b of buttons) b.setAttribute("aria-pressed", String(b.dataset.view === view));
   };

--- a/extension/src/content/views.ts
+++ b/extension/src/content/views.ts
@@ -1,13 +1,11 @@
 import type { DiffV2 } from "../types";
 
-// json is mutated in place by the push listener (merge resolved / replace on the final push)
+// json is mutated in place by the push listener (merge resolved / replace on final push)
 export type ViewEntry = {
   root: ShadowRoot;
   json: DiffV2;
-  /** Re-requests this file's semantic diff (incomplete-resolution affordance). */
-  retry(): void;
-  /** Timer that flips the view to the incomplete state if the final push never arrives. */
-  watchdog?: number;
+  retry(): void; // re-request semantic diff (incomplete-resolution affordance)
+  watchdog?: number; // flips to incomplete if the final push never arrives
 };
 
 export type ViewRegistry = {
@@ -16,17 +14,17 @@ export type ViewRegistry = {
   pruneDisconnected(): void;
 };
 
-/** path-keyed render targets: when a push (guidResolved) arrives, the matching entry re-renders. */
+// path-keyed render targets for guidResolved pushes
 export function createViewRegistry(): ViewRegistry {
   const views = new Map<string, ViewEntry>();
   return {
     set: (key, entry) => void views.set(key, entry),
     get: (key) => views.get(key),
-    // Views killed by an SPA navigation: not only ignore late pushes to them, but also cut the reference
+    // SPA navigation: drop refs so late pushes can't revive dead views
     pruneDisconnected() {
       for (const [key, view] of views) {
         if (view.root.host.isConnected) continue;
-        clearTimeout(view.watchdog); // don't let an orphaned timer render into a detached root
+        clearTimeout(view.watchdog); // orphaned timer must not render into a detached root
         views.delete(key);
       }
     },

--- a/extension/src/content/viewstate.ts
+++ b/extension/src/content/viewstate.ts
@@ -10,7 +10,7 @@ export type ViewState = {
   onDefaultChange(fn: (view: View) => void): void;
 };
 
-/** Default mode (persistent) + per-file overrides while on the page. A global switch always resets the overrides. */
+// Persistent default + per-file overrides; a global switch always clears overrides
 export function createViewState(initial: View, persist: (view: View) => void): ViewState {
   let def = initial;
   const overrides = new Map<string, View>();
@@ -27,14 +27,14 @@ export function createViewState(initial: View, persist: (view: View) => void): V
     clearOverrides: () => overrides.clear(),
     setDefault: (view) => {
       if (view === def) {
-        // Even a same-value click keeps "pressing global always lines everything up": clear overrides and re-apply, but don't write to storage
+        // Same-value click still realigns: clear overrides and re-apply, but don't persist
         if (overrides.size) change(view);
         return;
       }
       change(view);
       persist(view);
     },
-    // storage.onChanged fires even on the originating set tab, so ignore a same value and don't persist
+    // storage.onChanged also fires on the originating tab; ignore same value, don't persist
     applyExternal: (view) => {
       if (view !== def) change(view);
     },

--- a/extension/src/demo.ts
+++ b/extension/src/demo.ts
@@ -1,13 +1,7 @@
-// Live demo for the site's extension.html: the mock PR page runs the
-// extension's real renderer, toggle, and WASM diff engine, wired the same way
-// as the content script minus the GitHub API and auth layers (never import
-// anything that pulls github/client.ts — its module init needs the build-time
-// __API_BASE__ define, absent from the demo build). Living in the extension
-// toolchain keeps the demo type-checked against the modules it uses;
-// `node build.mjs --demo` bundles it as dist/demo.js for site/build.mjs.
-// Diff inputs are fixture files served next to the page; site/build.mjs marks
-// each Unity file header with data-before/data-after URLs (empty on the
-// added/removed side, matching the CLI's empty-side semantics).
+// Live demo for site/extension.html: real renderer + toggle + WASM, wired like
+// the content script minus github/client (needs __API_BASE__, absent here).
+// Bundled as dist/demo.js via `node build.mjs --demo`; fixtures via
+// data-before/data-after URLs (empty side = CLI empty-side semantics).
 import { createToggle, injectPageStyles, type View } from "./content/toggle";
 import { createViewState } from "./content/viewstate";
 import { applyResolved } from "./github/resolved";
@@ -23,10 +17,8 @@ async function fetchBytes(url: string | undefined): Promise<Uint8Array<ArrayBuff
   return new Uint8Array(await res.arrayBuffer());
 }
 
-/** Diff with guid resolution, mirroring the extension's background handler:
- *  applyResolved attaches paths from the index, and the mergeSources loop
- *  fetches the source prefab of added/removed instances by resolved path and
- *  re-diffs with assets — here from fixture URLs instead of the GitHub API. */
+// Guid resolution like the background handler: applyResolved + mergeSources loop,
+// but source prefabs come from fixture URLs instead of the GitHub API.
 async function diffResolved(
   differ: Differ,
   index: Map<string, string>,

--- a/extension/src/github/client.ts
+++ b/extension/src/github/client.ts
@@ -1,6 +1,6 @@
 export class AuthError extends Error {}
 export class RateLimitError extends Error {
-  /** Backoff advice from response headers; undefined when GitHub gave none. */
+  // Backoff from headers; undefined when GitHub gave none
   constructor(
     message: string,
     readonly retryAfterMs?: number,
@@ -9,8 +9,8 @@ export class RateLimitError extends Error {
   }
 }
 
-/** retry-after (seconds) wins; else x-ratelimit-reset (epoch seconds) relative to now.
- *  Number(null) is 0 and Number("") is NaN, so absent headers fail the > 0 guards. */
+// retry-after (seconds) wins; else x-ratelimit-reset (epoch seconds) relative to now.
+// Number(null) is 0 and Number("") is NaN, so absent headers fail the > 0 guards.
 function adviceMs(headers: Headers): number | undefined {
   const retryAfter = Number(headers.get("retry-after"));
   if (retryAfter > 0) return retryAfter * 1000;
@@ -37,10 +37,9 @@ const toChangedFile = (f: DiffEntry): ChangedFile => ({
   sha: f.sha,
 });
 
-// The REST base is fixed at build time (see build.mjs's esbuild define).
+// Fixed at build time (see build.mjs's esbuild define).
 export const API_BASE = __API_BASE__;
 
-/** Derives the GraphQL endpoint from the REST base. */
 export function graphqlUrl(restBase: string): string {
   return `${restBase}/graphql`;
 }
@@ -57,8 +56,7 @@ export class GithubClient {
   private async rawRequest(url: string, init: RequestInit): Promise<Response> {
     const res = await this.fetchFn(url, init);
     if (res.status === 403 || res.status === 429) {
-      // primary is 403 + x-ratelimit-remaining: 0, secondary is 403 + retry-after or
-      // no header (only the body message), newer API is 429. The body is used only for classification, not retained.
+      // 403 + remaining 0 / retry-after, or 429; body classifies only (not retained)
       const body = await res.text().catch(() => "");
       const rateLimited =
         res.status === 429 ||
@@ -88,7 +86,7 @@ export class GithubClient {
     return res.json() as Promise<T>;
   }
 
-  // The before side is the merge-base: GitHub's PR diff compares against the merge-base, not the base branch tip.
+  // before = merge-base (GitHub's PR diff), not the base branch tip
   async getPrRefs(owner: string, repo: string, prNumber: number): Promise<RefPair> {
     const pr = await this.json<{ base: { sha: string }; head: { sha: string } }>(
       `/repos/${owner}/${repo}/pulls/${prNumber}`,
@@ -108,9 +106,8 @@ export class GithubClient {
     }
   }
 
-  /** Commit metadata + changed files vs the first parent (what GitHub's commit page shows).
-   *  Files paginate 300 per page up to GitHub's 3,000-file cap; sha in the response is
-   *  full-length even when the request ref is abbreviated. */
+  // Commit vs first parent (GitHub's commit page). Files: 300/page, 3,000-file cap;
+  // response sha is full-length even when the request ref is abbreviated.
   async getCommit(
     owner: string,
     repo: string,
@@ -119,8 +116,7 @@ export class GithubClient {
     const files: ChangedFile[] = [];
     let sha = "";
     let parentSha: string | null = null;
-    // GitHub documents a 3,000-file cap for this endpoint: 10 pages of 300 bounds the loop
-    // even if the API ever stops honoring the paging params.
+    // 10×300 bounds the loop even if paging params stop being honored
     for (let page = 1; page <= 10; page++) {
       const body = await this.json<{ sha: string; parents: Array<{ sha: string }>; files?: DiffEntry[] }>(
         `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}?per_page=300&page=${page}`,
@@ -136,10 +132,8 @@ export class GithubClient {
     return { sha, parentSha, files };
   }
 
-  /** Three-dot comparison (what GitHub's compare page shows): merge base + changed files.
-   *  GitHub returns compare files only on the first page, capped at 300 for the whole
-   *  comparison — like the PR 3,000-file cap, unlisted files degrade to the handler's
-   *  treat-as-modified / 404→EMPTY path. */
+  // Three-dot compare (GitHub's compare page): merge base + files.
+  // Files only on first page, capped at 300 — unlisted degrade to treat-as-modified / 404→EMPTY.
   async compareRefs(
     owner: string,
     repo: string,
@@ -153,7 +147,7 @@ export class GithubClient {
     return { mergeBaseSha: body.merge_base_commit.sha, files: (body.files ?? []).map(toChangedFile) };
   }
 
-  /** Resolves a ref (branch, tag, abbreviated sha) to the full commit sha via the sha media type. */
+  // branch / tag / abbreviated sha → full commit sha (sha media type)
   async resolveRefSha(owner: string, repo: string, ref: string): Promise<string> {
     const res = await this.request(
       `/repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}`,
@@ -163,8 +157,8 @@ export class GithubClient {
     return (await res.text()).trim();
   }
 
-  /** Looks up guid → asset path (with .meta stripped) via Code Search. No hit / not indexed (422) → null.
-   *  The index covers only the default branch, authenticated 10 req/min. */
+  // guid → asset path via Code Search (.meta stripped). No hit / not indexed (422) → null.
+  // Default branch only; authenticated 10 req/min.
   async searchMetaByGuid(owner: string, repo: string, guid: string): Promise<string | null> {
     const q = encodeURIComponent(`"${guid}" repo:${owner}/${repo} extension:meta`);
     const res = await this.request(`/search/code?q=${q}&per_page=1`, "application/vnd.github+json");
@@ -174,9 +168,7 @@ export class GithubClient {
     return path?.endsWith(".meta") ? path.slice(0, -".meta".length) : null;
   }
 
-  /** Raw bytes at ref. null if the file is absent on that side.
-   *  Path resolution at an arbitrary ref has erratic multi-second TTFB on GitHub's side (#110):
-   *  prefer getBlobRaw whenever the blob SHA is known. */
+  // Raw bytes at ref; null if absent. Prefer getBlobRaw when sha known (#110 TTFB).
   async getFileAtRef(owner: string, repo: string, path: string, ref: string): Promise<Uint8Array | null> {
     const encoded = path.split("/").map(encodeURIComponent).join("/");
     const res = await this.request(
@@ -188,8 +180,8 @@ export class GithubClient {
     return new Uint8Array(await res.arrayBuffer());
   }
 
-  /** Raw blob bytes by SHA — content-addressed, so latency stays flat where contents-by-path stalls.
-   *  null on 404 (the SHA can vanish after a force push + gc). */
+  // Content-addressed blob bytes; latency stays flat where contents-by-path stalls.
+  // null on 404 (sha can vanish after force push + gc).
   async getBlobRaw(owner: string, repo: string, sha: string): Promise<Uint8Array | null> {
     const res = await this.request(`/repos/${owner}/${repo}/git/blobs/${sha}`, "application/vnd.github.raw+json");
     if (res.status === 404) return null;
@@ -205,7 +197,7 @@ export class GithubClient {
     return this.json(`/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`);
   }
 
-  /** path + blob SHA of every .meta at ref (a commit SHA is allowed). truncated means the listing was cut off past 100k entries. */
+  // Every .meta path + blob sha at ref. truncated → listing cut past 100k entries.
   async listMetaTree(
     owner: string,
     repo: string,
@@ -218,7 +210,7 @@ export class GithubClient {
     return { truncated: body.truncated, metas };
   }
 
-  /** path → blob SHA of every blob at ref. Feeds base-side getBlobRaw lookups; same truncation rule as listMetaTree. */
+  // path → blob sha for every blob at ref (feeds base-side getBlobRaw). Same truncation as listMetaTree.
   async listBlobShas(
     owner: string,
     repo: string,
@@ -230,7 +222,7 @@ export class GithubClient {
     return { truncated: body.truncated, byPath };
   }
 
-  /** Batch-fetches blob text via GraphQL (chunking is the caller's job). GraphQL has an independent 5,000 pt/h budget. */
+  // GraphQL blob text batch (caller chunks). Independent 5,000 pt/h budget.
   async batchBlobTexts(owner: string, repo: string, oids: string[]): Promise<Record<string, string | null>> {
     const aliases = oids
       .map((oid, i) => `b${i}: object(oid: ${JSON.stringify(oid)}) { ... on Blob { text } }`)
@@ -250,7 +242,7 @@ export class GithubClient {
       data?: { repository?: Record<string, { text?: string | null } | null> } | null;
       errors?: Array<{ type?: string }>;
     };
-    // GraphQL returns errors while still HTTP 200: RATE_LIMITED is caught here
+    // GraphQL can be HTTP 200 with RATE_LIMITED in errors[]
     if (body.errors?.some((e) => e.type === "RATE_LIMITED"))
       throw new RateLimitError("GitHub rate limit exceeded", adviceMs(res.headers));
     const blobs = body.data?.repository;

--- a/extension/src/github/deviceFlow.ts
+++ b/extension/src/github/deviceFlow.ts
@@ -22,8 +22,7 @@ export async function requestDeviceCode(fetchFn: typeof fetch): Promise<DeviceCo
     method: "POST",
     headers: { accept: "application/json" },
     body: new URLSearchParams({ client_id: CLIENT_ID, scope: "repo" }),
-    // OAuth device endpoints need no cookies: staying cookie-less keeps the same-origin
-    // call from the github.com content script free of session state.
+    // Cookie-less: same-origin content-script call must not attach session state
     credentials: "omit",
   });
   if (!res.ok) throw new Error(`device code request failed (HTTP ${res.status})`);
@@ -63,7 +62,7 @@ export async function pollForToken(
       case "authorization_pending":
         continue;
       case "slow_down":
-        // GitHub's own interval already accounts for the requested backoff; fall back to +5s otherwise.
+        // Prefer GitHub's interval; else +5s
         interval = body.interval ?? interval + 5;
         continue;
       case "expired_token":

--- a/extension/src/github/guids.ts
+++ b/extension/src/github/guids.ts
@@ -1,6 +1,6 @@
 import { type ChangedFile, RateLimitError } from "./client";
 
-/** Same rule as parseGuid in cli/src/resolve.zig: picks up "guid:" at the start of a line (after trim). */
+// Same rule as parseGuid in cli/src/resolve.zig: "guid:" at line start after trim
 export function parseGuidFromMeta(meta: string): string | undefined {
   for (const line of meta.split("\n")) {
     const t = line.trim();
@@ -11,8 +11,8 @@ export function parseGuidFromMeta(meta: string): string | undefined {
 
 export type MetaFetcher = (path: string, side: "base" | "head") => Promise<string | null>;
 
-/** Persistent cache of guid→asset path resolved via Code Search (repo key is `<API_BASE>/<owner>/<repo>`).
- *  guid→path is stable, so no TTL. save merges. */
+// Persistent guid→asset path via Code Search (repo key `<API_BASE>/<owner>/<repo>`).
+// Stable mapping → no TTL; save merges.
 export type GuidCache = {
   load(repo: string): Promise<Record<string, string>>;
   save(repo: string, entries: Record<string, string>): Promise<void>;
@@ -20,8 +20,8 @@ export type GuidCache = {
 
 const MAX_CONCURRENT_META_FETCHES = 8;
 
-/** Builds a guid → asset path index only from .meta files changed in the PR. removed ones are read from the base side.
- *  Caps concurrent fetches at 8 (avoids GitHub secondary rate limits on large .meta changes). */
+// guid→path from .meta files changed in the PR (removed → base side).
+// Cap 8 concurrent fetches to avoid GitHub secondary rate limits.
 export async function buildGuidIndex(files: ChangedFile[], fetchMeta: MetaFetcher): Promise<Map<string, string>> {
   const index = new Map<string, string>();
   const metas = files.filter((f) => f.path.endsWith(".meta"));

--- a/extension/src/github/repoIndex.ts
+++ b/extension/src/github/repoIndex.ts
@@ -13,8 +13,8 @@ export type RepoIndexStore = {
 const INDEX_MAX_METAS = 50_000; // above this, give up on the index to protect the storage quota
 const GRAPHQL_BATCH = 100;
 
-/** Whole-repo guid → asset path index. Not indexable (truncated / over the cap) → null, deferring to Code Search.
- *  blobSha → guid is content-derived, so it can be cached forever; after a push, only changed .meta are fetched. */
+// Whole-repo guid→asset path. Truncated / over cap → null (defer to Code Search).
+// blobSha→guid is content-derived (cache forever); after a push only changed .meta are fetched.
 export async function syncRepoIndex(
   client: ClientLike,
   store: RepoIndexStore,

--- a/extension/src/github/resolved.ts
+++ b/extension/src/github/resolved.ts
@@ -1,9 +1,7 @@
 import type { DiffV2 } from "../types";
 
-/** Host-side resolution seam. Attaches with the same scoping rule as core's "resolved".
- *  Lives apart from guids.ts so the site demo bundle (src/demo.ts) can import it
- *  without pulling the GitHub client (whose module init needs the build-time
- *  __API_BASE__ define). */
+// Host-side "resolved" attach (same scoping as core). Separate from guids.ts so
+// the site demo (src/demo.ts) can import without pulling GithubClient / __API_BASE__.
 export function applyResolved(diff: DiffV2, index: Map<string, string>): DiffV2 {
   const resolved: Record<string, string> = {};
   for (const g of diff.unresolvedGuids) {

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -23,8 +23,7 @@ type ClipboardLike = {
   writeText(text: string): Promise<void>;
 };
 
-// Injectable bundle for the device flow: real implementations (fetch/sleep/navigator.clipboard) are
-// bound once at the chrome bootstrap below, so initOptions itself never touches real I/O.
+// Injectable device-flow deps: chrome bootstrap binds real I/O; initOptions stays pure for tests.
 export type SignInFlow = {
   requestDeviceCode(): Promise<DeviceCode>;
   pollForToken(code: DeviceCode): Promise<PollResult>;
@@ -49,7 +48,7 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
 
   signinButton.addEventListener("click", () => {
     void (async () => {
-      // The poll can run for minutes; disabling the button while in flight makes concurrent flows impossible
+      // Poll can run for minutes — disable to block concurrent flows
       signinButton.disabled = true;
       status.textContent = "";
       try {
@@ -70,7 +69,7 @@ export async function initOptions(doc: Document, storage: StorageLike, flow: Sig
       } catch {
         status.textContent = "Sign-in failed";
       } finally {
-        // The code is consumed once the poll ends, whatever the outcome: hide it and allow a retry
+        // Code is one-shot: hide it and allow a retry whatever the outcome
         flowArea.hidden = true;
         signinButton.disabled = false;
       }

--- a/extension/src/renderer/icons.ts
+++ b/extension/src/renderer/icons.ts
@@ -1,4 +1,4 @@
-/** Inline SVG markup for tree glyphs. Static strings only — never interpolate data. */
+// Inline SVG for tree glyphs. Static strings only — never interpolate data.
 const svg = (body: string, size: number): string =>
   `<svg width="${size}" height="${size}" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">${body}</svg>`;
 

--- a/extension/src/renderer/render.ts
+++ b/extension/src/renderer/render.ts
@@ -79,7 +79,7 @@ export function renderLoading(root: ShadowRoot): void {
   mount(root).append(box);
 }
 
-/** Over-25MB guard: doesn't auto-render, waits for an explicit click. */
+// Over-25MB guard: no auto-render; waits for an explicit click.
 export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => void): void {
   const container = mount(root);
   const button = document.createElement("button");
@@ -90,7 +90,7 @@ export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => 
   container.append(note("pl-empty", `Large file (${Math.round(bytes / (1024 * 1024))} MB).`, ALERT), button);
 }
 
-/** Auth-error panel: the message plus a button that starts the GitHub device flow in place. */
+// Auth-error panel: message + in-place device-flow button.
 export function renderSignIn(root: ShadowRoot, message: string, onSignIn: () => void): void {
   const container = mount(root);
   const button = document.createElement("button");
@@ -101,7 +101,7 @@ export function renderSignIn(root: ShadowRoot, message: string, onSignIn: () => 
   container.append(note("pl-error", message, ALERT), button);
 }
 
-/** Device-flow pending state: keeps the user code visible while the user authorizes on GitHub. */
+// Device-flow pending: keep the user code visible while authorizing on GitHub.
 export function renderSignInPending(
   root: ShadowRoot,
   userCode: string,
@@ -182,7 +182,7 @@ function summaryRow(status: Status, icon: string, iconClass: string, name: strin
   return summary;
 }
 
-/** Appends kids into the details, or marks the summary as a leaf when there are none. */
+// Append kids, or mark the summary as a leaf when empty.
 function finish(details: HTMLDetailsElement, summary: HTMLElement, kids: HTMLElement): HTMLDetailsElement {
   details.append(summary);
   if (kids.childElementCount) details.append(kids);
@@ -237,8 +237,8 @@ function renderNode(node: NodeDiff, diff: DiffV2): HTMLElement {
   return finish(details, summary, kids);
 }
 
-/** Components fold as their own group one level below the object row, so cube rows
- *  alone form the hierarchy spine (Unity puts components in the Inspector, not the tree). */
+// Components nest under their own group so cube rows alone form the hierarchy spine
+// (Unity puts components in the Inspector, not the Hierarchy tree).
 function componentsSection(cards: HTMLElement[]): HTMLElement {
   const details = document.createElement("details");
   details.open = true;
@@ -263,11 +263,11 @@ function renderOverrideGroups(overrides: OverrideDiff[], diff: DiffV2): HTMLElem
     else groups.push({ name: ov.group, rows: [ov] });
   }
   return groups.map(({ name, rows }) => {
-    // The heading status: that status if uniform within the group, otherwise modified.
+    // The heading status: that status if uniform within the group, else modified.
     const [first] = rows;
     const status = first && rows.every((r) => r.status === first.status) ? first.status : "modified";
     const el = openDetails("pl-comp", status);
-    el.open = true; // override cards are always open (spec: light, just a collapsed summary)
+    el.open = true; // override cards stay expanded (summary is just a light grouping)
     const kids = kidsBox();
     for (const r of rows) kids.append(fieldRow(r.label, r.status, r.before, r.after, diff));
     return finish(el, summaryRow(status, GEAR, "pl-icon", name), kids);

--- a/extension/src/renderer/styles.ts
+++ b/extension/src/renderer/styles.ts
@@ -1,9 +1,6 @@
-/** Shadow-DOM stylesheet. Colors read Primer CSS variables (custom properties
- *  inherit through the shadow boundary on github.com, so every GitHub theme is
- *  followed automatically) and fall back to a built-in light/dark palette.
- *  The host declares display: block because all: initial resets display to its
- *  spec initial value (inline), which would break the card frame the react
- *  layout draws on the host. */
+// Shadow-DOM stylesheet. Primer CSS vars inherit through the shadow boundary on
+// github.com (every theme followed automatically); fall back to built-in light/dark.
+// :host needs display:block — all:initial resets display to inline and breaks the card frame.
 export const STYLES = `
   :host { all: initial; display: block; }
   .pl-root {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -63,10 +63,8 @@ export type DiffV2 = {
 
 export type DiffErrorV1 = { schema: "prefablens.error.v1"; error: string };
 
-/** Guids still lacking a name after resolution so far — the single definition of
- *  "unresolved" shared by handler, resolution, and the content indicator. Object.hasOwn
- *  is a prototype-pollution guard: guids are arbitrary strings, so "constructor" and
- *  friends must not falsely hit Object.prototype and count as resolved. */
+// Guids still lacking a name — shared by handler, resolution, and the content indicator.
+// Object.hasOwn: guids are arbitrary strings ("constructor" must not hit Object.prototype).
 export function unresolvedRemaining(json: Pick<DiffV2, "unresolvedGuids" | "resolved">): string[] {
   return json.unresolvedGuids.filter((g) => !Object.hasOwn(json.resolved ?? {}, g));
 }
@@ -78,7 +76,7 @@ export type DiffTarget =
   | { kind: "commit"; sha: string }
   | { kind: "compare"; base: string; head: string };
 
-/** Stable identity of a target within a repo — context caches and view keys derive from it. */
+// Stable identity within a repo — context caches and view keys derive from it.
 export function targetKey(owner: string, repo: string, target: DiffTarget): string {
   const suffix =
     target.kind === "pull"
@@ -115,11 +113,10 @@ export type SemanticDiffResponse =
   | { ok: false; error: BackgroundError }
   | { ok: false; error: "too-large"; bytes: number };
 
-// Outcome of the background resolution pipeline. Anything but "complete" means the run
-// gave up early (rate limit or error) and a manual retry may resolve more references.
+// Background resolution outcome. Anything but "complete" means a manual retry may help.
 export type ResolutionStatus = "complete" | "rateLimited" | "failed";
 
-// Async push from background → content (the second stage of the two-stage response).
+// Async push background → content (stage 2 of the two-stage response).
 export type GuidResolvedPush = {
   type: "guidResolved";
   owner: string;
@@ -127,7 +124,7 @@ export type GuidResolvedPush = {
   target: DiffTarget;
   path: string;
   resolved: Record<string, string>;
-  json?: DiffV2; // carried on the final push when mergeSources updated the structure (content replaces the view)
-  done: boolean; // when true, resolution is finished (sent even with empty resolved = the cue to turn off the indicator)
-  status?: ResolutionStatus; // rides on every done push: the content script keeps the indicator up unless "complete"
+  json?: DiffV2; // final push may carry a restructured diff after mergeSources
+  done: boolean; // resolution finished (even with empty resolved — turns off the indicator)
+  status?: ResolutionStatus; // on every done push; keep indicator unless "complete"
 };

--- a/extension/src/unity.ts
+++ b/extension/src/unity.ts
@@ -1,12 +1,10 @@
-// Extensions that Unity text-serializes (UnityYAML). Same set as unityyamlmerge
-// targets, i.e. the community Unity.gitattributes:
+// UnityYAML extensions (same set as unityyamlmerge / Unity.gitattributes):
 // https://github.com/gitattributes/gitattributes/blob/master/Unity.gitattributes
-// Excludes .meta (not !u! document format) and JSON like .asmdef. This is a
-// prefilter; content is the ground truth (core isUnityYaml via the wasm bridge).
+// Excludes .meta and JSON (.asmdef). Prefilter only — content truth is wasm isUnityYaml.
 const UNITY_PATH =
   /\.(prefab|unity|asset|mat|anim|controller|overrideController|physicMaterial|physicsMaterial2D|playable|mask|brush|flare|fontsettings|guiskin|giparams|renderTexture|spriteatlas|spriteatlasv2|terrainlayer|mixer|shadervariants|preset|signal|lighting|scenetemplate)$/i;
 
-/** Content detection and background prefetch share the same check. */
+// Shared by content detection and background prefetch.
 export function isUnityPath(path: string): boolean {
   return UNITY_PATH.test(path);
 }

--- a/extension/src/util/must.ts
+++ b/extension/src/util/must.ts
@@ -1,5 +1,4 @@
-/** Runtime-checked replacement for the banned `!` assertion: returns the value
- *  when present and fails loudly at the call site when the invariant breaks. */
+// Runtime-checked stand-in for banned `!`: present → return; absent → throw at call site.
 export function must<T>(v: T | null | undefined): T {
   if (v == null) throw new Error("invariant violated: value is absent");
   return v;

--- a/extension/src/wasm/differ.ts
+++ b/extension/src/wasm/differ.ts
@@ -17,8 +17,8 @@ type Exports = {
   is_unity_yaml(p: number, l: number): number;
 };
 
-/** assets TLV (LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }.
- *  1:1 with parseAssets in core/src/wasm.zig. */
+// assets TLV (LE): [u32 count] repeat{ [u32 guid_len][guid][u32 data_len][data] }.
+// 1:1 with parseAssets in core/src/wasm.zig.
 export function encodeAssets(assets: Map<string, Uint8Array>): Uint8Array {
   const enc = new TextEncoder();
   const entries = [...assets].map(([guid, data]) => ({ guid: enc.encode(guid), data }));


### PR DESCRIPTION
## Summary

Align `extension/src` production TypeScript with the short why-comment style used in `site/`, and rename a few ambiguous private helpers. No behavior change.

## Motivation

The site build and pages are easy to scan; the extension had longer JSDoc that often restated the code. A single clarity pass makes the extension match that bar without structural extracts.

Closes #NNN

## Changes

- Compress comments across `content/`, `background/`, `github/`, `renderer/` (except generated `builtin_refs.ts`), `wasm/`, `options/`, `types.ts`, `unity.ts`, `demo.ts`, and related helpers
- Keep non-obvious constraints (rate limits, SW/tab push races, React virtualization, raw-hide selector failure mode, `requestDiff` never-rejects contract)
- Private renames only: `state` → `viewState`, `reactPath` → `filePathFromReactHeader`, `ensureHideRule` → `ensureReactRawHideStyle`
- No chrome.runtime message types, storage keys, or wire-format fields changed

## Testing

```text
cd extension && ./node_modules/.bin/tsc --noEmit
# OK

cd extension && ./node_modules/.bin/vitest run
# Test Files  27 passed (27)
# Tests       291 passed (291)

cd extension && ./node_modules/.bin/biome ci --reporter=default .
# OK
```