### PR TITLE
refactor: simplify sign-in flow and layering tests

### DIFF
--- a/extension/biome.json
+++ b/extension/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "files": {
     "includes": ["**/*.{ts,mjs}"]
   },

--- a/extension/src/application/auth/sign-in.test.ts
+++ b/extension/src/application/auth/sign-in.test.ts
@@ -3,7 +3,7 @@ import type { PendingSignIn } from "../../domain/auth/token";
 import type { TokenRepository } from "../../domain/auth/token-repository";
 import { err, ok } from "../../domain/result";
 import type { DeviceCode, GithubAuthGateway, PollResult } from "../gateway/github-auth";
-import { type SignInFailure, signIn } from "./sign-in";
+import { signIn } from "./sign-in";
 
 const CODE: DeviceCode = {
   deviceCode: "dc1",
@@ -18,7 +18,6 @@ function fakeDeps(poll: () => Promise<PollResult>) {
   const calls: string[] = [];
   const pendings: PendingSignIn[] = [];
   const tokens: string[] = [];
-  const urls: string[] = [];
   const auth: GithubAuthGateway = {
     async requestDeviceCode() {
       calls.push("request");
@@ -50,93 +49,81 @@ function fakeDeps(poll: () => Promise<PollResult>) {
   };
   const fetchFn = fetch;
   const sleep = async () => {};
-  const openTab = (url: string) => {
-    calls.push("openTab");
-    urls.push(url);
-  };
   const now = () => 1_000;
-  return { auth, tokenStore, fetchFn, sleep, openTab, now, calls, pendings, tokens, urls };
+  return { auth, tokenStore, fetchFn, sleep, now, calls, pendings, tokens };
 }
 
-function fakeUi() {
-  const pending: Array<{ userCode: string; verificationUri: string }> = [];
-  const failures: SignInFailure[] = [];
-  const ui = {
-    showPending: (userCode: string, verificationUri: string) => void pending.push({ userCode, verificationUri }),
-    showFailure: (reason: SignInFailure) => void failures.push(reason),
-  };
-  return { ui, pending, failures };
+async function collect(gen: AsyncGenerator) {
+  const events = [];
+  for await (const event of gen) events.push(event);
+  return events;
 }
 
 describe("signIn", () => {
-  it("saves the pending code, opens the tab, and stores the token on success", async () => {
-    const { auth, tokenStore, fetchFn, sleep, openTab, now, pendings, tokens, urls, calls } = fakeDeps(async () => ({
+  it("saves the pending code, yields pending, then stores the token on success", async () => {
+    const { auth, tokenStore, fetchFn, sleep, now, pendings, tokens, calls } = fakeDeps(async () => ({
       status: "ok",
       token: "tok123",
     }));
-    const { ui, pending, failures } = fakeUi();
     const state = { inFlight: false };
-    await signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui);
+    const events = await collect(signIn(auth, tokenStore, fetchFn, sleep, now, state));
     // expiresAt derives from the injected now(): 1000 + 900s in ms.
     expect(pendings).toEqual([{ userCode: "ABCD-1234", expiresAt: 901_000 }]);
-    expect(pending).toEqual([{ userCode: "ABCD-1234", verificationUri: "https://github.com/login/device" }]);
-    expect(urls).toEqual(["https://github.com/login/device"]);
+    expect(events).toEqual([
+      { status: "pending", userCode: "ABCD-1234", verificationUri: "https://github.com/login/device" },
+      { status: "ok" },
+    ]);
     expect(tokens).toEqual(["tok123"]);
-    expect(failures).toEqual([]);
-    // The pending record must be saved before the tab opens (the device page reads it on load).
-    expect(calls.indexOf("savePending")).toBeLessThan(calls.indexOf("openTab"));
+    // The pending record must be saved before pending is yielded (the device page reads it on load).
+    expect(calls.indexOf("savePending")).toBeLessThan(calls.indexOf("poll"));
     expect(calls).toContain("clearPending");
   });
 
   it("reports denied without storing a token", async () => {
-    const { auth, tokenStore, fetchFn, sleep, openTab, now, tokens, calls } = fakeDeps(async () => ({
+    const { auth, tokenStore, fetchFn, sleep, now, tokens, calls } = fakeDeps(async () => ({
       status: "denied",
     }));
-    const { ui, failures } = fakeUi();
     const state = { inFlight: false };
-    await signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui);
-    expect(failures).toEqual(["denied"]);
+    const events = await collect(signIn(auth, tokenStore, fetchFn, sleep, now, state));
+    expect(events).toContainEqual({ status: "failed", reason: "denied" });
     expect(tokens).toEqual([]);
     expect(calls).toContain("clearPending");
   });
 
   it("reports expired", async () => {
-    const { auth, tokenStore, fetchFn, sleep, openTab, now } = fakeDeps(async () => ({ status: "expired" }));
-    const { ui, failures } = fakeUi();
+    const { auth, tokenStore, fetchFn, sleep, now } = fakeDeps(async () => ({ status: "expired" }));
     const state = { inFlight: false };
-    await signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui);
-    expect(failures).toEqual(["expired"]);
+    const events = await collect(signIn(auth, tokenStore, fetchFn, sleep, now, state));
+    expect(events).toContainEqual({ status: "failed", reason: "expired" });
   });
 
   it("reports the generic failure when the code request fails", async () => {
-    const { auth, tokenStore, fetchFn, sleep, openTab, now, calls } = fakeDeps(async () => ({
+    const { auth, tokenStore, fetchFn, sleep, now, calls } = fakeDeps(async () => ({
       status: "ok",
       token: "t",
     }));
     auth.requestDeviceCode = async () => err({ kind: "device-flow-failed", message: "network down" });
-    const { ui, failures } = fakeUi();
     const state = { inFlight: false };
-    await signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui);
-    expect(failures).toEqual(["failed"]);
-    expect(calls).not.toContain("openTab");
+    const events = await collect(signIn(auth, tokenStore, fetchFn, sleep, now, state));
+    expect(events).toEqual([{ status: "failed", reason: "failed" }]);
+    expect(calls).not.toContain("poll");
   });
 
   it("ignores a second start while a flow is polling", async () => {
     let resolvePoll!: (r: PollResult) => void;
-    const { auth, tokenStore, fetchFn, sleep, openTab, now, calls } = fakeDeps(
+    const { auth, tokenStore, fetchFn, sleep, now, calls } = fakeDeps(
       () => new Promise<PollResult>((resolve) => (resolvePoll = resolve)),
     );
-    const { ui } = fakeUi();
     const state = { inFlight: false };
-    const first = signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui);
-    await signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui); // resolves immediately: the guard rejects re-entry
+    const first = collect(signIn(auth, tokenStore, fetchFn, sleep, now, state));
+    await collect(signIn(auth, tokenStore, fetchFn, sleep, now, state)); // resolves immediately: the guard rejects re-entry
     expect(calls.filter((c) => c === "request")).toHaveLength(1);
     // Drain microtasks until the first flow reaches the poll, so resolvePoll is assigned.
     for (let i = 0; i < 10 && !calls.includes("poll"); i++) await Promise.resolve();
     resolvePoll({ status: "ok", token: "tok" });
     await first;
     // With the first flow settled, a new one can start (its poll stays pending). Only the guard matters here.
-    void signIn(auth, tokenStore, fetchFn, sleep, openTab, now, state, ui);
+    void collect(signIn(auth, tokenStore, fetchFn, sleep, now, state));
     expect(calls.filter((c) => c === "request")).toHaveLength(2);
   });
 });

--- a/extension/src/application/auth/sign-in.ts
+++ b/extension/src/application/auth/sign-in.ts
@@ -4,43 +4,52 @@ import type { GithubAuthGateway, PollResult } from "../gateway/github-auth";
 // Application reports only the outcome kind. Presentation owns the user-visible text.
 export type SignInFailure = Exclude<PollResult["status"], "ok">;
 
-export async function signIn(
+export type SignInEvent =
+  | { status: "pending"; userCode: string; verificationUri: string }
+  | { status: "ok" }
+  | { status: "failed"; reason: SignInFailure };
+
+export async function* signIn(
   auth: GithubAuthGateway,
   tokenStore: TokenRepository,
   fetchFn: typeof fetch,
   sleep: (ms: number) => Promise<void>,
-  openTab: (url: string) => void,
   now: () => number,
   state: { inFlight: boolean },
-  ui: {
-    showPending(userCode: string, verificationUri: string): void;
-    showFailure(reason: SignInFailure): void;
-  },
-): Promise<void> {
+): AsyncGenerator<SignInEvent> {
   if (state.inFlight) return;
   state.inFlight = true;
   try {
     const code = await auth.requestDeviceCode(fetchFn);
     if (!code.ok) {
-      ui.showFailure("failed");
+      yield { status: "failed", reason: "failed" };
       return;
     }
-    // Save the pending sign-in before the verification tab opens. /login/device reads it to pre-fill the code.
+    // Save the pending sign-in before yielding. Presentation opens the tab after pending.
+    // /login/device reads storage to pre-fill the code.
     await tokenStore.savePendingSignIn({
       userCode: code.value.userCode,
       expiresAt: now() + code.value.expiresIn * 1000,
     });
-    ui.showPending(code.value.userCode, code.value.verificationUri);
-    openTab(code.value.verificationUri);
+    yield {
+      status: "pending",
+      userCode: code.value.userCode,
+      verificationUri: code.value.verificationUri,
+    };
     const result = await auth.pollForToken(fetchFn, sleep, code.value);
     // Success: saveToken fires storage.onChanged, and index.ts retries auth-blocked panels
-    if (result.status === "ok") await tokenStore.saveAccessToken(result.token);
-    else ui.showFailure(result.status);
+    if (result.status === "ok") {
+      await tokenStore.saveAccessToken(result.token);
+      await tokenStore.clearPendingSignIn();
+      yield { status: "ok" };
+      return;
+    }
     await tokenStore.clearPendingSignIn();
+    yield { status: "failed", reason: result.status };
   } catch {
     // Only unexpected rejections (storage) land here. Expected failures arrive as values above.
-    ui.showFailure("failed");
     await tokenStore.clearPendingSignIn().catch(() => {});
+    yield { status: "failed", reason: "failed" };
   } finally {
     state.inFlight = false;
   }

--- a/extension/src/layering.test.ts
+++ b/extension/src/layering.test.ts
@@ -1,6 +1,6 @@
 import { globSync, readFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import { expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const SRC = import.meta.dirname;
 const SEPARATOR = /[\\/]/;
@@ -8,7 +8,6 @@ const TS_FILES = globSync("**/*.ts", { cwd: SRC }).map((f) => join(SRC, f));
 
 type Layer = "domain" | "application" | "infrastructure" | "presentation";
 
-// Allowed import targets per layer
 const ALLOWED: Record<Layer, Layer[]> = {
   domain: [],
   application: ["domain"],
@@ -18,7 +17,7 @@ const ALLOWED: Record<Layer, Layer[]> = {
 
 function layerOf(file: string): Layer | null {
   const top = relative(SRC, file).split(SEPARATOR)[0];
-  return top === "domain" || top === "application" || top === "infrastructure" || top === "presentation" ? top : null; // globals.d.ts, container.ts, internal/, this test
+  return top === "domain" || top === "application" || top === "infrastructure" || top === "presentation" ? top : null;
 }
 
 function* relativeImports(file: string): Generator<{ spec: string; target: string }> {
@@ -29,103 +28,99 @@ function* relativeImports(file: string): Generator<{ spec: string; target: strin
   }
 }
 
-it("keeps imports pointing inward across layers", () => {
-  const violations: string[] = [];
-  for (const file of TS_FILES) {
-    const from = layerOf(file);
-    if (from === null) continue;
-    for (const { spec, target } of relativeImports(file)) {
-      const to = layerOf(target);
-      if (to === null || to === from) continue;
-      if (!ALLOWED[from].includes(to)) violations.push(`${relative(SRC, file)} -> ${spec}`);
+describe("layer imports", () => {
+  it("each layer imports only allowed layers", () => {
+    const violations: string[] = [];
+    for (const file of TS_FILES) {
+      const from = layerOf(file);
+      if (from === null) continue;
+      for (const { spec, target } of relativeImports(file)) {
+        const to = layerOf(target);
+        if (to === null || to === from) continue;
+        if (!ALLOWED[from].includes(to)) violations.push(`${relative(SRC, file)} -> ${spec}`);
+      }
     }
-  }
-  expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
+  });
+
+  it("domain production files import only from domain/", () => {
+    const violations: string[] = [];
+    for (const file of TS_FILES) {
+      if (layerOf(file) !== "domain" || file.endsWith(".test.ts")) continue;
+      for (const match of readFileSync(file, "utf8").matchAll(/(?:from\s*|import\s*\(?\s*)"([^"]+)"/g)) {
+        const spec = match[1];
+        if (spec === undefined) continue;
+        const inside = spec.startsWith(".") && layerOf(`${resolve(dirname(file), spec)}.ts`) === "domain";
+        if (!inside) violations.push(`${relative(SRC, file)} -> ${spec}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
 });
 
-it("keeps infrastructure off application public functions", () => {
-  const violations: string[] = [];
-  for (const file of TS_FILES) {
-    const from = layerOf(file);
-    if (from === null) continue;
-    for (const { spec, target } of relativeImports(file)) {
-      const to = layerOf(target);
-      if (from !== "infrastructure") continue;
-      // Clients can import gateways to implement them.
-      // Public functions and internal helpers are the violation.
-      if (to !== "application" || /application[\\/]gateway[\\/]/.test(relative(SRC, target))) continue;
-      violations.push(`${relative(SRC, file)} -> ${spec}`);
+describe("application gateway", () => {
+  it("infrastructure imports application only through gateway/", () => {
+    const violations: string[] = [];
+    for (const file of TS_FILES) {
+      if (layerOf(file) !== "infrastructure") continue;
+      for (const { spec, target } of relativeImports(file)) {
+        if (layerOf(target) !== "application") continue;
+        if (/application[\\/]gateway[\\/]/.test(relative(SRC, target))) continue;
+        violations.push(`${relative(SRC, file)} -> ${spec}`);
+      }
     }
-  }
-  expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
+  });
 });
 
-it("keeps internal directories private to their parent", () => {
-  // Go rule for internal packages: only files under the parent of an
-  // internal/ directory can import from it. src/internal/ sits at the root,
-  // so every file can use it.
-  const violations: string[] = [];
-  for (const file of TS_FILES) {
-    const fileRel = relative(SRC, file).split(SEPARATOR).join("/");
-    for (const { spec, target } of relativeImports(file)) {
-      const parts = relative(SRC, target).split(SEPARATOR);
-      const index = parts.indexOf("internal");
-      if (index < 1) continue;
-      const parent = parts.slice(0, index).join("/");
-      if (!fileRel.startsWith(`${parent}/`)) violations.push(`${fileRel} -> ${spec}`);
+describe("internal/ access", () => {
+  it("a file imports internal/ only under its parent", () => {
+    const violations: string[] = [];
+    for (const file of TS_FILES) {
+      const fileRel = relative(SRC, file).split(SEPARATOR).join("/");
+      for (const { spec, target } of relativeImports(file)) {
+        const parts = relative(SRC, target).split(SEPARATOR);
+        const index = parts.indexOf("internal");
+        if (index < 1) continue;
+        const parent = parts.slice(0, index).join("/");
+        if (!fileRel.startsWith(`${parent}/`)) violations.push(`${fileRel} -> ${spec}`);
+      }
     }
-  }
-  expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
+  });
 });
 
-it("keeps container.ts reachable only from presentation entry points", () => {
-  // The composition root imports infrastructure. Any other importer leaks
-  // infrastructure into its own layer.
-  const violations: string[] = [];
-  for (const file of TS_FILES) {
-    const rel = relative(SRC, file);
-    if (/^presentation[\\/][^\\/]+[\\/]index\.ts$/.test(rel)) continue;
-    for (const { spec, target } of relativeImports(file)) {
-      if (target === join(SRC, "container.ts")) violations.push(`${rel} -> ${spec}`);
+describe("composition root", () => {
+  it("only presentation entry points import container.ts", () => {
+    const violations: string[] = [];
+    for (const file of TS_FILES) {
+      const rel = relative(SRC, file);
+      if (/^presentation[\\/][^\\/]+[\\/]index\.ts$/.test(rel)) continue;
+      for (const { spec, target } of relativeImports(file)) {
+        if (target === join(SRC, "container.ts")) violations.push(`${rel} -> ${spec}`);
+      }
     }
-  }
-  expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
+  });
 });
 
-it("keeps infrastructure/clients to interface implementations", () => {
-  // A client is a `*-client.ts` file that implements a repository interface
-  // from domain/ or a gateway type from application/gateway/. Helpers that
-  // implement no interface go in infrastructure/internal/.
-  const violations: string[] = [];
-  for (const file of TS_FILES) {
-    const rel = relative(SRC, file);
-    if (!/^infrastructure[\\/]clients[\\/]/.test(rel)) continue;
-    if (!/-client(\.test)?\.ts$/.test(rel)) {
-      violations.push(rel);
-      continue;
+describe("infrastructure clients", () => {
+  it("each file in infrastructure/clients implements a gateway or a repository", () => {
+    const violations: string[] = [];
+    for (const file of TS_FILES) {
+      const rel = relative(SRC, file);
+      if (!/^infrastructure[\\/]clients[\\/]/.test(rel)) continue;
+      if (!/-client(\.test)?\.ts$/.test(rel)) {
+        violations.push(rel);
+        continue;
+      }
+      if (rel.endsWith(".test.ts")) continue;
+      const targets = [...relativeImports(file)].map(({ target }) => relative(SRC, target));
+      const implementsInterface = targets.some(
+        (t) => /^application[\\/]gateway[\\/]/.test(t) || /^domain[\\/].*-repository\.ts$/.test(t),
+      );
+      if (!implementsInterface) violations.push(rel);
     }
-    if (rel.endsWith(".test.ts")) continue;
-    const targets = [...relativeImports(file)].map(({ target }) => relative(SRC, target));
-    const implementsInterface = targets.some(
-      (t) => /^application[\\/]gateway[\\/]/.test(t) || /^domain[\\/].*-repository\.ts$/.test(t),
-    );
-    if (!implementsInterface) violations.push(rel);
-  }
-  expect(violations).toEqual([]);
-});
-
-it("keeps production domain files inside domain", () => {
-  // Doc rule: "This layer imports nothing outside domain/." Tests are exempt
-  // (parity tests read sources via node:fs and use must).
-  const violations: string[] = [];
-  for (const file of TS_FILES) {
-    if (layerOf(file) !== "domain" || file.endsWith(".test.ts")) continue;
-    for (const match of readFileSync(file, "utf8").matchAll(/(?:from\s*|import\s*\(?\s*)"([^"]+)"/g)) {
-      const spec = match[1];
-      if (spec === undefined) continue;
-      const inside = spec.startsWith(".") && layerOf(`${resolve(dirname(file), spec)}.ts`) === "domain";
-      if (!inside) violations.push(`${relative(SRC, file)} -> ${spec}`);
-    }
-  }
-  expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
+  });
 });

--- a/extension/src/presentation/content/index.ts
+++ b/extension/src/presentation/content/index.ts
@@ -58,10 +58,9 @@ const WATCHDOG_MS = 120_000;
 
 function armWatchdog(view: ViewEntry): void {
   clearTimeout(view.watchdog);
-  view.watchdog = window.setTimeout(
-    () => render(view.root, view.json, { incomplete: { onRetry: view.retry } }),
-    WATCHDOG_MS,
-  );
+  view.watchdog = window.setTimeout(() => {
+    void render(view.root, view.json, { incomplete: true }).then(() => view.retry());
+  }, WATCHDOG_MS);
 }
 
 // Global switch targets: toggle + display for already-attached files
@@ -85,6 +84,8 @@ const tokenStore = createTokenStore();
 const auth = createGithubAuth();
 const signInState = { inFlight: false };
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+// _blank: Open in a new tab
+// noopener: Prevent the opened tab from accessing the original tab
 const openTab = (url: string) => void window.open(url, "_blank", "noopener");
 const now = () => Date.now();
 
@@ -93,14 +94,18 @@ const persistView = (view: View): void => {
 };
 
 // Auth-error panel: device flow. Failures land back here for retry.
-function signInPanel(root: ShadowRoot, message: string): void {
-  renderSignIn(root, message, () => {
-    void signIn(auth, tokenStore, fetch, sleep, openTab, now, signInState, {
-      showPending: (userCode, verificationUri) =>
-        renderSignInPending(root, userCode, verificationUri, () => void navigator.clipboard.writeText(userCode)),
-      showFailure: (reason) => signInPanel(root, SIGN_IN_FAILURE_TEXT[reason]),
-    });
-  });
+async function signInPanel(root: ShadowRoot, message: string): Promise<void> {
+  await renderSignIn(root, message);
+  for await (const event of signIn(auth, tokenStore, fetch, sleep, now, signInState)) {
+    if (event.status === "pending") {
+      renderSignInPending(root, event.userCode, event.verificationUri);
+      openTab(event.verificationUri);
+    } else if (event.status === "failed") {
+      await signInPanel(root, SIGN_IN_FAILURE_TEXT[event.reason]);
+      return;
+    }
+    // ok: accessToken storage.onChanged retries auth-blocked panels
+  }
 }
 
 function attach(viewState: ViewStateData): void {
@@ -166,10 +171,10 @@ function attachToggle(viewState: ViewStateData, page: DiffPage, entry: FileEntry
         },
         panel: {
           loading: () => renderLoading(root),
-          diff: (json, resolving) => render(root, json, { resolving }),
-          incomplete: (json, onRetry) => render(root, json, { incomplete: { onRetry } }),
-          tooLarge: (bytes, onForce) => renderTooLarge(root, bytes, onForce),
-          authError: (error) => signInPanel(root, ERROR_TEXT[error]),
+          diff: (json, resolving) => void render(root, json, { resolving }),
+          incomplete: (json) => render(root, json, { incomplete: true }),
+          tooLarge: (bytes) => renderTooLarge(root, bytes),
+          authError: (error) => void signInPanel(root, ERROR_TEXT[error]),
           error: (error) => renderError(root, ERROR_TEXT[error]),
         },
       };
@@ -214,8 +219,8 @@ function attachToggle(viewState: ViewStateData, page: DiffPage, entry: FileEntry
 }
 
 async function init(): Promise<void> {
-  // Device-page pre-fill: only the code that the PR page of this browser issued.
-  // A storage failure degrades to no pre-fill (the user pastes the code instead).
+  // Device-page pre-fill uses only the code that the PR page of this browser saved.
+  // If storage read fails, pre-fill does not run. The user pastes the code instead.
   if (location.pathname === "/login/device") {
     const pending = await tokenStore.readPendingSignIn().catch(() => undefined);
     if (pending) fillDeviceCode(document, pending, Date.now());
@@ -249,11 +254,11 @@ async function init(): Promise<void> {
     view.json = mergeResolvedPush(view.json, msg);
     if (msg.done && msg.status !== undefined && msg.status !== "complete") {
       // Gave up: keep arrived names, offer manual retry (#194)
-      render(view.root, view.json, { incomplete: { onRetry: view.retry } });
+      void render(view.root, view.json, { incomplete: true }).then(() => view.retry());
       return;
     }
     if (!msg.done) armWatchdog(view);
-    render(view.root, view.json, { resolving: msg.done ? 0 : resolvingCount(view.json) });
+    void render(view.root, view.json, { resolving: msg.done ? 0 : resolvingCount(view.json) });
   });
 
   // SPA: MutationObserver + 50ms debounce follows lazy loads and stays under the

--- a/extension/src/presentation/content/overlay/file-view.test.ts
+++ b/extension/src/presentation/content/overlay/file-view.test.ts
@@ -17,8 +17,8 @@ const DIFF: DiffV2 = emptyDiff();
 type Screen =
   | { kind: "loading" }
   | { kind: "diff"; json: DiffV2; resolving: number }
-  | { kind: "incomplete"; json: DiffV2; onRetry(): void }
-  | { kind: "tooLarge"; bytes: number; onForce(): void }
+  | { kind: "incomplete"; json: DiffV2; proceed(): void }
+  | { kind: "tooLarge"; bytes: number; proceed(): void }
   | { kind: "authError"; error: string }
   | { kind: "error"; error: string };
 
@@ -70,8 +70,14 @@ function makeHarness() {
         panel: {
           loading: () => void host.screens.push({ kind: "loading" }),
           diff: (json, resolving) => void host.screens.push({ kind: "diff", json, resolving }),
-          incomplete: (json, onRetry) => void host.screens.push({ kind: "incomplete", json, onRetry }),
-          tooLarge: (bytes, onForce) => void host.screens.push({ kind: "tooLarge", bytes, onForce }),
+          incomplete: (json) =>
+            new Promise<void>((resolve) => {
+              host.screens.push({ kind: "incomplete", json, proceed: resolve });
+            }),
+          tooLarge: (bytes) =>
+            new Promise<void>((resolve) => {
+              host.screens.push({ kind: "tooLarge", bytes, proceed: resolve });
+            }),
           authError: (error) => void host.screens.push({ kind: "authError", error }),
           error: (error) => void host.screens.push({ kind: "error", error }),
         },
@@ -266,7 +272,7 @@ describe("showFileView request", () => {
     h.responses.push({ ok: true, json: DIFF });
     const incomplete = h.screen();
     if (incomplete.kind !== "incomplete") throw new Error("expected incomplete screen");
-    incomplete.onRetry();
+    incomplete.proceed();
     await flush();
     expect(h.screen()).toMatchObject({ kind: "diff", json: DIFF });
     expect(h.requests).toHaveLength(3);
@@ -283,7 +289,7 @@ describe("showFileView request", () => {
     h.responses.push({ ok: true, json: DIFF, pending: true });
     const tooLarge = h.screen();
     if (tooLarge.kind !== "tooLarge") throw new Error("expected tooLarge screen");
-    tooLarge.onForce();
+    tooLarge.proceed();
     await flush();
     // Transition: force render → the request repeats with force, bypassing the size guard.
     expect(h.requests).toEqual([undefined, true]);

--- a/extension/src/presentation/content/overlay/file-view.ts
+++ b/extension/src/presentation/content/overlay/file-view.ts
@@ -14,8 +14,8 @@ import type { View } from "../../internal/view-mode";
 export type FilePanel = {
   loading(): void;
   diff(json: DiffV2, resolving: number): void;
-  incomplete(json: DiffV2, onRetry: () => void): void;
-  tooLarge(bytes: number, onForce: () => void): void;
+  incomplete(json: DiffV2): Promise<void>;
+  tooLarge(bytes: number): Promise<void>;
   authError(error: AuthError): void;
   error(error: BackgroundError): void;
 };
@@ -67,40 +67,42 @@ export function syncFileView(state: FileViewState, deps: FileViewDeps, view: Vie
   state.host.setVisible(!deps.file.collapsed());
 }
 
-function request(state: FileViewState, deps: FileViewDeps, force?: boolean): void {
+async function request(state: FileViewState, deps: FileViewDeps, force?: boolean): Promise<void> {
   state.requested = true;
   const panel = must(state.host).panel; // only reachable after show created the host
   panel.loading();
-  void deps.requestDiff(force).then((res) => {
-    if (res.ok) {
-      deps.results.set({
-        json: res.json,
-        // Retry re-enters background resolution. Without a latch reset, request() no-ops.
-        retry: () => {
-          state.requested = false;
-          request(state, deps, force);
-        },
-      });
-      if (res.pending) deps.results.armWatchdog();
-      panel.diff(res.json, res.pending ? resolvingCount(res.json) : 0);
-      return;
-    }
-    state.requested = false; // Do not cache errors: the next toggle re-fetches.
-    const prior = deps.results.get();
-    if (prior) {
-      // Failed retry must not wipe the diff the user is reading
-      panel.incomplete(prior.json, prior.retry);
-      return;
-    }
-    if (res.error === "too-large") panel.tooLarge(res.bytes, () => request(state, deps, true));
-    else if (isAuthError(res.error)) {
-      deps.onAuthRetry(() => {
-        // The first retry sets requested. Duplicate registrations no-op.
-        if (!state.requested && deps.effectiveView() === "semantic") request(state, deps);
-      });
-      panel.authError(res.error);
-    } else panel.error(res.error);
-  });
+  const res = await deps.requestDiff(force);
+  if (res.ok) {
+    deps.results.set({
+      json: res.json,
+      // Retry re-enters background resolution. Without a latch reset, request() no-ops.
+      retry: () => {
+        state.requested = false;
+        void request(state, deps, force);
+      },
+    });
+    if (res.pending) deps.results.armWatchdog();
+    panel.diff(res.json, res.pending ? resolvingCount(res.json) : 0);
+    return;
+  }
+  state.requested = false; // Do not cache errors: the next toggle re-fetches.
+  const prior = deps.results.get();
+  if (prior) {
+    // Failed retry must not wipe the diff the user is reading
+    await panel.incomplete(prior.json);
+    prior.retry();
+    return;
+  }
+  if (res.error === "too-large") {
+    await panel.tooLarge(res.bytes);
+    await request(state, deps, true);
+  } else if (isAuthError(res.error)) {
+    deps.onAuthRetry(() => {
+      // The first retry sets requested. Duplicate registrations no-op.
+      if (!state.requested && deps.effectiveView() === "semantic") void request(state, deps);
+    });
+    panel.authError(res.error);
+  } else panel.error(res.error);
 }
 
 export function showFileView(state: FileViewState, deps: FileViewDeps, view: View): void {
@@ -114,5 +116,5 @@ export function showFileView(state: FileViewState, deps: FileViewDeps, view: Vie
   }
   syncFileView(state, deps, view);
   if (state.requested) return; // Cache only successful results (a re-toggle does not re-fetch).
-  request(state, deps);
+  void request(state, deps);
 }

--- a/extension/src/presentation/internal/render.test.ts
+++ b/extension/src/presentation/internal/render.test.ts
@@ -240,15 +240,14 @@ describe("render", () => {
     expect(root.textContent).toContain("No semantic changes");
   });
 
-  it("renderTooLarge shows the size and renders on click", () => {
+  it("renderTooLarge shows the size and resolves on click", async () => {
     const root = freshRoot();
-    let renders = 0;
-    renderTooLarge(root, 26 * 1024 * 1024, () => void renders++);
+    const clicked = renderTooLarge(root, 26 * 1024 * 1024);
     expect(root.textContent).toContain("Large file (26 MB)");
     const button = must(root.querySelector<HTMLButtonElement>("button.pl-render"));
     expect(button.textContent).toBe("Render anyway");
     button.click();
-    expect(renders).toBe(1);
+    await clicked;
   });
 
   it("renderError shows a clean one-line message", () => {
@@ -612,28 +611,24 @@ describe("detectTheme", () => {
 });
 
 describe("renderSignIn", () => {
-  it("renders the message and a sign-in button that invokes the callback", () => {
+  it("renders the message and resolves when the sign-in button is clicked", async () => {
     const root = freshRoot();
-    let clicks = 0;
-    renderSignIn(root, "Sign in with GitHub to view semantic diffs.", () => clicks++);
+    const clicked = renderSignIn(root, "Sign in with GitHub to view semantic diffs.");
     expect(root.querySelector(".pl-error")?.textContent).toContain("Sign in with GitHub to view semantic diffs.");
     const button = root.querySelector<HTMLButtonElement>("button.pl-render");
     expect(button?.textContent).toBe("Sign in with GitHub");
     button?.click();
-    expect(clicks).toBe(1);
+    await clicked;
   });
 });
 
 describe("renderSignInPending", () => {
   it("shows the user code, a copy button, and a link to the verification page", () => {
     const root = freshRoot();
-    let copies = 0;
-    renderSignInPending(root, "ABCD-1234", "https://github.com/login/device", () => copies++);
+    renderSignInPending(root, "ABCD-1234", "https://github.com/login/device");
     expect(root.querySelector(".pl-user-code")?.textContent).toBe("ABCD-1234");
     const copy = root.querySelector<HTMLButtonElement>("button.pl-render");
     expect(copy?.textContent).toBe("Copy code");
-    copy?.click();
-    expect(copies).toBe(1);
     const link = root.querySelector<HTMLAnchorElement>("a.pl-render");
     expect(link?.href).toBe("https://github.com/login/device");
     // New tab without opener: the PR tab must keep polling while the user authorizes.

--- a/extension/src/presentation/internal/render.ts
+++ b/extension/src/presentation/internal/render.ts
@@ -24,9 +24,10 @@ export function createViewHost(): { host: HTMLDivElement; root: ShadowRoot } {
 export function render(
   root: ShadowRoot,
   diff: DiffV2,
-  opts?: { resolving?: number; incomplete?: { onRetry(): void } },
-): void {
+  opts?: { resolving?: number; incomplete?: boolean },
+): Promise<void> {
   const container = mount(root);
+  let retry: Promise<void> | undefined;
   // The resolving indicator: the diff body is correct from the start. Only reference names arrive later.
   if (opts?.resolving) {
     const busy = note("pl-resolving", `Resolving ${opts.resolving} reference(s)…`);
@@ -37,7 +38,7 @@ export function render(
   } else if (opts?.incomplete) {
     // Resolution gave up (rate limit or error): say so instead of pretending it finished (#194).
     const bar = note("pl-resolving", "Some references were not resolved (GitHub rate limit or error).", ALERT);
-    bar.append(actionButton("Retry", opts.incomplete.onRetry));
+    retry = clickPromise(bar, "Retry");
     container.append(bar);
   }
   for (const node of diff.roots) container.append(renderNode(node, diff));
@@ -46,6 +47,7 @@ export function render(
   if (!diff.roots.length && !diff.loose.length) {
     container.append(note("pl-empty", "No semantic changes", CHECK));
   }
+  return retry ?? Promise.resolve();
 }
 
 export function renderError(root: ShadowRoot, message: string): void {
@@ -82,34 +84,30 @@ export function renderLoading(root: ShadowRoot): void {
   mount(root).append(box);
 }
 
-// The over-25MB guard: no auto-render. It waits for an explicit click.
-export function renderTooLarge(root: ShadowRoot, bytes: number, onRender: () => void): void {
+// The over-25MB guard: no auto-render. Resolves when the user clicks "Render anyway".
+export function renderTooLarge(root: ShadowRoot, bytes: number): Promise<void> {
   const container = mount(root);
-  container.append(
-    note("pl-empty", `Large file (${Math.round(bytes / (1024 * 1024))} MB).`, ALERT),
-    actionButton("Render anyway", onRender),
-  );
+  container.append(note("pl-empty", `Large file (${Math.round(bytes / (1024 * 1024))} MB).`, ALERT));
+  return clickPromise(container, "Render anyway");
 }
 
-// Auth-error panel: message + in-place device-flow button.
-export function renderSignIn(root: ShadowRoot, message: string, onSignIn: () => void): void {
+// Auth-error panel: message + in-place device-flow button. Resolves on click.
+export function renderSignIn(root: ShadowRoot, message: string): Promise<void> {
   const container = mount(root);
-  container.append(note("pl-error", message, ALERT), actionButton("Sign in with GitHub", onSignIn));
+  container.append(note("pl-error", message, ALERT));
+  return clickPromise(container, "Sign in with GitHub");
 }
 
 // Device-flow pending: keep the user code visible while authorizing on GitHub.
-export function renderSignInPending(
-  root: ShadowRoot,
-  userCode: string,
-  verificationUri: string,
-  onCopy: () => void,
-): void {
+export function renderSignInPending(root: ShadowRoot, userCode: string, verificationUri: string): void {
   const container = mount(root);
   const row = note("pl-signin", "Enter this code on GitHub:");
   const code = document.createElement("code");
   code.className = "pl-user-code";
   code.textContent = userCode;
-  const copy = actionButton("Copy code", onCopy);
+  const copy = actionButton("Copy code", () => {
+    void navigator.clipboard?.writeText(userCode);
+  });
   const link = document.createElement("a");
   link.className = "pl-render";
   link.href = verificationUri;
@@ -158,6 +156,13 @@ function actionButton(label: string, onClick: () => void): HTMLButtonElement {
   button.textContent = label;
   button.addEventListener("click", onClick);
   return button;
+}
+
+// Append a button and resolve when the user clicks it once.
+function clickPromise(parent: HTMLElement, label: string): Promise<void> {
+  return new Promise((resolve) => {
+    parent.append(actionButton(label, () => resolve()));
+  });
 }
 
 function summaryRow(status: Status, icon: string, iconClass: string, name: string, meta?: string): HTMLElement {


### PR DESCRIPTION
## Summary

Clarify layering architecture tests with `describe` groups, and replace presentation UI callbacks with promises / an async generator for sign-in.

## Motivation

Layering tests were hard to read as a flat list of scanners. Sign-in and render APIs pushed UI callbacks into application and call sites. This PR keeps behavior the same while making ownership clearer: application yields state, presentation renders and opens tabs.

Closes #NNN

## Changes

- Group `layering.test.ts` rules under `describe` blocks with clearer names
- Turn `signIn` into an async generator that yields `pending` / `ok` / `failed`
- Make `renderSignIn`, `renderTooLarge`, and incomplete `render` resolve on click
- Move clipboard handling into `renderSignInPending`; drop `onCopy`
- Update `FilePanel` / `file-view` so incomplete and too-large waits are promises
- Bump Biome schema reference to 2.5.6

## Testing

```text
$ pnpm exec vitest run
 Test Files  31 passed (31)
      Tests  274 passed (274)

$ pnpm exec tsc --noEmit
(exit 0)
```