### PR TITLE
feat: add merge setup scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,24 +135,28 @@ PrefabLens uses Git **2.39** or later to resolve UnityYAML conflicts during `git
 Install `prefablens` and the packaged `git-merge-prefablens` script on `PATH`.
 The script runs `prefablens merge-strategy`.
 
-For a single clone, run:
+Choose a setup scope:
 
-```bash
-prefablens setup-merge
-```
+| Command | Attributes | Git configuration |
+| --- | --- | --- |
+| `prefablens setup-merge --project` | Shared `.gitattributes` | Current clone |
+| `prefablens setup-merge --local` | `.git/info/attributes` | Current clone |
+| `prefablens setup-merge --user` | User attributes file | Global |
 
-This command adds local Git configuration for the repository.
-It also adds UnityYAML attributes to `.git/info/attributes`.
+Without a flag, `prefablens setup-merge` uses `--local`.
+Run local and project setup inside a Git working tree.
+Outside a working tree, the command explains this requirement and suggests `--user`.
 
-For a team, use shared attributes:
+With `--project`, commit the generated `.gitattributes` to share the rules.
+Each clone needs setup unless the user has already configured merge integration with `--user`.
+Git does not share merge driver configuration through `.gitattributes`.
 
-```bash
-prefablens setup-merge --team
-```
+User setup works outside repositories.
+It uses the global `core.attributesFile` setting or Git's default user attributes file, usually `~/.config/git/attributes`.
+It selects PrefabLens as the default merge strategy in all your repositories, including repositories without Unity files.
+Existing repository settings can override these user defaults.
+See [setup scopes](docs/cli.md#setup-scopes) for attribute paths and precedence.
 
-Commit the generated `.gitattributes`.
-
-Each clone requires this setup command once.
 This setup keeps existing attributes and unrelated Git configuration.
 
 Use the normal merge command:

--- a/build.zig
+++ b/build.zig
@@ -131,6 +131,22 @@ pub fn build(b: *std.Build) void {
     const strategy_test_step = b.step("test-merge-strategy", "Run the native Git strategy integration tests");
     strategy_test_step.dependOn(&run_strategy_tests.step);
 
+    const setup_tests = b.addExecutable(.{
+        .name = "merge-setup-tests",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("cli/src/merge_setup_test_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_setup_tests = b.addRunArtifact(setup_tests);
+    run_setup_tests.addArtifactArg(exe);
+    run_setup_tests.addArg(installed_strategy_script);
+    run_setup_tests.step.dependOn(&strategy_script.step);
+    test_step.dependOn(&run_setup_tests.step);
+    const setup_test_step = b.step("test-merge-setup", "Run merge setup scope integration tests");
+    setup_test_step.dependOn(&run_setup_tests.step);
+
     // Real alternate-release commands expose mixed installations without a runtime version override.
     const alternate_opts = b.addOptions();
     alternate_opts.addOption([]const u8, "version", zon.version ++ "-installation-test");

--- a/cli/src/git_strategy_test_main.zig
+++ b/cli/src/git_strategy_test_main.zig
@@ -62,7 +62,6 @@ pub fn main(init: std.process.Init) !u8 {
         try candidateEncoding(ctx);
         return 0;
     }
-    try setup(ctx);
     try automatic(ctx);
     try nonInteractive(ctx);
     try guards(ctx);
@@ -191,33 +190,6 @@ fn contentPty(ctx: Context) !void {
     try git.ok(&.{ "add", "Assets/A.prefab" });
     try git.ok(&.{ "commit", "--no-edit" });
 }
-fn setup(ctx: Context) !void {
-    for ([_]bool{ false, true }) |team| {
-        const git = try ctx.repo(if (team) "setup-team" else "setup-local", &.{.{ .path = "Assets/A.prefab", .base = base, .ours = ours, .theirs = theirs }});
-        const path = if (team) ".gitattributes" else ".git/info/attributes";
-        try write(git, path, "# Existing project rule.\n*.txt text\n");
-        try git.ok(&.{ "config", "prefablens.test.setting", "keep" });
-        for (0..2) |_| {
-            const result = try std.process.run(git.arena, git.io, .{
-                .argv = if (team) &.{ ctx.prefablens, "setup-merge", "--team" } else &.{ ctx.prefablens, "setup-merge" },
-                .cwd = .{ .path = git.cwd },
-                .environ_map = git.env,
-            });
-            try t.expectCode(result, 0, "repository merge setup");
-        }
-        const attributes = try std.Io.Dir.cwd().readFileAlloc(git.io, try git.path(path), git.arena, .limited(1024 * 1024));
-        try t.require(std.mem.startsWith(u8, attributes, "# Existing project rule.\n*.txt text\n"), "setup removed existing attributes");
-        try t.require(std.mem.count(u8, attributes, "*.prefab merge=prefablens") == 1, "repeated setup duplicated attributes");
-        try t.require(std.mem.eql(u8, merge_git.trim(try git.output(&.{ "config", "prefablens.test.setting" })), "keep"), "setup changed unrelated config");
-        if (team) {
-            try git.ok(&.{ "add", ".gitattributes" });
-            try git.ok(&.{ "commit", "-qm", "Share merge attributes" });
-        }
-        try t.expectCode(try git.run(&.{ "merge", "--no-edit", "remote" }), 0, "merge after automatic setup");
-        try expectFile(git, "Assets/A.prefab", merged);
-    }
-}
-
 fn directoryConflict(ctx: Context) !void {
     const git = try ctx.repo("directory-conflict", &.{
         .{ .path = "Assets/A.prefab", .base = base, .ours = ours, .theirs = theirs },

--- a/cli/src/installation_test_main.zig
+++ b/cli/src/installation_test_main.zig
@@ -156,9 +156,9 @@ fn read(git: Git, path: []const u8) ![]const u8 {
     return std.Io.Dir.cwd().readFileAlloc(git.io, try git.path(path), git.arena, .limited(1024 * 1024));
 }
 
-fn setup(ctx: Context, git: Git, team: bool) !std.process.RunResult {
+fn setup(ctx: Context, git: Git, project: bool) !std.process.RunResult {
     return std.process.run(git.arena, git.io, .{
-        .argv = if (team) &.{ ctx.artifacts[0], "setup-merge", "--team" } else &.{ ctx.artifacts[0], "setup-merge" },
+        .argv = if (project) &.{ ctx.artifacts[0], "setup-merge", "--project" } else &.{ ctx.artifacts[0], "setup-merge" },
         .cwd = .{ .path = git.cwd },
         .environ_map = git.env,
         .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(30) } },
@@ -171,14 +171,14 @@ fn setupCase(ctx: Context, case: SetupCase) !void {
     const strategy = if (case.split) try ctx.layout(try std.fmt.allocPrint(a, "{s}-strategy", .{case.name}), .missing, case.strategy, false) else primary;
     const exec_path = try ctx.layout(try std.fmt.allocPrint(a, "{s}-exec", .{case.name}), case.exec_primary, case.exec_strategy, false);
     var env = try ctx.environment(&.{ primary, strategy }, exec_path);
-    for ([_]bool{ false, true }) |team| {
-        var git = try ctx.repo(try std.fmt.allocPrint(a, "{s}-{s}", .{ case.name, if (team) "team" else "local" }));
+    for ([_]bool{ false, true }) |project| {
+        var git = try ctx.repo(try std.fmt.allocPrint(a, "{s}-{s}", .{ case.name, if (project) "project" else "local" }));
         git.env = &env;
-        const attributes_path = if (team) ".gitattributes" else ".git/info/attributes";
+        const attributes_path = if (project) ".gitattributes" else ".git/info/attributes";
         const attributes = "# Keep the project rules.\n*.txt text\n";
         try std.Io.Dir.cwd().writeFile(git.io, .{ .sub_path = try git.path(attributes_path), .data = attributes });
         const config = try read(git, ".git/config");
-        const result = try setup(ctx, git, team);
+        const result = try setup(ctx, git, project);
         try t.expectCode(result, if (case.valid) 0 else 2, case.name);
         if (!case.valid) {
             try t.expectFile(git.io, a, git.cwd, attributes_path, attributes);
@@ -188,7 +188,7 @@ fn setupCase(ctx: Context, case: SetupCase) !void {
             continue;
         }
         try t.require(std.mem.eql(u8, merge_git.trim(try git.output(&.{ "config", "merge.prefablens.driver" })), driver), "setup pinned the driver to an installation path");
-        if (team) {
+        if (project) {
             try git.ok(&.{ "add", ".gitattributes" });
             try git.ok(&.{ "commit", "-qm", "Share merge rules" });
         }

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -789,9 +789,10 @@ pub const ArgError = error{ MissingOperands, UnknownFlag, TooManyArguments, Conf
 
 const usage_line = "usage: prefablens [--json|--html] [--open] [--project DIR|--no-project] [--color|--no-color] [<ref>] [<ref>] [<path>] | <before> <after>\n";
 
-const help_text = usage_line ++
-    \\
-    \\Git merge setup: prefablens setup-merge [--team]
+const help_text = usage_line ++ "\nGit merge setup: " ++ merge_setup.usage ++ "\n" ++
+    \\  --project              Share .gitattributes; configure the current clone
+    \\  --local                Configure the current clone (default)
+    \\  --user                 Configure all your repositories with global settings
     \\
     \\Operands ending in a Unity YAML extension (.prefab, .unity, .asset, ...)
     \\are paths; anything else is a git ref.
@@ -1345,7 +1346,9 @@ pub fn main(init: std.process.Init) !u8 {
             merge_setup.run(init.io, arena, setup_args, init.environ_map, stdout) catch |err| {
                 if (!try installation.writeError(stderr, err)) switch (err) {
                     error.Git239Required => try stderr.writeAll("prefablens: Automatic merge needs Git 2.39 or later.\n"),
-                    error.InvalidSetupArguments => try stderr.writeAll("usage: prefablens setup-merge [--team]\n"),
+                    error.InvalidSetupArguments => try stderr.writeAll("usage: " ++ merge_setup.usage ++ "\n"),
+                    error.SetupRequiresRepository => try stderr.writeAll("prefablens: Merge setup requires a Git working tree.\nRun this command inside a repository, or use: prefablens setup-merge --user\n"),
+                    error.InvalidUserAttributesPath => try stderr.writeAll("prefablens: Global core.attributesFile must name an absolute path or start with ~/.\nSet it with git config --global core.attributesFile <path>, then run setup again.\n"),
                     else => try stderr.print("prefablens: Merge setup failed: {s}.\n", .{@errorName(err)}),
                 };
                 break :blk @as(u8, 2);

--- a/cli/src/merge_setup.zig
+++ b/cli/src/merge_setup.zig
@@ -4,14 +4,69 @@ const atomic_file = @import("atomic_file.zig");
 const unity_path = @import("unity_path.zig");
 const installation = @import("installation.zig");
 
+const Scope = enum { project, local, user };
+pub const usage = "prefablens setup-merge [--project|--local|--user]";
+
+fn parseScope(args: []const []const u8) !Scope {
+    if (args.len == 0) return .local;
+    if (args.len != 1) return error.InvalidSetupArguments;
+    if (std.mem.eql(u8, args[0], "--project")) return .project;
+    if (std.mem.eql(u8, args[0], "--local")) return .local;
+    if (std.mem.eql(u8, args[0], "--user")) return .user;
+    return error.InvalidSetupArguments;
+}
+
+const UserAttributes = struct {
+    path: []const u8,
+    default_path: ?[]const u8,
+};
+
+fn userAttributes(git: merge_git.Git) !UserAttributes {
+    const xdg = git.env.get("XDG_CONFIG_HOME") orelse "";
+    const default = if (xdg.len == 0) "~/.config/git/attributes" else try std.fs.path.join(git.arena, &.{ xdg, "git/attributes" });
+    // Git expands home paths on every platform, including values in included user configuration.
+    const configured = try git.run(&.{ "config", "--global", "--includes", "--path", "--null", "--get", "core.attributesFile" });
+    const missing = merge_git.exitCode(configured) == 1;
+    if (!missing and merge_git.exitCode(configured) != 0) {
+        try std.Io.File.stderr().writeStreamingAll(git.io, configured.stderr);
+        return error.GitFailed;
+    }
+    const output = if (missing)
+        try git.output(&.{ "config", "--global", "--includes", "--path", "--null", "--get", "--default", default, "core.attributesFile" })
+    else
+        configured.stdout;
+    const path = std.mem.trimEnd(u8, output, "\x00");
+    // Relative global paths select a different file in each repository and cannot provide user-wide setup.
+    if (!std.fs.path.isAbsolute(path)) return error.InvalidUserAttributesPath;
+    // User attributes are often symlinked from dotfiles; update the target without replacing the link.
+    const resolved = std.Io.Dir.cwd().realPathFileAlloc(git.io, path, git.arena) catch |err| switch (err) {
+        error.FileNotFound => path,
+        else => return err,
+    };
+    return .{ .path = resolved, .default_path = if (missing) default else null };
+}
+
 pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, env: *std.process.Environ.Map, stdout: *std.Io.Writer) !void {
-    const team = args.len == 1 and std.mem.eql(u8, args[0], "--team");
-    if (args.len != 0 and !team) return error.InvalidSetupArguments;
+    const scope = try parseScope(args);
     var git: merge_git.Git = .{ .io = io, .arena = arena, .env = env };
     if (!(try merge_git.version(git)).atLeast(2, 39)) return error.Git239Required;
-    git.cwd = merge_git.trim(try git.output(&.{ "rev-parse", "--show-toplevel" }));
+    if (scope != .user) {
+        const root = git.output(&.{ "rev-parse", "--show-toplevel" }) catch |err| {
+            return if (err == error.GitFailed) error.SetupRequiresRepository else err;
+        };
+        git.cwd = merge_git.trim(root);
+    }
     try installation.requireCompatible(git);
-    const path = if (team) try git.path(".gitattributes") else merge_git.trim(try git.output(&.{ "rev-parse", "--git-path", "info/attributes" }));
+    var default_user_path: ?[]const u8 = null;
+    const path = switch (scope) {
+        .project => try git.path(".gitattributes"),
+        .local => merge_git.trim(try git.output(&.{ "rev-parse", "--git-path", "info/attributes" })),
+        .user => blk: {
+            const attributes = try userAttributes(git);
+            default_user_path = attributes.default_path;
+            break :blk attributes.path;
+        },
+    };
     const absolute = if (std.fs.path.isAbsolute(path)) path else try git.path(path);
     const old = std.Io.Dir.cwd().readFileAlloc(io, absolute, arena, .limited(1024 * 1024)) catch |err| switch (err) {
         error.FileNotFound => "",
@@ -31,13 +86,16 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, env: 
     }
     try std.Io.Dir.cwd().createDirPath(io, std.fs.path.dirname(absolute).?);
     if (!std.mem.eql(u8, old, attributes.items)) try atomic_file.replace(io, arena, absolute, if (old.len == 0) null else old, attributes.items);
-    try git.ok(&.{ "config", "--local", "merge.prefablens.name", "PrefabLens semantic Unity YAML merge" });
-    try git.ok(&.{ "config", "--local", "merge.prefablens.driver", "prefablens merge-driver %O %A %B %P %L" });
+    // A system attributesFile setting would otherwise prevent Git from reading the fallback user file.
+    if (default_user_path) |default| try git.ok(&.{ "config", "--global", "core.attributesFile", default });
+    const config_scope = if (scope == .user) "--global" else "--local";
+    try git.ok(&.{ "config", config_scope, "merge.prefablens.name", "PrefabLens semantic Unity YAML merge" });
+    try git.ok(&.{ "config", config_scope, "merge.prefablens.driver", "prefablens merge-driver %O %A %B %P %L" });
     // Virtual merge bases must not ask for semantic decisions or contain a selected partial result.
-    try git.ok(&.{ "config", "--local", "merge.prefablens.recursive", "text" });
-    try git.ok(&.{ "config", "--local", "mergetool.prefablens.cmd", "prefablens mergetool \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"" });
-    try git.ok(&.{ "config", "--local", "mergetool.prefablens.trustExitCode", "true" });
-    try git.ok(&.{ "config", "--local", "pull.twohead", "prefablens" });
-    try stdout.writeAll("PrefabLens merge is ready for this repository. Run git merge as usual.\n");
-    if (team) try stdout.writeAll("Share .gitattributes with your team. Each clone must run prefablens setup-merge --team once.\n");
+    try git.ok(&.{ "config", config_scope, "merge.prefablens.recursive", "text" });
+    try git.ok(&.{ "config", config_scope, "mergetool.prefablens.cmd", "prefablens mergetool \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"" });
+    try git.ok(&.{ "config", config_scope, "mergetool.prefablens.trustExitCode", "true" });
+    try git.ok(&.{ "config", config_scope, "pull.twohead", "prefablens" });
+    try stdout.print("PrefabLens merge is ready for {s}. Run git merge as usual.\n", .{if (scope == .user) "your repositories" else "this repository"});
+    if (scope == .project) try stdout.writeAll("Commit .gitattributes to share the rules. Each clone needs setup unless your user configuration already provides it.\n");
 }

--- a/cli/src/merge_setup_test_main.zig
+++ b/cli/src/merge_setup_test_main.zig
@@ -1,0 +1,334 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const t = @import("git_merge_test_main.zig");
+const merge_git = @import("merge_git.zig");
+const Git = merge_git.Git;
+
+const base = "--- !u!114 &1\nMonoBehaviour:\n  m_Left: 1\n  m_Right: 1\n";
+const ours = "--- !u!114 &1\nMonoBehaviour:\n  m_Left: 2\n  m_Right: 1\n";
+const theirs = "--- !u!114 &1\nMonoBehaviour:\n  m_Left: 1\n  m_Right: 3\n";
+const merged = "--- !u!114 &1\nMonoBehaviour:\n  m_Left: 2\n  m_Right: 3\n";
+const existing_attributes = "# Keep existing rules.\n*.txt text";
+
+const Context = struct {
+    git: Git,
+    root: []const u8,
+    prefablens: []const u8,
+
+    fn setup(self: Context, git: Git, flags: []const []const u8) !std.process.RunResult {
+        return std.process.run(git.arena, git.io, .{
+            .argv = try std.mem.concat(git.arena, []const u8, &.{ &.{ self.prefablens, "setup-merge" }, flags }),
+            .cwd = .{ .path = git.cwd },
+            .environ_map = git.env,
+            .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(30) } },
+        });
+    }
+
+    fn repo(self: Context, name: []const u8) !Git {
+        var git = self.git;
+        git.cwd = try std.fs.path.join(git.arena, &.{ self.root, name });
+        try t.prepareRepository(git.io, git.arena, git.cwd, self.prefablens, .local, &.{.{
+            .path = "Assets/A.prefab",
+            .base = base,
+            .ours = ours,
+            .theirs = theirs,
+        }});
+        // Fixture merge settings would hide a setup command that failed to install its own settings.
+        try git.ok(&.{ "config", "--local", "--remove-section", "merge.prefablens" });
+        try git.ok(&.{ "config", "--local", "--unset", "core.attributesFile" });
+        try std.Io.Dir.cwd().deleteFile(git.io, try git.path(".git/info/attributes"));
+        return git;
+    }
+
+    fn isolated(self: Context, name: []const u8, xdg: bool) !Context {
+        const a = self.git.arena;
+        const root = try std.fs.path.join(a, &.{ self.root, name });
+        const user_dir = try std.fs.path.join(a, &.{ root, "user" });
+        const outside = try std.fs.path.join(a, &.{ root, "outside" });
+        try std.Io.Dir.cwd().createDirPath(self.git.io, user_dir);
+        try std.Io.Dir.cwd().createDirPath(self.git.io, outside);
+        const env = try a.create(std.process.Environ.Map);
+        env.* = try self.git.env.clone(a);
+        // Child processes must never read or write the developer's user configuration.
+        for ([_][]const u8{ "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_CONFIG", "GIT_CONFIG_PARAMETERS", "XDG_CONFIG_HOME" }) |key| _ = env.swapRemove(key);
+        try env.put("HOME", user_dir);
+        try env.put("GIT_CONFIG_GLOBAL", try std.fs.path.join(a, &.{ user_dir, ".gitconfig" }));
+        try env.put("GIT_CONFIG_NOSYSTEM", "1");
+        try env.put("GIT_CONFIG_COUNT", "0");
+        try env.put("GIT_ATTR_NOSYSTEM", "1");
+        try env.put("GIT_CEILING_DIRECTORIES", root);
+        if (xdg) try env.put("XDG_CONFIG_HOME", try std.fs.path.join(a, &.{ root, "config" }));
+        return .{ .git = .{ .io = self.git.io, .arena = a, .env = env, .cwd = outside }, .root = root, .prefablens = self.prefablens };
+    }
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    const args = try init.minimal.args.toSlice(a);
+    const scratch = try t.scratchDirectory(init.io, a, "setup space 日本語");
+    defer std.Io.Dir.cwd().deleteTree(init.io, scratch) catch {};
+    const prefablens = try std.Io.Dir.cwd().realPathFileAlloc(init.io, args[1], a);
+    const script = try std.Io.Dir.cwd().realPathFileAlloc(init.io, args[2], a);
+    var env = try init.environ_map.clone(a);
+    try env.put("PATH", try std.fmt.allocPrint(a, "{s}{c}{s}{c}{s}", .{ std.fs.path.dirname(prefablens).?, std.fs.path.delimiter, std.fs.path.dirname(script).?, std.fs.path.delimiter, env.get("PATH") orelse "" }));
+    const ctx: Context = .{ .git = .{ .io = init.io, .arena = a, .env = &env }, .root = scratch, .prefablens = prefablens };
+    const cases = .{ repositoryScopes, linkedWorktree, outsideRepository, invalidArguments, newUser, userScopes, systemAttributes, invalidUserPaths, userInstallationFailure };
+    var failures: usize = 0;
+    inline for (cases) |case| {
+        case(ctx) catch |err| {
+            std.debug.print("merge setup case failed: {s}\n", .{@errorName(err)});
+            failures += 1;
+        };
+    }
+    if (failures != 0) return 1;
+    try std.Io.File.stdout().writeStreamingAll(init.io, "merge setup integration: passed\n");
+    return 0;
+}
+
+fn read(git: Git, path: []const u8) ![]const u8 {
+    return std.Io.Dir.cwd().readFileAlloc(git.io, path, git.arena, .limited(1024 * 1024));
+}
+
+fn write(git: Git, path: []const u8, bytes: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(git.io, std.fs.path.dirname(path).?);
+    try std.Io.Dir.cwd().writeFile(git.io, .{ .sub_path = path, .data = bytes });
+}
+
+fn expectAbsent(git: Git, path: []const u8) !void {
+    std.Io.Dir.cwd().access(git.io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    std.debug.print("unexpected setup file: {s}\n", .{path});
+    return error.TestFailed;
+}
+
+fn expectAttributes(git: Git, path: []const u8) !void {
+    const attributes = try read(git, path);
+    try t.require(std.mem.startsWith(u8, attributes, existing_attributes ++ "\n"), "setup removed existing attributes or joined two rules");
+    try t.require(std.mem.count(u8, attributes, "*.prefab merge=prefablens\n") == 1, "setup omitted or duplicated the prefab rule");
+    const actual = try git.output(&.{ "check-attr", "merge", "--", "Assets/A.prefab", "Assets/A.unity", "Notes/A.txt" });
+    try t.require(std.mem.eql(u8, actual, "Assets/A.prefab: merge: prefablens\nAssets/A.unity: merge: prefablens\nNotes/A.txt: merge: unspecified\n"), "setup did not select the driver for Unity files");
+}
+
+fn expectConfiguration(git: Git, scope: []const u8) !void {
+    const expected = [_][2][]const u8{
+        .{ "merge.prefablens.name", "PrefabLens semantic Unity YAML merge" },
+        .{ "merge.prefablens.driver", "prefablens merge-driver %O %A %B %P %L" },
+        .{ "merge.prefablens.recursive", "text" },
+        .{ "mergetool.prefablens.cmd", "prefablens mergetool \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"" },
+        .{ "mergetool.prefablens.trustExitCode", "true" },
+        .{ "pull.twohead", "prefablens" },
+    };
+    for (expected) |entry| {
+        const actual = merge_git.trim(try git.output(&.{ "config", scope, "--get", entry[0] }));
+        try t.require(std.mem.eql(u8, actual, entry[1]), "setup wrote the wrong merge configuration or scope");
+    }
+}
+
+fn expectMerge(git: Git) !void {
+    try t.expectCode(try git.run(&.{ "merge", "--no-edit", "remote" }), 0, "merge after setup");
+    try t.expectFile(git.io, git.arena, git.cwd, "Assets/A.prefab", merged);
+}
+
+fn repositoryScopes(parent: Context) !void {
+    const ctx = try parent.isolated("repository-scopes", false);
+    try ctx.git.ok(&.{ "config", "--global", "prefablens.test.setting", "keep" });
+    const global_path = ctx.git.env.get("GIT_CONFIG_GLOBAL").?;
+    const global_before = try read(ctx.git, global_path);
+    const cases = [_]struct { name: []const u8, flags: []const []const u8, project: bool = false }{
+        .{ .name = "default", .flags = &.{} },
+        .{ .name = "local", .flags = &.{"--local"} },
+        .{ .name = "project", .flags = &.{"--project"}, .project = true },
+    };
+    for (cases) |case| {
+        var git = try ctx.repo(case.name);
+        const path = try git.path(if (case.project) ".gitattributes" else ".git/info/attributes");
+        try write(git, path, existing_attributes);
+        try git.ok(&.{ "config", "--local", "prefablens.test.setting", "keep" });
+        // Setup from a subdirectory must still write attributes at the repository root.
+        git.cwd = try git.path("Assets");
+        for (0..2) |_| try t.expectCode(try ctx.setup(git, case.flags), 0, case.name);
+        git.cwd = std.fs.path.dirname(git.cwd).?;
+        try expectAttributes(git, path);
+        try expectConfiguration(git, "--local");
+        try t.require(std.mem.eql(u8, try read(git, global_path), global_before), "repository setup modified global configuration");
+        try t.require(std.mem.eql(u8, merge_git.trim(try git.output(&.{ "config", "--local", "prefablens.test.setting" })), "keep"), "setup changed unrelated local configuration");
+        try expectAbsent(git, try git.path(if (case.project) ".git/info/attributes" else ".gitattributes"));
+        if (case.project) {
+            try git.ok(&.{ "add", ".gitattributes" });
+            try git.ok(&.{ "commit", "-qm", "Share merge attributes" });
+        }
+        try expectMerge(git);
+    }
+}
+
+fn linkedWorktree(parent: Context) !void {
+    const ctx = try parent.isolated("linked-worktree", false);
+    var git = try ctx.repo("repo");
+    const path = try std.fs.path.join(git.arena, &.{ ctx.root, "linked" });
+    try git.ok(&.{ "worktree", "add", "-q", "-b", "linked", path });
+    const attributes = try git.path(".git/info/attributes");
+    try write(git, attributes, existing_attributes);
+    git.cwd = path;
+    try t.expectCode(try ctx.setup(git, &.{"--local"}), 0, "setup in a linked worktree");
+    try expectAttributes(git, attributes);
+    try expectConfiguration(git, "--local");
+    try expectMerge(git);
+}
+
+fn outsideRepository(parent: Context) !void {
+    const ctx = try parent.isolated("outside-repository", false);
+    const bare_path = try std.fs.path.join(ctx.git.arena, &.{ ctx.root, "bare.git" });
+    try ctx.git.ok(&.{ "init", "--bare", "-q", bare_path });
+    for ([_][]const u8{ ctx.git.cwd, bare_path }) |path| {
+        var git = ctx.git;
+        git.cwd = path;
+        for ([_][]const []const u8{ &.{}, &.{"--local"}, &.{"--project"} }) |flags| {
+            const result = try ctx.setup(git, flags);
+            try t.expectCode(result, 2, "setup requires a working tree");
+            try t.require(std.mem.indexOf(u8, result.stderr, "working tree") != null and std.mem.indexOf(u8, result.stderr, "setup-merge --user") != null, "setup omitted repository guidance or the user scope command");
+            try expectAbsent(git, try git.path(".gitattributes"));
+            try expectAbsent(git, try git.path(".git/info/attributes"));
+        }
+    }
+    try expectAbsent(ctx.git, ctx.git.env.get("GIT_CONFIG_GLOBAL").?);
+}
+
+fn invalidArguments(parent: Context) !void {
+    const ctx = try parent.isolated("invalid-arguments", false);
+    const git = try ctx.repo("repo");
+    const before = try read(git, try git.path(".git/config"));
+    const cases = [_][]const []const u8{
+        &.{"--team"},                &.{"--unknown"},           &.{"extra"},                &.{ "--local", "--project" },
+        &.{ "--project", "--user" }, &.{ "--user", "--local" }, &.{ "--local", "--local" },
+    };
+    for (cases) |flags| {
+        try t.expectCode(try ctx.setup(git, flags), 2, "invalid setup arguments");
+        try t.require(std.mem.eql(u8, before, try read(git, try git.path(".git/config"))), "invalid arguments changed repository configuration");
+        try expectAbsent(git, try git.path(".gitattributes"));
+        try expectAbsent(git, try git.path(".git/info/attributes"));
+        try expectAbsent(git, git.env.get("GIT_CONFIG_GLOBAL").?);
+    }
+}
+
+fn newUser(parent: Context) !void {
+    const ctx = try parent.isolated("new-user", false);
+    // Empty XDG_CONFIG_HOME uses the home fallback, even when its parent directories do not exist yet.
+    try ctx.git.env.put("XDG_CONFIG_HOME", "");
+    const attributes = try std.fs.path.join(ctx.git.arena, &.{ ctx.git.env.get("HOME").?, ".config/git/attributes" });
+    try expectAbsent(ctx.git, attributes);
+    try expectAbsent(ctx.git, ctx.git.env.get("GIT_CONFIG_GLOBAL").?);
+    try t.expectCode(try ctx.setup(ctx.git, &.{"--user"}), 0, "first user setup");
+    try expectConfiguration(ctx.git, "--global");
+    const repo = try ctx.repo("repo");
+    const actual = try repo.output(&.{ "check-attr", "merge", "--", "Assets/A.prefab" });
+    try t.require(std.mem.eql(u8, actual, "Assets/A.prefab: merge: prefablens\n"), "first user setup did not create active attributes");
+    try expectMerge(repo);
+}
+
+fn userScopes(parent: Context) !void {
+    const cases = [_]enum { home_default, xdg_default, custom, included, symlink }{ .home_default, .xdg_default, .custom, .included, .symlink };
+    for (cases) |case| {
+        if (case == .symlink and builtin.os.tag == .windows) continue;
+        const ctx = try parent.isolated(@tagName(case), case == .xdg_default);
+        const git = ctx.git;
+        const user_dir = git.env.get("HOME").?;
+        const attributes = switch (case) {
+            .home_default => try std.fs.path.join(git.arena, &.{ user_dir, ".config/git/attributes" }),
+            .xdg_default => try std.fs.path.join(git.arena, &.{ git.env.get("XDG_CONFIG_HOME").?, "git/attributes" }),
+            else => try std.fs.path.join(git.arena, &.{ user_dir, "custom attributes 日本語" }),
+        };
+        try write(git, attributes, existing_attributes);
+        try git.ok(&.{ "config", "--global", "prefablens.test.setting", "keep" });
+        if (case == .custom or case == .symlink) try git.ok(&.{ "config", "--global", "core.attributesFile", "~/custom attributes 日本語" });
+        if (case == .included) {
+            const included = try std.fs.path.join(git.arena, &.{ user_dir, "included config" });
+            try git.ok(&.{ "config", "--file", included, "core.attributesFile", "~/custom attributes 日本語" });
+            try git.ok(&.{ "config", "--global", "include.path", included });
+        }
+        const target = try std.fs.path.join(git.arena, &.{ user_dir, "attributes target" });
+        if (case == .symlink) {
+            try std.Io.Dir.cwd().rename(attributes, .cwd(), target, git.io);
+            try std.Io.Dir.cwd().symLink(git.io, target, attributes, .{});
+        }
+        try t.expectCode(try ctx.setup(git, &.{"--user"}), 0, @tagName(case));
+        try expectConfiguration(git, "--global");
+        const repo = try ctx.repo("repo");
+        const local_attributes = try repo.path("local attributes");
+        try write(repo, local_attributes, "*.prefab merge=text\n");
+        try repo.ok(&.{ "config", "--local", "core.attributesFile", local_attributes });
+        const config_before = try read(repo, try repo.path(".git/config"));
+        // A local override must not redirect a later user setup into this repository's attributes file.
+        try t.expectCode(try ctx.setup(repo, &.{"--user"}), 0, "repeat user setup inside a repository");
+        try t.require(std.mem.eql(u8, config_before, try read(repo, try repo.path(".git/config"))), "user setup changed local configuration");
+        try t.require(std.mem.eql(u8, try read(repo, local_attributes), "*.prefab merge=text\n"), "user setup followed a local attributes override");
+        try expectAbsent(repo, try repo.path(".gitattributes"));
+        try expectAbsent(repo, try repo.path(".git/info/attributes"));
+        try repo.ok(&.{ "config", "--local", "--unset", "core.attributesFile" });
+        try expectAttributes(repo, attributes);
+        try t.require(std.mem.eql(u8, merge_git.trim(try git.output(&.{ "config", "--global", "prefablens.test.setting" })), "keep"), "user setup changed unrelated configuration");
+        if (case == .symlink) {
+            const stat = try std.Io.Dir.cwd().statFile(git.io, attributes, .{ .follow_symlinks = false });
+            try t.require(stat.kind == .sym_link, "user setup replaced an attributes symlink");
+            try t.require(std.mem.eql(u8, try read(git, target), try read(git, attributes)), "user setup did not update the symlink target");
+        }
+        try expectMerge(repo);
+    }
+}
+
+fn systemAttributes(parent: Context) !void {
+    const ctx = try parent.isolated("system-attributes", true);
+    const git = ctx.git;
+    const system_config = try std.fs.path.join(git.arena, &.{ ctx.root, "system.config" });
+    const system_attributes = try std.fs.path.join(git.arena, &.{ ctx.root, "system.attributes" });
+    try write(git, system_attributes, "*.txt text\n");
+    try git.ok(&.{ "config", "--file", system_config, "core.attributesFile", system_attributes });
+    const before = try read(git, system_config);
+    try git.env.put("GIT_CONFIG_SYSTEM", system_config);
+    _ = git.env.swapRemove("GIT_CONFIG_NOSYSTEM");
+    // A system attributes path must not make successful user setup silently ineffective.
+    try t.expectCode(try ctx.setup(git, &.{"--user"}), 0, "user setup with system attributes");
+    const repo = try ctx.repo("repo");
+    const actual = try repo.output(&.{ "check-attr", "merge", "--", "Assets/A.prefab" });
+    try t.require(std.mem.eql(u8, actual, "Assets/A.prefab: merge: prefablens\n"), "system configuration bypassed user attributes");
+    try t.require(std.mem.eql(u8, before, try read(git, system_config)), "user setup changed system configuration");
+    try t.require(std.mem.eql(u8, "*.txt text\n", try read(git, system_attributes)), "user setup changed system attributes");
+    try expectMerge(repo);
+}
+
+fn invalidUserPaths(parent: Context) !void {
+    const ctx = try parent.isolated("invalid-user-paths", false);
+    for ([_][]const u8{ "", "relative-attributes" }) |path| {
+        try ctx.git.ok(&.{ "config", "--global", "core.attributesFile", path });
+        const global_path = ctx.git.env.get("GIT_CONFIG_GLOBAL").?;
+        const before = try read(ctx.git, global_path);
+        const result = try ctx.setup(ctx.git, &.{"--user"});
+        try t.expectCode(result, 2, "invalid user attributes path");
+        try t.require(std.mem.indexOf(u8, result.stderr, "core.attributesFile") != null and std.mem.indexOf(u8, result.stderr, "absolute") != null, "invalid attributes path omitted repair guidance");
+        try t.require(std.mem.eql(u8, before, try read(ctx.git, global_path)), "invalid user attributes path changed global configuration");
+        try expectAbsent(ctx.git, try ctx.git.path("relative-attributes"));
+    }
+}
+
+fn userInstallationFailure(parent: Context) !void {
+    const ctx = try parent.isolated("user-installation-failure", false);
+    const attributes = try std.fs.path.join(ctx.git.arena, &.{ ctx.root, "attributes" });
+    try write(ctx.git, attributes, existing_attributes);
+    try ctx.git.ok(&.{ "config", "--global", "core.attributesFile", attributes });
+    const global_path = ctx.git.env.get("GIT_CONFIG_GLOBAL").?;
+    const before = try read(ctx.git, global_path);
+    const exec_path = try std.fs.path.join(ctx.git.arena, &.{ ctx.root, "exec" });
+    try std.Io.Dir.cwd().createDirPath(ctx.git.io, exec_path);
+    // A real incompatible executable in Git's exec path must fail validation before any setup writes.
+    const shadow_name = if (builtin.os.tag == .windows) "git-merge-prefablens.exe" else "git-merge-prefablens";
+    try std.Io.Dir.cwd().copyFile(ctx.prefablens, .cwd(), try std.fs.path.join(ctx.git.arena, &.{ exec_path, shadow_name }), ctx.git.io, .{});
+    try ctx.git.env.put("GIT_EXEC_PATH", exec_path);
+    const result = try ctx.setup(ctx.git, &.{"--user"});
+    try t.expectCode(result, 2, "invalid user installation");
+    try t.require(std.mem.indexOf(u8, result.stderr, "PATH") != null, "invalid installation omitted repair guidance");
+    try t.require(std.mem.eql(u8, before, try read(ctx.git, global_path)), "invalid installation changed global configuration");
+    try t.require(std.mem.eql(u8, existing_attributes, try read(ctx.git, attributes)), "invalid installation changed user attributes");
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,8 +62,6 @@ Dependencies point from `cli/` to `core/`.
 
 ### Git merge integration
 
-`prefablens setup-merge` configures the current clone.
-With `--team`, this command writes shared `.gitattributes` instead of `.git/info/attributes`.
 One native executable and the packaged `git-merge-prefablens` script must be on `PATH`.
 The script contains only this command:
 
@@ -84,6 +82,51 @@ The script must be a custom Git command on `PATH`, outside this directory.
 The setup keeps existing attribute lines and unrelated configuration.
 The configuration uses command names without absolute paths.
 You do not need to run setup again after a complete upgrade.
+
+#### Setup scopes
+
+```text
+prefablens setup-merge [--project|--local|--user]
+```
+
+| Scope | Attributes | Git configuration |
+| --- | --- | --- |
+| `--project` | `.gitattributes` at the repository root | Local |
+| `--local` or no flag | Git's `info/attributes` file, usually `.git/info/attributes` | Local |
+| `--user` | User attributes file | Global |
+
+Choose at most one scope.
+The former `--team` flag has been replaced by `--project` and is no longer accepted.
+Existing merge configuration remains valid.
+
+Local and project setup require a Git working tree and also work from its subdirectories.
+Local setup resolves the attributes path through Git, including in linked worktrees.
+Outside a working tree, these scopes exit with status 2 and explain where to run setup.
+The message also suggests `prefablens setup-merge --user` for user configuration.
+This failure does not write setup files.
+
+With `--project`, commit `.gitattributes` to share the attribute rules.
+The merge driver, mergetool, and strategy settings remain local to the clone.
+Each clone needs setup unless those settings are already available from user configuration.
+
+User setup also works outside repositories and writes merge settings with `git config --global`.
+It uses the global `core.attributesFile` value, including values from included configuration files.
+Git expands `~` in that path.
+An empty or relative value is rejected because it cannot identify one shared attributes file across repositories.
+Set an absolute path or a path starting with `~/` before running user setup.
+
+When `core.attributesFile` is unset, user setup uses `$XDG_CONFIG_HOME/git/attributes`.
+If `XDG_CONFIG_HOME` is unset or empty, it uses `~/.config/git/attributes`.
+Setup registers this default path in global configuration so that a system `core.attributesFile` setting cannot redirect Git to another file.
+Existing attribute lines are preserved, and repeated setup does not duplicate the rules.
+If the user attributes file is a symlink, setup updates its target and preserves the link.
+
+User setup sets `pull.twohead=prefablens` globally, selecting PrefabLens for ordinary merges across all repositories, including repositories without Unity files.
+Repository configuration takes precedence over global configuration.
+For attributes, Git gives `info/attributes` precedence over `.gitattributes`, which takes precedence over user attributes.
+See [Git attributes](https://git-scm.com/docs/gitattributes) for the full precedence rules.
+
+#### Merge behavior
 
 Before the strategy writes merge objects, the index, or working files, it checks the installed CLI version.
 


### PR DESCRIPTION
## Summary

Add project, local, and user scopes to `prefablens setup-merge`.
Outside a working tree, repository setup explains the requirement and suggests `prefablens setup-merge --user`.

## Motivation

Merge setup previously offered only implicit local setup and shared attributes through `--team`.
It could not configure merge integration for a user's repositories globally.

Closes #343

## Changes

- Replace `--team` with `--project`, add explicit `--local`, and preserve local setup as the default.
- Add `--user` for global attributes and merge settings, including setup outside repositories.
- Respect existing user attribute paths, included configuration, and symlinks. Register default paths globally so system configuration cannot bypass them.
- Reject incompatible scopes and invalid user attribute paths with guidance before setup writes.
- Add real Git integration coverage and update CLI help, README, and CLI documentation.

## Testing

- `zig build test lint --summary all`: 32/32 steps succeeded; 589/589 tests passed. Git integration and PTY suites also passed.
- `zig build test-merge-setup --summary all`: 9/9 steps succeeded, including the system attributes regression.
- `zig build --summary all`: 8/8 steps succeeded.
- `git diff --cached --check`: passed.
- Verified CLI help, repository guidance, and documentation links. Independent review confirmed the system attributes fix on Git 2.39.5.
