### PR TITLE
docs: reorganize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,6 @@ It shows changes to GameObjects, components, and fields.
 Use the [Chrome extension](#chrome-extension), [Unity Editor package](#unity-editor), or [CLI](#cli).
 Try the [live demo](https://prefablens.hashiiiii.workers.dev/).
 
-## Supported files
-
-PrefabLens supports text-serialized Unity assets.
-Supported extensions include `.prefab`, `.unity`, `.asset`, `.mat`, `.anim`, and `.controller`.
-See the [CLI reference](docs/cli.md#operands-and-argument-resolution) for the full list.
-PrefabLens does not support `.meta`, `.asmdef`, or other formats that are not UnityYAML.
-
-The project must use text asset serialization.
-Select `Edit > Project Settings > Editor > Asset Serialization > Force Text`.
-Binary-serialized assets do not produce useful diffs.
-
 ## Chrome extension
 
 The extension shows semantic diffs on GitHub pull requests.
@@ -42,7 +31,6 @@ You do not need to set a token.
 </p>
 
 The package requires Unity 2022.3 or newer.
-The project must be inside a git repository.
 
 ### Installation
 
@@ -53,7 +41,7 @@ openupm add com.hashiiiii.prefablens
 ```
 
 If you do not use [openupm-cli](https://github.com/openupm/openupm-cli), follow the scoped registry instructions on the [package page](https://openupm.com/packages/com.hashiiiii.prefablens/).
-Alternatively, install from this git URL in the Package Manager:
+Alternatively, install the package from this git URL in the Package Manager:
 
 `https://github.com/hashiiiii/PrefabLens.git?path=editor`
 
@@ -61,8 +49,8 @@ Alternatively, install from this git URL in the Package Manager:
 
 Open `Window > PrefabLens`.
 
-The left pane lists every changed UnityYAML asset against the **Base** ref.
-An empty **Base** ref means HEAD.
+The left pane lists every UnityYAML asset that differs from the Git reference in **Base**.
+The window uses HEAD if **Base** is empty.
 The right pane shows the semantic diff for the selected asset.
 
 The window refreshes when it gains focus.
@@ -81,7 +69,7 @@ To use a local CLI:
 Alternatively, set the `PrefabLens.CliPath` EditorPrefs key to an absolute path.
 
 The CLI must run and report its version.
-A manual CLI can use a version other than the pinned version.
+A local CLI can use a version other than the pinned version.
 If the override is invalid, PrefabLens uses a valid downloaded CLI or offers a download.
 
 ### Troubleshooting
@@ -128,10 +116,10 @@ Download the zip for your platform from [GitHub Releases](https://github.com/has
 Each zip contains one native `prefablens` executable and the `git-merge-prefablens` script.
 
 Git needs the script name to select the PrefabLens merge strategy.
-Git for Windows reads the script shebang and runs the script with `sh`.
+Git for Windows reads the script's first line (the shebang) and runs the script with `sh`.
 
 If you replace an older manual installation on Windows, remove `git-merge-prefablens.exe`.
-The old executable can hide the new script.
+Git can run the old executable instead of the new script.
 Scoop removes its old `git-merge-prefablens` shim during `scoop update prefablens`.
 
 ### Usage
@@ -149,7 +137,7 @@ prefablens --open main                  # write the report to a temp file and op
 ```
 
 Operands with a UnityYAML extension (`.prefab`, `.unity`, `.asset`, and more) are paths.
-All other operands are git refs.
+All other operands are Git references (refs).
 
 ### Git merge
 
@@ -164,7 +152,8 @@ For one clone, run:
 prefablens setup-merge
 ```
 
-This command adds repository-local Git configuration and UnityYAML attributes in `.git/info/attributes`.
+This command adds local Git configuration for the repository.
+It also adds UnityYAML attributes to `.git/info/attributes`.
 
 For a team, use shared attributes instead:
 
@@ -188,20 +177,20 @@ If a UnityYAML conflict remains and a terminal is available, the merge UI opens.
 
 Resolve the values. Then select **Complete**.
 
-File deletion and rename conflicts offer a file choice before content resolution.
+For file deletion and rename conflicts, PrefabLens offers a file choice before you resolve the content.
 PrefabLens applies the asset choice to matching `.meta` files.
 Ambiguous metadata conflicts stay unresolved.
 
 Other file formats use normal Git merge behavior.
-If other formats also conflict, those conflicts remain unresolved after PrefabLens resolves the UnityYAML conflicts.
-Before Git can complete the merge, every conflict must have a resolution.
+If files in other formats also conflict, those conflicts remain unresolved after PrefabLens resolves the UnityYAML conflicts.
+Git can complete the merge only after every conflict is resolved.
 `--no-commit`, `--squash`, and `git merge --abort` remain available.
 Strategy options (`-X`) require Git 2.43 or later.
 
-If you quit or no terminal is available, unresolved text keeps Git conflict markers.
+If you quit or no terminal is available, Git conflict markers remain in unresolved text.
 The `merge.conflictStyle` configuration and `conflict-marker-size` attribute control the markers.
 Even when a line-based merge is clean, a semantic conflict can require markers.
-Binary and file deletion or rename conflicts keep the normal Git file representation.
+Files with binary, deletion, or rename conflicts keep their normal Git representation.
 
 To complete the merge with another editor:
 
@@ -209,7 +198,7 @@ To complete the merge with another editor:
 2. Stage the resolved files with `git add`.
 3. Run `git merge --continue`.
 
-To reopen the UnityYAML content UI for one unresolved path:
+To reopen the UI for UnityYAML content at one unresolved path:
 
 ```bash
 git mergetool --tool=prefablens -- Assets/Prefabs/Robot.prefab
@@ -238,7 +227,7 @@ mise install
 
 ### Build and test
 
-Run each code block from the repository root.
+Run the commands in each code block from the repository root.
 
 #### Core and CLI
 
@@ -265,7 +254,8 @@ The build and test commands run `zig build wasm` when needed.
 
 #### Unity Editor
 
-These tests run on .NET with real native CLI commands and do not require Unity.
+These tests run on .NET and call the native CLI.
+They do not require Unity.
 
 ```bash
 zig build test-installation-binaries -Doptimize=ReleaseSafe

--- a/README.md
+++ b/README.md
@@ -72,17 +72,6 @@ The CLI must run and report its version.
 A local CLI can use a version other than the pinned version.
 If the override is invalid, PrefabLens uses a valid downloaded CLI or offers a download.
 
-### Troubleshooting
-
-| Symptom                                               | What to do                                                                                 |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `Download failed: …`                                  | Retry. If the retry fails, download the release zip. Then set the CLI path override.       |
-| `CLI path override … is invalid. …`                   | Select a working `prefablens` executable. Or clear the CLI path override.                  |
-| `prefablens exited with N` / one-line CLI error       | Check that the project is in a git repository. Check that git finishes within the timeout. |
-| `Could not parse CLI output (CLI version mismatch?):` | Clear the CLI path override or update the CLI.                                             |
-| `prefablens timed out after 90s and was killed`       | Check that `git status` is fast in the repository.                                         |
-| Changed assets never appear                           | Switch Asset Serialization to Force Text.                                                  |
-
 ## CLI
 
 <p align="center">
@@ -129,10 +118,10 @@ prefablens                              # HEAD vs working tree, all changed Unit
 prefablens Assets/Foo.prefab            # HEAD vs working tree, one file
 prefablens main                         # ref vs working tree, all changed Unity files
 prefablens HEAD~1 HEAD Assets/Foo.prefab  # ref vs ref, one file
-prefablens before.prefab after.prefab   # plain two-file compare (no git)
+prefablens before.prefab after.prefab   # plain two files compare
 
 prefablens --json before.prefab after.prefab
-prefablens --html main                  # self-contained HTML report on stdout
+prefablens --html main                  # self contained HTML report on stdout
 prefablens --open main                  # write the report to a temp file and open it
 ```
 
@@ -141,7 +130,7 @@ All other operands are Git references (refs).
 
 ### Git merge
 
-PrefabLens uses Git 2.39 or later to resolve UnityYAML conflicts during `git merge`.
+PrefabLens uses Git **2.39** or later to resolve UnityYAML conflicts during `git merge`.
 
 Install `prefablens` and the packaged `git-merge-prefablens` script on `PATH`.
 The script runs `prefablens merge-strategy`.
@@ -169,40 +158,13 @@ Setup keeps existing attributes and unrelated Git configuration.
 Use the normal merge command:
 
 ```bash
-git merge main
+git merge origin/main
 ```
 
 PrefabLens merges independent UnityYAML changes automatically.
 If a UnityYAML conflict remains and a terminal is available, the merge UI opens.
 
 Resolve the values. Then select **Complete**.
-
-For file deletion and rename conflicts, PrefabLens offers a file choice before you resolve the content.
-PrefabLens applies the asset choice to matching `.meta` files.
-Ambiguous metadata conflicts stay unresolved.
-
-Other file formats use normal Git merge behavior.
-If files in other formats also conflict, those conflicts remain unresolved after PrefabLens resolves the UnityYAML conflicts.
-Git can complete the merge only after every conflict is resolved.
-`--no-commit`, `--squash`, and `git merge --abort` remain available.
-Strategy options (`-X`) require Git 2.43 or later.
-
-If you quit or no terminal is available, Git conflict markers remain in unresolved text.
-The `merge.conflictStyle` configuration and `conflict-marker-size` attribute control the markers.
-Even when a line-based merge is clean, a semantic conflict can require markers.
-Files with binary, deletion, or rename conflicts keep their normal Git representation.
-
-To complete the merge with another editor:
-
-1. Resolve the conflicts with your editor.
-2. Stage the resolved files with `git add`.
-3. Run `git merge --continue`.
-
-To reopen the UI for UnityYAML content at one unresolved path:
-
-```bash
-git mergetool --tool=prefablens -- Assets/Prefabs/Robot.prefab
-```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,46 +4,104 @@
 [![Release](https://img.shields.io/github/v/release/hashiiiii/PrefabLens)](https://github.com/hashiiiii/PrefabLens/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/hashiiiii/PrefabLens/ci.yml?branch=main&label=CI)](https://github.com/hashiiiii/PrefabLens/actions/workflows/ci.yml)
 
-PrefabLens shows human readable diffs of UnityYAML assets.
-A semantic diff shows changes at the GameObject, component, and field level.
+PrefabLens shows semantic diffs of UnityYAML assets.
+It shows changes to GameObjects, components, and fields.
 
-A [live demo](https://prefablens.hashiiiii.workers.dev/) is available.
+Use the [Chrome extension](#chrome-extension), [Unity Editor package](#unity-editor), or [CLI](#cli).
+Try the [live demo](https://prefablens.hashiiiii.workers.dev/).
 
-## Chrome extension (Chrome Web Store)
+## Supported files
+
+PrefabLens supports text-serialized Unity assets.
+Supported extensions include `.prefab`, `.unity`, `.asset`, `.mat`, `.anim`, and `.controller`.
+See the [CLI reference](docs/cli.md#operands-and-argument-resolution) for the full list.
+PrefabLens does not support `.meta`, `.asmdef`, or other formats that are not UnityYAML.
+
+The project must use text asset serialization.
+Select `Edit > Project Settings > Editor > Asset Serialization > Force Text`.
+Binary-serialized assets do not produce useful diffs.
+
+## Chrome extension
+
+The extension shows semantic diffs on GitHub pull requests.
+It works on github.com only.
 
 <p align="center">
-  <img width="924" src="docs/images/extension.png" alt="extension" />
+  <img width="924" src="docs/images/extension.png" alt="Semantic diff in a GitHub pull request" />
 </p>
+
+Install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip).
+
+You can sign in from the diff panel with GitHub Device Flow.
+You do not need to set a token.
 
 ## Unity Editor
 
 <p align="center">
-  <img width="924" src="docs/images/editor.png" alt="editor" />
+  <img width="924" src="docs/images/editor.png" alt="Semantic diff in the Unity Editor" />
 </p>
+
+The package requires Unity 2022.3 or newer.
+The project must be inside a git repository.
+
+### Installation
+
+Install from OpenUPM:
+
+```bash
+openupm add com.hashiiiii.prefablens
+```
+
+If you do not use [openupm-cli](https://github.com/openupm/openupm-cli), follow the scoped registry instructions on the [package page](https://openupm.com/packages/com.hashiiiii.prefablens/).
+Alternatively, install from this git URL in the Package Manager:
+
+`https://github.com/hashiiiii/PrefabLens.git?path=editor`
+
+### Usage
+
+Open `Window > PrefabLens`.
+
+The left pane lists every changed UnityYAML asset against the **Base** ref.
+An empty **Base** ref means HEAD.
+The right pane shows the semantic diff for the selected asset.
+
+The window refreshes when it gains focus.
+Click **Refresh** to refresh it manually.
+
+On first use, the package downloads a pinned CLI archive from GitHub Releases.
+The package extracts only `prefablens` into `Library/PrefabLens/`.
+On Windows, the file name is `prefablens.exe`.
+Git does not track this directory.
+
+To use a local CLI:
+
+1. Open Preferences > PrefabLens.
+2. Set **CLI path override** to the absolute path of `prefablens`.
+
+Alternatively, set the `PrefabLens.CliPath` EditorPrefs key to an absolute path.
+
+The CLI must run and report its version.
+A manual CLI can use a version other than the pinned version.
+If the override is invalid, PrefabLens uses a valid downloaded CLI or offers a download.
+
+### Troubleshooting
+
+| Symptom                                               | What to do                                                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `Download failed: …`                                  | Retry. If the retry fails, download the release zip. Then set the CLI path override.       |
+| `CLI path override … is invalid. …`                   | Select a working `prefablens` executable. Or clear the CLI path override.                  |
+| `prefablens exited with N` / one-line CLI error       | Check that the project is in a git repository. Check that git finishes within the timeout. |
+| `Could not parse CLI output (CLI version mismatch?):` | Clear the CLI path override or update the CLI.                                             |
+| `prefablens timed out after 90s and was killed`       | Check that `git status` is fast in the repository.                                         |
+| Changed assets never appear                           | Switch Asset Serialization to Force Text.                                                  |
 
 ## CLI
 
 <p align="center">
-  <img width="924" src="docs/images/cli.png" alt="cli" />
+  <img width="924" src="docs/images/cli.png" alt="Semantic diff in the CLI" />
 </p>
 
-## Components
-
-| Directory    | Description                                                                              |
-| ------------ | ---------------------------------------------------------------------------------------- |
-| `core/`      | Zig diff engine for the CLI and WASM                                                     |
-| `cli/`       | `prefablens` CLI tool                                                                    |
-| `extension/` | Chrome extension. The extension shows semantic diffs on GitHub pull requests.            |
-| `editor/`    | Unity Editor package for semantic diffs                                                  |
-| `site/`      | Live demo on Cloudflare Workers. The demo uses artifacts from the CLI and the extension. |
-
-## Installation
-
-### Chrome extension (Chrome Web Store)
-
-Install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/dlhnalbfkikchkfedfneiimadommcnip).
-
-### CLI
+### Installation
 
 #### Homebrew (macOS / Linux)
 
@@ -76,31 +134,26 @@ If you replace an older manual installation on Windows, remove `git-merge-prefab
 The old executable can hide the new script.
 Scoop removes its old `git-merge-prefablens` shim during `scoop update prefablens`.
 
-### Unity Editor package (OpenUPM)
-
-Unity `2022.3+` is required.
+### Usage
 
 ```bash
-openupm add com.hashiiiii.prefablens
+prefablens                              # HEAD vs working tree, all changed Unity files
+prefablens Assets/Foo.prefab            # HEAD vs working tree, one file
+prefablens main                         # ref vs working tree, all changed Unity files
+prefablens HEAD~1 HEAD Assets/Foo.prefab  # ref vs ref, one file
+prefablens before.prefab after.prefab   # plain two-file compare (no git)
+
+prefablens --json before.prefab after.prefab
+prefablens --html main                  # self-contained HTML report on stdout
+prefablens --open main                  # write the report to a temp file and open it
 ```
 
-If you do not use [openupm-cli](https://github.com/openupm/openupm-cli), add the scoped registry as described on the [package page](https://openupm.com/packages/com.hashiiiii.prefablens/).
-Alternatively, in the Package Manager, install from the git URL `https://github.com/hashiiiii/PrefabLens.git?path=editor`.
-
-## Usage
-
-### Chrome extension
-
-The extension shows human readable diffs of UnityYAML assets on GitHub pull requests.
-You can authenticate with the GitHub Device Flow from the diff panel.
-You do not need to set a token.
-
-> [!NOTE]
-> The extension works on github.com only.
+Operands with a UnityYAML extension (`.prefab`, `.unity`, `.asset`, and more) are paths.
+All other operands are git refs.
 
 ### Git merge
 
-PrefabLens uses Git 2.39 or later to resolve Unity YAML conflicts during `git merge`.
+PrefabLens uses Git 2.39 or later to resolve UnityYAML conflicts during `git merge`.
 
 Install `prefablens` and the packaged `git-merge-prefablens` script on `PATH`.
 The script runs `prefablens merge-strategy`.
@@ -111,7 +164,7 @@ For one clone, run:
 prefablens setup-merge
 ```
 
-This command adds repository-local Git configuration and Unity YAML attributes in `.git/info/attributes`.
+This command adds repository-local Git configuration and UnityYAML attributes in `.git/info/attributes`.
 
 For a team, use shared attributes instead:
 
@@ -130,8 +183,8 @@ Use the normal merge command:
 git merge main
 ```
 
-PrefabLens merges independent Unity YAML changes automatically.
-If a Unity YAML conflict remains and a terminal is available, the merge UI opens.
+PrefabLens merges independent UnityYAML changes automatically.
+If a UnityYAML conflict remains and a terminal is available, the merge UI opens.
 
 Resolve the values. Then select **Complete**.
 
@@ -140,7 +193,7 @@ PrefabLens applies the asset choice to matching `.meta` files.
 Ambiguous metadata conflicts stay unresolved.
 
 Other file formats use normal Git merge behavior.
-If other formats also conflict, those conflicts remain unresolved after PrefabLens resolves the Unity YAML conflicts.
+If other formats also conflict, those conflicts remain unresolved after PrefabLens resolves the UnityYAML conflicts.
 Before Git can complete the merge, every conflict must have a resolution.
 `--no-commit`, `--squash`, and `git merge --abort` remain available.
 Strategy options (`-X`) require Git 2.43 or later.
@@ -156,110 +209,81 @@ To complete the merge with another editor:
 2. Stage the resolved files with `git add`.
 3. Run `git merge --continue`.
 
-To reopen the Unity YAML content UI for one unresolved path:
+To reopen the UnityYAML content UI for one unresolved path:
 
 ```bash
 git mergetool --tool=prefablens -- Assets/Prefabs/Robot.prefab
 ```
 
-### CLI
-
-```bash
-prefablens                              # HEAD vs working tree, all changed Unity files
-prefablens Assets/Foo.prefab            # HEAD vs working tree, one file
-prefablens main                         # ref vs working tree, all changed Unity files
-prefablens HEAD~1 HEAD Assets/Foo.prefab  # ref vs ref, one file
-prefablens before.prefab after.prefab   # plain two-file compare (no git)
-
-prefablens --json before.prefab after.prefab
-prefablens --html main                  # self-contained HTML report on stdout
-prefablens --open main                  # write the report to a temp file and open it
-```
-
-Operands with a Unity YAML extension (`.prefab`, `.unity`, `.asset`, and more) are paths.
-All other operands are git refs.
-
-The project must use text asset serialization (Edit > Project Settings > Editor >
-Asset Serialization > Force Text).
-Binary-serialized assets do not produce useful diffs.
-
-### Unity Editor
-
-Requirements:
-
-- Unity 2022.3 or newer
-- The project is inside a git repository
-- Text asset serialization (Force Text)
-
-Open `Window > PrefabLens`.
-
-The left pane lists every changed UnityYAML asset against the **Base** ref.
-An empty **Base** ref means HEAD.
-The right pane shows the semantic diff for the selected asset.
-The window refreshes on focus.
-The **Refresh** control also refreshes the window.
-
-On first use, the package downloads a pinned CLI archive from GitHub Releases.
-The package extracts only `prefablens` into `Library/PrefabLens/`.
-On Windows, the file name is `prefablens.exe`.
-Git does not track this directory.
-
-To use a local CLI:
-
-1. Open Preferences > PrefabLens.
-2. Set **CLI path override** to the absolute path of `prefablens`.
-
-Alternatively, set the `PrefabLens.CliPath` EditorPrefs key to an absolute path.
-
-The CLI must run and report its version.
-A manual CLI can use a version other than the pinned version.
-If the override is invalid, PrefabLens uses a valid downloaded CLI or offers a download.
-
-| Symptom                                               | What to do                                                                                         |
-| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `Download failed: …`                                  | Retry. If the retry fails, download the release zip. Then set the CLI path override.               |
-| `CLI path override … is invalid. …`                   | Select a working `prefablens` executable. Or clear the CLI path override.                           |
-| `prefablens exited with N` / one-line CLI error       | Make sure that the project is in a git repository. Make sure that git finishes within the timeout. |
-| `Could not parse CLI output (CLI version mismatch?):` | Clear the CLI path override. Or update the CLI.                                                    |
-| `prefablens timed out after 90s and was killed`       | Make sure that `git status` is fast in the repository.                                             |
-| Changed assets never appear                           | Switch Asset Serialization to Force Text.                                                          |
-
-## Supported files
-
-PrefabLens supports text-serialized Unity assets.
-The supported extensions are `.prefab`, `.unity`, `.asset`, `.mat`, `.anim`, and `.controller`.
-PrefabLens does not support `.meta`, `.asmdef`, or other formats that are not UnityYAML.
-
 ## Development
 
 Install [mise](https://mise.jdx.dev/).
+The toolchain is Zig 0.16, Node 24, pnpm 12, and .NET 10.
 
-The toolchain is Zig 0.16, Node 24, pnpm 11, and .NET 10.
+Install the toolchain from the repository root:
 
 ```bash
 mise install
+```
 
-# Core / CLI
+### Repository layout
+
+| Directory    | Description                                                        |
+| ------------ | ------------------------------------------------------------------ |
+| `core/`      | Zig diff engine for the CLI and WASM                               |
+| `cli/`       | `prefablens` CLI tool                                              |
+| `extension/` | Chrome extension for semantic diffs on GitHub pull requests        |
+| `editor/`    | Unity Editor package for semantic diffs                            |
+| `site/`      | Live demo on Cloudflare Workers, using CLI and extension artifacts |
+
+### Build and test
+
+Run each code block from the repository root.
+
+#### Core and CLI
+
+```bash
 zig build test
 zig build run -- before.prefab after.prefab
+```
 
-# WASM (for the extension)
+#### WASM
+
+Build the WASM module for the extension:
+
+```bash
 zig build wasm
+```
 
-# Extension (build / test run zig build wasm when needed)
+#### Chrome extension
+
+The build and test commands run `zig build wasm` when needed.
+
+```bash
 (cd extension && pnpm install && pnpm run build && pnpm test)
+```
 
-# Editor (headless tests use real native CLI commands)
+#### Unity Editor
+
+These tests run on .NET with real native CLI commands and do not require Unity.
+
+```bash
 zig build test-installation-binaries -Doptimize=ReleaseSafe
 PREFABLENS_TEST_BIN_DIR="$PWD/zig-out/bin" \
 PREFABLENS_TEST_ALT_BIN_DIR="$PWD/zig-out/test-alternate-bin" \
   dotnet test editor/DotNetTests~/Tests
+```
 
-# Site (build the CLI, WASM, and extension demo bundle first: `pnpm run demo`)
+#### Site
+
+First, build the CLI, WASM module, and extension demo bundle.
+Run `pnpm run demo` in `extension/` to build the demo bundle.
+
+```bash
 (cd site && node build.mjs)
 ```
 
-Related documents:
+### Further reading
 
 - [CLI](docs/cli.md)
 - [Chrome extension](docs/extension.md)


### PR DESCRIPTION
## Summary

Group installation and usage instructions by tool in the README.
Keep each screenshot with its related instructions.

## Motivation

Readers currently move between repeated tool sections to install and use PrefabLens.

## Changes

- Group the Chrome extension, Unity Editor, and CLI instructions.
- Move shared asset requirements before setup and repository details into Development.
- Simplify the prose and link the complete list of supported file extensions.
- Split build examples into separate blocks and match the pnpm version to `mise.toml`.

## Testing

- `git diff --cached --check`: passed with no output.
- `python3 -` (README validation): passed. All 27 shell command lines and 13 external URLs match `main`.
- All 10 local links and 3 image paths resolve. Code fences are balanced.
- Git merge guidance, error messages, contribution rules, and license text are preserved.
- Application tests were not run because only `README.md` changed.
