### PR TITLE
test: guard device activation autofill with shared fixture

### DIFF
--- a/extension/e2e/fixtures/device-activation.html
+++ b/extension/e2e/fixtures/device-activation.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <!-- Trimmed copy of github.com/login/device (2026-07-11).
      Eight fillable input.js-user-code-field boxes and one hidden readonly hyphen box.
-     If autofill breaks in production, re-capture this page and update this file. -->
+     CI does not fetch live GitHub HTML. Re-capture this file when autofill fails in production,
+     then run tests. DEVICE_CODE_CHAR_COUNT in device-page.ts must match the box count. -->
 <html>
   <head>
     <meta charset="utf-8" />

--- a/extension/e2e/fixtures/device-activation.html
+++ b/extension/e2e/fixtures/device-activation.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<!-- Trimmed copy of github.com/login/device (2026-07-11).
+     Eight fillable input.js-user-code-field boxes and one hidden readonly hyphen box.
+     If autofill breaks in production, re-capture this page and update this file. -->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Device activation fixture</title>
+  </head>
+  <body>
+    <form action="/login/device/confirmation" method="post">
+      <input type="hidden" name="authenticity_token" value="tok" />
+      <input
+        type="text"
+        name="user-code-0"
+        id="user-code-0"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 0"
+      />
+      <input
+        type="text"
+        name="user-code-1"
+        id="user-code-1"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 1"
+      />
+      <input
+        type="text"
+        name="user-code-2"
+        id="user-code-2"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 2"
+      />
+      <input
+        type="text"
+        name="user-code-3"
+        id="user-code-3"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 3"
+      />
+      <input
+        type="text"
+        name="user-code-4"
+        id="user-code-4"
+        class="d-none"
+        aria-label="User code 4"
+        value="-"
+        readonly=""
+      />
+      <input
+        type="text"
+        name="user-code-5"
+        id="user-code-5"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 5"
+      />
+      <input
+        type="text"
+        name="user-code-6"
+        id="user-code-6"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 6"
+      />
+      <input
+        type="text"
+        name="user-code-7"
+        id="user-code-7"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 7"
+      />
+      <input
+        type="text"
+        name="user-code-8"
+        id="user-code-8"
+        class="form-control js-user-code-field h1"
+        maxlength="1"
+        aria-label="User code 8"
+      />
+      <input type="submit" name="commit" value="Continue" />
+    </form>
+  </body>
+</html>

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -134,7 +134,10 @@ async function signInFromPrPanel(ctx: BrowserContext): Promise<void> {
     timeout: 10_000,
     predicate: (p) => p.url().includes("/login/device"),
   });
-  await expect(devicePage.locator("input.js-user-code-field")).toHaveValues(["A", "B", "C", "D", "1", "2", "3", "4"]);
+  await devicePage.waitForLoadState("domcontentloaded");
+  const codeBoxes = devicePage.locator("input.js-user-code-field");
+  await expect(codeBoxes.first()).toHaveValue("A", { timeout: 15_000 });
+  await expect(codeBoxes).toHaveValues(["A", "B", "C", "D", "1", "2", "3", "4"]);
   await expect(devicePage.locator('input[name="user-code-4"]')).toHaveValue("-");
   // Device flow completes when the auth panel is replaced by diff content (or Signed-in recovery).
   await expect(view).toContainText("Sound", { timeout: 15_000 });

--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -11,6 +11,7 @@ import { type BrowserContext, chromium, expect, test } from "@playwright/test";
 
 const DIST = fileURLToPath(new URL("../dist", import.meta.url));
 const fixture = readFileSync(new URL("./fixtures/pr-files.html", import.meta.url), "utf8");
+const deviceFixture = readFileSync(new URL("./fixtures/device-activation.html", import.meta.url), "utf8");
 
 // Matches the port baked into __API_BASE__ by build.mjs --e2e
 const PORT = 8471;
