### PR TITLE
build: bump js-yaml for security fixes

### DIFF
--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -719,12 +719,12 @@ packages:
     resolution: {integrity: sha512-ZFar/L4ngX7wZh2QX+Fiftmuf0igWJsrJtfizrovWifF1gAWkfmRa5Z1m0LQZbm0hKCHRDYhLRSLFrSqNe4EJA==}
     engines: {node: '>=6.0'}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   junk@3.1.0:
@@ -1067,7 +1067,7 @@ snapshots:
       filesize: 10.1.6
       gray-matter: 4.0.3
       iso-639-1: 3.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       kleur: 4.1.5
       liquidjs: 10.27.2
       luxon: 3.7.2
@@ -1557,7 +1557,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -1608,12 +1608,12 @@ snapshots:
 
   iso-639-1@3.1.6: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

Update js-yaml to 3.15.1 and 4.3.1 in `site/`. This update fixes the two open Dependabot alerts.

## Motivation

Dependabot reports two js-yaml alerts (#11, #12) against `site/pnpm-lock.yaml`. Both point to [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (high): quadratic CPU consumption in `!!omap` resolution. js-yaml is a transitive dependency of `@11ty/eleventy`, so Renovate cannot update it. No issue exists for this change — the issue gate exempts owner PRs.

## Changes

- `site/pnpm-lock.yaml`: js-yaml 3.15.0 → 3.15.1 (via gray-matter) and 4.3.0 → 4.3.1 (via @11ty/eleventy). The patched versions are inside the declared ranges (`^3.13.1`, `^4.1.1`), so no override is necessary.

## Testing

- `site`: `pnpm update js-yaml --depth Infinity`, then `pnpm build` — Eleventy wrote 6 files with no errors.