### PR TITLE
chore: remove renovate schedule window

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "timezone": "Asia/Tokyo",
-  "schedule": [
-    "on monday"
-  ],
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
## Summary

Remove the weekly `schedule` window from the Renovate configuration. Renovate can now create update PRs on any day.

## Motivation

The Mend-hosted Renovate app runs at irregular times for this repository. PR #233 widened the window to all of Monday, but on 2026-08-03 no run landed inside the window before 14:00 JST. All pending updates stayed in "Awaiting Schedule" again. Grouped PRs and `minimumReleaseAge: 7 days` already control the PR volume, so the window only adds the risk of missed weeks.

## Changes

- Remove `schedule` (`on monday`) from `renovate.json`
- Remove `timezone`, which only applies to schedule calculations

## Testing

- `npx --yes --package renovate -- renovate-config-validator renovate.json`

  ```
  INFO: Validating renovate.json as global config
  INFO: Config validated successfully against 1 file(s)
  ```