### PR TITLE
ci: shorten native test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,10 @@ jobs:
         # Windows Zig caching was measured as not worth it (see PR #36 context)
         if: matrix.os == 'ubuntu-latest'
         uses: ./.github/actions/setup-zig-cache
-      - name: Packaging render test
-        if: matrix.os != 'windows-latest'
-        run: |
-          zig build -Doptimize=ReleaseSafe --prefix .zig-cache/release-check/native
-          cli/pkg/render_test.sh .zig-cache/release-check/native/bin
       - name: Lint
         run: zig build lint
       - name: Test
-        run: zig build test
+        run: zig build test --summary all
       - name: Performance budget
         # Windows runners are too noisy; the measurements swing too much, so skip them here
         if: matrix.os == 'ubuntu-latest'
@@ -130,6 +125,9 @@ jobs:
             ${{ runner.os }}-nuget-
       - name: Build real CLI test bundles
         run: zig build test-installation-binaries -Doptimize=ReleaseSafe
+      - name: Packaging render test
+        if: matrix.os != 'windows-latest'
+        run: cli/pkg/render_test.sh zig-out/bin
       - name: Lint
         working-directory: editor
         run: |

--- a/build.zig
+++ b/build.zig
@@ -47,6 +47,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const core_tests = b.addTest(.{
+        .name = "core-test",
         .root_module = core_mod,
     });
     const cli_test_mod = b.createModule(.{
@@ -58,6 +59,7 @@ pub fn build(b: *std.Build) void {
     // Test fixtures stay explicit so the external-cwd gate cannot read ambient paths.
     cli_test_mod.addImport("test_options", test_options_mod);
     const cli_tests = b.addTest(.{
+        .name = "cli-test",
         .root_module = cli_test_mod,
     });
     const run_cli_tests = b.addRunArtifact(cli_tests);
@@ -78,7 +80,7 @@ pub fn build(b: *std.Build) void {
     run_merge_driver_cwd_tests.setEnvironmentVariable("GIT_CONFIG_KEY_0", "merge.conflictStyle");
     run_merge_driver_cwd_tests.setEnvironmentVariable("GIT_CONFIG_VALUE_0", "merge");
 
-    const test_step = b.step("test", "Run all unit tests");
+    const test_step = b.step("test", "Run native unit and integration tests");
     test_step.dependOn(&b.addRunArtifact(core_tests).step);
     test_step.dependOn(&run_cli_tests.step);
     test_step.dependOn(&run_merge_driver_cwd_tests.step);
@@ -217,6 +219,21 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_pty_smoke.step);
     const pty_test_step = b.step("test-merge-pty", "Run merge interaction tests in a real terminal");
     pty_test_step.dependOn(&run_pty_smoke.step);
+
+    for ([_]*std.Build.Step.Run{
+        run_git_merge_tests,
+        run_collection_fixture_tests,
+        run_strategy_tests,
+        run_setup_tests,
+        run_installation_tests,
+        run_structural_tests,
+        run_pty_smoke,
+    }) |run| {
+        // Independent scratch directories let these checks share the build without inherited stdio.
+        run.expectExitCode(0);
+        // Git and terminal checks must execute even when compilation inputs are cached.
+        run.has_side_effects = true;
+    }
 
     const merge_driver_test_step = b.step("test-merge-driver", "Run merge-driver fixture tests outside the checkout");
     merge_driver_test_step.dependOn(&run_merge_driver_cwd_tests.step);

--- a/cli/src/git_strategy_test_main.zig
+++ b/cli/src/git_strategy_test_main.zig
@@ -280,10 +280,21 @@ fn concurrentContent(ctx: Context) !void {
             .index => try std.fmt.allocPrint(git.arena, "git update-index --cacheinfo 100644,{s},Assets/A.prefab", .{oid}),
             .source => try std.fmt.allocPrint(git.arena, "git update-index --add --cacheinfo 100644,{s},Assets/Source.cs", .{oid}),
         };
-        // Hold the first UI open while another process changes the index or a later file.
-        const inner = try std.fmt.allocPrint(git.arena, "(sleep 3; {s}) & exec git merge --no-edit remote", .{edit});
-        const command = try std.fmt.allocPrint(git.arena, "env PATH={s} sh -c {s}", .{ try t.shellQuote(git.arena, git.env.get("PATH").?), try t.shellQuote(git.arena, inner) });
-        const result = try pty.runCommandInPtyBatches(git.io, git.arena, git.cwd, command, "", "\x1b[C\r\r", 30);
+        const command = try std.fmt.allocPrint(
+            git.arena,
+            "env PATH={s} git merge --no-edit remote",
+            .{try t.shellQuote(git.arena, git.env.get("PATH").?)},
+        );
+        const result = try pty.runCommandInPtyWithUiAction(
+            git.io,
+            git.arena,
+            git.cwd,
+            command,
+            edit,
+            "\x1b[C\r\r",
+            "",
+            30,
+        );
         try t.expectCode(result, 1, "preserve changes made while merge UI waits");
         if (later_file) {
             try expectFile(git, "Assets/A.prefab", ours);

--- a/cli/src/git_structural_test_main.zig
+++ b/cli/src/git_structural_test_main.zig
@@ -301,28 +301,22 @@ fn concurrentChanges(ctx: Context) !void {
 }
 
 fn runWithUiAction(git: merge_git.Git, keys: []const u8, second_keys: []const u8, action: []const u8) !std.process.RunResult {
-    // Raw terminal mode begins only after the resolver snapshots all paths.
-    // The other process performs a real concurrent change while the UI waits.
-    const script = try std.fmt.allocPrint(git.arena,
-        \\(
-        \\i=0
-        \\while [ "$i" -lt 100 ]; do
-        \\  case "$(stty -a < /dev/tty 2>/dev/null)" in
-        \\    *-icanon*) {s}; exit $? ;;
-        \\  esac
-        \\  sleep 0.05
-        \\  i=$((i + 1))
-        \\done
-        \\exit 90
-        \\) &
-        \\watch_pid=$!
-        \\git merge --no-edit remote
-        \\status=$?
-        \\wait "$watch_pid" || exit 90
-        \\exit "$status"
-    , .{action});
-    const command = try std.fmt.allocPrint(git.arena, "env PATH={s} sh -c {s}", .{ try t.shellQuote(git.arena, git.env.get("PATH").?), try t.shellQuote(git.arena, script) });
-    return pty.runCommandInPtyBatches(git.io, git.arena, git.cwd, command, keys, second_keys, 30);
+    const command = try std.fmt.allocPrint(
+        git.arena,
+        "env PATH={s} git merge --no-edit remote",
+        .{try t.shellQuote(git.arena, git.env.get("PATH").?)},
+    );
+    // Wait for the first UI, then finish the mutation before sending input.
+    return pty.runCommandInPtyWithUiAction(
+        git.io,
+        git.arena,
+        git.cwd,
+        command,
+        action,
+        keys,
+        second_keys,
+        30,
+    );
 }
 
 fn escapedPaths(ctx: Context) !void {

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -643,7 +643,7 @@ fn runPty(
         // Reply once per Kitty query so capability logs cannot disturb later UI frames.
         // DA1 must follow keyboard support because it ends capability discovery.
         // libvaxis needs a DSR reply to stop its input thread.
-        // Keep the minimum delays used by fixtures that mutate state while a UI is open.
+        // Wait for the active UI and any fixture mutation before sending user input.
         \\(
         \\capture_file=$4
         \\keyboard_replies=0
@@ -675,13 +675,6 @@ fn runPty(
         \\    sleep 0.1
         \\  done
         \\}}
-        \\i=0
-        \\while [ "$i" -lt 10 ]; do
-        \\  reply_terminal || exit 0
-        \\  sleep 0.1
-        \\  i=$((i + 1))
-        \\done
-        \\sleep 1
         \\wait_frame 1 0
         \\first_session=$observed_session
         // Action output must not become terminal input. Keep failures visible after the UI exits.
@@ -690,13 +683,6 @@ fn runPty(
         \\fi
         \\printf '%s' "$1"
         \\if [ -n "$2" ]; then
-        \\  i=0
-        \\  while [ "$i" -lt 10 ]; do
-        \\    reply_terminal || exit 0
-        \\    sleep 0.1
-        \\    i=$((i + 1))
-        \\  done
-        \\  sleep 1
         \\  if [ -n "$1" ]; then
         \\    wait_frame "$((first_session + 1))" 0
         \\  else
@@ -707,7 +693,6 @@ fn runPty(
         \\  printf '%s' "$2"
         \\fi
         \\if [ -n "$3" ]; then
-        \\  sleep 2
         \\  wait_frame "$second_session" "$second_frame"
         \\  printf '%s' "$3"
         \\fi

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,7 @@ The schema remains stable unless a release documents a breaking change.
 | CLI entry | `cli/src/main.zig` → binary `prefablens` |
 | Version source | `build.zig.zon` (injected via `build_options`) |
 | Build | `zig build` installs to `zig-out/bin/` |
-| Unit tests | `zig build test` (core + CLI) |
+| Native tests | `zig build test` (core and CLI unit tests, Git integration, and supported terminal tests) |
 | Lint | `zig build lint` |
 | Performance checks | `zig build perf` (includes the GUID scan budget) |
 


### PR DESCRIPTION
## Summary

Shorten native CI by running independent integration executables concurrently and reusing the editor's ReleaseSafe binaries for packaging. Synchronize terminal input and concurrent file mutations with completed UI frames to remove fixed waits while retaining every test case.

## Motivation

On main at `68e11c9`, the macOS `core` job took 423 seconds, including 343 seconds in `Test` and 59 seconds in packaging. Native integration executables were serialized by inherited standard I/O, and terminal input batches each included unconditional waits. [Baseline CI run](https://github.com/hashiiiii/PrefabLens/actions/runs/34109457921).

## Changes

- Capture output and require successful exit codes for the seven integration executables, while forcing them to run even when compilation is cached.
- Run Linux and macOS packaging checks after the existing native editor bundle build, preserving the required `editor` aggregate result.
- Run concurrent index/file mutations after the first UI frame and before input. Remove generic PTY delays while preserving delayed-start, multiple-session, timeout, rollback, and permission checks.
- Name the core and CLI unit-test binaries, emit build summaries in CI, and describe the full native test command in the CLI documentation.

## Testing

Local validation on macOS with Zig 0.16.0 and an Apple M4:

- `zig build lint --summary all`: 2/2 steps succeeded.
- `zig build test --summary all`: 30/30 steps succeeded; 593/593 Zig tests and all seven integration executables passed in 39.85 seconds with cached compilation. The baseline on `68e11c9` took 243.76 seconds and included test compilation.
- Two full runs and a `zig build test -j3 --summary all` run after enabling concurrency: all passed; the warm run confirmed integration checks still execute with cached compilation.
- Five focused transaction, concurrent-edit, rollback, and permission checks passed before removing the fixed delays.
- `zig build test-merge-pty test-merge-strategy test-merge-structural -j3 --summary all`: three consecutive runs passed 15/15 steps in 39.66, 38.61, and 39.02 seconds.
- `zig build test-installation-binaries -Doptimize=ReleaseSafe --summary all`: 12/12 steps succeeded. `cli/pkg/render_test.sh zig-out/bin`: `PASS`.
- `git diff --check`: passed.

All 15 CI jobs passed in each of three attempts of `2900be0`: [attempt 1](https://github.com/hashiiiii/PrefabLens/actions/runs/34128523430/attempts/1), [attempt 2](https://github.com/hashiiiii/PrefabLens/actions/runs/34128523430/attempts/2), [attempt 3](https://github.com/hashiiiii/PrefabLens/actions/runs/34128523430/attempts/3).

Durations below compare the baseline main run linked above with the median of the three PR attempts. Job times exclude time waiting for a runner; `Test` includes compilation.

| OS | Main Test | PR Test median (range) | Main core job | PR core job median |
|---|---:|---:|---:|---:|
| macOS | 343 s | 175 s (149–189 s) | 423 s | 226 s |
| Linux | 194 s | 59 s (56–61 s) | 301 s | 104 s |
| Windows | 234 s | 158 s (96–166 s) | 333 s | 248 s |

Linux and macOS passed 593/593 Zig tests in every attempt. Windows passed 592/593 with its existing permission-test skip; its existing PTY skips remain. All seven executable run steps succeeded on every OS. Packaging passed on Linux and macOS in every attempt, and the editor aggregate and isolated performance gate passed. No test cases or OS coverage were removed.
