### PR TITLE
test: align e2e sniff expectation with new text

### DIFF
--- a/extension/e2e/full.spec.ts
+++ b/extension/e2e/full.spec.ts
@@ -208,7 +208,7 @@ test("rejects a binary .asset through the real wasm sniff", async () => {
   await header.getByRole("button", { name: "Semantic" }).click();
 
   const view = page.locator("[data-prefablens-view]");
-  await expect(view).toContainText("not a text-serialized Unity asset", { timeout: 30_000 });
+  await expect(view).toContainText("not a Unity asset file in text format", { timeout: 30_000 });
   await page.close();
 });
 


### PR DESCRIPTION
## Summary

Update the expected error text in one E2E test.

## Motivation

Commit 23cc4d4 changed the error text for the "not-unity-yaml" case. The E2E test still expected the old text. As a result, CI failed on main.

## Changes

- Change the expected substring in `extension/e2e/full.spec.ts` to "not a Unity asset file in text format".

## Testing

- `pnpm run e2e` in `extension/`: 20 passed.