### PR TITLE
docs: require English in repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ Automation also converts the pull request to draft until the issue-first flow is
 For security vulnerabilities, do **not** open a public issue.
 Follow [SECURITY.md](SECURITY.md) instead.
 
+## Language
+
+Use English in this repository.
+
 ## Releases and changelog
 
 There is no curated `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

This pull request adds an English language rule to `CONTRIBUTING.md`.

## Motivation

The repository uses English as its common language.

## Changes

- `CONTRIBUTING.md` now contains a Language section.

## Testing

- `.github/scripts/check-version-sync.sh` passed.
- `cli/pkg/render_test.sh` passed.
- `zig build lint` passed.
- `zig build test` passed.
- `zig build perf` passed.
- `node --test core/tests/*.test.mjs` passed 7 tests.
- `pnpm run size` passed in `extension`.
- `pnpm run lint` passed in `extension`.
- `pnpm run typecheck` passed in `extension`.
- `pnpm test` passed 236 tests in `extension`.
- `pnpm run build` passed in `extension`.
- `pnpm run e2e` passed 26 tests in `extension`.
- `dotnet csharpier check . --no-msbuild-check` passed in `editor`.
- `dotnet test DotNetTests~/Tests` passed 77 tests in `editor`.
- `pnpm run build` passed in `site`.
