### PR TITLE
fix: stabilize GitHub diff controls

### DIFF
--- a/extension/src/application/diff/prefetch-pr.ts
+++ b/extension/src/application/diff/prefetch-pr.ts
@@ -1,20 +1,21 @@
 import type { AuthRepository } from "../../domain/auth/auth-repository";
 import type { DiffRepository } from "../../domain/diff/diff-repository";
+import { applyResolved } from "../../domain/diff/fn/apply-resolved";
 import { repoKey } from "../../domain/diff/fn/repo-key";
 import type { RepoIndexRepository } from "../../domain/guid/repo-index-repository";
 import { isUnityPath } from "../../domain/unity/fn/is-unity-path";
 import type { DifferGateway } from "../gateway/differ";
-import type { MakeGithubGateway } from "../gateway/github";
+import { type GithubGateway, isRateLimited, type MakeGithubGateway } from "../gateway/github";
 import type { PrefetchRequest } from "../gateway/messenger";
 import { API_BASE } from "../internal/api-base";
-import { getContext, getDiff } from "../internal/raw-diff";
+import { mergeGithubSourcesFromIndex } from "../internal/github-source-merge";
+import { diffCacheKey, getContext, getDiff, getPair } from "../internal/raw-diff";
 import { getRepoIndex } from "../internal/repo-index";
-import type { DiffSession } from "./create-diff-session";
+import type { DiffContext, DiffSession } from "./create-diff-session";
 
 const PREFETCH_MAX = 100; // bounds API usage per PR
 const PREFETCH_CONCURRENCY = 4;
 
-// Raw diff only. Code Search and the source merge stay at serve time (10 req/min).
 export async function prefetchPr(
   authRepository: AuthRepository,
   makeGithubGateway: MakeGithubGateway,
@@ -37,8 +38,7 @@ export async function prefetchPr(
       return;
     }
     const ctx = ctxResult.value;
-    // Index sync independent of raw-diff prefetch (speeds 3-stage resolution at serve time)
-    void getRepoIndex(
+    const indexPromise = getRepoIndex(
       repoIndexRepository,
       session,
       githubGateway,
@@ -48,21 +48,88 @@ export async function prefetchPr(
       ctx.refs.headSha,
     );
     const unity = ctx.files.filter((f) => isUnityPath(f.path)).slice(0, PREFETCH_MAX);
-    for (let i = 0; i < unity.length; i += PREFETCH_CONCURRENCY) {
-      const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);
-      const outcomes = await Promise.all(
-        chunk.map((f) =>
-          getDiff(getDiffer, diffRepository, session, githubGateway, ctx, req.owner, req.repo, f.path, false),
-        ),
-      );
-      // Only a rate limit stops the whole run. Other per-file failures appear again on a manual toggle.
-      if (outcomes.some((o) => !o.ok && o.error === "rate-limited")) {
-        console.debug("prefablens: prefetch aborted", { kind: "rate-limited" });
-        return;
+    let stopped = false;
+
+    const rawWork = async (): Promise<void> => {
+      for (let i = 0; i < unity.length && !stopped; i += PREFETCH_CONCURRENCY) {
+        const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);
+        const outcomes = await Promise.all(
+          chunk.map((f) =>
+            getDiff(getDiffer, diffRepository, session, githubGateway, ctx, req.owner, req.repo, f.path, false),
+          ),
+        );
+        if (outcomes.some((outcome) => !outcome.ok && outcome.error === "rate-limited")) stopped = true;
       }
-    }
+    };
+
+    const semanticWork = async (): Promise<void> => {
+      const repoIndex = await indexPromise;
+      const index = new Map(Object.entries(repoIndex ?? {}));
+      for (const [guid, path] of ctx.guidIndex) index.set(guid, path);
+      for (let i = 0; i < unity.length && !stopped; i += PREFETCH_CONCURRENCY) {
+        const chunk = unity.slice(i, i + PREFETCH_CONCURRENCY);
+        const outcomes = await Promise.all(
+          chunk.map((file) =>
+            preloadSemanticDiff(
+              getDiffer,
+              diffRepository,
+              session,
+              githubGateway,
+              ctx,
+              req.owner,
+              req.repo,
+              file.path,
+              index,
+            ),
+          ),
+        );
+        if (outcomes.includes("rate-limited")) stopped = true;
+      }
+    };
+
+    await Promise.all([rawWork(), semanticWork()]);
+    if (stopped) console.debug("prefablens: prefetch aborted", { kind: "rate-limited" });
   } catch (err) {
     // Prefetch stops quietly. Only the user-action path shows error UI.
     console.debug("prefablens: prefetch aborted", err);
   }
+}
+
+async function preloadSemanticDiff(
+  getDiffer: () => Promise<DifferGateway>,
+  diffRepository: DiffRepository,
+  session: DiffSession,
+  githubGateway: GithubGateway,
+  ctx: DiffContext,
+  owner: string,
+  repo: string,
+  path: string,
+  index: Map<string, string>,
+): Promise<"rate-limited" | undefined> {
+  const outcome = await getDiff(getDiffer, diffRepository, session, githubGateway, ctx, owner, repo, path, false);
+  if (!outcome.ok) return outcome.error === "rate-limited" ? "rate-limited" : undefined;
+
+  let json = applyResolved(outcome.json, index);
+  if (json.neededSources?.length) {
+    const [differ, pair] = await Promise.all([getDiffer(), getPair(session, githubGateway, ctx, owner, repo, path)]);
+    if (!pair.ok) return isRateLimited(pair.error) ? "rate-limited" : undefined;
+    const [before, after] = pair.value;
+    // This path uses the repo index. Code Search permits 10 authenticated requests each minute.
+    const merged = await mergeGithubSourcesFromIndex(
+      differ,
+      session,
+      githubGateway,
+      owner,
+      repo,
+      ctx,
+      before,
+      after,
+      json,
+      index,
+    );
+    if (merged.status !== "complete") return merged.status === "rateLimited" ? "rate-limited" : undefined;
+    json = merged.json;
+  }
+  await diffRepository.save(diffCacheKey(ctx, path), json);
+  return undefined;
 }

