### PR TITLE
refactor: use domain repositories for storage I/O

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -25,6 +25,9 @@ container wiring:
 
 Pure types and pure functions. Imports nothing outside `domain/`.
 
+- **Repository**: interfaces for domain-model persistence live in
+  `domain/` (alongside models). Use cases depend on these interfaces;
+  infrastructure supplies the implementations.
 - **Result**: expected failures travel as tagged unions via
   `Result<T, E>` from `domain/result.ts` — no `Error` subclasses,
   no `throw` for expected failures. Shared by ports, use cases, and
@@ -43,7 +46,8 @@ Use cases composed from domain logic and ports.
   No `create<UseCase>(deps)` factories, no method-bag objects, no `XxxDeps`
   bags.
 - **Port** (`application/port/<name>.ts`): `XxxPort` types abstracting
-  infrastructure capabilities.
+  outside capabilities that do **not** load or save domain models (GitHub
+  API, WASM differ, chrome.runtime messaging, device-flow helpers).
 - **Shared internals**: files used by several use cases in a feature folder
   get an underscore prefix (`_diff-session.ts`, `_resolution.ts`,
   `_promise-cache.ts`) to distinguish them from verb-noun use cases.
@@ -53,15 +57,14 @@ Use cases composed from domain logic and ports.
 
 ### Infrastructure (`src/infrastructure/`)
 
-- **`providers/`**: implementations of `application/port` contracts and
-  other outside-world adapters (GitHub client, WASM differ, chrome.storage,
-  chrome.runtime messaging).
-- **`repositories/`**: chrome.storage-backed stores.
+- **`providers/`**: implementations of `application/port` contracts
+  (GitHub client, WASM differ, chrome.runtime messaging, device-flow helpers).
+- **`repositories/`**: implementations of domain repository interfaces
+  (chrome.storage-backed). `merge-store.ts` is an internal helper for
+  those implementations.
 - **`container.ts`**: the only DI file. Exports individual `createX()`
-  factories that return ports (and lifetime-managed loaders). Does not import
-  application use cases or session constructors. Entry points
-  (`presentation/*/index.ts`) call factories, `createDiffSession` where
-  needed, and use-case verbs.
+  factories that return ports and repositories (and lifetime-managed
+  loaders). Does not import application use cases or session constructors.
 
 ### Presentation (`src/presentation/`)
 
@@ -71,7 +74,8 @@ Receives outside input and decides which use case to call.
   pure functions, other presentation files.
 - Must not import: `application/port`, any infrastructure file — except the
   entry point (`presentation/*/index.ts`), which imports `container.ts` to
-  construct ports. Presentation holds port values and passes them to use
+  construct ports **and repositories** and pass them into use cases.
+  Presentation holds port and repository values and passes them to use
   cases; it never invokes port methods itself (except where already
   documented for UI prefs / token change observation).
 - **Inbound vs outbound**: inbound transport events
@@ -82,7 +86,7 @@ Receives outside input and decides which use case to call.
   state machine, auth retries) are presentation-owned. The `viewMode`
   storage key is a UI preference and is read/written directly by
   presentation; the `accessToken`/`signin` keys are owned by the token
-  store, and presentation only observes their change events.
+  repository, and presentation only observes their change events.
 
 ## Startup pattern
 

--- a/extension/src/application/auth/get-pending-sign-in.test.ts
+++ b/extension/src/application/auth/get-pending-sign-in.test.ts
@@ -1,8 +1,8 @@
 import { expect, it } from "vitest";
-import type { TokenStorePort } from "../port/token-store";
+import type { TokenRepository } from "../../domain/auth/token-repository";
 import { getPendingSignIn } from "./get-pending-sign-in";
 
