### PR TITLE
docs: explain English language rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ Follow [SECURITY.md](SECURITY.md) instead.
 
 Use English in this repository.
 
+Contributors often read related issues and pull requests to understand the reasons for earlier changes.
+Many software engineers are familiar with English.
+English makes this project history available to more people and lowers the barrier to using and contributing to PrefabLens.
+
 ## Releases and changelog
 
 There is no curated `CHANGELOG.md`.


### PR DESCRIPTION
## Summary

This pull request explains why PrefabLens uses English as its common language.

## Motivation

Contributors read issues and pull requests to understand earlier changes.
English makes this history available to more people.

## Changes

- The Language section now explains the reason for the rule.

## Testing

- `git diff --check` passed.
- Automated tests do not apply because this pull request changes only documentation.