--- a/extension/src/application/internal/github-source-merge.ts
+++ b/extension/src/application/internal/github-source-merge.ts
@@ -10,6 +10,38 @@ import { resolveGuids } from "./guid-resolution";
 import { getBlob } from "./raw-diff";
 import { mergeSourceRounds } from "./source-rounds";
 
+type ReResolve = (json: DiffV2) => Promise<{ json: DiffV2; rateLimited: boolean }>;
+
+async function mergeGithubSourcesWithResolver(
+  differ: DifferGateway,
+  session: DiffSession,
+  githubGateway: Pick<GithubGateway, "getBlobRaw" | "getFileAtRef">,
+  owner: string,
+  repo: string,
+  context: DiffContext,
+  before: Uint8Array,
+  after: Uint8Array,
+  first: DiffV2,
+  reResolve: ReResolve,
+): Promise<{ json: DiffV2; status: ResolutionStatus }> {
+  return mergeSourceRounds(
+    differ,
+    before,
+    after,
+    first,
+    async (source, path) => {
+      const sha = source.side === "before" ? context.refs.baseSha : context.refs.headSha;
+      // The base tree supplies a blob SHA for a source outside the changed-file list.
+      const blobSha = source.side === "before" ? context.baseShas?.get(path) : undefined;
+      const bytes = await getBlob(session, githubGateway, owner, repo, path, sha, blobSha);
+      if (!bytes.ok) return { abort: isRateLimited(bytes.error) ? "rateLimited" : "failed" };
+      if (!bytes.value) return { skip: true };
+      return { bytes: bytes.value };
+    },
+    reResolve,
+  );
+}
+
 export async function mergeGithubSources(
   differ: DifferGateway,
   guidRepository: GuidRepository,
@@ -23,20 +55,16 @@ export async function mergeGithubSources(
   after: Uint8Array,
   first: DiffV2,
 ): Promise<{ json: DiffV2; status: ResolutionStatus }> {
-  return mergeSourceRounds(
+  return mergeGithubSourcesWithResolver(
     differ,
+    session,
+    githubGateway,
+    owner,
+    repo,
+    context,
     before,
     after,
     first,
-    async (source, path) => {
-      const sha = source.side === "before" ? context.refs.baseSha : context.refs.headSha;
-      // Only the base tree can supply a blob sha for a source outside the changed-file list.
-      const blobSha = source.side === "before" ? context.baseShas?.get(path) : undefined;
-      const bytes = await getBlob(session, githubGateway, owner, repo, path, sha, blobSha);
-      if (!bytes.ok) return { abort: isRateLimited(bytes.error) ? "rateLimited" : "failed" };
-      if (!bytes.value) return { skip: true };
-      return { bytes: bytes.value };
-    },
     async (json) => {
       const withIndex = applyResolved(json, context.guidIndex);
       const found = await resolveGuids(
@@ -53,5 +81,31 @@ export async function mergeGithubSources(
         rateLimited: found.rateLimited,
       };
     },
+  );
+}
+
+export function mergeGithubSourcesFromIndex(
+  differ: DifferGateway,
+  session: DiffSession,
+  githubGateway: Pick<GithubGateway, "getBlobRaw" | "getFileAtRef">,
+  owner: string,
+  repo: string,
+  context: DiffContext,
+  before: Uint8Array,
+  after: Uint8Array,
+  first: DiffV2,
+  index: Map<string, string>,
+): Promise<{ json: DiffV2; status: ResolutionStatus }> {
+  return mergeGithubSourcesWithResolver(
+    differ,
+    session,
+    githubGateway,
+    owner,
+    repo,
+    context,
+    before,
+    after,
+    first,
+    async (json) => ({ json: applyResolved(json, index), rateLimited: false }),
   );
 }

--- a/extension/src/application/internal/raw-diff.ts
+++ b/extension/src/application/internal/raw-diff.ts
@@ -224,7 +224,7 @@ async function computeDiff(
 }
 
 // Sha-keyed: a push produces a new key (no invalidation)
-export function getDiff(
+export async function getDiff(
   getDiffer: () => Promise<DifferGateway>,
   diffRepository: DiffRepository,
   session: DiffSession,
@@ -235,12 +235,16 @@ export function getDiff(
   path: string,
   force: boolean,
 ): Promise<DiffOutcome> {
-  const key = `${ctx.refs.baseSha}:${ctx.refs.headSha}:${path}`;
+  const key = diffCacheKey(ctx, path);
+  const stored = await diffRepository.load(key);
+  if (stored) return { ok: true, json: stored };
   return session.diffs.get(key, async (): Promise<DiffOutcome> => {
-    const stored = await diffRepository.load(key); // prior SW life
-    if (stored) return { ok: true, json: stored };
     const outcome = await computeDiff(getDiffer, session, githubGateway, ctx, owner, repo, path, force);
-    if (outcome.ok) void diffRepository.save(key, outcome.json);
+    if (outcome.ok) await diffRepository.save(key, outcome.json);
     return outcome;
   });
+}
+
+export function diffCacheKey(ctx: DiffContext, path: string): string {
+  return `${ctx.refs.baseSha}:${ctx.refs.headSha}:${path}`;
 }

--- a/extension/src/domain/diff/fn/apply-resolved.ts
+++ b/extension/src/domain/diff/fn/apply-resolved.ts
@@ -4,8 +4,9 @@ import type { DiffV2 } from "../types";
 // domain so the site demo can import it without a GitHub gateway or __API_BASE__.
 export function applyResolved(diff: DiffV2, index: Map<string, string>): DiffV2 {
   const resolved: Record<string, string> = {};
+  const stored = diff.resolved ?? {};
   for (const g of diff.unresolvedGuids) {
-    const path = index.get(g);
+    const path = index.get(g) ?? (Object.hasOwn(stored, g) ? stored[g] : undefined);
     if (path !== undefined) resolved[g] = path;
   }
   return { ...diff, resolved };

--- a/extension/src/infrastructure/clients/chrome-diff-client.ts
+++ b/extension/src/infrastructure/clients/chrome-diff-client.ts
@@ -5,7 +5,7 @@ import type { StorageAreaWithRemove } from "../internal/storage-area";
 const PREFIX = "diff:";
 const MAX_BYTES = 512 * 1024; // storage.session is 10MB: large diffs stay in the memory cache only.
 
-// Raw diffs in storage.session under a sha key across SW restarts.
+// SHA-keyed diffs stay in storage.session across service worker restarts.
 // On quota overflow, wipe the diffs and rewrite once. Without this, every SW restart recomputes forever.
 export function createChromeDiffRepository(area: StorageAreaWithRemove): DiffRepository {
   return {

--- a/extension/src/presentation/background/index.ts
+++ b/extension/src/presentation/background/index.ts
@@ -55,7 +55,16 @@ chrome.runtime.onMessage.addListener((msg: BackgroundRequest, sender, sendRespon
       return true; // async response
     }
     case "prefetch":
-      void prefetchPr(authRepository, makeGithubGateway, getDiffer, diffRepository, repoIndexRepository, session, msg);
-      return undefined; // prefetch is fire-and-forget
+      // Keep the message open so Chrome keeps the worker active until the semantic cache is ready.
+      void prefetchPr(
+        authRepository,
+        makeGithubGateway,
+        getDiffer,
+        diffRepository,
+        repoIndexRepository,
+        session,
+        msg,
+      ).finally(() => sendResponse());
+      return true;
   }
 });

--- a/extension/src/presentation/content/detect.ts
+++ b/extension/src/presentation/content/detect.ts
@@ -8,7 +8,6 @@ export type FileEntry = {
   attachHost(host: HTMLElement): void;
   setRawHidden(hidden: boolean): void; // idempotent: re-resolves the live DOM on each call
   collapsed(): boolean; // github file collapse (react chevron)
-  globalAnchor(): Element | null;
 };
 
 export type DiffPage = { owner: string; repo: string; target: DiffTarget };
@@ -20,6 +19,37 @@ function decodeRef(s: string): string {
   } catch {
     return s;
   }
+}
+
+const BIDI_MARKS = /[‎‏]/g;
+const REACT_LIST_SELECTOR = '[data-testid="virtualized-diffs-list"], [data-testid="progressive-diffs-list"]';
+
+function classicGlobalAnchor(root: ParentNode, fallback: Element): Element {
+  const firstFile = root.querySelector<HTMLElement>(".file-header[data-path]")?.closest(".file");
+  if (!firstFile) return fallback;
+  const list = firstFile.closest(".js-diff-progressive-container");
+  if (!list) return firstFile;
+
+  let anchor: Element = firstFile;
+  while (anchor.parentElement && anchor.parentElement !== list) anchor = anchor.parentElement;
+  return anchor;
+}
+
+export function findGlobalAnchor(root: ParentNode): Element | null {
+  const classicUnity = [...root.querySelectorAll<HTMLElement>(".file-header[data-path]")].find((header) => {
+    const path = header.dataset.path;
+    return path !== undefined && isUnityPath(path);
+  });
+  const classicFile = classicUnity?.closest(".file");
+  if (classicFile) return classicGlobalAnchor(root, classicFile);
+
+  const reactList = root.querySelector(REACT_LIST_SELECTOR);
+  if (!reactList) return null;
+  const hasUnity = [...root.querySelectorAll<HTMLAnchorElement>('a[href^="#diff-"]')].some((link) => {
+    const path = (link.querySelector("code")?.textContent ?? link.textContent ?? "").replace(BIDI_MARKS, "").trim();
+    return isUnityPath(path);
+  });
+  return hasUnity ? reactList : null;
 }
 
 // Diff pages we can serve. Compare is same-repo three-dot only (fork owner:branch needs a second repo).
@@ -60,7 +90,7 @@ function scanClassic(root: ParentNode): FileEntry[] {
     if (!path || !isUnityPath(path)) continue;
     const container = header.closest(".file");
     const content = container?.querySelector<HTMLElement>(".js-file-content") ?? null;
-    if (!content) continue;
+    if (!container || !content) continue;
     out.push({
       path,
       header,
@@ -73,13 +103,10 @@ function scanClassic(root: ParentNode): FileEntry[] {
         content.style.display = hidden ? "none" : "";
       },
       collapsed: () => false, // Details--on CSS hides collapsed content without our help
-      globalAnchor: () => container,
     });
   }
   return out;
 }
-
-const BIDI_MARKS = /[‎‏]/g;
 
 // React has no path attribute: the path is header text (+ LRM marks). Renames hide "OLD renamed to NEW".
 function filePathFromReactHeader(header: HTMLElement): string | null {
@@ -144,7 +171,6 @@ function scanReact(root: ParentNode): FileEntry[] {
           block.querySelector('[class*="DiffFileHeader-module__collapsed"]') !== null
         );
       },
-      globalAnchor: () => region.closest('[data-testid="progressive-diffs-list"]') ?? region.parentElement,
     });
   }
   return out;

--- a/extension/src/presentation/content/index.ts
+++ b/extension/src/presentation/content/index.ts
@@ -6,7 +6,7 @@ import { renderSignIn, renderSignInPending } from "../internal/render";
 import { mountGlobalBar, type Toggle } from "../internal/toggle";
 import type { ViewMode } from "../internal/view-mode";
 import { createViewState, type ViewState } from "../internal/view-state";
-import { type DiffPage, type FileEntry, parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
+import { type DiffPage, findGlobalAnchor, parseDiffUrl, parsePrPage, scanUnityFiles } from "./detect";
 import { fillDeviceCode } from "./device-page";
 import { createFileView, type FileRegistry, fileKey } from "./overlay/file-view";
 
@@ -90,9 +90,9 @@ function attach(viewState: ViewState): void {
 
   updateFiles();
 
+  const globalAnchor = findGlobalAnchor(document);
+  if (globalAnchor) ensureGlobalToggle(viewState, globalAnchor);
   const entries = scanUnityFiles(document);
-  const first = entries[0];
-  if (first) ensureGlobalToggle(viewState, first);
   for (const entry of entries) {
     const file = createFileView(entry, page, messengerGateway, viewState);
     file.subscribeAuth((root, error) => {
@@ -103,11 +103,10 @@ function attach(viewState: ViewState): void {
   }
 }
 
-// Global bar must sit outside recycled react list items (classic: before .file, react: list root)
-function ensureGlobalToggle(viewState: ViewState, first: FileEntry): void {
+// The global bar stays outside the recycled rows from GitHub.
+function ensureGlobalToggle(viewState: ViewState, anchor: Element): void {
   if (globalToggle?.element.closest("[data-prefablens-global]")?.isConnected) return;
-  const anchor = first.globalAnchor();
-  if (!anchor?.parentElement) return;
+  if (!anchor.parentElement) return;
   const bar = mountGlobalBar(viewState.page);
   bar.toggle.subscribe((view) => viewState.savePage(view));
   anchor.before(bar.element);
@@ -166,10 +165,11 @@ async function init(): Promise<void> {
   new MutationObserver(() => {
     if (scheduled) return;
     scheduled = true;
-    setTimeout(() => {
+    // If React replaces a complete file during a scroll, reattach before the browser paints the raw body.
+    queueMicrotask(() => {
       scheduled = false;
       attach(viewState);
-    }, 50);
+    });
   }).observe(document.body, { childList: true, subtree: true });
 }
 

--- a/extension/test/application/diff/prefetch-pr.test.ts
+++ b/extension/test/application/diff/prefetch-pr.test.ts
@@ -13,7 +13,7 @@ import type { RepoGuidIndex } from "../../../src/domain/guid/repo-guid-index";
 import type { RepoIndexRepository } from "../../../src/domain/guid/repo-index-repository";
 import { createGithubGateway } from "../../../src/infrastructure/clients/github-client";
 import { createDifferGateway } from "../../../src/infrastructure/clients/wasm-differ-client";
-import { AFTER_PREFAB, BEFORE_PREFAB } from "../../fixtures/unity";
+import { AFTER_PREFAB, BEFORE_PREFAB, SOURCE_PREFAB, VARIANT_PREFAB } from "../../fixtures/unity";
 
 class MemoryAuthRepository implements AuthRepository {
   private accessToken = "token";
@@ -125,6 +125,58 @@ describe("prefetchPr", () => {
       before: "0.5",
       after: "0.8",
     });
+  });
+
+  it("stores a semantic diff from the repo index without Code Search", async () => {
+    const requests: URL[] = [];
+    const client = createGithubGateway("https://api.github.com", "token", async (input) => {
+      const request = new URL(String(input));
+      requests.push(request);
+      if (request.pathname === "/repos/o/r/pulls/1") {
+        return Response.json({ base: { sha: "base-tip" }, head: { sha: "head-sha" } });
+      }
+      if (request.pathname === "/repos/o/r/compare/base-tip...head-sha") {
+        return Response.json({ merge_base_commit: { sha: "base-sha" }, files: [] });
+      }
+      if (request.pathname === "/repos/o/r/pulls/1/files") {
+        return Response.json([{ filename: "Assets/Foo.prefab", status: "modified", sha: "head-blob" }]);
+      }
+      if (request.pathname === "/repos/o/r/git/trees/base-sha") {
+        return Response.json({
+          truncated: false,
+          tree: [{ path: "Assets/Foo.prefab", type: "blob", sha: "base-blob" }],
+        });
+      }
+      if (request.pathname === "/repos/o/r/git/trees/head-sha") {
+        return Response.json({
+          truncated: false,
+          tree: [{ path: "Assets/Source.prefab.meta", type: "blob", sha: "source-meta" }],
+        });
+      }
+      if (request.pathname === "/repos/o/r/git/blobs/base-blob") return new Response(new Uint8Array());
+      if (request.pathname === "/repos/o/r/git/blobs/head-blob") return new Response(VARIANT_PREFAB);
+      if (request.pathname === "/repos/o/r/contents/Assets/Source.prefab") return new Response(SOURCE_PREFAB);
+      if (request.pathname === "/graphql") {
+        return Response.json({ data: { repository: { b0: { text: "guid: src0\n" } } } });
+      }
+      return new Response(null, { status: 500 });
+    });
+    const repository = new MemoryDiffRepository();
+
+    await prefetchPr(
+      new MemoryAuthRepository(),
+      () => client,
+      async () => differ,
+      repository,
+      new MemoryRepoIndexRepository(),
+      createDiffSession(),
+      { type: "prefetch", owner: "o", repo: "r", prNumber: 1 },
+    );
+
+    const stored = await repository.load("base-sha:head-sha:Assets/Foo.prefab");
+    expect(stored?.resolved).toEqual({ src0: "Assets/Source.prefab" });
+    expect(stored?.neededSources).toBeUndefined();
+    expect(requests.some((request) => request.pathname === "/search/code")).toBe(false);
   });
 
   it("uses a stored diff after a worker restart", async () => {

--- a/extension/test/application/internal/raw-diff.test.ts
+++ b/extension/test/application/internal/raw-diff.test.ts
@@ -101,6 +101,65 @@ describe("raw diff", () => {
     ).toBe(false);
   });
 
+  it("uses a newer stored diff instead of the memory entry", async () => {
+    const client = githubClient((request) => {
+      if (request.pathname === "/repos/o/r/pulls/1") {
+        return json({ base: { sha: "base-tip" }, head: { sha: "head-sha" } });
+      }
+      if (request.pathname === "/repos/o/r/compare/base-tip...head-sha") {
+        return json({ merge_base_commit: { sha: "base-sha" }, files: [] });
+      }
+      if (request.pathname === "/repos/o/r/pulls/1/files") {
+        return json([{ filename: PATH, status: "modified", sha: "head-blob" }]);
+      }
+      if (request.pathname === "/repos/o/r/git/trees/base-sha") {
+        return json({ truncated: false, tree: [{ path: PATH, type: "blob", sha: "base-blob" }] });
+      }
+      if (request.pathname === "/repos/o/r/git/blobs/base-blob") return raw(BEFORE_PREFAB);
+      if (request.pathname === "/repos/o/r/git/blobs/head-blob") return raw(AFTER_PREFAB);
+      return new Response(null, { status: 500 });
+    });
+    const repository = new MemoryDiffRepository();
+    const session = createDiffSession();
+    const context = await getContext(session, client, OWNER, REPO, PULL);
+    expect(context.ok).toBe(true);
+    if (!context.ok) return;
+
+    const first = await getDiff(
+      async () => differ,
+      repository,
+      session,
+      client,
+      context.value,
+      OWNER,
+      REPO,
+      PATH,
+      false,
+    );
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    await repository.save("base-sha:head-sha:Assets/Foo.prefab", {
+      ...first.json,
+      resolved: { def: "Assets/Sound.cs" },
+    });
+
+    const second = await getDiff(
+      async () => differ,
+      repository,
+      session,
+      client,
+      context.value,
+      OWNER,
+      REPO,
+      PATH,
+      false,
+    );
+
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+    expect(second.json.resolved).toEqual({ def: "Assets/Sound.cs" });
+  });
+
   it("uses an empty after side for a removed file", async () => {
     const requests: URL[] = [];
     const client = githubClient((request) => {

--- a/extension/test/domain/diff/fn/apply-resolved.test.ts
+++ b/extension/test/domain/diff/fn/apply-resolved.test.ts
@@ -33,4 +33,17 @@ describe("applyResolved", () => {
     expect(result).not.toBe(input);
     expect(input.resolved).toBeUndefined();
   });
+
+  it("keeps a stored name when the new index has no match", () => {
+    const result = applyResolved(
+      {
+        ...emptyDiff(),
+        unresolvedGuids: ["aaa"],
+        resolved: { aaa: "Assets/Stored.cs" },
+      },
+      new Map(),
+    );
+
+    expect(result.resolved).toEqual({ aaa: "Assets/Stored.cs" });
+  });
 });

--- a/extension/test/e2e/fixtures/pr-files-react-virtualized.html
+++ b/extension/test/e2e/fixtures/pr-files-react-virtualized.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html data-color-mode="light">
+  <head>
+    <meta charset="utf-8" /><title>PR fixture (virtualized react diff ui)</title>
+  </head>
+  <body>
+    <ul role="tree" aria-label="Changed files">
+      <li role="treeitem"><a href="#diff-readme">README.md</a></li>
+      <li role="treeitem"><a href="#diff-prefab">Assets/Foo.prefab</a></li>
+    </ul>
+    <div data-testid="diff-content">
+      <div data-hpc="true" data-testid="virtualized-diffs-list" class="d-flex flex-column gap-3">
+        <div class="PullRequestVirtualizedDiffsList-module__virtualized-diff-row">
+          <div role="region" id="diff-readme" aria-labelledby="readme-heading" class="Diff-module__diffTargetable Diff-module__diff">
+            <div class="Diff-module__diffHeaderWrapper">
+              <div class="DiffFileHeader-module__diff-file-header">
+                <h3 id="readme-heading" class="DiffFileHeader-module__file-name">
+                  <a class="Link--primary" href="#diff-readme"><code>&#x200e;README.md&#x200e;</code></a>
+                </h3>
+              </div>
+            </div>
+            <div class="border position-relative rounded-bottom-2">raw github diff table</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/extension/test/e2e/fixtures/pr-files-react.html
+++ b/extension/test/e2e/fixtures/pr-files-react.html
@@ -5,7 +5,22 @@
   </head>
   <body>
     <div data-testid="diff-content">
-      <div data-hpc="true" data-testid="progressive-diffs-list" class="d-flex flex-column gap-3">
+      <div data-hpc="true" data-testid="virtualized-diffs-list" class="d-flex flex-column gap-3">
+        <div class="PullRequestDiffsList-module__diffEntry__djnVa">
+          <div role="region" id="diff-ccc333" aria-labelledby="h2" class="Diff-module__diffTargetable Diff-module__diff">
+            <div class="Diff-module__diffHeaderWrapper">
+              <div class="DiffFileHeader-module__diff-file-header">
+                <h3 id="h2" class="DiffFileHeader-module__file-name">
+                  <a class="Link--primary" href="#diff-ccc333"><code>&#x200e;README.md&#x200e;</code></a>
+                </h3>
+                <button type="button" aria-expanded="true" aria-label="Collapse file">
+                  <svg class="octicon octicon-chevron-down"></svg>
+                </button>
+              </div>
+            </div>
+            <div class="border position-relative rounded-bottom-2">raw github diff table</div>
+          </div>
+        </div>
         <div class="PullRequestDiffsList-module__diffEntry__djnVa">
           <div role="region" id="diff-aaa111" aria-labelledby="h0" class="Diff-module__diffTargetable Diff-module__diff">
             <div class="Diff-module__diffHeaderWrapper">
@@ -27,21 +42,6 @@
               <div class="DiffFileHeader-module__diff-file-header">
                 <h3 id="h1" class="DiffFileHeader-module__file-name">
                   <a class="Link--primary" href="#diff-bbb222"><code>&#x200e;Assets/Big.unity&#x200e;</code></a>
-                </h3>
-                <button type="button" aria-expanded="true" aria-label="Collapse file">
-                  <svg class="octicon octicon-chevron-down"></svg>
-                </button>
-              </div>
-            </div>
-            <div class="border position-relative rounded-bottom-2">raw github diff table</div>
-          </div>
-        </div>
-        <div class="PullRequestDiffsList-module__diffEntry__djnVa">
-          <div role="region" id="diff-ccc333" aria-labelledby="h2" class="Diff-module__diffTargetable Diff-module__diff">
-            <div class="Diff-module__diffHeaderWrapper">
-              <div class="DiffFileHeader-module__diff-file-header">
-                <h3 id="h2" class="DiffFileHeader-module__file-name">
-                  <a class="Link--primary" href="#diff-ccc333"><code>&#x200e;README.md&#x200e;</code></a>
                 </h3>
                 <button type="button" aria-expanded="true" aria-label="Collapse file">
                   <svg class="octicon octicon-chevron-down"></svg>

--- a/extension/test/e2e/fixtures/pr-files.html
+++ b/extension/test/e2e/fixtures/pr-files.html
@@ -9,29 +9,39 @@
     </style>
   </head>
   <body>
-    <div class="file js-details-container Details Details--on open">
-      <div class="file-header" data-path="Assets/Foo.prefab">
-        <span class="file-info">Assets/Foo.prefab</span>
-      </div>
-      <div class="js-file-content Details-content--hidden">raw github diff table</div>
-    </div>
-    <div class="file js-details-container Details Details--on open">
-      <div class="file-header" data-path="Assets/Big.unity">
-        <span class="file-info">Assets/Big.unity</span>
-      </div>
-      <div class="js-file-content Details-content--hidden">raw github diff table</div>
-    </div>
-    <div class="file js-details-container Details Details--on open">
-      <div class="file-header" data-path="Assets/Baked.asset">
-        <span class="file-info">Assets/Baked.asset</span>
-      </div>
-      <div class="js-file-content Details-content--hidden">raw github diff table</div>
-    </div>
-    <div class="file js-details-container Details Details--on open">
-      <div class="file-header" data-path="README.md">
-        <span class="file-info">README.md</span>
-      </div>
-      <div class="js-file-content Details-content--hidden">raw github diff table</div>
+    <div class="js-diff-progressive-container">
+      <copilot-diff-entry>
+        <div class="file js-details-container Details Details--on open">
+          <div class="file-header" data-path="README.md">
+            <span class="file-info">README.md</span>
+          </div>
+          <div class="js-file-content Details-content--hidden">raw github diff table</div>
+        </div>
+      </copilot-diff-entry>
+      <copilot-diff-entry>
+        <div class="file js-details-container Details Details--on open">
+          <div class="file-header" data-path="Assets/Foo.prefab">
+            <span class="file-info">Assets/Foo.prefab</span>
+          </div>
+          <div class="js-file-content Details-content--hidden">raw github diff table</div>
+        </div>
+      </copilot-diff-entry>
+      <copilot-diff-entry>
+        <div class="file js-details-container Details Details--on open">
+          <div class="file-header" data-path="Assets/Big.unity">
+            <span class="file-info">Assets/Big.unity</span>
+          </div>
+          <div class="js-file-content Details-content--hidden">raw github diff table</div>
+        </div>
+      </copilot-diff-entry>
+      <copilot-diff-entry>
+        <div class="file js-details-container Details Details--on open">
+          <div class="file-header" data-path="Assets/Baked.asset">
+            <span class="file-info">Assets/Baked.asset</span>
+          </div>
+          <div class="js-file-content Details-content--hidden">raw github diff table</div>
+        </div>
+      </copilot-diff-entry>
     </div>
   </body>
 </html>

--- a/extension/test/e2e/full.spec.ts
+++ b/extension/test/e2e/full.spec.ts
@@ -308,8 +308,9 @@ test.afterEach(async () => {
 test("finishes prefetch after the semantic cache is ready", async () => {
   holdPrefetchBlob();
   const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+  // The packaged manifest supplies an extension context without relying on unbuilt pages.
   const extensionPage = await context.newPage();
-  await extensionPage.goto(`chrome-extension://${new URL(worker.url()).host}/options.html`);
+  await extensionPage.goto(`chrome-extension://${new URL(worker.url()).host}/manifest.json`);
 
   const stateBeforeBlob = await extensionPage.evaluate(async () =>
     Promise.race([

--- a/extension/test/e2e/full.spec.ts
+++ b/extension/test/e2e/full.spec.ts
@@ -12,6 +12,10 @@ import { type BrowserContext, chromium, expect, type Page, test } from "@playwri
 const DIST = fileURLToPath(new URL("../../dist", import.meta.url));
 const fixture = readFileSync(new URL("./fixtures/pr-files.html", import.meta.url), "utf8");
 const reactFixture = readFileSync(new URL("./fixtures/pr-files-react.html", import.meta.url), "utf8");
+const virtualizedReactFixture = readFileSync(
+  new URL("./fixtures/pr-files-react-virtualized.html", import.meta.url),
+  "utf8",
+);
 
 // build.mjs --e2e puts this port in __API_BASE__.
 const PORT = 8471;
@@ -34,6 +38,8 @@ const state: ServerState = {
 
 let guidSearchGate: Promise<void> | undefined;
 let releaseGuidSearch: (() => void) | undefined;
+let prefetchBlobGate: Promise<void> | undefined;
+let releasePrefetchBlob: (() => void) | undefined;
 
 function holdGuidSearch(): void {
   guidSearchGate = new Promise((resolve) => {
@@ -45,6 +51,18 @@ function releaseHeldGuidSearch(): void {
   releaseGuidSearch?.();
   guidSearchGate = undefined;
   releaseGuidSearch = undefined;
+}
+
+function holdPrefetchBlob(): void {
+  prefetchBlobGate = new Promise((resolve) => {
+    releasePrefetchBlob = resolve;
+  });
+}
+
+function releaseHeldPrefetchBlob(): void {
+  releasePrefetchBlob?.();
+  prefetchBlobGate = undefined;
+  releasePrefetchBlob = undefined;
 }
 
 // This prefab matches the golden WASM input and keeps the expected diff stable.
@@ -79,6 +97,8 @@ function startServer(): Promise<Server> {
         return send(fixture, "text/html");
       case "/o/r/pull/2/files":
         return send(reactFixture, "text/html");
+      case "/o/r/pull/3/files":
+        return send(virtualizedReactFixture, "text/html");
       case "/repos/o/r/pulls/1/files":
         return json([
           { filename: "Assets/Foo.prefab", status: "modified" },
@@ -91,8 +111,18 @@ function startServer(): Promise<Server> {
         return json([{ filename: "Assets/Foo.prefab", status: "modified" }]);
       case "/repos/o/r/pulls/2":
         return json({ base: { sha: "B" }, head: { sha: "H" } });
+      case "/repos/o/r/pulls/3/files":
+        return json([{ filename: "Assets/Foo.prefab", status: "modified" }]);
+      case "/repos/o/r/pulls/3":
+        return json({ base: { sha: "B" }, head: { sha: "H" } });
+      case "/repos/o/r/pulls/4/files":
+        return json([{ filename: "Assets/Foo.prefab", status: "modified" }]);
+      case "/repos/o/r/pulls/4":
+        return json({ base: { sha: "B4" }, head: { sha: "H4" } });
       case "/repos/o/r/compare/B...H":
         return json({ merge_base_commit: { sha: "MB" } });
+      case "/repos/o/r/compare/B4...H4":
+        return json({ merge_base_commit: { sha: "MB4" } });
       // Commit discovery uses the first parent as the base.
       case "/o/r/commit/abcdef0":
         return send(fixture, "text/html");
@@ -153,13 +183,14 @@ function startServer(): Promise<Server> {
         }
         // These refs are the base side of the pull, commit, compare, and backoff flows.
         const ref = url.searchParams.get("ref") ?? "";
+        if (ref === "H4" && prefetchBlobGate) await prefetchBlobGate;
         if (ref === "H429" && !servedRateLimit) {
           servedRateLimit = true;
           res.writeHead(429, { "retry-after": "1" });
           return res.end("rate limit");
         }
         return send(
-          ["MB", "PC", "MC", "P429", "P500", "P600"].includes(ref) ? BEFORE : AFTER,
+          ["MB", "MB4", "PC", "MC", "P429", "P500", "P600"].includes(ref) ? BEFORE : AFTER,
           "application/vnd.github.raw+json",
         );
       }
@@ -264,12 +295,41 @@ test.beforeEach(async () => {
   });
   if (!context.serviceWorkers()[0]) await context.waitForEvent("serviceworker");
   releaseHeldGuidSearch();
+  releaseHeldPrefetchBlob();
   await setLocalStorage({ accessToken: "e2e-token" });
 });
 
 test.afterEach(async () => {
   releaseHeldGuidSearch();
+  releaseHeldPrefetchBlob();
   await context?.close();
+});
+
+test("finishes prefetch after the semantic cache is ready", async () => {
+  holdPrefetchBlob();
+  const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+  const extensionPage = await context.newPage();
+  await extensionPage.goto(`chrome-extension://${new URL(worker.url()).host}/options.html`);
+
+  const stateBeforeBlob = await extensionPage.evaluate(async () =>
+    Promise.race([
+      chrome.runtime.sendMessage({ type: "prefetch", owner: "o", repo: "r", prNumber: 4 }).then(() => "complete"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("pending"), 100)),
+    ]),
+  );
+
+  // A pending message keeps the MV3 worker active while it builds the semantic cache.
+  expect(stateBeforeBlob).toBe("pending");
+  releaseHeldPrefetchBlob();
+  await expect
+    .poll(() =>
+      extensionPage.evaluate(async () => {
+        const stored = await chrome.storage.session.get("diff:MB4:H4:Assets/Foo.prefab");
+        return stored["diff:MB4:H4:Assets/Foo.prefab"] !== undefined;
+      }),
+    )
+    .toBe(true);
+  await extensionPage.close();
 });
 
 test("starts PR prefetch before a manual semantic request", async () => {
@@ -495,15 +555,23 @@ test("applies the persisted semantic default to current and later files", async 
   await page.close();
 });
 
+test("mounts the global toggle before the first classic file", async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/1/files`);
+
+  await expect(page.locator("[data-prefablens-global]")).toHaveCount(1);
+  await expect(
+    page.locator('[data-prefablens-global] + copilot-diff-entry .file-header[data-path="README.md"]'),
+  ).toHaveCount(1);
+  await page.close();
+});
+
 test("clears per-file overrides after a global selection", async () => {
   const page = await context.newPage();
   await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/1/files`);
 
   const global = page.locator("[data-prefablens-global]");
   await expect(global).toHaveCount(1);
-  await expect(
-    page.locator('[data-prefablens-global] + .file .file-header[data-path="Assets/Foo.prefab"]'),
-  ).toHaveCount(1);
 
   await global.getByRole("button", { name: "Semantic" }).click();
   const header = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
@@ -557,12 +625,57 @@ test("hides a remounted raw body before paint", async () => {
   await page.close();
 });
 
-test("mounts the global toggle outside the recycled item", async () => {
+test("mounts the global toggle before the React file list", async () => {
   const page = await context.newPage();
   await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/2/files`);
 
   await expect(page.locator("[data-prefablens-global]")).toHaveCount(1);
-  await expect(page.locator('[data-prefablens-global] + [data-testid="progressive-diffs-list"]')).toHaveCount(1);
+  await expect(page.locator('[data-prefablens-global] + [data-testid="virtualized-diffs-list"]')).toHaveCount(1);
+  await expect(page.locator('[data-testid="virtualized-diffs-list"] > :first-child #diff-ccc333')).toHaveCount(1);
+  await page.close();
+});
+
+test("mounts the global toggle before a Unity region enters the virtual list", async () => {
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/3/files`);
+
+  await expect(page.locator('div[role="region"] [data-prefablens]')).toHaveCount(0);
+  await expect(page.locator('[data-prefablens-global] + [data-testid="virtualized-diffs-list"]')).toHaveCount(1);
+  await page.close();
+});
+
+test("restores a fully remounted React file before the next paint", async () => {
+  await setLocalStorage({ accessToken: "e2e-token", viewMode: "semantic" });
+  const page = await context.newPage();
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/2/files`);
+
+  await expect(page.locator("#diff-aaa111 [data-prefablens-view]")).toBeVisible();
+  const firstPaint = await page.evaluate(
+    () =>
+      new Promise<{ rawDisplay: string; semanticView: boolean }>((resolve) => {
+        const entry = document.querySelector("#diff-aaa111")?.parentElement;
+        if (!entry) throw new Error("diff region missing");
+        const clone = entry.cloneNode(true) as HTMLElement;
+        // GitHub rebuilds this node from React state. The new node has no PrefabLens attributes or styles.
+        clone.querySelector("[data-prefablens-view]")?.remove();
+        clone.querySelector("[data-prefablens-toggle]")?.remove();
+        clone.querySelector("[data-prefablens]")?.removeAttribute("data-prefablens");
+        clone.querySelector("[data-prefablens-raw-hidden]")?.removeAttribute("data-prefablens-raw-hidden");
+        for (const element of clone.querySelectorAll<HTMLElement>("[style]")) element.style.display = "";
+        entry.replaceWith(clone);
+
+        requestAnimationFrame(() => {
+          const region = document.querySelector("#diff-aaa111");
+          const raw = region?.querySelector<HTMLElement>(".border.rounded-bottom-2");
+          resolve({
+            rawDisplay: raw ? getComputedStyle(raw).display : "missing",
+            semanticView: region?.querySelector("[data-prefablens-view]") !== null,
+          });
+        });
+      }),
+  );
+
+  expect(firstPaint).toEqual({ rawDisplay: "none", semanticView: true });
   await page.close();
 });
 

--- a/extension/test/presentation/content/detect.test.ts
+++ b/extension/test/presentation/content/detect.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import { must } from "../../../src/internal/must";
-import { parseDiffUrl, parsePrPage, scanUnityFiles } from "../../../src/presentation/content/detect";
+import { findGlobalAnchor, parseDiffUrl, parsePrPage, scanUnityFiles } from "../../../src/presentation/content/detect";
 
 const FIXTURE = `
   <div class="file">
@@ -183,7 +183,7 @@ describe("scanUnityFiles", () => {
 
     // Primer CSS controls the collapsed state for classic file containers.
     expect(entry.collapsed()).toBe(false);
-    expect(entry.globalAnchor()).toBe(document.querySelector(".file"));
+    expect(findGlobalAnchor(document)).toBe(document.querySelector(".file"));
   });
 
   it("attaches the semantic host after the raw content", () => {


### PR DESCRIPTION
## Summary

Fix the global view-mode control on classic and new GitHub diff pages. Remove raw and semantic flashes during virtualized row replacement.

## Motivation

The global control appeared above the first Unity file instead of the first changed file. React row replacement could briefly show the raw diff.

Follow-up to #326.

## Changes

- Mount the global control before the first classic file or the React virtual diff list.
- Reattach semantic views before the next browser paint.
- Preload semantic diffs from the repository index on each PR page.
- Preserve semantic cache data across service worker restarts and resolution passes.
- Add classic and React E2E coverage for placement, prefetch, and row replacement.

## Testing

- `pnpm run typecheck`: passed
- `pnpm run lint`: passed (99 files)
- `pnpm test`: passed (236 tests in 29 files)
- `pnpm run e2e`: passed (26 tests)
- `pnpm run build`: passed
- `pnpm run size`: passed (44.4 KB gzip, 80 KB target)