-function tokenStore(readPendingSignIn: TokenStorePort["readPendingSignIn"]): TokenStorePort {
+function tokenStore(readPendingSignIn: TokenRepository["readPendingSignIn"]): TokenRepository {
   return {
     readAccessToken: async () => undefined,
     saveAccessToken: async () => {},

--- a/extension/src/application/auth/get-pending-sign-in.ts
+++ b/extension/src/application/auth/get-pending-sign-in.ts
@@ -1,9 +1,9 @@
-import type { TokenStorePort } from "../port/token-store";
+import type { TokenRepository } from "../../domain/auth/token-repository";
 
 // Device-page pre-fill: only the code this browser's PR page issued; storage
 // failure degrades to no pre-fill (the user pastes the code instead)
 export function getPendingSignIn(
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
 ): Promise<{ userCode: string; expiresAt: number } | undefined> {
   return tokenStore.readPendingSignIn().catch(() => undefined);
 }

--- a/extension/src/application/auth/sign-in.test.ts
+++ b/extension/src/application/auth/sign-in.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { TokenRepository } from "../../domain/auth/token-repository";
 import type { DeviceCode, GithubAuthPort, PollResult } from "../port/github-auth";
-import type { TokenStorePort } from "../port/token-store";
 import { FAILURE_TEXT, type PendingSignIn, type SignInState, type SignInUi, signIn } from "./sign-in";
 
 const CODE: DeviceCode = {
@@ -27,7 +27,7 @@ function fakeDeps(poll: () => Promise<PollResult>) {
       return poll();
     },
   };
-  const tokenStore: TokenStorePort = {
+  const tokenStore: TokenRepository = {
     async readAccessToken() {
       return undefined;
     },

--- a/extension/src/application/auth/sign-in.ts
+++ b/extension/src/application/auth/sign-in.ts
@@ -1,5 +1,5 @@
+import type { TokenRepository } from "../../domain/auth/token-repository";
 import type { GithubAuthPort } from "../port/github-auth";
-import type { TokenStorePort } from "../port/token-store";
 
 // Written before the verification tab opens; /login/device reads it to pre-fill
 export type PendingSignIn = { userCode: string; expiresAt: number };
@@ -19,7 +19,7 @@ export const FAILURE_TEXT = {
 
 export async function signIn(
   auth: GithubAuthPort,
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
   fetchFn: typeof fetch,
   sleep: (ms: number) => Promise<void>,
   openTab: (url: string) => void,

--- a/extension/src/application/diff/_get-diff.ts
+++ b/extension/src/application/diff/_get-diff.ts
@@ -1,4 +1,4 @@
-import type { DiffCachePort } from "../port/diff-cache";
+import type { DiffRepository } from "../../domain/diff/diff-repository";
 import type { DifferPort } from "../port/differ";
 import type { GithubPort } from "../port/github";
 import type { DiffContext, DiffOutcome, DiffSession } from "./_diff-session";
@@ -37,7 +37,7 @@ async function computeDiff(
 // Sha-keyed: a push produces a new key (no invalidation)
 export function getDiff(
   getDiffer: () => Promise<DifferPort>,
-  diffStore: DiffCachePort,
+  diffStore: DiffRepository,
   session: DiffSession,
   client: GithubPort,
   ctx: DiffContext,

--- a/extension/src/application/diff/_resolution.test.ts
+++ b/extension/src/application/diff/_resolution.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { DiffV2, GuidResolvedPush, SemanticDiffRequest } from "../../domain/diff/types";
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { must } from "../../domain/must";
 import { err, ok } from "../../domain/result";
 import type { DifferPort } from "../port/differ";
-import type { GuidCachePort } from "../port/guid-cache";
-import type { RepoIndexPort } from "../port/repo-index";
 import { createDiffSession, type DiffContext } from "./_diff-session";
 import { getGuids, getRepoIndex, updateRemaining, updateSources } from "./_resolution";
 
@@ -321,8 +321,8 @@ describe("updateSources", () => {
 
 describe("updateRemaining", () => {
   async function run(
-    guidCache: GuidCachePort,
-    repoIndexStore: RepoIndexPort,
+    guidCache: GuidRepository,
+    repoIndexStore: RepoIndexRepository,
     getDiffer: () => Promise<DifferPort>,
     session: ReturnType<typeof createDiffSession>,
     client: ReturnType<typeof makeResolution>["client"],

--- a/extension/src/application/diff/_resolution.ts
+++ b/extension/src/application/diff/_resolution.ts
@@ -6,10 +6,10 @@ import {
   type SemanticDiffRequest,
   unresolvedRemaining,
 } from "../../domain/diff/types";
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import type { DifferPort } from "../port/differ";
 import { type GithubPort, isRateLimited } from "../port/github";
-import type { GuidCachePort } from "../port/guid-cache";
-import type { RepoIndexPort } from "../port/repo-index";
 import type { DiffContext, DiffSession } from "./_diff-session";
 import { type BlobClient, getBlob, getPair } from "./_get-blobs";
 import { updateRepoIndex } from "./update-repo-index";
@@ -24,7 +24,7 @@ const MAX_SOURCE_ROUNDS = 3; // re-diff cap for nested sources (independent of c
 
 // cache → Code Search; failures (incl. rate limits) don't drop the diff — return what resolved
 export async function getGuids(
-  guidCache: GuidCachePort,
+  guidCache: GuidRepository,
   session: DiffSession,
   guids: string[],
   client: SearchClient,
@@ -67,7 +67,7 @@ export async function getGuids(
 
 // Unresolved-by-in-PR-.meta → cache → Code Search; rateLimited folds into updateSources status
 async function getUnresolved(
-  guidCache: GuidCachePort,
+  guidCache: GuidRepository,
   session: DiffSession,
   json: DiffV2,
   client: SearchClient,
@@ -83,7 +83,7 @@ async function getUnresolved(
 
 // Memoized whole-repo index; rate-limited repos stay on fallback for the SW lifetime
 export async function getRepoIndex(
-  repoIndexStore: RepoIndexPort,
+  repoIndexStore: RepoIndexRepository,
   session: DiffSession,
   client: SearchClient,
   owner: string,
@@ -105,7 +105,7 @@ export async function getRepoIndex(
 
 // Fetch neededSources via resolved path and re-diff with assets; failure degrades (doesn't drop)
 export async function updateSources(
-  guidCache: GuidCachePort,
+  guidCache: GuidRepository,
   session: DiffSession,
   first: DiffV2,
   differ: DifferPort,
@@ -171,8 +171,8 @@ function combine(a: ResolutionStatus, b: ResolutionStatus): ResolutionStatus {
 
 // Background index → Code Search + source re-merge via push; catch still emits done to release waiters
 export async function updateRemaining(
-  guidCache: GuidCachePort,
-  repoIndexStore: RepoIndexPort,
+  guidCache: GuidRepository,
+  repoIndexStore: RepoIndexRepository,
   getDiffer: () => Promise<DifferPort>,
   session: DiffSession,
   first: DiffV2,

--- a/extension/src/application/diff/create-pr-prefetch.test.ts
+++ b/extension/src/application/diff/create-pr-prefetch.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import type { TokenRepository } from "../../domain/auth/token-repository";
+import type { DiffRepository } from "../../domain/diff/diff-repository";
 import type { DiffV2, GuidResolvedPush, SemanticDiffRequest, SemanticDiffResponse } from "../../domain/diff/types";
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { err, ok } from "../../domain/result";
-import type { DiffCachePort } from "../port/diff-cache";
 import type { DifferPort } from "../port/differ";
 import type { ChangedFile, GithubPort } from "../port/github";
-import type { GuidCachePort } from "../port/guid-cache";
-import type { RepoIndexPort } from "../port/repo-index";
-import type { TokenStorePort } from "../port/token-store";
 import { createDiffSession, type DiffSession } from "./_diff-session";
 import { createPrPrefetch } from "./create-pr-prefetch";
 import { getSemanticDiff } from "./get-semantic-diff";
@@ -105,7 +105,7 @@ function makeFakes(overrides?: {
       indexData[repo] = index;
     }),
   };
-  const tokenStore: TokenStorePort = {
+  const tokenStore: TokenRepository = {
     readAccessToken: async () => (Object.hasOwn(overrides ?? {}, "accessToken") ? overrides?.accessToken : "tok"),
     saveAccessToken: async () => {},
     savePendingSignIn: async () => {},
@@ -121,12 +121,12 @@ function makeFakes(overrides?: {
  *  fully-resolved response. Errors and fully-in-PR-resolved diffs pass through unchanged; a pending
  *  diff resolves to the final push's json, i.e. what the pipeline ultimately produces. */
 async function resolveFully(
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
   makeClient: MakeClient,
   getDiffer: GetDiffer,
-  guidCache: GuidCachePort,
-  diffStore: DiffCachePort,
-  repoIndexStore: RepoIndexPort,
+  guidCache: GuidRepository,
+  diffStore: DiffRepository,
+  repoIndexStore: RepoIndexRepository,
   session: DiffSession,
   req: SemanticDiffRequest,
 ): Promise<SemanticDiffResponse> {

--- a/extension/src/application/diff/create-pr-prefetch.ts
+++ b/extension/src/application/diff/create-pr-prefetch.ts
@@ -1,11 +1,11 @@
+import type { TokenRepository } from "../../domain/auth/token-repository";
+import type { DiffRepository } from "../../domain/diff/diff-repository";
 import type { PrefetchRequest } from "../../domain/diff/types";
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { isUnityPath } from "../../domain/unity";
-import type { DiffCachePort } from "../port/diff-cache";
 import type { DifferPort } from "../port/differ";
 import type { GithubPort } from "../port/github";
-import type { GuidCachePort } from "../port/guid-cache";
-import type { RepoIndexPort } from "../port/repo-index";
-import type { TokenStorePort } from "../port/token-store";
 import type { DiffSession } from "./_diff-session";
 import { getContext } from "./_get-context";
 import { getDiff } from "./_get-diff";
@@ -17,12 +17,12 @@ const API_BASE = __API_BASE__;
 
 // Raw diff only — leave Code Search / updateSources to serve time (10 req/min)
 export async function createPrPrefetch(
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
   makeClient: (base: string, token: string, lane: "user" | "prefetch") => GithubPort,
   getDiffer: () => Promise<DifferPort>,
-  _guidCache: GuidCachePort,
-  diffStore: DiffCachePort,
-  repoIndexStore: RepoIndexPort,
+  _guidCache: GuidRepository,
+  diffStore: DiffRepository,
+  repoIndexStore: RepoIndexRepository,
   session: DiffSession,
   req: PrefetchRequest,
 ): Promise<void> {

--- a/extension/src/application/diff/get-semantic-diff.test.ts
+++ b/extension/src/application/diff/get-semantic-diff.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
+import type { TokenRepository } from "../../domain/auth/token-repository";
+import type { DiffRepository } from "../../domain/diff/diff-repository";
 import type { DiffV2, GuidResolvedPush, SemanticDiffRequest, SemanticDiffResponse } from "../../domain/diff/types";
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { must } from "../../domain/must";
 import { err, ok } from "../../domain/result";
-import type { DiffCachePort } from "../port/diff-cache";
 import type { DifferPort } from "../port/differ";
 import type { ChangedFile, GithubPort } from "../port/github";
-import type { GuidCachePort } from "../port/guid-cache";
-import type { RepoIndexPort } from "../port/repo-index";
-import type { TokenStorePort } from "../port/token-store";
 import { createDiffSession, type DiffSession } from "./_diff-session";
 import { createPrPrefetch } from "./create-pr-prefetch";
 import { getSemanticDiff } from "./get-semantic-diff";
@@ -106,7 +106,7 @@ function makeFakes(overrides?: {
       indexData[repo] = index;
     }),
   };
-  const tokenStore: TokenStorePort = {
+  const tokenStore: TokenRepository = {
     readAccessToken: async () => (Object.hasOwn(overrides ?? {}, "accessToken") ? overrides?.accessToken : "tok"),
     saveAccessToken: async () => {},
     savePendingSignIn: async () => {},
@@ -120,12 +120,12 @@ function makeFakes(overrides?: {
 
 /** Cleanup for a pending response: wait until the done push arrives before asserting. */
 async function serveAndResolve(
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
   makeClient: MakeClient,
   getDiffer: GetDiffer,
-  guidCache: GuidCachePort,
-  diffStore: DiffCachePort,
-  repoIndexStore: RepoIndexPort,
+  guidCache: GuidRepository,
+  diffStore: DiffRepository,
+  repoIndexStore: RepoIndexRepository,
   session: DiffSession,
   req: SemanticDiffRequest,
 ): Promise<{ res: SemanticDiffResponse; pushes: GuidResolvedPush[] }> {
@@ -149,12 +149,12 @@ async function serveAndResolve(
  *  fully-resolved response. Errors and fully-in-PR-resolved diffs pass through unchanged; a pending
  *  diff resolves to the final push's json, i.e. what the pipeline ultimately produces. */
 async function resolveFully(
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
   makeClient: MakeClient,
   getDiffer: GetDiffer,
-  guidCache: GuidCachePort,
-  diffStore: DiffCachePort,
-  repoIndexStore: RepoIndexPort,
+  guidCache: GuidRepository,
+  diffStore: DiffRepository,
+  repoIndexStore: RepoIndexRepository,
   session: DiffSession,
   req: SemanticDiffRequest,
 ): Promise<SemanticDiffResponse> {

--- a/extension/src/application/diff/get-semantic-diff.ts
+++ b/extension/src/application/diff/get-semantic-diff.ts
@@ -1,3 +1,5 @@
+import type { TokenRepository } from "../../domain/auth/token-repository";
+import type { DiffRepository } from "../../domain/diff/diff-repository";
 import { applyResolved } from "../../domain/diff/resolved";
 import {
   type GuidResolvedPush,
@@ -5,12 +7,10 @@ import {
   type SemanticDiffResponse,
   unresolvedRemaining,
 } from "../../domain/diff/types";
-import type { DiffCachePort } from "../port/diff-cache";
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import type { DifferPort } from "../port/differ";
 import type { GithubPort } from "../port/github";
-import type { GuidCachePort } from "../port/guid-cache";
-import type { RepoIndexPort } from "../port/repo-index";
-import type { TokenStorePort } from "../port/token-store";
 import type { DiffSession } from "./_diff-session";
 import { getContext } from "./_get-context";
 import { getDiff } from "./_get-diff";
@@ -19,12 +19,12 @@ import { updateRemaining } from "./_resolution";
 const API_BASE = __API_BASE__;
 
 export async function getSemanticDiff(
-  tokenStore: TokenStorePort,
+  tokenStore: TokenRepository,
   makeClient: (base: string, token: string, lane: "user" | "prefetch") => GithubPort,
   getDiffer: () => Promise<DifferPort>,
-  guidCache: GuidCachePort,
-  diffStore: DiffCachePort,
-  repoIndexStore: RepoIndexPort,
+  guidCache: GuidRepository,
+  diffStore: DiffRepository,
+  repoIndexStore: RepoIndexRepository,
   session: DiffSession,
   req: SemanticDiffRequest,
   push: (msg: GuidResolvedPush) => void,

--- a/extension/src/application/diff/update-repo-index.test.ts
+++ b/extension/src/application/diff/update-repo-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { ok } from "../../domain/result";
-import type { RepoIndexPort } from "../port/repo-index";
 import { updateRepoIndex } from "./update-repo-index";
 
 function makeFakes(overrides?: {
@@ -24,7 +24,7 @@ function makeFakes(overrides?: {
   const guids: Record<string, Record<string, string>> = { repoKey: { ...overrides?.knownGuids } };
   const indexes: Record<string, { treeSha: string; guids: Record<string, string> }> = {};
   if (overrides?.storedIndex) indexes.repoKey = overrides.storedIndex;
-  const store: RepoIndexPort = {
+  const store: RepoIndexRepository = {
     loadGuids: vi.fn(async (repo) => guids[repo] ?? {}),
     saveGuids: vi.fn(async (repo, entries) => {
       guids[repo] = { ...guids[repo], ...entries };

--- a/extension/src/application/diff/update-repo-index.ts
+++ b/extension/src/application/diff/update-repo-index.ts
@@ -1,7 +1,7 @@
 import { parseGuidFromMeta } from "../../domain/diff/meta-guid";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { ok, type Result } from "../../domain/result";
 import type { GithubFailure, GithubPort } from "../port/github";
-import type { RepoIndexPort } from "../port/repo-index";
 
 type ClientLike = Pick<GithubPort, "listMetaTree" | "batchBlobTexts">;
 
@@ -12,7 +12,7 @@ const GRAPHQL_BATCH = 100;
 // blobSha→guid is content-derived (cache forever); after a push only changed .meta are fetched.
 export async function updateRepoIndex(
   client: ClientLike,
-  store: RepoIndexPort,
+  store: RepoIndexRepository,
   owner: string,
   repo: string,
   repoKey: string,

--- a/extension/src/application/port/diff-cache.ts
+++ b/extension/src/application/port/diff-cache.ts
@@ -1,6 +1,0 @@
-import type { DiffV2 } from "../../domain/diff/types";
-
-export type DiffCachePort = {
-  load(key: string): Promise<DiffV2 | undefined>;
-  save(key: string, json: DiffV2): Promise<void>;
-};

--- a/extension/src/application/port/guid-cache.ts
+++ b/extension/src/application/port/guid-cache.ts
@@ -1,4 +1,0 @@
-export type GuidCachePort = {
-  load(repo: string): Promise<Record<string, string>>;
-  save(repo: string, entries: Record<string, string>): Promise<void>;
-};

--- a/extension/src/application/port/repo-index.ts
+++ b/extension/src/application/port/repo-index.ts
@@ -1,6 +1,0 @@
-export type RepoIndexPort = {
-  loadGuids(repo: string): Promise<Record<string, string>>;
-  saveGuids(repo: string, entries: Record<string, string>): Promise<void>;
-  loadIndex(repo: string): Promise<{ treeSha: string; guids: Record<string, string> } | undefined>;
-  saveIndex(repo: string, index: { treeSha: string; guids: Record<string, string> }): Promise<void>;
-};

--- a/extension/src/application/port/token-store.ts
+++ b/extension/src/application/port/token-store.ts
@@ -1,7 +1,0 @@
-export type TokenStorePort = {
-  readAccessToken(): Promise<string | undefined>;
-  saveAccessToken(token: string): Promise<void>;
-  savePendingSignIn(pending: { userCode: string; expiresAt: number }): Promise<void>;
-  readPendingSignIn(): Promise<{ userCode: string; expiresAt: number } | undefined>;
-  clearPendingSignIn(): Promise<void>;
-};

--- a/extension/src/domain/auth/token-repository.ts
+++ b/extension/src/domain/auth/token-repository.ts
@@ -1,0 +1,9 @@
+import type { AccessToken, PendingSignIn } from "./token";
+
+export type TokenRepository = {
+  readAccessToken(): Promise<AccessToken | undefined>;
+  saveAccessToken(token: AccessToken): Promise<void>;
+  savePendingSignIn(pending: PendingSignIn): Promise<void>;
+  readPendingSignIn(): Promise<PendingSignIn | undefined>;
+  clearPendingSignIn(): Promise<void>;
+};

--- a/extension/src/domain/auth/token.ts
+++ b/extension/src/domain/auth/token.ts
@@ -1,0 +1,2 @@
+export type AccessToken = string;
+export type PendingSignIn = { userCode: string; expiresAt: number };

--- a/extension/src/domain/diff/diff-repository.ts
+++ b/extension/src/domain/diff/diff-repository.ts
@@ -1,0 +1,6 @@
+import type { DiffV2 } from "./types";
+
+export type DiffRepository = {
+  load(key: string): Promise<DiffV2 | undefined>;
+  save(key: string, json: DiffV2): Promise<void>;
+};

--- a/extension/src/domain/guid/guid-map.ts
+++ b/extension/src/domain/guid/guid-map.ts
@@ -1,0 +1,1 @@
+export type GuidMap = Record<string, string>;

--- a/extension/src/domain/guid/guid-repository.ts
+++ b/extension/src/domain/guid/guid-repository.ts
@@ -1,0 +1,6 @@
+import type { GuidMap } from "./guid-map";
+
+export type GuidRepository = {
+  load(repo: string): Promise<GuidMap>;
+  save(repo: string, entries: GuidMap): Promise<void>;
+};

--- a/extension/src/domain/guid/repo-guid-index.ts
+++ b/extension/src/domain/guid/repo-guid-index.ts
@@ -1,0 +1,3 @@
+import type { GuidMap } from "./guid-map";
+
+export type RepoGuidIndex = { treeSha: string; guids: GuidMap };

--- a/extension/src/domain/guid/repo-index-repository.ts
+++ b/extension/src/domain/guid/repo-index-repository.ts
@@ -1,0 +1,9 @@
+import type { GuidMap } from "./guid-map";
+import type { RepoGuidIndex } from "./repo-guid-index";
+
+export type RepoIndexRepository = {
+  loadGuids(repo: string): Promise<GuidMap>;
+  saveGuids(repo: string, entries: GuidMap): Promise<void>;
+  loadIndex(repo: string): Promise<RepoGuidIndex | undefined>;
+  saveIndex(repo: string, index: RepoGuidIndex): Promise<void>;
+};

--- a/extension/src/infrastructure/container.ts
+++ b/extension/src/infrastructure/container.ts
@@ -1,18 +1,19 @@
 import type { DifferPort } from "../application/port/differ";
 import type { GithubPort } from "../application/port/github";
 import type { GithubAuthPort } from "../application/port/github-auth";
-import type { GuidCachePort } from "../application/port/guid-cache";
 import type { MessengerPort } from "../application/port/messenger";
-import type { RepoIndexPort } from "../application/port/repo-index";
 import type { TokenStorePort } from "../application/port/token-store";
 import type { DiffRepository } from "../domain/diff/diff-repository";
+import type { GuidRepository } from "../domain/guid/guid-repository";
+import type { RepoIndexRepository } from "../domain/guid/repo-index-repository";
 import { createChromeMessenger } from "./providers/chrome-messenger";
 import { createChromeTokenStore } from "./providers/chrome-token-store";
 import { createQueue, type Queue } from "./providers/fetch-queue";
 import { GithubClient } from "./providers/github-client";
 import { pollForToken, requestDeviceCode } from "./providers/github-device-flow";
 import { createDiffer } from "./providers/wasm-differ";
-import { createMergeStore } from "./repositories/merge-store";
+import { createChromeGuidRepository } from "./repositories/chrome-guid-repository";
+import { createChromeRepoIndexRepository } from "./repositories/chrome-repo-index-repository";
 import { createSessionDiffStore } from "./repositories/session-diff-store";
 
 export function createTokenStore(): TokenStorePort {
@@ -27,25 +28,12 @@ export function createDiffStore(): DiffRepository {
   return createSessionDiffStore(chrome.storage.session);
 }
 
-export function createGuidCache(): GuidCachePort {
-  return createMergeStore(chrome.storage.local, "guids");
+export function createGuidCache(): GuidRepository {
+  return createChromeGuidRepository(chrome.storage.local);
 }
 
-export function createRepoIndexStore(): RepoIndexPort {
-  // Whole-repo .meta guid records for loadGuids/saveGuids
-  const metaGuids = createMergeStore(chrome.storage.local, "metaGuids");
-  return {
-    loadGuids: (repo) => metaGuids.load(repo),
-    saveGuids: (repo, entries) => metaGuids.save(repo, entries).catch(() => {}), // quota overflow → memory only
-    async loadIndex(repo) {
-      const key = `guidIndex:${repo}`;
-      const stored = await chrome.storage.local.get([key]);
-      return stored[key] as { treeSha: string; guids: Record<string, string> } | undefined;
-    },
-    async saveIndex(repo, index) {
-      await chrome.storage.local.set({ [`guidIndex:${repo}`]: index }).catch(() => {});
-    },
-  };
+export function createRepoIndexStore(): RepoIndexRepository {
+  return createChromeRepoIndexRepository(chrome.storage.local);
 }
 
 export function createGithubAuth(): GithubAuthPort {

--- a/extension/src/infrastructure/container.ts
+++ b/extension/src/infrastructure/container.ts
@@ -2,22 +2,22 @@ import type { DifferPort } from "../application/port/differ";
 import type { GithubPort } from "../application/port/github";
 import type { GithubAuthPort } from "../application/port/github-auth";
 import type { MessengerPort } from "../application/port/messenger";
-import type { TokenStorePort } from "../application/port/token-store";
+import type { TokenRepository } from "../domain/auth/token-repository";
 import type { DiffRepository } from "../domain/diff/diff-repository";
 import type { GuidRepository } from "../domain/guid/guid-repository";
 import type { RepoIndexRepository } from "../domain/guid/repo-index-repository";
 import { createChromeMessenger } from "./providers/chrome-messenger";
-import { createChromeTokenStore } from "./providers/chrome-token-store";
 import { createQueue, type Queue } from "./providers/fetch-queue";
 import { GithubClient } from "./providers/github-client";
 import { pollForToken, requestDeviceCode } from "./providers/github-device-flow";
 import { createDiffer } from "./providers/wasm-differ";
 import { createChromeGuidRepository } from "./repositories/chrome-guid-repository";
 import { createChromeRepoIndexRepository } from "./repositories/chrome-repo-index-repository";
+import { createChromeTokenRepository } from "./repositories/chrome-token-repository";
 import { createSessionDiffStore } from "./repositories/session-diff-store";
 
-export function createTokenStore(): TokenStorePort {
-  return createChromeTokenStore(chrome.storage.local);
+export function createTokenStore(): TokenRepository {
+  return createChromeTokenRepository(chrome.storage.local);
 }
 
 export function createMessenger(): MessengerPort {

--- a/extension/src/infrastructure/container.ts
+++ b/extension/src/infrastructure/container.ts
@@ -1,4 +1,3 @@
-import type { DiffCachePort } from "../application/port/diff-cache";
 import type { DifferPort } from "../application/port/differ";
 import type { GithubPort } from "../application/port/github";
 import type { GithubAuthPort } from "../application/port/github-auth";
@@ -6,6 +5,7 @@ import type { GuidCachePort } from "../application/port/guid-cache";
 import type { MessengerPort } from "../application/port/messenger";
 import type { RepoIndexPort } from "../application/port/repo-index";
 import type { TokenStorePort } from "../application/port/token-store";
+import type { DiffRepository } from "../domain/diff/diff-repository";
 import { createChromeMessenger } from "./providers/chrome-messenger";
 import { createChromeTokenStore } from "./providers/chrome-token-store";
 import { createQueue, type Queue } from "./providers/fetch-queue";
@@ -23,7 +23,7 @@ export function createMessenger(): MessengerPort {
   return createChromeMessenger();
 }
 
-export function createDiffStore(): DiffCachePort {
+export function createDiffStore(): DiffRepository {
   return createSessionDiffStore(chrome.storage.session);
 }
 

--- a/extension/src/infrastructure/repositories/chrome-guid-repository.ts
+++ b/extension/src/infrastructure/repositories/chrome-guid-repository.ts
@@ -1,0 +1,11 @@
+import type { GuidRepository } from "../../domain/guid/guid-repository";
+import { createMergeStore } from "./merge-store";
+
+type Area = {
+  get(keys: string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+};
+
+export function createChromeGuidRepository(area: Area): GuidRepository {
+  return createMergeStore(area, "guids");
+}

--- a/extension/src/infrastructure/repositories/chrome-repo-index-repository.ts
+++ b/extension/src/infrastructure/repositories/chrome-repo-index-repository.ts
@@ -1,0 +1,24 @@
+import type { RepoGuidIndex } from "../../domain/guid/repo-guid-index";
+import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
+import { createMergeStore } from "./merge-store";
+
+type Area = {
+  get(keys: string[]): Promise<Record<string, unknown>>;
+  set(items: Record<string, unknown>): Promise<void>;
+};
+
+export function createChromeRepoIndexRepository(area: Area): RepoIndexRepository {
+  const metaGuids = createMergeStore(area, "metaGuids");
+  return {
+    loadGuids: (repo) => metaGuids.load(repo),
+    saveGuids: (repo, entries) => metaGuids.save(repo, entries).catch(() => {}),
+    async loadIndex(repo) {
+      const key = `guidIndex:${repo}`;
+      const stored = await area.get([key]);
+      return stored[key] as RepoGuidIndex | undefined;
+    },
+    async saveIndex(repo, index) {
+      await area.set({ [`guidIndex:${repo}`]: index }).catch(() => {});
+    },
+  };
+}

--- a/extension/src/infrastructure/repositories/chrome-token-repository.test.ts
+++ b/extension/src/infrastructure/repositories/chrome-token-repository.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createChromeTokenStore, readAccessToken, type SettingsStorage } from "./chrome-token-store";
+import { createChromeTokenRepository, readAccessToken, type SettingsStorage } from "./chrome-token-repository";
 
 function mem(initial: Record<string, unknown> = {}): SettingsStorage & { data: Record<string, unknown> } {
   const data = { ...initial };
@@ -39,7 +39,7 @@ describe("readAccessToken", () => {
 it("round-trips the pending sign-in", async () => {
   // In-memory SettingsStorage fake, same shape as the other tests in this file
   const data: Record<string, unknown> = {};
-  const store = createChromeTokenStore({
+  const store = createChromeTokenRepository({
     get: async (keys) => Object.fromEntries(keys.filter((k) => k in data).map((k) => [k, data[k]])),
     set: async (items) => void Object.assign(data, items),
     remove: async (keys) => {

--- a/extension/src/infrastructure/repositories/chrome-token-repository.ts
+++ b/extension/src/infrastructure/repositories/chrome-token-repository.ts
@@ -1,4 +1,5 @@
-import type { TokenStorePort } from "../../application/port/token-store";
+import type { PendingSignIn } from "../../domain/auth/token";
+import type { TokenRepository } from "../../domain/auth/token-repository";
 
 export type SettingsStorage = {
   get(keys: string[]): Promise<Record<string, unknown>>;
@@ -16,14 +17,14 @@ export async function readAccessToken(storage: SettingsStorage): Promise<string 
   return stored.pat;
 }
 
-export function createChromeTokenStore(storage: SettingsStorage): TokenStorePort {
+export function createChromeTokenRepository(storage: SettingsStorage): TokenRepository {
   return {
     readAccessToken: () => readAccessToken(storage),
     saveAccessToken: (token) => storage.set({ accessToken: token }),
     savePendingSignIn: (pending) => storage.set({ signin: pending }),
     readPendingSignIn: async () => {
       const stored = await storage.get(["signin"]);
-      return stored.signin as { userCode: string; expiresAt: number } | undefined;
+      return stored.signin as PendingSignIn | undefined;
     },
     clearPendingSignIn: () => storage.remove("signin"),
   };

--- a/extension/src/infrastructure/repositories/session-diff-store.ts
+++ b/extension/src/infrastructure/repositories/session-diff-store.ts
@@ -1,4 +1,4 @@
-import type { DiffCachePort } from "../../application/port/diff-cache";
+import type { DiffRepository } from "../../domain/diff/diff-repository";
 import type { DiffV2 } from "../../domain/diff/types";
 
 const PREFIX = "diff:";
@@ -11,11 +11,11 @@ type Area = {
   remove(keys: string | string[]): Promise<void>;
 };
 
-export type DiffStore = DiffCachePort;
+export type DiffStore = DiffRepository;
 
 // Raw diffs in storage.session under a sha key across SW restarts.
 // Quota overflow → wipe diffs and rewrite once; without this every SW restart recomputes forever.
-export function createSessionDiffStore(area: Area): DiffCachePort {
+export function createSessionDiffStore(area: Area): DiffRepository {
   return {
     async load(key) {
       const stored = await area.get(PREFIX + key);


### PR DESCRIPTION
## Summary

Move chrome.storage-backed domain-model I/O from `application/port` to domain repository interfaces with implementations under `infrastructure/repositories`, following the reknotes repository-vs-port rule.

## Motivation

Outside I/O that loads or saves a domain model should go through a repository (interface in `domain/`, implementation in infra). Ports/providers remain for capabilities that do not persist domain models (GitHub, WASM differ, messaging, device-flow auth).

No tracking issue for this refactor.

## Changes

- Add domain models/interfaces: `DiffRepository`, `GuidRepository`, `RepoIndexRepository`, `TokenRepository` (plus `GuidMap`, `RepoGuidIndex`, `AccessToken`, `PendingSignIn`)
- Implement them under `infrastructure/repositories/` (`session-diff-store`, `chrome-guid-repository`, `chrome-repo-index-repository`, `chrome-token-repository`)
- Retarget application use cases and tests to domain repositories; delete storage ports (`diff-cache`, `guid-cache`, `repo-index`, `token-store`)
- Keep capability ports: `github`, `github-auth`, `differ`, `messenger`
- Document the rule in `docs/extension.md`

## Testing

```text
cd extension
pnpm exec vitest run
# Test Files  35 passed (35)
# Tests  298 passed (298)

pnpm typecheck
# (clean)

pnpm lint
# (clean)
```