### PR TITLE
build: cap nunit below v4 in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,13 @@
       "allowedVersions": "24"
     },
     {
+      "description": "Cap NUnit below v4: the editor tests compile inside Unity with C# 9, and NUnit 4 classic asserts need C# 14 extension members",
+      "matchPackageNames": [
+        "NUnit"
+      ],
+      "allowedVersions": "<4"
+    },
+    {
       "description": "Keep GitHub Actions on tag references (no SHA pinning) and update them together",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
## Summary

Add a Renovate package rule that caps NUnit below v4. Renovate then stops proposing the NUnit v4 major update, which cannot compile in this repository.

## Motivation

The Renovate PR #267 (NUnit 3.14 -> 4.6.1) fails CI in the `editor` job. Every classic assert call (`Assert.AreEqual`) fails with `CS8773: Feature 'extensions' is not available in C# 9.0`.

The cause is structural, not transient:

- The editor test sources also compile inside Unity (EditMode), so the mirror csproj pins `LangVersion` to 9.0. A comment in the csproj records this constraint.
- NUnit 4 removed the classic asserts from `Assert`. NUnit 4.6 supplies them again as C# 14 extension members.
- A C# 9.0 project cannot bind extension members, so each call site fails with CS8773.

The same cap pattern already exists for `@types/node`.

## Changes

- Add a `packageRules` entry in `renovate.json`: `matchPackageNames: ["NUnit"]`, `allowedVersions: "<4"`

## Testing

- `npx --yes --package renovate -- renovate-config-validator renovate.json`

  ```
  INFO: Validating renovate.json as global config
  INFO: Config validated successfully against 1 file(s)
  ```

- Reproduced the CS8773 errors locally with `dotnet build` on the `renovate/nunit-4.x` branch. The same build passes on `main` (NUnit 3.14).