### PR TITLE
fix: parse quoted array strings with colons

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -126,6 +126,7 @@ pub fn build(b: *std.Build) void {
     run_strategy_tests.addArtifactArg(exe);
     run_strategy_tests.addArg(installed_strategy_script);
     run_strategy_tests.addArg(b.pathFromRoot("core/src/testdata/collections"));
+    if (b.args) |args| run_strategy_tests.addArgs(args);
     run_strategy_tests.step.dependOn(&strategy_script.step);
     test_step.dependOn(&run_strategy_tests.step);
     const strategy_test_step = b.step("test-merge-strategy", "Run the native Git strategy integration tests");

--- a/cli/src/git_strategy_test_main.zig
+++ b/cli/src/git_strategy_test_main.zig
@@ -30,6 +30,10 @@ pub fn main(init: std.process.Init) !u8 {
     var env = try init.environ_map.clone(a);
     try env.put("PATH", try std.fmt.allocPrint(a, "{s}{c}{s}{c}{s}", .{ std.fs.path.dirname(prefablens).?, std.fs.path.delimiter, std.fs.path.dirname(strategy_path).?, std.fs.path.delimiter, env.get("PATH") orelse "" }));
     const ctx: Context = .{ .git = .{ .io = init.io, .arena = a, .env = &env }, .scratch = scratch, .prefablens = prefablens, .fixture_root = args[3] };
+    if (args.len == 5 and std.mem.eql(u8, args[4], "private-permissions")) {
+        if (supports_pty) try privatePermissions(ctx);
+        return 0;
+    }
     if (args.len == 5 and std.mem.eql(u8, args[4], "independent-additions")) {
         try independentAdditions(ctx);
         return 0;
@@ -334,10 +338,14 @@ fn privatePermissions(ctx: Context) !void {
         .{ .path = "Assets/A.prefab", .base = base, .ours = ours, .theirs = conflict_theirs },
         .{ .path = "Assets/B.prefab", .base = base, .ours = ours, .theirs = conflict_theirs },
     });
-    // The second file has private permissions before its UI begins. A content choice must keep them.
-    const inner = "(sleep 1.5; chmod 0600 Assets/B.prefab) & exec git merge --no-edit remote";
-    const command = try std.fmt.allocPrint(git.arena, "env PATH={s} sh -c {s}", .{ try t.shellQuote(git.arena, git.env.get("PATH").?), try t.shellQuote(git.arena, inner) });
-    const result = try pty.runCommandInPtyBatches(git.io, git.arena, git.cwd, command, "\x1b[C\r\r", "\x1b[C\r\r", 30);
+    // Delay the real driver so a fixed timer races with checkout even on a fast runner.
+    const driver = merge_git.trim(try git.output(&.{ "config", "merge.prefablens.driver" }));
+    try git.ok(&.{ "config", "merge.prefablens.driver", try std.fmt.allocPrint(git.arena, "sleep 3; {s}", .{driver}) });
+    try git.ok(&.{ "config", "core.trustctime", "true" });
+    // Changing the later file while the first UI is open avoids racing with Git's checkout.
+    // The second UI's content choice must preserve those private permissions.
+    const command = try std.fmt.allocPrint(git.arena, "env PATH={s} git merge --no-edit remote", .{try t.shellQuote(git.arena, git.env.get("PATH").?)});
+    const result = try pty.runCommandInPtyWithUiAction(git.io, git.arena, git.cwd, command, "chmod 0600 Assets/B.prefab", "\x1b[C\r\r", "\x1b[C\r\r", 30);
     try t.expectCode(result, 0, "retain private permissions during content resolution");
     try expectFile(git, "Assets/B.prefab", ours);
     const stat = try std.Io.Dir.cwd().statFile(git.io, try git.path("Assets/B.prefab"), .{});

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -595,12 +595,42 @@ pub fn runCommandInPtyThreeBatches(
     third_keys: []const u8,
     timeout_seconds: i64,
 ) !std.process.RunResult {
+    return runPty(io, arena, repository, git_command, input_keys, second_keys, third_keys, "", timeout_seconds);
+}
+
+// Concurrent changes must happen after checkout finishes and before the first UI accepts input.
+pub fn runCommandInPtyWithUiAction(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    repository: []const u8,
+    git_command: []const u8,
+    ui_action: []const u8,
+    input_keys: []const u8,
+    second_keys: []const u8,
+    timeout_seconds: i64,
+) !std.process.RunResult {
+    return runPty(io, arena, repository, git_command, input_keys, second_keys, "", ui_action, timeout_seconds);
+}
+
+fn runPty(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    repository: []const u8,
+    git_command: []const u8,
+    input_keys: []const u8,
+    second_keys: []const u8,
+    third_keys: []const u8,
+    ui_action: []const u8,
+    timeout_seconds: i64,
+) !std.process.RunResult {
     var random: [16]u8 = undefined;
     io.random(&random);
     const capture = try std.fmt.allocPrint(arena, "/tmp/prefablens-pty-{x}.log", .{random});
     defer std.Io.Dir.cwd().deleteFile(io, capture) catch {};
     const completed = try std.fmt.allocPrint(arena, "{s}.done", .{capture});
     defer std.Io.Dir.cwd().deleteFile(io, completed) catch {};
+    const action_failed = try std.fmt.allocPrint(arena, "{s}.action-failed", .{capture});
+    defer std.Io.Dir.cwd().deleteFile(io, action_failed) catch {};
     const capture_argument = try integration.shellQuote(arena, capture);
     const terminal_command = try integration.shellQuote(arena, try std.fmt.allocPrint(arena, "stty cols 100 rows 24; {s}; terminal_status=$?; : > {s}; exit \"$terminal_status\"", .{ git_command, try integration.shellQuote(arena, completed) }));
     const shell_command = switch (builtin.os.tag) {
@@ -654,6 +684,10 @@ pub fn runCommandInPtyThreeBatches(
         \\sleep 1
         \\wait_frame 1 0
         \\first_session=$observed_session
+        // Action output must not become terminal input. Keep failures visible after the UI exits.
+        \\if [ -n "$5" ]; then
+        \\  sh -c "$5" >&2 || : > "$capture_file.action-failed"
+        \\fi
         \\printf '%s' "$1"
         \\if [ -n "$2" ]; then
         \\  i=0
@@ -689,12 +723,13 @@ pub fn runCommandInPtyThreeBatches(
         \\wait "$pty_pid"
         \\status=$?
         \\trap - HUP INT TERM
+        \\if [ -e "$4.action-failed" ]; then status=125; fi
         \\exit "$status"
     ,
         .{ try integration.shellQuote(arena, frame_probe), shell_command },
     );
     return std.process.run(arena, io, .{
-        .argv = &.{ "sh", "-c", command, "prefablens-keys", input_keys, second_keys, third_keys, capture },
+        .argv = &.{ "sh", "-c", command, "prefablens-keys", input_keys, second_keys, third_keys, capture, ui_action },
         .cwd = .{ .path = repository },
         .stdout_limit = .limited(1024 * 1024),
         .stderr_limit = .limited(1024 * 1024),

--- a/core/src/fixture_test.zig
+++ b/core/src/fixture_test.zig
@@ -326,3 +326,42 @@ test "fixture: GameObject whose long name is folded still diffs its later fields
     try testing.expectEqualStrings("1", spawner.overrides[0].before.?.scalar);
     try testing.expectEqualStrings("0", spawner.overrides[0].after.?.scalar);
 }
+
+test "fixture: quoted array changes include the entire scalar and folded continuation" {
+    // Unity 6000.5.2f1 saved these ScriptableObjects. Only the array element changes;
+    // the folded pair changes only on its continuation line, which used to disappear from the diff.
+    const cases = [_]struct {
+        before: []const u8,
+        after: []const u8,
+        before_value: []const u8,
+        after_value: []const u8,
+    }{
+        .{
+            .before = @embedFile("testdata/quoted_array_before.asset"),
+            .after = @embedFile("testdata/quoted_array_after.asset"),
+            .before_value = "foo: hoge:bar",
+            .after_value = "foo: hoge:BAZ",
+        },
+        .{
+            .before = @embedFile("testdata/folded_quoted_array_before.asset"),
+            .after = @embedFile("testdata/folded_quoted_array_after.asset"),
+            .before_value = "prefix: A long string that contains several words and reaches the line width limit with enough characters",
+            .after_value = "prefix: A long string that contains several words and reaches the line width limit with enough CHARACTERS",
+        },
+    };
+    for (cases) |case| {
+        var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena_state.deinit();
+
+        const res = try root.diffBytes(arena_state.allocator(), case.before, case.after);
+
+        try testing.expectEqual(@as(usize, 0), res.roots.len);
+        try testing.expectEqual(@as(usize, 1), res.loose.len);
+        try testing.expectEqual(@as(usize, 1), res.loose[0].fields.len);
+        const field = res.loose[0].fields[0];
+        try testing.expectEqualStrings("Texts[0]", field.path);
+        try testing.expectEqual(model.Status.modified, field.status);
+        try testing.expectEqualStrings(case.before_value, field.before.?.scalar);
+        try testing.expectEqualStrings(case.after_value, field.after.?.scalar);
+    }
+}

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -284,6 +284,83 @@ test "parse: block sequence of plain scalars" {
     try testing.expectEqualStrings("Water", layers.seq[1].scalar);
 }
 
+test "parse: quoted array elements keep colons inside the scalar" {
+    const cases = [_]struct { yaml: []const u8, value: []const u8 }{
+        .{ .yaml = "'foo:hoge:bar'", .value = "foo:hoge:bar" },
+        .{ .yaml = "'foo: hoge:bar'", .value = "foo: hoge:bar" },
+        .{ .yaml = "\"foo: hoge:bar\"", .value = "foo: hoge:bar" },
+        .{ .yaml = "'it''s: a value'", .value = "it's: a value" },
+        .{ .yaml = "\"say \\\"hello: world\\\"\"", .value = "say \"hello: world\"" },
+        .{ .yaml = "\"C:\\\\path: value\"", .value = "C:\\path: value" },
+    };
+    for (cases) |case| {
+        var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        const src = try std.fmt.allocPrint(arena, "--- !u!114 &1\nMonoBehaviour:\n  texts:\n  - {s}\n", .{case.yaml});
+
+        const doc = try parseOne(arena, src);
+        const parsed = try parseSpanned(arena, src);
+
+        // Both diff and merge parsing must keep the complete array element and its source span.
+        try testing.expectEqual(@as(usize, 1), parsed.documents.len);
+        try testing.expectEqual(@as(usize, 0), parsed.diagnostics.len);
+        for ([_]Document{ doc, parsed.documents[0] }) |document| {
+            const items = model.findValue(document.body.map, "texts").?.seq;
+            try testing.expectEqual(@as(usize, 1), items.len);
+            try testing.expect(items[0].* == .scalar);
+            try testing.expectEqualStrings(case.value, items[0].scalar);
+        }
+        const item = model.findValue(parsed.documents[0].body.map, "texts").?.seq[0];
+        try testing.expectEqualStrings(case.yaml, parsed.nodeBytes(item).?);
+    }
+}
+
+test "parse: folded quoted array elements keep continuations and the next item" {
+    for ([_]u8{ '\'', '"' }) |quote| {
+        var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        // Unity aligns scalar continuations two spaces past the dash, just like later map keys.
+        const src = try std.fmt.allocPrint(
+            arena,
+            "--- !u!114 &1\nMonoBehaviour:\n  texts:\n  - {c}prefix: first\n    second{c}\n  - next\n  m_Enabled: 1\n",
+            .{ quote, quote },
+        );
+
+        const doc = try parseOne(arena, src);
+
+        const items = model.findValue(doc.body.map, "texts").?.seq;
+        try testing.expectEqual(@as(usize, 2), items.len);
+        try testing.expect(items[0].* == .scalar);
+        try testing.expectEqualStrings("prefix: first second", items[0].scalar);
+        try testing.expectEqualStrings("next", items[1].scalar);
+        try testing.expectEqualStrings("1", model.findValue(doc.body.map, "m_Enabled").?.scalar);
+    }
+}
+
+test "parse: quoted keys and apostrophes in plain keys remain map entries" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    // Quotes around a key do not quote the entire mapping; an apostrophe inside a plain key is literal.
+    const src =
+        \\--- !u!114 &1
+        \\MonoBehaviour:
+        \\  items:
+        \\  - 'key': first
+        \\    other: second
+        \\  - can't: third
+    ;
+
+    const doc = try parseOne(arena_state.allocator(), src);
+
+    const items = model.findValue(doc.body.map, "items").?.seq;
+    try testing.expectEqual(@as(usize, 2), items.len);
+    try testing.expectEqualStrings("first", model.findValue(items[0].map, "'key'").?.scalar);
+    try testing.expectEqualStrings("second", model.findValue(items[0].map, "other").?.scalar);
+    try testing.expectEqualStrings("third", model.findValue(items[1].map, "can't").?.scalar);
+}
+
 test "parse: same-indent sequence inside a sequence map item" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -1129,10 +1206,26 @@ const KV = struct { key: []const u8, value: []const u8, has_colon: bool };
 
 // Split "key: value" / "key:" at the first ": " or a trailing ":".
 // Don't split inside a flow value (the value starts after the first colon).
-fn splitKeyValue(line: []const u8) KV {
-    // Find the first ":" followed by a space or end of line.
+fn splitKeyValue(raw: []const u8) KV {
+    const line = std.mem.trimStart(u8, raw, " ");
+    // A colon inside quotes belongs to the scalar; a colon after the closing quote can separate a key.
+    var quote: ?u8 = null;
     var i: usize = 0;
     while (i < line.len) : (i += 1) {
+        if (quote) |delimiter| {
+            if (delimiter == '"' and line[i] == '\\') {
+                i += 1;
+            } else if (line[i] == delimiter) {
+                if (delimiter == '\'' and i + 1 < line.len and line[i + 1] == '\'') {
+                    i += 1;
+                } else quote = null;
+            }
+            continue;
+        }
+        if (i == 0 and (line[i] == '\'' or line[i] == '"')) {
+            quote = line[i];
+            continue;
+        }
         if (line[i] == ':' and (i + 1 == line.len or line[i + 1] == ' ')) {
             const key = std.mem.trim(u8, line[0..i], " ");
             const value = std.mem.trim(u8, line[i + 1 ..], " ");

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -1208,24 +1208,25 @@ const KV = struct { key: []const u8, value: []const u8, has_colon: bool };
 // Don't split inside a flow value (the value starts after the first colon).
 fn splitKeyValue(raw: []const u8) KV {
     const line = std.mem.trimStart(u8, raw, " ");
-    // A colon inside quotes belongs to the scalar; a colon after the closing quote can separate a key.
-    var quote: ?u8 = null;
     var i: usize = 0;
-    while (i < line.len) : (i += 1) {
-        if (quote) |delimiter| {
+    // Only a leading quote can hide separators. Keep quote handling out of the scan for plain keys.
+    if (line.len > 0 and (line[0] == '\'' or line[0] == '"')) {
+        const delimiter = line[0];
+        i = 1;
+        while (i < line.len) : (i += 1) {
             if (delimiter == '"' and line[i] == '\\') {
                 i += 1;
             } else if (line[i] == delimiter) {
                 if (delimiter == '\'' and i + 1 < line.len and line[i + 1] == '\'') {
                     i += 1;
-                } else quote = null;
+                } else {
+                    i += 1;
+                    break;
+                }
             }
-            continue;
         }
-        if (i == 0 and (line[i] == '\'' or line[i] == '"')) {
-            quote = line[i];
-            continue;
-        }
+    }
+    while (i < line.len) : (i += 1) {
         if (line[i] == ':' and (i + 1 == line.len or line[i + 1] == ' ')) {
             const key = std.mem.trim(u8, line[0..i], " ");
             const value = std.mem.trim(u8, line[i + 1 ..], " ");

--- a/core/src/testdata/folded_quoted_array_after.asset
+++ b/core/src/testdata/folded_quoted_array_after.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35dfc2189b56948e4894885f2f34e602, type: 3}
+  m_Name: Case3
+  m_EditorClassIdentifier: Assembly-CSharp::QuotedArrayReviewData
+  texts:
+  - 'prefix: A long string that contains several words and reaches the line width
+    limit with enough CHARACTERS'

--- a/core/src/testdata/folded_quoted_array_before.asset
+++ b/core/src/testdata/folded_quoted_array_before.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35dfc2189b56948e4894885f2f34e602, type: 3}
+  m_Name: Case3
+  m_EditorClassIdentifier: Assembly-CSharp::QuotedArrayReviewData
+  texts:
+  - 'prefix: A long string that contains several words and reaches the line width
+    limit with enough characters'

--- a/core/src/testdata/quoted_array_after.asset
+++ b/core/src/testdata/quoted_array_after.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35dfc2189b56948e4894885f2f34e602, type: 3}
+  m_Name: Case2
+  m_EditorClassIdentifier: Assembly-CSharp::QuotedArrayReviewData
+  texts:
+  - 'foo: hoge:BAZ'

--- a/core/src/testdata/quoted_array_before.asset
+++ b/core/src/testdata/quoted_array_before.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 35dfc2189b56948e4894885f2f34e602, type: 3}
+  m_Name: Case2
+  m_EditorClassIdentifier: Assembly-CSharp::QuotedArrayReviewData
+  texts:
+  - 'foo: hoge:bar'


### PR DESCRIPTION
## Summary

Parse quoted string array elements as scalars when they contain `: `. Single-line edits and folded continuation edits now report the complete value at `Texts[0]`.

## Motivation

Follow-up to the folded-value support in #334; related to #328.

Previously, changing `'foo: hoge:bar'` to `'foo: hoge:BAZ'` produced the malformed field path `Texts[0].'foo`. Changes on a folded continuation line could produce an empty diff.

## Changes

- Make `splitKeyValue` ignore separators inside single or double quotes while preserving separators after closing quotes.
- Keep quote handling outside the colon scan for plain keys to avoid extra work on each byte.
- Handle escaped quotes and doubled apostrophes without interpreting apostrophes inside plain keys as quote delimiters.
- Add parser regression tests and two fixture pairs generated by Unity 6000.5.2f1. Existing parser and fixture tests are unchanged.
- Wait for the first merge UI frame before changing the later file's permissions in the Git strategy integration test. Keep a delayed real merge driver to cover slow CI runners.

## Testing

- [CI](https://github.com/hashiiiii/PrefabLens/actions/runs/34106895481): all jobs passed at `d5473b3`. The Linux diff benchmark completed in 561 ms against the 600 ms limit.
- `zig build test-merge-strategy --summary all -- private-permissions`: passed with delayed merge startup; the old timer reproduced the macOS CI failure under the same delay.
- `zig build test lint wasm --summary all`: 593/593 tests passed, including Git and PTY integration tests.
- `zig build -Doptimize=ReleaseSafe --summary all`: passed.
- `node --test core/tests/*.test.mjs`: passed, 7/7 WASM tests.
- `zig build perf --summary all`: 50,000 objects diffed in 224 ms (600 ms ceiling); 50,000 meta files scanned in 293 ms (1,200 ms ceiling).
- `zig build perf -Dtarget=x86_64-macos --summary all`: passed. Three alternating benchmark runs measured 376–380 ms before separating the quote scan and 359–366 ms after it.
- CLI reproduction on the preserved Unity files: all six cases passed across both inline mapping settings.
- The bug regression tests failed on main before the fix, reproducing the scalar misclassification and malformed field path.