@@ -111,7 +112,7 @@ function startServer(): Promise<Server> {
         // The first poll succeeds: no human Authorize step. The extension still runs the full poll loop.
         return json({ access_token: "e2e-token" });
       case "/login/device":
-        return send("<!doctype html><title>device</title>", "text/html");
+        return send(deviceFixture, "text/html");
       default:
         res.writeHead(404);
         res.end();
@@ -129,6 +130,12 @@ async function signInFromPrPanel(ctx: BrowserContext): Promise<void> {
   await header.getByRole("button", { name: "Semantic" }).click();
   const view = page.locator("[data-prefablens-view]");
   await view.getByRole("button", { name: "Sign in with GitHub" }).click();
+  const devicePage = await ctx.waitForEvent("page", {
+    timeout: 10_000,
+    predicate: (p) => p.url().includes("/login/device"),
+  });
+  await expect(devicePage.locator("input.js-user-code-field")).toHaveValues(["A", "B", "C", "D", "1", "2", "3", "4"]);
+  await expect(devicePage.locator('input[name="user-code-4"]')).toHaveValue("-");
   // Device flow completes when the auth panel is replaced by diff content (or Signed-in recovery).
   await expect(view).toContainText("Sound", { timeout: 15_000 });
   // Close any verification tab the flow opened

--- a/extension/src/presentation/content/device-page.test.ts
+++ b/extension/src/presentation/content/device-page.test.ts
@@ -1,82 +1,49 @@
 // @vitest-environment jsdom
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { must } from "../../internal/must";
 import { fillDeviceCode } from "./device-page";
 
 const PENDING = { userCode: "ABCD-1234", expiresAt: 10_000 };
+const fixture = readFileSync(join(process.cwd(), "e2e/fixtures/device-activation.html"), "utf8");
 
-// Trimmed copy of the real Device Activation form (captured 2026-07-11): eight fillable
-// boxes marked js-user-code-field plus a ninth CSS-hidden readonly input holding the hyphen.
-function box(n: number): string {
-  return `<input type="text" name="user-code-${n}" id="user-code-${n}" class="form-control js-user-code-field h1" maxlength="1" aria-label="User code ${n}">`;
+function loadFixture(doc: Document): void {
+  doc.body.innerHTML = new DOMParser().parseFromString(fixture, "text/html").body.innerHTML;
 }
-const FORM =
-  '<form action="/login/device/confirmation" method="post">' +
-  '<input type="hidden" name="authenticity_token" value="tok">' +
-  box(0) +
-  box(1) +
-  box(2) +
-  box(3) +
-  '<input type="text" name="user-code-4" id="user-code-4" class="d-none" aria-label="User code 4" value="-" readonly="">' +
-  box(5) +
-  box(6) +
-  box(7) +
-  box(8) +
-  '<input type="submit" name="commit" value="Continue">' +
-  "</form>";
 
-function boxes(): HTMLInputElement[] {
-  return [...document.querySelectorAll<HTMLInputElement>("input.js-user-code-field")];
+function boxes(doc: Document): HTMLInputElement[] {
+  return [...doc.querySelectorAll<HTMLInputElement>("input.js-user-code-field")];
 }
 
 describe("fillDeviceCode", () => {
-  it("fills the eight code boxes in order, skipping the hyphen, and fires input on each", () => {
-    document.body.innerHTML = FORM;
-    // GitHub enhances the boxes with JS (auto-advance via data-next). Input events keep it in sync.
-    let fired = 0;
-    for (const b of boxes()) {
-      b.addEventListener("input", () => {
-        fired += 1;
-      });
-    }
-    fillDeviceCode(document, PENDING, 5_000);
-    expect(boxes().map((b) => b.value)).toEqual(["A", "B", "C", "D", "1", "2", "3", "4"]);
-    expect(fired).toBe(8);
-  });
-
-  it("leaves the readonly hyphen placeholder and the csrf token untouched", () => {
-    document.body.innerHTML = FORM;
-    fillDeviceCode(document, PENDING, 5_000);
-    // The hyphen input carries value "-" from the server. It must neither block the fill nor be overwritten.
-    expect(must(document.querySelector<HTMLInputElement>('input[name="user-code-4"]')).value).toBe("-");
-    expect(must(document.querySelector<HTMLInputElement>('input[name="authenticity_token"]')).value).toBe("tok");
-  });
-
-  it("does not touch anything once the pending code expired", () => {
-    document.body.innerHTML = FORM;
-    fillDeviceCode(document, PENDING, 10_001);
-    expect(boxes().every((b) => b.value === "")).toBe(true);
+  it.each([
+    { name: "expired pending", now: 10_001, setup: () => loadFixture(document) },
+    {
+      name: "box count mismatch",
+      now: 5_000,
+      setup: () => {
+        loadFixture(document);
+        must(boxes(document)[7]).remove();
+      },
+    },
+  ])("no-ops when $name", ({ now, setup }) => {
+    setup();
+    fillDeviceCode(document, PENDING, now);
+    expect(boxes(document).every((b) => b.value === "")).toBe(true);
   });
 
   it("does not clobber a box the user already typed into", () => {
-    document.body.innerHTML = FORM;
-    must(boxes()[2]).value = "X";
+    loadFixture(document);
+    must(boxes(document)[2]).value = "X";
     fillDeviceCode(document, PENDING, 5_000);
-    expect(must(boxes()[0]).value).toBe("");
-    expect(must(boxes()[2]).value).toBe("X");
+    expect(must(boxes(document)[0]).value).toBe("");
+    expect(must(boxes(document)[2]).value).toBe("X");
   });
 
-  it("no-ops when the box count does not match the code length (unknown layout)", () => {
-    document.body.innerHTML = FORM;
-    must(boxes()[7]).remove();
-    fillDeviceCode(document, PENDING, 5_000);
-    expect(boxes().every((b) => b.value === "")).toBe(true);
-  });
-
-  it("no-ops when the boxes are absent (redesigned page)", () => {
+  it("no-ops when the boxes are absent", () => {
     document.body.innerHTML = "<form><input type='text' name='something-else'></form>";
     fillDeviceCode(document, PENDING, 5_000);
-    expect(document.querySelector("input[name='something-else']")).not.toBeNull();
     expect(must(document.querySelector<HTMLInputElement>("input[name='something-else']")).value).toBe("");
   });
 });

--- a/extension/src/presentation/content/device-page.test.ts
+++ b/extension/src/presentation/content/device-page.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { must } from "../../internal/must";
-import { fillDeviceCode } from "./device-page";
+import { DEVICE_CODE_BOX_SELECTOR, DEVICE_CODE_CHAR_COUNT, fillDeviceCode } from "./device-page";
 
 const PENDING = { userCode: "ABCD-1234", expiresAt: 10_000 };
 const fixture = readFileSync(join(process.cwd(), "e2e/fixtures/device-activation.html"), "utf8");
@@ -13,10 +13,15 @@ function loadFixture(doc: Document): void {
 }
 
 function boxes(doc: Document): HTMLInputElement[] {
-  return [...doc.querySelectorAll<HTMLInputElement>("input.js-user-code-field")];
+  return [...doc.querySelectorAll<HTMLInputElement>(DEVICE_CODE_BOX_SELECTOR)];
 }
 
 describe("fillDeviceCode", () => {
+  it("fixture matches the autofill contract", () => {
+    loadFixture(document);
+    expect(boxes(document).length).toBe(DEVICE_CODE_CHAR_COUNT);
+  });
+
   it.each([
     { name: "expired pending", now: 10_001, setup: () => loadFixture(document) },
     {

--- a/extension/src/presentation/content/device-page.ts
+++ b/extension/src/presentation/content/device-page.ts
@@ -1,10 +1,14 @@
 import type { PendingSignIn } from "../../domain/auth/token";
 
-// Autofill input.js-user-code-field on github.com/login/device.
-// Markup contract: e2e/fixtures/device-activation.html
+export const DEVICE_CODE_BOX_SELECTOR = "input.js-user-code-field";
+// GitHub user codes are eight characters without the hyphen (ABCD-1234).
+export const DEVICE_CODE_CHAR_COUNT = 8;
+
+// Autofill DEVICE_CODE_BOX_SELECTOR on github.com/login/device.
+// Markup contract: e2e/fixtures/device-activation.html (re-capture when autofill fails in production).
 export function fillDeviceCode(doc: Document, pending: PendingSignIn, now: number): void {
   if (now > pending.expiresAt) return;
-  const boxes = [...doc.querySelectorAll<HTMLInputElement>("input.js-user-code-field")];
+  const boxes = [...doc.querySelectorAll<HTMLInputElement>(DEVICE_CODE_BOX_SELECTOR)];
   const chars = pending.userCode.replace(/-/g, "");
   if (boxes.length !== chars.length || boxes.some((box) => box.value)) return;
   boxes.forEach((box, i) => {

--- a/extension/src/presentation/content/device-page.ts
+++ b/extension/src/presentation/content/device-page.ts
@@ -1,7 +1,7 @@
 import type { PendingSignIn } from "../../domain/auth/token";
 
-// Fill the device activation code boxes (inputs with class js-user-code-field).
-// If the form structure changes, this function does nothing and the user can enter the code manually.
+// Autofill input.js-user-code-field on github.com/login/device.
+// Markup contract: e2e/fixtures/device-activation.html
 export function fillDeviceCode(doc: Document, pending: PendingSignIn, now: number): void {
   if (now > pending.expiresAt) return;
   const boxes = [...doc.querySelectorAll<HTMLInputElement>("input.js-user-code-field")];

--- a/extension/src/presentation/content/index.ts
+++ b/extension/src/presentation/content/index.ts
@@ -218,11 +218,6 @@ function attachToggle(viewState: ViewStateData, page: DiffPage, entry: FileEntry
   if (effectiveView(viewState, entry.path) === "semantic") showFileView(fileState, fileDeps, "semantic");
 }
 
-async function initDevicePage(): Promise<void> {
-  const pending = await tokenStore.readPendingSignIn();
-  if (pending) fillDeviceCode(document, pending, Date.now());
-}
-
 async function initDiffRuntime(): Promise<void> {
   const stored = await chrome.storage.local.get(["viewMode"]).catch(() => ({}) as Record<string, unknown>);
   const initial: View = stored.viewMode === "semantic" ? "semantic" : "raw";
@@ -273,13 +268,9 @@ async function initDiffRuntime(): Promise<void> {
 }
 
 async function init(): Promise<void> {
-  // The device activation page opens in a new tab.
-  // The PR (pull request) tab already starts the main runtime.
-  // This tab's only job is to fill in the activation code.
-  // If you use soft navigation, it does not reload this script.
-  // All other pages also start the runtime, but do nothing until on a diff or PR URL.
   if (location.pathname === "/login/device") {
-    await initDevicePage();
+    const pending = await tokenStore.readPendingSignIn();
+    if (pending) fillDeviceCode(document, pending, now());
     return;
   }
   await initDiffRuntime();


### PR DESCRIPTION
## Summary

Add a shared device activation HTML fixture, full e2e autofill coverage, and explicit markup contract constants. Simplify device-page init in the content script.

## Motivation

GitHub markup drift can make `fillDeviceCode` no-op without a clear signal. This change adds regression tests against a pinned fixture and ties the fixture to exported contract constants.

CI does not fetch live GitHub HTML. Unauthenticated requests to `github.com/login/device` return the sign-in page, not the eight-box form. When autofill breaks in production, re-capture the fixture and run tests.

## Changes

- Add `e2e/fixtures/device-activation.html` as the markup contract snapshot
- Export `DEVICE_CODE_BOX_SELECTOR` and `DEVICE_CODE_CHAR_COUNT` from `device-page.ts`
- Unit test: fixture box count matches `DEVICE_CODE_CHAR_COUNT`; guard paths only
- Full e2e: serve the fixture at `/login/device` and assert autofill during sign-in
- Wait for the first filled box before asserting all values (fixes CI race)
- Inline device-page init in `index.ts`; `fillDeviceCode` returns `void`

## Testing

```bash
cd extension
pnpm exec vitest run src/presentation/content/device-page.test.ts
pnpm run typecheck
pnpm run lint
```

```
Test Files  1 passed (1)
Tests  5 passed (5)
```

E2e runs in CI on this PR (`pnpm run e2e`).