### PR TITLE
refactor: simplify core data and YAML helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,23 @@ jobs:
         # Windows runners are too noisy; the measurements swing too much, so skip them here
         if: matrix.os == 'ubuntu-latest'
         run: zig build perf
+      - name: Compare core performance
+        if: always() && matrix.os == 'ubuntu-latest'
+        shell: bash
+        env:
+          BASE_REVISION: 14a7f6505780d23c6cfc2042781bc15ae4740053
+        run: |
+          lscpu
+          git fetch --no-tags --depth=1 origin "$BASE_REVISION"
+          baseline_dir="$RUNNER_TEMP/core-perf-baseline"
+          mkdir -p "$baseline_dir"
+          git archive "$BASE_REVISION" core | tar -x -C "$baseline_dir"
+          zig build-exe "$baseline_dir/core/src/perf_main.zig" -O ReleaseFast -femit-bin="$RUNNER_TEMP/base-perf"
+          zig build-exe core/src/perf_main.zig -O ReleaseFast -femit-bin="$RUNNER_TEMP/head-perf"
+          for revision in base head head base base head; do
+            printf 'Revision: %s\n' "$revision"
+            /usr/bin/time -f 'wall=%e user=%U system=%S max_rss_kb=%M' "$RUNNER_TEMP/$revision-perf" || true
+          done
 
   release-builds:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,23 +39,6 @@ jobs:
         # Windows runners are too noisy; the measurements swing too much, so skip them here
         if: matrix.os == 'ubuntu-latest'
         run: zig build perf
-      - name: Compare core performance
-        if: always() && matrix.os == 'ubuntu-latest'
-        shell: bash
-        env:
-          BASE_REVISION: 14a7f6505780d23c6cfc2042781bc15ae4740053
-        run: |
-          lscpu
-          git fetch --no-tags --depth=1 origin "$BASE_REVISION"
-          baseline_dir="$RUNNER_TEMP/core-perf-baseline"
-          mkdir -p "$baseline_dir"
-          git archive "$BASE_REVISION" core | tar -x -C "$baseline_dir"
-          zig build-exe "$baseline_dir/core/src/perf_main.zig" -O ReleaseFast -femit-bin="$RUNNER_TEMP/base-perf"
-          zig build-exe core/src/perf_main.zig -O ReleaseFast -femit-bin="$RUNNER_TEMP/head-perf"
-          for revision in base head head base base head; do
-            printf 'Revision: %s\n' "$revision"
-            /usr/bin/time -f 'wall=%e user=%U system=%S max_rss_kb=%M' "$RUNNER_TEMP/$revision-perf" || true
-          done
 
   release-builds:
     runs-on: ubuntu-latest

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -5,7 +5,7 @@ const testing = std.testing;
 // Test-only lookup of one document's diff by fileID.
 // pub: diff_overrides' tests use it too.
 pub fn findDoc(fd: FlatDiff, file_id: i64) ?DocDiff {
-    for (fd.docs) |d| if (d.file_id == file_id) return d;
+    for (fd.docs) |d| if (d.component.file_id == file_id) return d;
     return null;
 }
 
@@ -27,13 +27,13 @@ test "diff: modified scalar field is detected old->new" {
     ;
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 5).?;
-    try testing.expectEqual(model.Status.modified, d.status);
-    try testing.expectEqualStrings("abc", d.script_guid.?);
-    try testing.expectEqual(@as(usize, 1), d.fields.len);
-    try testing.expectEqualStrings("Max Hp", d.fields[0].path);
-    try testing.expectEqual(model.Status.modified, d.fields[0].status);
-    try testing.expectEqualStrings("100", d.fields[0].before.?.scalar);
-    try testing.expectEqualStrings("150", d.fields[0].after.?.scalar);
+    try testing.expectEqual(model.Status.modified, d.component.status);
+    try testing.expectEqualStrings("abc", d.component.script_guid.?);
+    try testing.expectEqual(@as(usize, 1), d.component.fields.len);
+    try testing.expectEqualStrings("Max Hp", d.component.fields[0].path);
+    try testing.expectEqual(model.Status.modified, d.component.fields[0].status);
+    try testing.expectEqualStrings("100", d.component.fields[0].before.?.scalar);
+    try testing.expectEqualStrings("150", d.component.fields[0].after.?.scalar);
 }
 
 test "diff: unknown classID falls back to the document top-level key" {
@@ -54,8 +54,8 @@ test "diff: unknown classID falls back to the document top-level key" {
     ;
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 7).?;
-    try testing.expectEqualStrings("MyCustomThing", d.type_name);
-    try testing.expectEqual(model.Status.modified, d.status);
+    try testing.expectEqualStrings("MyCustomThing", d.component.type_name);
+    try testing.expectEqual(model.Status.modified, d.component.status);
 }
 
 test "diff: added and removed documents" {
@@ -76,16 +76,16 @@ test "diff: added and removed documents" {
         \\  m_Name: B
     ;
     const fd = try compute(arena, before, after);
-    try testing.expectEqual(model.Status.unchanged, findDoc(fd, 1).?.status);
-    try testing.expectEqual(model.Status.added, findDoc(fd, 2).?.status);
+    try testing.expectEqual(model.Status.unchanged, findDoc(fd, 1).?.component.status);
+    try testing.expectEqual(model.Status.added, findDoc(fd, 2).?.component.status);
 
     const fd2 = try compute(arena, after, before);
     const removed = findDoc(fd2, 2).?;
-    try testing.expectEqual(model.Status.removed, removed.status);
+    try testing.expectEqual(model.Status.removed, removed.component.status);
     // Removed side enumerates fully too: the Name visible in the hierarchy remains with its before value.
-    try testing.expectEqual(@as(usize, 1), removed.fields.len);
-    try testing.expectEqualStrings("Name", removed.fields[0].path);
-    try testing.expectEqualStrings("B", removed.fields[0].before.?.scalar);
+    try testing.expectEqual(@as(usize, 1), removed.component.fields.len);
+    try testing.expectEqualStrings("Name", removed.component.fields[0].path);
+    try testing.expectEqualStrings("B", removed.component.fields[0].before.?.scalar);
 }
 
 test "diff: nested field path and added field" {
@@ -105,12 +105,12 @@ test "diff: nested field path and added field" {
     ;
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
-    try testing.expectEqual(model.Status.modified, d.status);
+    try testing.expectEqual(model.Status.modified, d.component.status);
     // Expect: the modified leaf (m_LocalPosition.y) plus the added m_LocalScale
     // collapsed as a vector into a single "Scale" row.
     var saw_y = false;
     var saw_added_scale = false;
-    for (d.fields) |f| {
+    for (d.component.fields) |f| {
         if (std.mem.eql(u8, f.path, "Position.y")) {
             saw_y = true;
             try testing.expectEqual(model.Status.modified, f.status);
@@ -148,11 +148,11 @@ test "diff: duplicate before fileIDs match the first occurrence" {
     ;
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 5).?;
-    try testing.expectEqual(model.Status.modified, d.status);
-    try testing.expectEqual(@as(usize, 1), d.fields.len);
+    try testing.expectEqual(model.Status.modified, d.component.status);
+    try testing.expectEqual(@as(usize, 1), d.component.fields.len);
     // First occurrence wins: before is 100, not the duplicate's 999.
-    try testing.expectEqualStrings("100", d.fields[0].before.?.scalar);
-    try testing.expectEqualStrings("150", d.fields[0].after.?.scalar);
+    try testing.expectEqualStrings("100", d.component.fields[0].before.?.scalar);
+    try testing.expectEqualStrings("150", d.component.fields[0].after.?.scalar);
 }
 
 test "diff: unresolved guids collected from external refs" {
@@ -249,8 +249,8 @@ test "diff: hidden fields are dropped and paths humanized" {
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
     // The m_GameObject change is hidden. m_LocalPosition.x becomes "Position.x".
-    try testing.expectEqual(@as(usize, 1), d.fields.len);
-    try testing.expectEqualStrings("Position.x", d.fields[0].path);
+    try testing.expectEqual(@as(usize, 1), d.component.fields.len);
+    try testing.expectEqualStrings("Position.x", d.component.fields[0].path);
 }
 
 test "diff: hidden-only changes leave the document unchanged" {
@@ -268,7 +268,7 @@ test "diff: hidden-only changes leave the document unchanged" {
         \\  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
     ;
     const fd = try compute(arena, before, after);
-    try testing.expectEqual(model.Status.unchanged, findDoc(fd, 4).?.status);
+    try testing.expectEqual(model.Status.unchanged, findDoc(fd, 4).?.component.status);
 }
 
 test "diff: editor class identifier tail is extracted" {
@@ -288,7 +288,7 @@ test "diff: editor class identifier tail is extracted" {
         \\  hp: 2
     ;
     const fd = try compute(arena, src, src2);
-    try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.class_name.?);
+    try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.component.class_name.?);
 }
 
 test "diff: editor class identifier without separator or with empty tail" {
@@ -305,8 +305,8 @@ test "diff: editor class identifier without separator or with empty tail" {
     ;
     const fd = try compute(arena, src, src);
     // No separator uses the whole string as the class name; an empty tail means no class_name.
-    try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.class_name.?);
-    try testing.expect(findDoc(fd, 6).?.class_name == null);
+    try testing.expectEqualStrings("Cylinder1", findDoc(fd, 5).?.component.class_name.?);
+    try testing.expect(findDoc(fd, 6).?.component.class_name == null);
 }
 
 test "diff: unresolved guids are deduplicated in first-reference order" {
@@ -346,12 +346,12 @@ test "diff: added document enumerates fields with vector collapse" {
     ;
     const fd = try compute(arena, before, after);
     const d = findDoc(fd, 4).?;
-    try testing.expectEqual(model.Status.added, d.status);
+    try testing.expectEqual(model.Status.added, d.component.status);
     // m_GameObject is hidden. Position is a single vector row, maxHp is Max Hp.
-    try testing.expectEqual(@as(usize, 2), d.fields.len);
-    try testing.expectEqualStrings("Position", d.fields[0].path);
-    try testing.expectEqualStrings("(4, 0, 0)", d.fields[0].after.?.scalar);
-    try testing.expectEqualStrings("Max Hp", d.fields[1].path);
+    try testing.expectEqual(@as(usize, 2), d.component.fields.len);
+    try testing.expectEqualStrings("Position", d.component.fields[0].path);
+    try testing.expectEqualStrings("(4, 0, 0)", d.component.fields[0].after.?.scalar);
+    try testing.expectEqualStrings("Max Hp", d.component.fields[1].path);
 }
 
 test "diff: removed document enumerates fields with vector collapse" {
@@ -367,15 +367,15 @@ test "diff: removed document enumerates fields with vector collapse" {
     ;
     const fd = try compute(arena, before, "");
     const d = findDoc(fd, 4).?;
-    try testing.expectEqual(model.Status.removed, d.status);
+    try testing.expectEqual(model.Status.removed, d.component.status);
     // Symmetric with the added side: m_GameObject hidden, Position a single vector row, values on before.
-    try testing.expectEqual(@as(usize, 2), d.fields.len);
-    try testing.expectEqualStrings("Position", d.fields[0].path);
-    try testing.expectEqual(model.Status.removed, d.fields[0].status);
-    try testing.expectEqualStrings("(4, 0, 0)", d.fields[0].before.?.scalar);
-    try testing.expect(d.fields[0].after == null);
-    try testing.expectEqualStrings("Max Hp", d.fields[1].path);
-    try testing.expectEqualStrings("100", d.fields[1].before.?.scalar);
+    try testing.expectEqual(@as(usize, 2), d.component.fields.len);
+    try testing.expectEqualStrings("Position", d.component.fields[0].path);
+    try testing.expectEqual(model.Status.removed, d.component.fields[0].status);
+    try testing.expectEqualStrings("(4, 0, 0)", d.component.fields[0].before.?.scalar);
+    try testing.expect(d.component.fields[0].after == null);
+    try testing.expectEqualStrings("Max Hp", d.component.fields[1].path);
+    try testing.expectEqualStrings("100", d.component.fields[1].before.?.scalar);
 }
 
 const parser = @import("parser.zig");
@@ -387,13 +387,7 @@ const Status = model.Status;
 const FieldDiff = model.FieldDiff;
 
 pub const DocDiff = struct {
-    file_id: i64,
-    class_id: u32,
-    type_name: []const u8,
-    script_guid: ?[]const u8 = null,
-    class_name: ?[]const u8 = null,
-    status: Status,
-    fields: []FieldDiff,
+    component: model.ComponentDiff,
     overrides: []model.OverrideDiff = &.{},
 };
 
@@ -417,20 +411,13 @@ fn buildIndex(arena: std.mem.Allocator, docs: []model.Document) !std.AutoHashMap
 }
 
 fn scriptGuid(doc: *const model.Document) ?[]const u8 {
-    const s = model.findValue(doc.body.map, "m_Script") orelse return null;
-    return switch (s.*) {
-        .ref => |r| r.guid,
-        else => null,
-    };
+    const script = Node.asRef(doc.body.get("m_Script")) orelse return null;
+    return script.guid;
 }
 
 // "Assembly-CSharp::Cylinder1" -> "Cylinder1" (after the last ':').
 fn editorClassName(doc: *const model.Document) ?[]const u8 {
-    const v = model.findValue(doc.body.map, "m_EditorClassIdentifier") orelse return null;
-    const s = switch (v.*) {
-        .scalar => |s| s,
-        else => return null,
-    };
+    const s = Node.asScalar(doc.body.get("m_EditorClassIdentifier")) orelse return null;
     const tail = if (std.mem.lastIndexOfScalar(u8, s, ':')) |idx| s[idx + 1 ..] else s;
     return if (tail.len != 0) tail else null;
 }
@@ -477,88 +464,14 @@ pub fn computeParsed(arena: std.mem.Allocator, before: []model.Document, after: 
         if (ad.stripped) continue;
         try collectGuids(arena, &guids, ad.body);
         const bd = before_idx.get(ad.file_id);
-        if (bd) |b| {
-            try collectGuids(arena, &guids, b.body);
-            if (ad.class_id == 1001) {
-                const overrides = try diff_overrides.diffOverrides(arena, b, ad);
-                try docs.append(arena, .{
-                    .file_id = ad.file_id,
-                    .class_id = ad.class_id,
-                    .type_name = resolvedTypeName(ad),
-                    .script_guid = scriptGuid(ad),
-                    .status = if (overrides.len == 0) .unchanged else .modified,
-                    .fields = &.{},
-                    .overrides = overrides,
-                });
-            } else {
-                var raw: std.ArrayList(FieldDiff) = .empty;
-                try diffNode(arena, &raw, "", b.body, ad.body);
-                const fields = try presentFields(arena, raw.items);
-                try docs.append(arena, .{
-                    .file_id = ad.file_id,
-                    .class_id = ad.class_id,
-                    .type_name = resolvedTypeName(ad),
-                    .script_guid = scriptGuid(ad),
-                    .class_name = editorClassName(ad),
-                    .status = if (fields.len == 0) .unchanged else .modified,
-                    .fields = fields,
-                });
-            }
-        } else {
-            if (ad.class_id == 1001) {
-                try docs.append(arena, .{
-                    .file_id = ad.file_id,
-                    .class_id = ad.class_id,
-                    .type_name = resolvedTypeName(ad),
-                    .script_guid = scriptGuid(ad),
-                    .status = .added,
-                    .fields = &.{},
-                    .overrides = try diff_overrides.soleInstanceOverrides(arena, ad, .added),
-                });
-            } else {
-                var raw: std.ArrayList(FieldDiff) = .empty;
-                for (ad.body.map) |e| try flattenSubtree(arena, &raw, e.key, e.value, .added);
-                try docs.append(arena, .{
-                    .file_id = ad.file_id,
-                    .class_id = ad.class_id,
-                    .type_name = resolvedTypeName(ad),
-                    .script_guid = scriptGuid(ad),
-                    .class_name = editorClassName(ad),
-                    .status = .added,
-                    .fields = try presentFields(arena, raw.items),
-                });
-            }
-        }
+        if (bd) |b| try collectGuids(arena, &guids, b.body);
+        try docs.append(arena, try diffDocument(arena, bd, ad));
     }
     for (before) |*bd| {
         if (bd.stripped) continue;
         if (after_idx.contains(bd.file_id)) continue;
         try collectGuids(arena, &guids, bd.body);
-        if (bd.class_id == 1001) {
-            try docs.append(arena, .{
-                .file_id = bd.file_id,
-                .class_id = bd.class_id,
-                .type_name = resolvedTypeName(bd),
-                .script_guid = scriptGuid(bd),
-                .class_name = editorClassName(bd),
-                .status = .removed,
-                .fields = &.{},
-                .overrides = try diff_overrides.soleInstanceOverrides(arena, bd, .removed),
-            });
-        } else {
-            // Full enumeration symmetric with the added side (flattenSubtree ~ presentFields).
-            var raw: std.ArrayList(FieldDiff) = .empty;
-            for (bd.body.map) |e| try flattenSubtree(arena, &raw, e.key, e.value, .removed);
-            try docs.append(arena, .{
-                .file_id = bd.file_id,
-                .class_id = bd.class_id,
-                .type_name = resolvedTypeName(bd),
-                .script_guid = scriptGuid(bd),
-                .class_name = editorClassName(bd),
-                .status = .removed,
-                .fields = try presentFields(arena, raw.items),
-            });
-        }
+        try docs.append(arena, try diffDocument(arena, bd, null));
     }
 
     return .{
@@ -567,6 +480,37 @@ pub fn computeParsed(arena: std.mem.Allocator, before: []model.Document, after: 
         .before = before,
         .after = after,
     };
+}
+
+fn diffDocument(arena: std.mem.Allocator, before: ?*const model.Document, after: ?*const model.Document) !DocDiff {
+    const doc = after orelse before.?;
+    const status: Status = if (before == null) .added else if (after == null) .removed else .unchanged;
+    var result = DocDiff{ .component = .{
+        .file_id = doc.file_id,
+        .class_id = doc.class_id,
+        .type_name = resolvedTypeName(doc),
+        .script_guid = scriptGuid(doc),
+        .class_name = if (doc.class_id != 1001 or after == null) editorClassName(doc) else null,
+        .status = status,
+        .fields = &.{},
+    } };
+    if (doc.class_id == 1001) {
+        result.overrides = if (status == .unchanged)
+            try diff_overrides.diffOverrides(arena, before.?, after.?)
+        else
+            try diff_overrides.soleInstanceOverrides(arena, doc, status);
+        if (status == .unchanged and result.overrides.len != 0) result.component.status = .modified;
+    } else {
+        var raw: std.ArrayList(FieldDiff) = .empty;
+        if (status == .unchanged) {
+            try diffNode(arena, &raw, "", before.?.body, after.?.body);
+        } else {
+            for (doc.body.map) |entry| try flattenSubtree(arena, &raw, entry.key, entry.value, status);
+        }
+        result.component.fields = try presentFields(arena, raw.items);
+        if (status == .unchanged and result.component.fields.len != 0) result.component.status = .modified;
+    }
+    return result;
 }
 
 // Recursive field diff. `prefix` is the dot/index-separated path into `a`/`b`.

--- a/core/src/diff_overrides.zig
+++ b/core/src/diff_overrides.zig
@@ -64,8 +64,8 @@ test "diff: prefab instance override keyed by target+propertyPath" {
     const diffmod = @import("diff.zig");
     const fd = try diffmod.compute(arena, before, after);
     const d = diffmod.findDoc(fd, 1001).?;
-    try testing.expectEqual(model.Status.modified, d.status);
-    try testing.expectEqual(@as(usize, 0), d.fields.len);
+    try testing.expectEqual(model.Status.modified, d.component.status);
+    try testing.expectEqual(@as(usize, 0), d.component.fields.len);
     try testing.expectEqual(@as(usize, 1), d.overrides.len);
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Position.x", d.overrides[0].label);
@@ -102,7 +102,7 @@ test "diff: prefab instance name rename emits GameObject override" {
     const diffmod = @import("diff.zig");
     const fd = try diffmod.compute(arena, before, after);
     const d = diffmod.findDoc(fd, 1001).?;
-    try testing.expectEqual(model.Status.modified, d.status);
+    try testing.expectEqual(model.Status.modified, d.component.status);
     try testing.expectEqual(@as(usize, 1), d.overrides.len);
     try testing.expectEqualStrings("GameObject", d.overrides[0].group);
     try testing.expectEqualStrings("Name", d.overrides[0].label);
@@ -157,7 +157,7 @@ test "diff: modified instance overrides are sorted group-contiguous, Transform f
     const diffmod = @import("diff.zig");
     const fd = try diffmod.compute(arena, before, after);
     const d = diffmod.findDoc(fd, 1001).?;
-    try testing.expectEqual(model.Status.modified, d.status);
+    try testing.expectEqual(model.Status.modified, d.component.status);
     try testing.expectEqual(@as(usize, 3), d.overrides.len);
     try testing.expectEqualStrings("Transform", d.overrides[0].group);
     try testing.expectEqualStrings("Overrides", d.overrides[1].group);
@@ -208,7 +208,7 @@ test "diff: added prefab instance emits placement summary rows" {
     const diffmod = @import("diff.zig");
     const fd = try diffmod.compute(arena, "", after);
     const d = diffmod.findDoc(fd, 1001).?;
-    try testing.expectEqual(model.Status.added, d.status);
+    try testing.expectEqual(model.Status.added, d.component.status);
     // Recorded placement is emitted as a single synthesized row even at default values (identity Rotation).
     // EulerAnglesHint (hidden in Inspector) is not emitted; m_Name appears as a GameObject row.
     try testing.expectEqual(@as(usize, 3), d.overrides.len);
@@ -266,7 +266,7 @@ test "diff: removed prefab instance mirrors overrides to before" {
     const diffmod = @import("diff.zig");
     const fd = try diffmod.compute(arena, before, "");
     const d = diffmod.findDoc(fd, 1001).?;
-    try testing.expectEqual(model.Status.removed, d.status);
+    try testing.expectEqual(model.Status.removed, d.component.status);
     // Mirror of added: values on the before side, structural summary removed with the before-side count.
     try testing.expectEqual(@as(usize, 2), d.overrides.len);
     try testing.expectEqualStrings("Scale.y", d.overrides[0].label);
@@ -422,14 +422,6 @@ const placements = [_]Placement{
     .{ .prefix = "m_LocalScale", .label = "Scale", .comps = &.{ "x", "y", "z" } },
 };
 
-fn scalarOf(n: ?*Node) ?[]const u8 {
-    const node = n orelse return null;
-    return switch (node.*) {
-        .scalar => |s| s,
-        else => null,
-    };
-}
-
 fn findMod(mods: []Mod, path: []const u8) ?Mod {
     for (mods) |m| if (std.mem.eql(u8, m.property_path, path)) return m;
     return null;
@@ -478,7 +470,7 @@ fn soleOverridesFromMods(arena: std.mem.Allocator, doc: *const model.Document, m
                 all = false;
                 break;
             };
-            const v = scalarOf(m.value) orelse {
+            const v = Node.asScalar(m.value) orelse {
                 all = false;
                 break;
             };
@@ -530,9 +522,9 @@ fn soleOverridesFromMods(arena: std.mem.Allocator, doc: *const model.Document, m
 }
 
 fn modificationSeqLen(doc: *const model.Document, key: []const u8) usize {
-    const m = model.findValue(doc.body.map, "m_Modification") orelse return 0;
+    const m = doc.body.get("m_Modification") orelse return 0;
     if (m.* != .map) return 0;
-    const v = model.findValue(m.map, key) orelse return 0;
+    const v = m.get(key) orelse return 0;
     return switch (v.*) {
         .seq => |s| s.len,
         else => 0,

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -135,9 +135,9 @@ fn concatObjects(arena: std.mem.Allocator, a: []model.ObjectDiff, b: []model.Obj
 // Mark the referents of m_RemovedComponents (source-internal fileIDs) as stripped
 // (computeParsed excludes stripped docs).
 fn applyRemovedComponents(inst_doc: *const model.Document, src_docs: []model.Document) void {
-    const m = model.findValue(inst_doc.body.map, "m_Modification") orelse return;
+    const m = inst_doc.body.get("m_Modification") orelse return;
     if (m.* != .map) return;
-    const list = model.findValue(m.map, "m_RemovedComponents") orelse return;
+    const list = m.get("m_RemovedComponents") orelse return;
     if (list.* != .seq) return;
     for (list.seq) |item| {
         if (item.* != .ref) continue;
@@ -198,9 +198,9 @@ fn pushDown(arena: std.mem.Allocator, src_docs: []model.Document, target_id: i64
 }
 
 fn appendMod(arena: std.mem.Allocator, pi_doc: *model.Document, inner_id: i64, pguid: []const u8, property_path: []const u8, value: ?*model.Node, obj_ref: ?*model.Node) !bool {
-    const m = model.findValue(pi_doc.body.map, "m_Modification") orelse return false;
+    const m = pi_doc.body.get("m_Modification") orelse return false;
     if (m.* != .map) return false;
-    const list = model.findValue(m.map, "m_Modifications") orelse return false;
+    const list = m.get("m_Modifications") orelse return false;
     if (list.* != .seq) return false;
     const target = try arena.create(model.Node);
     target.* = .{ .ref = .{ .file_id = inner_id, .guid = pguid, .type_id = 3 } };
@@ -614,7 +614,7 @@ test "instantiate: setByPropertyPath handles nested and array paths" {
     // Nested path.
     setByPropertyPath(docs[0].body, "m_LocalScale.y", &value);
     const scale = model.findValue(docs[0].body.map, "m_LocalScale").?;
-    try testing.expectEqualStrings("9", model.findValue(scale.map, "y").?.scalar);
+    try testing.expectEqualStrings("9", scale.get("y").?.scalar);
 
     // Array.data[i] path (leaf replacement).
     setByPropertyPath(docs[0].body, "m_Materials.Array.data[1]", &value);

--- a/core/src/merge.zig
+++ b/core/src/merge.zig
@@ -74,7 +74,7 @@ fn verifyOursDocumentCoverage(plan: *const MergePlan) Error!void {
         const selected = switch (operation.resolution) {
             .unresolved => continue,
             .remove => null,
-            .take => |side| valueForSide(operation, side),
+            .take => |side| operation.values.get(side),
             .custom => return error.InvalidMerge,
         };
         if (selected) |value| {
@@ -98,7 +98,7 @@ pub fn resolve(
     var stored_resolution = resolution;
     switch (resolution) {
         .unresolved => return error.InvalidResolution,
-        .take => |side| if (side == .base or valueForSide(operation, side) == null)
+        .take => |side| if (side == .base or operation.values.get(side) == null)
             return error.InvalidResolution,
         .custom => |value| {
             if (operation.collection) |binding_ref| {
@@ -168,14 +168,6 @@ pub fn supportsCustomResolution(plan: *const MergePlan, operation_id: OperationI
     const operation = merge_model.operationByIdConst(plan, operation_id) orelse return false;
     if (operation.collection != null) return true;
     return (operation.kind == .field or (operation.kind == .prefab_override and operation.item_path != null)) and supportsCustomValue(operation) and wasConflict(operation);
-}
-
-fn valueForSide(operation: *const Operation, side: merge_model.Side) ?SideValue {
-    return switch (side) {
-        .base => operation.values.base,
-        .ours => operation.values.ours,
-        .theirs => operation.values.theirs,
-    };
 }
 
 fn supportsCustomValue(operation: *const Operation) bool {

--- a/core/src/merge_apply.zig
+++ b/core/src/merge_apply.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 const merge_identity = @import("merge_identity.zig");
 const merge_model = @import("merge_model.zig");
-const merge_planner = @import("merge_planner.zig");
 const model = @import("model.zig");
 const parser = @import("parser.zig");
 const source = @import("source.zig");
+const merge_yaml = @import("merge_yaml.zig");
 
 const testing = std.testing;
 
@@ -152,7 +152,7 @@ fn appendPatch(
         const ours = operation.values.ours orelse return;
         const node = ours.node orelse return error.InvalidMerge;
         return patches.append(arena, .{
-            .span = completeEntrySpan(plan.ours, node) orelse return error.UnsupportedStructure,
+            .span = plan.ours.completeEntrySpan(node) orelse return error.UnsupportedStructure,
             .replacement = "",
             .atomic_id = operation.atomic_id,
             .order = operation.id,
@@ -161,7 +161,7 @@ fn appendPatch(
 
     const replacement = switch (operation.resolution) {
         .unresolved, .remove => return error.InvalidResolution,
-        .take => |side| (valueForSide(operation, side) orelse return error.InvalidResolution).bytes,
+        .take => |side| (operation.values.get(side) orelse return error.InvalidResolution).bytes,
         .custom => |input| blk: {
             _ = try parseCustomValue(arena, input);
             break :blk input;
@@ -172,10 +172,10 @@ fn appendPatch(
             if (ours_node.* == .map or ours_node.* == .seq) {
                 const selected = selectedValue(operation) orelse return error.InvalidResolution;
                 const selected_node = selected.value.node orelse return error.InvalidMerge;
-                const selected_file = fileForSide(plan, selected.side);
-                const ours_span = completeEntrySpan(plan.ours, ours_node) orelse
+                const selected_file = plan.file(selected.side);
+                const ours_span = plan.ours.completeEntrySpan(ours_node) orelse
                     return error.UnsupportedStructure;
-                const selected_span = completeEntrySpan(selected_file, selected_node) orelse
+                const selected_span = selected_file.completeEntrySpan(selected_node) orelse
                     return error.UnsupportedStructure;
                 const selected_bytes = selected_span.bytes(selected_file.bytes);
                 if (std.mem.eql(u8, ours_span.bytes(plan.ours.bytes), selected_bytes)) return;
@@ -199,11 +199,11 @@ fn appendPatch(
 
     const template = insertionTemplate(operation) orelse return error.InvalidResolution;
     const node = template.value.node orelse return error.InvalidMerge;
-    const template_file = fileForSide(plan, template.side);
+    const template_file = plan.file(template.side);
     const entry = template_file.entry_spans.get(node) orelse return error.UnsupportedStructure;
     const inserted = switch (operation.resolution) {
         .take => if (node.* == .map or node.* == .seq)
-            (completeEntrySpan(template_file, node) orelse return error.UnsupportedStructure).bytes(template_file.bytes)
+            (template_file.completeEntrySpan(node) orelse return error.UnsupportedStructure).bytes(template_file.bytes)
         else
             entry.whole.bytes(template_file.bytes),
         .custom => try entryWithValue(arena, template_file, entry, template.value, replacement),
@@ -216,15 +216,6 @@ fn appendPatch(
         .atomic_id = operation.atomic_id,
         .order = entry.whole.start,
     });
-}
-
-fn completeEntrySpan(file: source.ParsedFile, node: *const model.Node) ?source.Span {
-    const entry = file.entry_spans.get(node) orelse return null;
-    const node_span = file.node_spans.get(node) orelse return entry.whole;
-    return .{
-        .start = @min(entry.whole.start, node_span.start),
-        .end = @max(entry.whole.end, node_span.end),
-    };
 }
 
 fn isComponentSequenceOrder(
@@ -287,7 +278,7 @@ fn appendComposedHierarchySequencePatch(
             return error.InvalidResolution,
         .take => |side| SelectedValue{
             .side = side,
-            .value = valueForSide(order_operation, side) orelse return error.InvalidResolution,
+            .value = order_operation.values.get(side) orelse return error.InvalidResolution,
         },
         .remove, .custom => return error.InvalidResolution,
     };
@@ -311,8 +302,8 @@ fn appendComposedHierarchySequencePatch(
         }
     }
 
-    const destination_indent = sequenceIndent(plan.ours, ours_sequence) orelse
-        (sequenceFieldIndent(plan.ours, ours_sequence) orelse return error.UnsupportedStructure);
+    const destination_indent = merge_yaml.sequenceIndent(plan.ours, ours_sequence) orelse
+        (merge_yaml.sequenceFieldIndent(plan.ours, ours_sequence) orelse return error.UnsupportedStructure);
     const merged_bytes = try renderHierarchySequence(
         arena,
         plan,
@@ -322,7 +313,7 @@ fn appendComposedHierarchySequencePatch(
         choices.items,
         destination_indent,
     );
-    const replacement = try merge_planner.sequenceReplacement(arena, plan.ours, ours_sequence, merged_bytes);
+    const replacement = try merge_yaml.sequenceReplacement(arena, plan.ours, ours_sequence, merged_bytes);
     var ours_value = order_operation.values.ours orelse return error.UnsupportedStructure;
     if (order.items.len == 0 and ours_sequence.seq.len != 0) {
         const entry = plan.ours.entry_spans.get(ours_sequence) orelse return error.UnsupportedStructure;
@@ -351,7 +342,7 @@ fn effectiveHierarchyChoice(
             else => return error.InvalidMerge,
         },
         .remove => null,
-        .take => |side| if (valueForSide(operation, side)) |value|
+        .take => |side| if (operation.values.get(side)) |value|
             .{ .side = side, .value = value }
         else
             null,
@@ -393,7 +384,7 @@ fn insertHierarchyId(
     selected_side: merge_model.Side,
     file_id: i64,
 ) merge_model.Error!void {
-    const selected_file = fileForSide(plan, selected_side);
+    const selected_file = plan.file(selected_side);
     const selected_sequence = findSequence(selected_file, operation) orelse return error.UnsupportedStructure;
     if (selected_sequence.* != .seq) return error.UnsupportedStructure;
     const selected_index = for (selected_sequence.seq, 0..) |item, index| {
@@ -426,7 +417,7 @@ fn renderHierarchySequence(
             try output.appendSlice(arena, selected.value.bytes);
             try appendOursHierarchyGap(arena, &output, plan.ours, ours_sequence, file_id);
         } else {
-            try output.appendSlice(arena, try merge_planner.reindentSequenceItem(
+            try output.appendSlice(arena, try merge_yaml.reindentSequenceItem(
                 arena,
                 selected.value.bytes,
                 destination_indent,
@@ -445,7 +436,7 @@ fn hierarchyItem(
 ) ?SelectedValue {
     for (choices) |choice| if (choice.file_id == file_id) return choice.selected;
     for ([_]merge_model.Side{ .ours, .base, .theirs }) |side| {
-        const file = fileForSide(plan, side);
+        const file = plan.file(side);
         const sequence = findSequence(file, operation) orelse continue;
         if (sequence.* != .seq) continue;
         const item = findHierarchyItem(sequence.seq, file_id) orelse continue;
@@ -517,7 +508,7 @@ fn appendComposedPrefabSequencePatch(
             return error.InvalidResolution,
         .take => |side| SelectedValue{
             .side = side,
-            .value = valueForSide(order_operation, side) orelse return error.InvalidResolution,
+            .value = order_operation.values.get(side) orelse return error.InvalidResolution,
         },
         .remove, .custom => return error.InvalidResolution,
     };
@@ -548,8 +539,8 @@ fn appendComposedPrefabSequencePatch(
         }
     }
 
-    const destination_indent = sequenceIndent(plan.ours, ours_sequence) orelse
-        (sequenceFieldIndent(plan.ours, ours_sequence) orelse return error.UnsupportedStructure);
+    const destination_indent = merge_yaml.sequenceIndent(plan.ours, ours_sequence) orelse
+        (merge_yaml.sequenceFieldIndent(plan.ours, ours_sequence) orelse return error.UnsupportedStructure);
     const merged_bytes = try renderPrefabSequence(
         arena,
         plan,
@@ -560,7 +551,7 @@ fn appendComposedPrefabSequencePatch(
         destination_indent,
         kind,
     );
-    const replacement = try merge_planner.sequenceReplacement(
+    const replacement = try merge_yaml.sequenceReplacement(
         arena,
         plan.ours,
         ours_sequence,
@@ -589,7 +580,7 @@ fn effectivePrefabChoice(operation: *const merge_model.Operation) merge_model.Er
     return switch (operation.resolution) {
         .unresolved => if (operation.values.base) |value| .{ .side = .base, .value = value } else null,
         .remove => null,
-        .take => |side| if (valueForSide(operation, side)) |value|
+        .take => |side| if (operation.values.get(side)) |value|
             .{ .side = side, .value = value }
         else
             null,
@@ -620,7 +611,7 @@ fn prefabOrder(
     const modification = model.findValue(parsed.documents[0].body.map, "m_Modification") orelse
         return error.UnsupportedStructure;
     if (modification.* != .map) return error.UnsupportedStructure;
-    const sequence = model.findValue(modification.map, prefabField(kind)) orelse
+    const sequence = modification.get(prefabField(kind)) orelse
         return error.UnsupportedStructure;
     if (sequence.* != .seq) return error.UnsupportedStructure;
     var result: std.ArrayList([]const u8) = .empty;
@@ -668,7 +659,7 @@ fn prefabItemId(
 ) merge_model.Error![]const u8 {
     const identity = merge_identity.sequenceItemId(kind, item) orelse
         return error.UnsupportedStructure;
-    return merge_planner.sequenceId(arena, identity);
+    return identity.key(arena);
 }
 
 fn removePrefabId(order: *std.ArrayList([]const u8), id: []const u8) void {
@@ -700,7 +691,7 @@ fn insertPrefabId(
     id: []const u8,
     kind: merge_identity.SequenceKind,
 ) merge_model.Error!void {
-    const selected_file = fileForSide(plan, selected_side);
+    const selected_file = plan.file(selected_side);
     const selected_sequence = findSequence(selected_file, operation) orelse
         return error.UnsupportedStructure;
     if (selected_sequence.* != .seq) return error.UnsupportedStructure;
@@ -739,7 +730,7 @@ fn renderPrefabSequence(
             );
         } else {
             if (hasPrefabItemFields(plan, operation, id)) return error.UnsupportedStructure;
-            try output.appendSlice(arena, try merge_planner.reindentSequenceItem(
+            try output.appendSlice(arena, try merge_yaml.reindentSequenceItem(
                 arena,
                 selected.value.bytes,
                 destination_indent,
@@ -803,7 +794,7 @@ fn appendPrefabItemFieldPatch(
         else
             null,
         .remove => null,
-        .take => |side| if (valueForSide(operation, side)) |value|
+        .take => |side| if (operation.values.get(side)) |value|
             SelectedValue{ .side = side, .value = value }
         else
             null,
@@ -813,15 +804,15 @@ fn appendPrefabItemFieldPatch(
         const ours_node = ours.node orelse return error.InvalidMerge;
         const absolute_span = if (operation.resolution == .remove or
             ours_node.* == .map or ours_node.* == .seq)
-            completeEntrySpan(plan.ours, ours_node) orelse return error.UnsupportedStructure
+            plan.ours.completeEntrySpan(ours_node) orelse return error.UnsupportedStructure
         else
             ours.span orelse return error.UnsupportedStructure;
         const replacement = switch (operation.resolution) {
             .unresolved, .take => if (selected) |value| blk: {
                 if (ours_node.* == .map or ours_node.* == .seq) {
                     const selected_node = value.value.node orelse return error.InvalidMerge;
-                    const selected_file = fileForSide(plan, value.side);
-                    const span = completeEntrySpan(selected_file, selected_node) orelse
+                    const selected_file = plan.file(value.side);
+                    const span = selected_file.completeEntrySpan(selected_node) orelse
                         return error.UnsupportedStructure;
                     break :blk span.bytes(selected_file.bytes);
                 }
@@ -838,11 +829,11 @@ fn appendPrefabItemFieldPatch(
         else => return,
     };
     const template_node = selected_value.value.node orelse return error.InvalidMerge;
-    const template_file = fileForSide(plan, selected_value.side);
+    const template_file = plan.file(selected_value.side);
     const template_entry = template_file.entry_spans.get(template_node) orelse
         return error.UnsupportedStructure;
     const template_span = if (template_node.* == .map or template_node.* == .seq)
-        completeEntrySpan(template_file, template_node) orelse return error.UnsupportedStructure
+        template_file.completeEntrySpan(template_node) orelse return error.UnsupportedStructure
     else
         template_entry.whole;
     const inserted = switch (operation.resolution) {
@@ -905,7 +896,7 @@ fn prefabItemFieldInsertionOffset(
         operation.property_path,
     ) orelse return error.UnsupportedStructure;
     const ours_item = try findPrefabItemNode(arena, plan.ours, operation, item_id, kind);
-    const template_file = fileForSide(plan, template_side);
+    const template_file = plan.file(template_side);
     const template_item = try findPrefabItemNode(arena, template_file, operation, item_id, kind);
     const ours_parent = try fieldParent(ours_item, item_path);
     const template_parent = try fieldParent(template_item, item_path);
@@ -916,15 +907,15 @@ fn prefabItemFieldInsertionOffset(
     } else return error.UnsupportedStructure;
     var next_index = template_index + 1;
     while (next_index < template_parent.map.len) : (next_index += 1) {
-        const ours_next = model.findValue(ours_parent.map, template_parent.map[next_index].key) orelse continue;
+        const ours_next = ours_parent.get(template_parent.map[next_index].key) orelse continue;
         const entry = plan.ours.entry_spans.get(ours_next) orelse return error.UnsupportedStructure;
         return entry.whole.start;
     }
     var previous_index = template_index;
     while (previous_index > 0) {
         previous_index -= 1;
-        const ours_previous = model.findValue(ours_parent.map, template_parent.map[previous_index].key) orelse continue;
-        const span = completeEntrySpan(plan.ours, ours_previous) orelse return error.UnsupportedStructure;
+        const ours_previous = ours_parent.get(template_parent.map[previous_index].key) orelse continue;
+        const span = plan.ours.completeEntrySpan(ours_previous) orelse return error.UnsupportedStructure;
         return span.end;
     }
     if (plan.ours.node_spans.get(ours_parent)) |span| return span.end;
@@ -959,7 +950,7 @@ fn prefabItem(
         if (std.mem.eql(u8, choice.id, id)) return choice.selected;
     }
     for ([_]merge_model.Side{ .ours, .base, .theirs }) |side| {
-        const file = fileForSide(plan, side);
+        const file = plan.file(side);
         const sequence = findSequence(file, operation) orelse continue;
         if (sequence.* != .seq) continue;
         for (sequence.seq) |item| {
@@ -1013,7 +1004,7 @@ fn appendComposedComponentSequencePatch(
             return error.InvalidResolution,
         .take => |side| SelectedValue{
             .side = side,
-            .value = valueForSide(order_operation, side) orelse return error.InvalidResolution,
+            .value = order_operation.values.get(side) orelse return error.InvalidResolution,
         },
         .remove => return error.InvalidResolution,
         .custom => return error.InvalidResolution,
@@ -1038,8 +1029,8 @@ fn appendComposedComponentSequencePatch(
         }
     }
 
-    const destination_indent = sequenceIndent(plan.ours, ours_sequence) orelse
-        (sequenceFieldIndent(plan.ours, ours_sequence) orelse return error.UnsupportedStructure);
+    const destination_indent = merge_yaml.sequenceIndent(plan.ours, ours_sequence) orelse
+        (merge_yaml.sequenceFieldIndent(plan.ours, ours_sequence) orelse return error.UnsupportedStructure);
     const merged_bytes = try renderComponentSequence(
         arena,
         plan,
@@ -1049,7 +1040,7 @@ fn appendComposedComponentSequencePatch(
         choices.items,
         destination_indent,
     );
-    const replacement = try merge_planner.sequenceReplacement(arena, plan.ours, ours_sequence, merged_bytes);
+    const replacement = try merge_yaml.sequenceReplacement(arena, plan.ours, ours_sequence, merged_bytes);
     var ours_value = order_operation.values.ours orelse return error.UnsupportedStructure;
     if (order.items.len == 0 and ours_sequence.seq.len != 0) {
         const entry = plan.ours.entry_spans.get(ours_sequence) orelse return error.UnsupportedStructure;
@@ -1071,7 +1062,7 @@ fn effectiveComponentChoice(operation: *const merge_model.Operation) merge_model
     return switch (operation.resolution) {
         .unresolved => if (operation.values.base) |value| .{ .side = .base, .value = value } else null,
         .remove => null,
-        .take => |side| if (valueForSide(operation, side)) |value|
+        .take => |side| if (operation.values.get(side)) |value|
             .{ .side = side, .value = value }
         else
             null,
@@ -1131,7 +1122,7 @@ fn insertComponentId(
     selected_side: merge_model.Side,
     file_id: i64,
 ) merge_model.Error!void {
-    const selected_file = fileForSide(plan, selected_side);
+    const selected_file = plan.file(selected_side);
     const selected_sequence = findSequence(selected_file, operation) orelse return error.UnsupportedStructure;
     if (selected_sequence.* != .seq) return error.UnsupportedStructure;
     const selected_index = for (selected_sequence.seq, 0..) |item, index| {
@@ -1164,7 +1155,7 @@ fn renderComponentSequence(
             try output.appendSlice(arena, selected.value.bytes);
             try appendOursComponentGap(arena, &output, plan.ours, ours_sequence, file_id);
         } else {
-            try output.appendSlice(arena, try merge_planner.reindentSequenceItem(
+            try output.appendSlice(arena, try merge_yaml.reindentSequenceItem(
                 arena,
                 selected.value.bytes,
                 destination_indent,
@@ -1185,7 +1176,7 @@ fn componentItem(
         if (choice.file_id == file_id) return choice.selected;
     }
     for ([_]merge_model.Side{ .ours, .base, .theirs }) |side| {
-        const file = fileForSide(plan, side);
+        const file = plan.file(side);
         const sequence = findSequence(file, operation) orelse continue;
         if (sequence.* != .seq) continue;
         const item = findComponentItem(sequence.seq, file_id) orelse continue;
@@ -1226,7 +1217,7 @@ fn findSequence(file: source.ParsedFile, operation: *const merge_model.Operation
         var path = std.mem.splitScalar(u8, operation.property_path, '.');
         while (path.next()) |field| {
             if (node.* != .map) return null;
-            node = model.findValue(node.map, field) orelse return null;
+            node = node.get(field) orelse return null;
         }
         return node;
     }
@@ -1235,7 +1226,7 @@ fn findSequence(file: source.ParsedFile, operation: *const merge_model.Operation
 
 fn componentFileId(item: *const model.Node) ?i64 {
     if (item.* != .map) return null;
-    const component = model.findValue(item.map, "component") orelse return null;
+    const component = item.get("component") orelse return null;
     if (component.* != .ref) return null;
     return component.ref.file_id;
 }
@@ -1243,25 +1234,6 @@ fn componentFileId(item: *const model.Node) ?i64 {
 fn findComponentItem(items: []const *model.Node, file_id: i64) ?*const model.Node {
     for (items) |item| if (componentFileId(item) == file_id) return item;
     return null;
-}
-
-fn sequenceIndent(file: source.ParsedFile, sequence: *const model.Node) ?usize {
-    if (sequence.* != .seq or sequence.seq.len == 0) return null;
-    const span = file.sequence_item_spans.get(sequence.seq[0]) orelse return null;
-    const end = std.mem.indexOfScalarPos(u8, file.bytes, span.start, '\n') orelse span.end;
-    return leadingSpaces(file.bytes[span.start..end]);
-}
-
-fn sequenceFieldIndent(file: source.ParsedFile, sequence: *const model.Node) ?usize {
-    const entry = file.entry_spans.get(sequence) orelse return null;
-    const line_start = if (std.mem.lastIndexOfScalar(u8, file.bytes[0..entry.key.start], '\n')) |lf| lf + 1 else 0;
-    return entry.key.start - line_start;
-}
-
-fn leadingSpaces(line: []const u8) usize {
-    var count: usize = 0;
-    while (count < line.len and line[count] == ' ') count += 1;
-    return count;
 }
 
 fn appendDocumentPatch(
@@ -1273,7 +1245,7 @@ fn appendDocumentPatch(
     const selected = switch (operation.resolution) {
         .unresolved => return error.InvalidResolution,
         .remove => null,
-        .take => |side| valueForSide(operation, side),
+        .take => |side| operation.values.get(side),
         .custom => return error.InvalidResolution,
     };
     if (operation.values.ours) |ours| {
@@ -1315,7 +1287,7 @@ fn documentInsertionOrder(
     operation: *const merge_model.Operation,
     selected_side: merge_model.Side,
 ) usize {
-    const selected_file = fileForSide(plan, selected_side);
+    const selected_file = plan.file(selected_side);
     return for (selected_file.documents, 0..) |document, index| {
         if (document.class_id == operation.identity.document.class_id and
             document.file_id == operation.identity.document.file_id) break index;
@@ -1327,7 +1299,7 @@ fn documentInsertionOffset(
     operation: *const merge_model.Operation,
     selected_side: merge_model.Side,
 ) usize {
-    const selected_file = fileForSide(plan, selected_side);
+    const selected_file = plan.file(selected_side);
     const selected_index = for (selected_file.documents, 0..) |document, index| {
         if (document.class_id == operation.identity.document.class_id and
             document.file_id == operation.identity.document.file_id) break index;
@@ -1346,7 +1318,7 @@ const SelectedValue = struct { side: merge_model.Side, value: merge_model.SideVa
 
 fn selectedValue(operation: *const merge_model.Operation) ?SelectedValue {
     return switch (operation.resolution) {
-        .take => |side| if (valueForSide(operation, side)) |value| .{ .side = side, .value = value } else null,
+        .take => |side| if (operation.values.get(side)) |value| .{ .side = side, .value = value } else null,
         else => null,
     };
 }
@@ -1375,22 +1347,6 @@ fn entryWithValue(
     return bytes.toOwnedSlice(arena);
 }
 
-fn valueForSide(operation: *const merge_model.Operation, side: merge_model.Side) ?merge_model.SideValue {
-    return switch (side) {
-        .base => operation.values.base,
-        .ours => operation.values.ours,
-        .theirs => operation.values.theirs,
-    };
-}
-
-fn fileForSide(plan: *const merge_model.MergePlan, side: merge_model.Side) source.ParsedFile {
-    return switch (side) {
-        .base => plan.base,
-        .ours => plan.ours,
-        .theirs => plan.theirs,
-    };
-}
-
 pub fn insertionOffset(
     plan: *const merge_model.MergePlan,
     operation: *const merge_model.Operation,
@@ -1401,7 +1357,7 @@ pub fn insertionOffset(
 
         const parent = try fieldParent(document.body, operation.property_path);
         if (insertionTemplate(operation)) |template| {
-            const template_file = fileForSide(plan, template.side);
+            const template_file = plan.file(template.side);
             const template_document = findDocument(template_file, operation.identity.document) orelse
                 return error.UnsupportedStructure;
             const template_parent = try fieldParent(template_document.body, operation.property_path);
@@ -1412,15 +1368,15 @@ pub fn insertionOffset(
             } else return error.UnsupportedStructure;
             var next_index = template_index + 1;
             while (next_index < template_parent.map.len) : (next_index += 1) {
-                const ours_next = model.findValue(parent.map, template_parent.map[next_index].key) orelse continue;
+                const ours_next = parent.get(template_parent.map[next_index].key) orelse continue;
                 const entry = plan.ours.entry_spans.get(ours_next) orelse return error.UnsupportedStructure;
                 return entry.whole.start;
             }
             var previous_index = template_index;
             while (previous_index > 0) {
                 previous_index -= 1;
-                const ours_previous = model.findValue(parent.map, template_parent.map[previous_index].key) orelse continue;
-                const span = completeEntrySpan(plan.ours, ours_previous) orelse return error.UnsupportedStructure;
+                const ours_previous = parent.get(template_parent.map[previous_index].key) orelse continue;
+                const span = plan.ours.completeEntrySpan(ours_previous) orelse return error.UnsupportedStructure;
                 return span.end;
             }
         }
@@ -1535,6 +1491,7 @@ fn hasYamlComment(input: []const u8) bool {
 }
 
 test "merge apply: reuses selected token bytes and keeps untouched bytes" {
+    const merge_planner = @import("merge_planner.zig");
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -1662,6 +1619,7 @@ test "merge apply: keeps the declared order of inserts at one offset" {
 }
 
 fn threeFieldPlan(arena: std.mem.Allocator) !merge_model.MergePlan {
+    const merge_planner = @import("merge_planner.zig");
     const base = "--- !u!114 &1\nMonoBehaviour:\n  first: 0\n  second: 0\n  third: 0\n";
     const ours = "--- !u!114 &1\nMonoBehaviour:\n  first: 1\n  second: 1\n  third: 1\n";
     const theirs = "--- !u!114 &1\nMonoBehaviour:\n  first: 2\n  second: 2\n  third: 2\n";

--- a/core/src/merge_binding.zig
+++ b/core/src/merge_binding.zig
@@ -77,7 +77,7 @@ pub fn replacement(arena: std.mem.Allocator, plan: *const mm.MergePlan, binding:
     };
     if (result == null) {
         const original = binding.original orelse return null;
-        return .{ .span = yaml.completeEntrySpan(plan.ours, original) orelse return error.InvalidMerge, .bytes = "" };
+        return .{ .span = plan.ours.completeEntrySpan(original) orelse return error.InvalidMerge, .bytes = "" };
     }
     var final = result.?;
     const borrowed = final == binding.plan.input.nodes.ours or final == binding.plan.input.nodes.theirs or final == binding.plan.input.nodes.base;
@@ -97,7 +97,7 @@ pub fn replacement(arena: std.mem.Allocator, plan: *const mm.MergePlan, binding:
     if (binding.plan.input.schema) |descriptor| {
         if (descriptor.kind == .int32_array and final.* == .scalar and final.scalar.len == 0) {
             const entry = plan.ours.entry_spans.get(original) orelse return error.InvalidMerge;
-            const span = yaml.completeEntrySpan(plan.ours, original) orelse return error.InvalidMerge;
+            const span = plan.ours.completeEntrySpan(original) orelse return error.InvalidMerge;
             return .{ .span = span, .bytes = try std.mem.concat(arena, u8, &.{ plan.ours.bytes[span.start..entry.value.start], plan.ours.bytes[entry.value.end..span.end] }) };
         }
     }
@@ -112,7 +112,7 @@ const Evidence = struct { field: ?ctx.Field = null, conflict: bool = false };
 fn field(snapshot: ctx.Snapshot, file: source.ParsedFile, document: mm.DocumentId, path: []const u8) ?ctx.Field {
     for (file.documents) |doc| {
         if (doc.class_id != document.class_id or doc.file_id != document.file_id) continue;
-        const script = model.findValue(doc.body.map, "m_Script") orelse return null;
+        const script = doc.body.get("m_Script") orelse return null;
         if (script.* != .ref) return null;
         return snapshot.field(script.ref.guid orelse return null, path);
     }

--- a/core/src/merge_identity.zig
+++ b/core/src/merge_identity.zig
@@ -53,11 +53,11 @@ pub fn componentOwners(
     var owners: ComponentOwnerIndex = .empty;
     for (documents) |document| {
         if (document.class_id != 1) continue;
-        const components = model.findValue(document.body.map, "m_Component") orelse continue;
+        const components = document.body.get("m_Component") orelse continue;
         if (components.* != .seq) return error.UnsupportedStructure;
         for (components.seq) |item| {
             if (item.* != .map) return error.UnsupportedStructure;
-            const component = prefab.reference(model.findValue(item.map, "component")) orelse
+            const component = model.Node.asRef(item.get("component")) orelse
                 return error.UnsupportedStructure;
             const result = try owners.getOrPut(arena, component.file_id);
             if (result.found_existing) return error.InvalidMerge;
@@ -94,6 +94,23 @@ pub const SequenceItemId = struct {
     property_path: ?[]const u8 = null,
     added_object: ?merge_model.RefId = null,
     override_kind: ?merge_model.PrefabOverrideKind = null,
+
+    pub fn key(identity: SequenceItemId, arena: std.mem.Allocator) std.mem.Allocator.Error![]const u8 {
+        return std.fmt.allocPrint(
+            arena,
+            "{d}|{s}|{?d}|{s}|{?d}|{s}|{?d}|{?d}",
+            .{
+                identity.target.file_id,
+                identity.target.guid orelse "",
+                identity.target.type_id,
+                identity.property_path orelse "",
+                if (identity.added_object) |added| added.file_id else null,
+                if (identity.added_object) |added| added.guid orelse "" else "",
+                if (identity.added_object) |added| added.type_id else null,
+                if (identity.override_kind) |override_kind| @intFromEnum(override_kind) else null,
+            },
+        );
+    }
 };
 
 pub fn sequenceItemId(kind: SequenceKind, item: *const model.Node) ?SequenceItemId {
@@ -110,11 +127,11 @@ pub fn sequenceItemId(kind: SequenceKind, item: *const model.Node) ?SequenceItem
 
 fn itemFileIdField(item: *const model.Node, field: []const u8) ?SequenceItemId {
     if (item.* != .map) return null;
-    return directFileId(model.findValue(item.map, field) orelse return null);
+    return directFileId(item.get(field) orelse return null);
 }
 
 fn directFileId(item: *const model.Node) ?SequenceItemId {
-    const target = prefab.reference(item) orelse return null;
+    const target = model.Node.asRef(item) orelse return null;
     return .{ .target = .{ .file_id = target.file_id, .guid = null, .type_id = null } };
 }
 

--- a/core/src/merge_model.zig
+++ b/core/src/merge_model.zig
@@ -50,6 +50,14 @@ pub const Values = struct {
     base: ?SideValue,
     ours: ?SideValue,
     theirs: ?SideValue,
+
+    pub fn get(self: Values, side: Side) ?SideValue {
+        return switch (side) {
+            .base => self.base,
+            .ours => self.ours,
+            .theirs => self.theirs,
+        };
+    }
 };
 
 pub const Resolution = union(enum) {
@@ -91,6 +99,14 @@ pub const MergePlan = struct {
     operations: []Operation,
     atomic_operations: []AtomicOperation,
     collections: []const @import("merge_binding.zig").Binding = &.{},
+
+    pub fn file(self: MergePlan, side: Side) source.ParsedFile {
+        return switch (side) {
+            .base => self.base,
+            .ours => self.ours,
+            .theirs => self.theirs,
+        };
+    }
 
     pub fn unresolvedCount(self: MergePlan) usize {
         var count: usize = 0;

--- a/core/src/merge_planner.zig
+++ b/core/src/merge_planner.zig
@@ -7,6 +7,7 @@ const model = @import("model.zig");
 const parser = @import("parser.zig");
 const prefab = @import("prefab.zig");
 const source = @import("source.zig");
+const merge_yaml = @import("merge_yaml.zig");
 
 const testing = std.testing;
 
@@ -424,12 +425,12 @@ fn operationMatchesOverrideObject(
     }) |value| {
         const body = (value orelse continue).node orelse continue;
         if (body.* != .map) continue;
-        const owner = prefab.reference(model.findValue(body.map, "m_PrefabInstance")) orelse
+        const owner = model.Node.asRef(body.get("m_PrefabInstance")) orelse
             continue;
         if (owner.guid != null or owner.file_id != prefab_instance) continue;
         if (object.guid == null and operation.identity.document.file_id == object.file_id) return true;
-        const corresponding = prefab.reference(
-            model.findValue(body.map, "m_CorrespondingSourceObject"),
+        const corresponding = model.Node.asRef(
+            body.get("m_CorrespondingSourceObject"),
         ) orelse continue;
         if (modelRefEql(corresponding, object)) return true;
     }
@@ -572,7 +573,7 @@ fn transformParent(
     child: merge_model.DocumentId,
 ) merge_model.Error!?merge_model.DocumentId {
     const document = index.document(child) orelse return error.UnsupportedStructure;
-    const father = model.findValue(document.body.map, "m_Father") orelse return null;
+    const father = document.body.get("m_Father") orelse return null;
     if (father.* != .ref or father.ref.guid != null) return error.UnsupportedStructure;
     if (father.ref.file_id == 0) return null;
     const parent = try indexedDocumentByFileId(index, father.ref.file_id);
@@ -598,7 +599,7 @@ pub fn gameObjectBundle(
 ) merge_model.Error!GameObjectBundle {
     const game_object = index.document(.{ .class_id = 1, .file_id = game_object_file_id }) orelse
         return error.UnsupportedStructure;
-    const component_node = model.findValue(game_object.body.map, "m_Component") orelse
+    const component_node = game_object.body.get("m_Component") orelse
         return error.UnsupportedStructure;
     if (component_node.* != .seq) return error.UnsupportedStructure;
 
@@ -624,7 +625,7 @@ pub fn gameObjectBundle(
     }
     const transform_id = transform orelse return error.UnsupportedStructure;
     const transform_document = index.document(transform_id) orelse return error.UnsupportedStructure;
-    const father = model.findValue(transform_document.body.map, "m_Father") orelse
+    const father = transform_document.body.get("m_Father") orelse
         return error.UnsupportedStructure;
     if (father.* != .ref or father.ref.guid != null) return error.UnsupportedStructure;
 
@@ -632,7 +633,7 @@ pub fn gameObjectBundle(
     if (father.ref.file_id != 0) {
         const parent = try indexedDocumentByFileId(index, father.ref.file_id);
         if (parent.class_id != 4 and parent.class_id != 224) return error.UnsupportedStructure;
-        const children = model.findValue(parent.body.map, "m_Children") orelse
+        const children = parent.body.get("m_Children") orelse
             return error.UnsupportedStructure;
         if (children.* != .seq) return error.UnsupportedStructure;
         var matches: usize = 0;
@@ -761,7 +762,7 @@ fn changedGameObjectParent(
         const bundle = try gameObjectBundle(arena, index, game_object_file_id);
         const parent_item = bundle.parent_child_item orelse return false;
         const parent_transform = index.document(parent_item.document) orelse return error.UnsupportedStructure;
-        const parent_game_object = model.findValue(parent_transform.body.map, "m_GameObject") orelse
+        const parent_game_object = parent_transform.body.get("m_GameObject") orelse
             return error.UnsupportedStructure;
         if (parent_game_object.* != .ref or parent_game_object.ref.guid != null) return error.UnsupportedStructure;
         const parent_file_id = parent_game_object.ref.file_id;
@@ -796,14 +797,14 @@ fn appendGameObjectSubtree(
     const bundle = try gameObjectBundle(arena, index, game_object_file_id);
     try bundles.append(arena, bundle);
     const transform = index.document(bundle.transform) orelse return error.UnsupportedStructure;
-    const children = model.findValue(transform.body.map, "m_Children") orelse return;
+    const children = transform.body.get("m_Children") orelse return;
     if (children.* != .seq) return error.UnsupportedStructure;
     for (children.seq) |child_node| {
         if (child_node.* != .ref or child_node.ref.guid != null) return error.UnsupportedStructure;
         const child_transform = try indexedDocumentByFileId(index, child_node.ref.file_id);
         if (child_transform.class_id != 4 and child_transform.class_id != 224)
             return error.UnsupportedStructure;
-        const child_game_object = model.findValue(child_transform.body.map, "m_GameObject") orelse
+        const child_game_object = child_transform.body.get("m_GameObject") orelse
             return error.UnsupportedStructure;
         if (child_game_object.* != .ref or child_game_object.ref.guid != null)
             return error.UnsupportedStructure;
@@ -820,7 +821,7 @@ fn appendGameObjectSubtree(
 fn gameObjectChangeHasFather(indexes: MergeIndexes, game_object_file_id: i64) bool {
     for ([_]*const merge_identity.Index{ &indexes.base, &indexes.ours, &indexes.theirs }) |index| {
         const game_object = index.document(.{ .class_id = 1, .file_id = game_object_file_id }) orelse continue;
-        const components = model.findValue(game_object.body.map, "m_Component") orelse continue;
+        const components = game_object.body.get("m_Component") orelse continue;
         if (components.* != .seq) continue;
         for (components.seq) |item| {
             const item_id = merge_identity.sequenceItemId(.components, item) orelse continue;
@@ -829,7 +830,7 @@ fn gameObjectChangeHasFather(indexes: MergeIndexes, game_object_file_id: i64) bo
                 const component = entry.value_ptr.*;
                 if (component.file_id != item_id.target.file_id or
                     (component.class_id != 4 and component.class_id != 224)) continue;
-                if (model.findValue(component.body.map, "m_Father") != null) return true;
+                if (component.body.get("m_Father") != null) return true;
             }
         }
     }
@@ -1117,7 +1118,7 @@ fn semanticValue(
     while (path.next()) |field| {
         if (field.len == 0) continue;
         if (node.* != .map) return null;
-        node = model.findValue(node.map, field) orelse return null;
+        node = node.get(field) orelse return null;
     }
     const item_ref = identity.item_ref orelse return sideValue(file, node);
     if (node.* != .seq) return null;
@@ -1140,14 +1141,14 @@ fn validateComponentOwners(
     while (owner_iterator.next()) |entry| {
         const document = findDocumentByFileId(file.documents, entry.key_ptr.*) orelse
             return error.UnsupportedStructure;
-        const game_object = model.findValue(document.body.map, "m_GameObject") orelse
+        const game_object = document.body.get("m_GameObject") orelse
             return error.UnsupportedStructure;
         if (game_object.* != .ref or game_object.ref.file_id != entry.value_ptr.*) {
             return error.UnsupportedStructure;
         }
     }
     for (file.documents) |*document| {
-        const game_object = model.findValue(document.body.map, "m_GameObject") orelse continue;
+        const game_object = document.body.get("m_GameObject") orelse continue;
         if (game_object.* != .ref) return error.UnsupportedStructure;
         const owner = owners.get(document.file_id) orelse return error.UnsupportedStructure;
         if (owner != game_object.ref.file_id) return error.UnsupportedStructure;
@@ -1182,8 +1183,8 @@ fn collectMapFields(
             entry.key,
             .{
                 .base = entry.value,
-                .ours = findValueConst(ours_entries, entry.key),
-                .theirs = findValueConst(theirs_entries, entry.key),
+                .ours = model.findValue(ours_entries, entry.key),
+                .theirs = model.findValue(theirs_entries, entry.key),
             },
             base_file,
             ours_file,
@@ -1192,7 +1193,7 @@ fn collectMapFields(
         );
     }
     for (ours_entries) |entry| {
-        if (findValueConst(base_entries, entry.key) != null) continue;
+        if (model.findValue(base_entries, entry.key) != null) continue;
         try collectField(
             arena,
             operations,
@@ -1204,7 +1205,7 @@ fn collectMapFields(
             .{
                 .base = null,
                 .ours = entry.value,
-                .theirs = findValueConst(theirs_entries, entry.key),
+                .theirs = model.findValue(theirs_entries, entry.key),
             },
             base_file,
             ours_file,
@@ -1213,7 +1214,7 @@ fn collectMapFields(
         );
     }
     for (theirs_entries) |entry| {
-        if (findValueConst(base_entries, entry.key) != null or findValueConst(ours_entries, entry.key) != null) continue;
+        if (model.findValue(base_entries, entry.key) != null or model.findValue(ours_entries, entry.key) != null) continue;
         try collectField(
             arena,
             operations,
@@ -1704,8 +1705,8 @@ fn collectPrefabItemMapFields(
             entry.key,
             .{
                 .base = entry.value,
-                .ours = findValueConst(ours_entries, entry.key),
-                .theirs = findValueConst(theirs_entries, entry.key),
+                .ours = model.findValue(ours_entries, entry.key),
+                .theirs = model.findValue(theirs_entries, entry.key),
             },
             base_file,
             ours_file,
@@ -1713,7 +1714,7 @@ fn collectPrefabItemMapFields(
         );
     }
     for (ours_entries) |entry| {
-        if (findValueConst(base_entries, entry.key) != null) continue;
+        if (model.findValue(base_entries, entry.key) != null) continue;
         try collectPrefabItemField(
             arena,
             operations,
@@ -1728,7 +1729,7 @@ fn collectPrefabItemMapFields(
             .{
                 .base = null,
                 .ours = entry.value,
-                .theirs = findValueConst(theirs_entries, entry.key),
+                .theirs = model.findValue(theirs_entries, entry.key),
             },
             base_file,
             ours_file,
@@ -1736,8 +1737,8 @@ fn collectPrefabItemMapFields(
         );
     }
     for (theirs_entries) |entry| {
-        if (findValueConst(base_entries, entry.key) != null or
-            findValueConst(ours_entries, entry.key) != null) continue;
+        if (model.findValue(base_entries, entry.key) != null or
+            model.findValue(ours_entries, entry.key) != null) continue;
         try collectPrefabItemField(
             arena,
             operations,
@@ -1869,7 +1870,7 @@ fn childHasFather(
 ) bool {
     for ([_]source.ParsedFile{ base, ours, theirs }) |file| {
         const transform = findDocumentByFileId(file.documents, transform_file_id) orelse continue;
-        if (model.findValue(transform.body.map, "m_Father") != null) return true;
+        if (transform.body.get("m_Father") != null) return true;
     }
     return false;
 }
@@ -1885,29 +1886,12 @@ fn identifiedItems(
     var seen: std.StringHashMapUnmanaged(void) = .empty;
     for (sequence.seq) |item| {
         const identity = merge_identity.sequenceItemId(kind, item) orelse return error.UnsupportedStructure;
-        const id = try sequenceId(arena, identity);
+        const id = try identity.key(arena);
         const entry = try seen.getOrPut(arena, id);
         if (entry.found_existing) return error.MalformedInput;
         try result.append(arena, .{ .id = id, .identity = identity, .node = item });
     }
     return result.toOwnedSlice(arena);
-}
-
-pub fn sequenceId(arena: std.mem.Allocator, identity: merge_identity.SequenceItemId) std.mem.Allocator.Error![]const u8 {
-    return std.fmt.allocPrint(
-        arena,
-        "{d}|{s}|{?d}|{s}|{?d}|{s}|{?d}|{?d}",
-        .{
-            identity.target.file_id,
-            identity.target.guid orelse "",
-            identity.target.type_id,
-            identity.property_path orelse "",
-            if (identity.added_object) |added| added.file_id else null,
-            if (identity.added_object) |added| added.guid orelse "" else "",
-            if (identity.added_object) |added| added.type_id else null,
-            if (identity.override_kind) |override_kind| @intFromEnum(override_kind) else null,
-        },
-    );
 }
 
 fn unionIds(arena: std.mem.Allocator, items: SequenceItems) std.mem.Allocator.Error![]const []const u8 {
@@ -2081,7 +2065,7 @@ fn appendOrderOperation(
     const replacement = if (keep_ours)
         if (ours_value) |value| value.bytes else ""
     else if (!has_conflict)
-        try sequenceReplacement(arena, ours_file, nodes.ours, merged_bytes)
+        try merge_yaml.sequenceReplacement(arena, ours_file, nodes.ours, merged_bytes)
     else
         merged_bytes;
     if (!keep_ours and !has_conflict and merged_bytes.len == 0) {
@@ -2111,15 +2095,13 @@ fn appendOrderOperation(
 }
 
 fn sequenceSideValue(file: source.ParsedFile, node: ?*const model.Node) ?merge_model.SideValue {
-    var value = sideValue(file, node) orelse return null;
-    const present = node.?;
-    if (present.* == .seq and present.seq.len == 0 and value.span.?.start > 0 and
-        file.bytes[value.span.?.start - 1] == ' ')
-    {
-        value.span.?.start -= 1;
-        value.bytes = value.span.?.bytes(file.bytes);
-    }
-    return value;
+    const present = node orelse return null;
+    const span = merge_yaml.sequenceSpan(file, present);
+    return .{
+        .node = present,
+        .bytes = if (span) |value| value.bytes(file.bytes) else "",
+        .span = span,
+    };
 }
 
 fn renderSequence(
@@ -2132,12 +2114,12 @@ fn renderSequence(
     nodes: DocumentNodes,
 ) merge_model.Error![]const u8 {
     var output: std.ArrayList(u8) = .empty;
-    const destination_indent = sequenceIndent(ours_file, nodes.ours) orelse
-        sequenceFieldIndent(ours_file, nodes.ours) orelse
-        sequenceIndent(base_file, nodes.base) orelse
-        sequenceFieldIndent(base_file, nodes.base) orelse
-        sequenceIndent(theirs_file, nodes.theirs) orelse
-        sequenceFieldIndent(theirs_file, nodes.theirs) orelse 0;
+    const destination_indent = merge_yaml.sequenceIndent(ours_file, nodes.ours) orelse
+        merge_yaml.sequenceFieldIndent(ours_file, nodes.ours) orelse
+        merge_yaml.sequenceIndent(base_file, nodes.base) orelse
+        merge_yaml.sequenceFieldIndent(base_file, nodes.base) orelse
+        merge_yaml.sequenceIndent(theirs_file, nodes.theirs) orelse
+        merge_yaml.sequenceFieldIndent(theirs_file, nodes.theirs) orelse 0;
     for (order, 0..) |id, index| {
         const base_item = findSequenceItem(items.base, id);
         const ours_item = findSequenceItem(items.ours, id);
@@ -2164,7 +2146,7 @@ fn renderSequence(
             try output.appendSlice(arena, bytes);
         } else {
             const offset = insertionOffsetForItem(ours_file, items.ours, order, index, nodes.ours);
-            try output.appendSlice(arena, try reindentSequenceItem(
+            try output.appendSlice(arena, try merge_yaml.reindentSequenceItem(
                 arena,
                 bytes,
                 destination_indent,
@@ -2174,33 +2156,6 @@ fn renderSequence(
         try appendOursGap(arena, &output, ours_file, items.ours, id);
     }
     return output.toOwnedSlice(arena);
-}
-
-pub fn sequenceReplacement(
-    arena: std.mem.Allocator,
-    ours_file: source.ParsedFile,
-    ours_node: ?*const model.Node,
-    merged_bytes: []const u8,
-) std.mem.Allocator.Error![]const u8 {
-    const node = ours_node orelse return merged_bytes;
-    if (merged_bytes.len == 0) {
-        if (node.* != .seq or node.seq.len == 0) {
-            return if (sequenceSideValue(ours_file, node)) |value| value.bytes else "[]";
-        }
-        const span = ours_file.node_spans.get(node) orelse return " []";
-        const source_bytes = span.bytes(ours_file.bytes);
-        if (std.mem.endsWith(u8, source_bytes, "\r\n")) return " []\r\n";
-        if (std.mem.endsWith(u8, source_bytes, "\n")) return " []\n";
-        return " []";
-    }
-    if (node.* != .seq or node.seq.len != 0) return merged_bytes;
-    const span = ours_file.node_spans.get(node) orelse return merged_bytes;
-    const line_ending = ours_file.lineEndingAt(span.end);
-    const item_bytes = if (std.mem.endsWith(u8, merged_bytes, line_ending))
-        merged_bytes[0 .. merged_bytes.len - line_ending.len]
-    else
-        merged_bytes;
-    return std.fmt.allocPrint(arena, "{s}{s}", .{ line_ending, item_bytes });
 }
 
 fn sequenceEmptyPatchValue(file: source.ParsedFile, node: ?*const model.Node) ?merge_model.SideValue {
@@ -2236,21 +2191,6 @@ fn appendOursGap(
     try output.appendSlice(arena, gap);
 }
 
-fn sequenceIndent(file: source.ParsedFile, node: ?*const model.Node) ?usize {
-    const sequence = node orelse return null;
-    if (sequence.* != .seq or sequence.seq.len == 0) return null;
-    const span = file.sequence_item_spans.get(sequence.seq[0]) orelse return null;
-    const end = std.mem.indexOfScalarPos(u8, file.bytes, span.start, '\n') orelse span.end;
-    return leadingSpaces(file.bytes[span.start..end]);
-}
-
-fn sequenceFieldIndent(file: source.ParsedFile, node: ?*const model.Node) ?usize {
-    const sequence = node orelse return null;
-    const entry = file.entry_spans.get(sequence) orelse return null;
-    const line_start = if (std.mem.lastIndexOfScalar(u8, file.bytes[0..entry.key.start], '\n')) |lf| lf + 1 else 0;
-    return entry.key.start - line_start;
-}
-
 fn insertionOffsetForItem(
     file: source.ParsedFile,
     ours_items: []const SequenceItem,
@@ -2273,40 +2213,6 @@ fn insertionOffsetForItem(
     }
     if (sequence_node) |node| if (file.node_spans.get(node)) |span| return span.end;
     return file.bytes.len;
-}
-
-fn leadingSpaces(line: []const u8) usize {
-    var count: usize = 0;
-    while (count < line.len and line[count] == ' ') count += 1;
-    return count;
-}
-
-pub fn reindentSequenceItem(
-    arena: std.mem.Allocator,
-    source_item: []const u8,
-    destination_indent: usize,
-    line_ending: []const u8,
-) merge_model.Error![]const u8 {
-    const first_lf = std.mem.indexOfScalar(u8, source_item, '\n') orelse source_item.len;
-    const first_line = std.mem.trimEnd(u8, source_item[0..first_lf], "\r");
-    const source_indent = leadingSpaces(first_line);
-    var output: std.ArrayList(u8) = .empty;
-    var cursor: usize = 0;
-    while (cursor < source_item.len) {
-        const relative_lf = std.mem.indexOfScalar(u8, source_item[cursor..], '\n');
-        const end = if (relative_lf) |line_index| cursor + line_index else source_item.len;
-        const raw_line = source_item[cursor..end];
-        const line = std.mem.trimEnd(u8, raw_line, "\r");
-        const indent = leadingSpaces(line);
-        if (line.len != 0 and indent < source_indent) return error.UnsupportedStructure;
-        if (line.len != 0) {
-            try output.appendNTimes(arena, ' ', destination_indent + indent - source_indent);
-            try output.appendSlice(arena, line[indent..]);
-        }
-        if (relative_lf != null) try output.appendSlice(arena, line_ending);
-        cursor = if (relative_lf != null) end + 1 else end;
-    }
-    return output.toOwnedSlice(arena);
 }
 
 fn appendComponentDocumentOperation(
@@ -2502,7 +2408,7 @@ fn gameObjectId(
     transform_file_id: i64,
 ) ?i64 {
     const transform = findDocumentByFileId(file.documents, transform_file_id) orelse return null;
-    const game_object = model.findValue(transform.body.map, "m_GameObject") orelse return null;
+    const game_object = transform.body.get("m_GameObject") orelse return null;
     if (game_object.* != .ref) return null;
     return game_object.ref.file_id;
 }
@@ -2520,13 +2426,6 @@ fn mapEntries(node: ?*const model.Node) []const model.Entry {
         .map => |entries| entries,
         else => &.{},
     };
-}
-
-fn findValueConst(entries: []const model.Entry, key: []const u8) ?*const model.Node {
-    for (entries) |entry| {
-        if (std.mem.eql(u8, entry.key, key)) return entry.value;
-    }
-    return null;
 }
 
 fn hasMap(nodes: DocumentNodes) bool {

--- a/core/src/merge_validate.zig
+++ b/core/src/merge_validate.zig
@@ -53,13 +53,13 @@ const Index = struct {
         var owners: std.AutoHashMapUnmanaged(i64, i64) = .empty;
         for (self.all_documents) |document| {
             if (document.class_id != 1) continue;
-            const components = model.findValue(document.body.map, "m_Component") orelse
+            const components = document.body.get("m_Component") orelse
                 return error.InvalidMerge;
             if (components.* != .seq) return error.InvalidMerge;
             var transform_count: usize = 0;
             for (components.seq) |item| {
                 if (item.* != .map) return error.InvalidMerge;
-                const component_node = model.findValue(item.map, "component") orelse
+                const component_node = item.get("component") orelse
                     return error.InvalidMerge;
                 if (component_node.* != .ref or component_node.ref.guid != null or
                     component_node.ref.file_id == 0) return error.InvalidMerge;
@@ -69,7 +69,7 @@ const Index = struct {
                 const owner = try owners.getOrPut(self.arena, component.file_id);
                 if (owner.found_existing) return error.InvalidMerge;
                 owner.value_ptr.* = document.file_id;
-                const back_reference = model.findValue(component.body.map, "m_GameObject") orelse
+                const back_reference = component.body.get("m_GameObject") orelse
                     return error.InvalidMerge;
                 if (back_reference.* != .ref or back_reference.ref.guid != null or
                     back_reference.ref.file_id != document.file_id) return error.InvalidMerge;
@@ -77,7 +77,7 @@ const Index = struct {
             if (transform_count != 1) return error.InvalidMerge;
         }
         for (self.all_documents) |document| {
-            const game_object = model.findValue(document.body.map, "m_GameObject") orelse {
+            const game_object = document.body.get("m_GameObject") orelse {
                 if (document.class_id == 4 or document.class_id == 224) return error.InvalidMerge;
                 continue;
             };
@@ -92,7 +92,7 @@ const Index = struct {
         var parents: std.AutoHashMapUnmanaged(i64, i64) = .empty;
         for (self.all_documents) |document| {
             if (document.class_id != 4 and document.class_id != 224) continue;
-            const children = model.findValue(document.body.map, "m_Children") orelse
+            const children = document.body.get("m_Children") orelse
                 return error.InvalidMerge;
             if (children.* != .seq) return error.InvalidMerge;
             for (children.seq) |item| {
@@ -107,7 +107,7 @@ const Index = struct {
         }
         for (self.all_documents) |document| {
             if (document.class_id != 4 and document.class_id != 224) continue;
-            const father = model.findValue(document.body.map, "m_Father") orelse
+            const father = document.body.get("m_Father") orelse
                 return error.InvalidMerge;
             if (father.* != .ref or father.ref.guid != null) return error.InvalidMerge;
             if (father.ref.file_id == 0) {
@@ -133,7 +133,7 @@ const Index = struct {
                 if (complete.contains(transform.file_id)) break;
                 const visited = try path.getOrPut(self.arena, transform.file_id);
                 if (visited.found_existing) return error.InvalidMerge;
-                const father = model.findValue(transform.body.map, "m_Father") orelse break;
+                const father = transform.body.get("m_Father") orelse break;
                 if (father.* != .ref or father.ref.guid != null) return error.InvalidMerge;
                 if (father.ref.file_id == 0) break;
                 const parent = self.documents.get(father.ref.file_id) orelse break;

--- a/core/src/merge_yaml.zig
+++ b/core/src/merge_yaml.zig
@@ -16,7 +16,7 @@ pub fn parseValue(arena: std.mem.Allocator, input: []const u8) Error!*const mode
     if (parsed.diagnostics.len != 0 or parsed.documents.len != 1) return error.InvalidValue;
     const body = parsed.documents[0].body;
     if (body.* != .map or body.map.len != 1) return error.InvalidValue;
-    const value = model.findValue(body.map, "value") orelse return error.InvalidValue;
+    const value = body.get("value") orelse return error.InvalidValue;
     const raw = parsed.nodeBytes(value) orelse return error.InvalidValue;
     if (!std.mem.eql(u8, raw, input)) return error.InvalidValue;
     try validateFlowNode(arena, parsed, value);
@@ -118,12 +118,6 @@ fn appendScalar(arena: std.mem.Allocator, output: *std.ArrayList(u8), scalar: []
     try output.appendSlice(arena, scalar);
 }
 
-pub fn completeEntrySpan(file: source.ParsedFile, node: *const model.Node) ?source.Span {
-    const entry = file.entry_spans.get(node) orelse return null;
-    const span = file.node_spans.get(node) orelse return entry.whole;
-    return .{ .start = @min(entry.whole.start, span.start), .end = @max(entry.whole.end, span.end) };
-}
-
 pub fn replaceEntry(
     arena: std.mem.Allocator,
     ours: source.ParsedFile,
@@ -132,10 +126,10 @@ pub fn replaceEntry(
     inputs: []const source.ParsedFile,
 ) Error!Replacement {
     const entry = ours.entry_spans.get(original) orelse return error.InvalidValue;
-    const span = completeEntrySpan(ours, original) orelse return error.InvalidValue;
+    const span = ours.completeEntrySpan(original) orelse return error.InvalidValue;
     // Selecting a complete side must also select its formatting and comments.
     for (inputs) |input| {
-        if (completeEntrySpan(input, result)) |selected| {
+        if (input.completeEntrySpan(result)) |selected| {
             const selected_entry = input.entry_spans.get(result).?;
             if (entry.key.start - entry.whole.start != selected_entry.key.start - selected_entry.whole.start) continue;
             const bytes = selected.bytes(input.bytes);
@@ -197,7 +191,7 @@ fn lineEnd(bytes: []const u8, offset: usize) usize {
     return if (std.mem.indexOfScalarPos(u8, bytes, offset, '\n')) |end| end + 1 else bytes.len;
 }
 
-fn leadingSpaces(bytes: []const u8) usize {
+pub fn leadingSpaces(bytes: []const u8) usize {
     var count: usize = 0;
     while (count < bytes.len and bytes[count] == ' ') : (count += 1) {}
     return count;
@@ -222,6 +216,84 @@ fn appendIndented(arena: std.mem.Allocator, output: *std.ArrayList(u8), raw: []c
 }
 
 const decodeScalar = @import("yaml_scalar.zig").decode;
+
+pub fn sequenceSpan(file: source.ParsedFile, node: *const model.Node) ?source.Span {
+    var span = file.node_spans.get(node) orelse return null;
+    // An inline empty sequence includes the separator before [] when replaced by block items.
+    if (node.* == .seq and node.seq.len == 0 and span.start > 0 and file.bytes[span.start - 1] == ' ')
+        span.start -= 1;
+    return span;
+}
+
+pub fn sequenceReplacement(
+    arena: std.mem.Allocator,
+    ours_file: source.ParsedFile,
+    ours_node: ?*const model.Node,
+    merged_bytes: []const u8,
+) std.mem.Allocator.Error![]const u8 {
+    const node = ours_node orelse return merged_bytes;
+    if (merged_bytes.len == 0) {
+        if (node.* != .seq or node.seq.len == 0) {
+            return if (sequenceSpan(ours_file, node)) |span| span.bytes(ours_file.bytes) else "[]";
+        }
+        const span = ours_file.node_spans.get(node) orelse return " []";
+        const source_bytes = span.bytes(ours_file.bytes);
+        if (std.mem.endsWith(u8, source_bytes, "\r\n")) return " []\r\n";
+        if (std.mem.endsWith(u8, source_bytes, "\n")) return " []\n";
+        return " []";
+    }
+    if (node.* != .seq or node.seq.len != 0) return merged_bytes;
+    const span = ours_file.node_spans.get(node) orelse return merged_bytes;
+    const line_ending = ours_file.lineEndingAt(span.end);
+    const item_bytes = if (std.mem.endsWith(u8, merged_bytes, line_ending))
+        merged_bytes[0 .. merged_bytes.len - line_ending.len]
+    else
+        merged_bytes;
+    return std.fmt.allocPrint(arena, "{s}{s}", .{ line_ending, item_bytes });
+}
+
+pub fn sequenceIndent(file: source.ParsedFile, node: ?*const model.Node) ?usize {
+    const sequence = node orelse return null;
+    if (sequence.* != .seq or sequence.seq.len == 0) return null;
+    const span = file.sequence_item_spans.get(sequence.seq[0]) orelse return null;
+    const end = std.mem.indexOfScalarPos(u8, file.bytes, span.start, '\n') orelse span.end;
+    return leadingSpaces(file.bytes[span.start..end]);
+}
+
+pub fn sequenceFieldIndent(file: source.ParsedFile, node: ?*const model.Node) ?usize {
+    const sequence = node orelse return null;
+    const entry = file.entry_spans.get(sequence) orelse return null;
+    const line_start = if (std.mem.lastIndexOfScalar(u8, file.bytes[0..entry.key.start], '\n')) |lf| lf + 1 else 0;
+    return entry.key.start - line_start;
+}
+
+pub fn reindentSequenceItem(
+    arena: std.mem.Allocator,
+    source_item: []const u8,
+    destination_indent: usize,
+    line_ending: []const u8,
+) (std.mem.Allocator.Error || error{UnsupportedStructure})![]const u8 {
+    const first_lf = std.mem.indexOfScalar(u8, source_item, '\n') orelse source_item.len;
+    const first_line = std.mem.trimEnd(u8, source_item[0..first_lf], "\r");
+    const source_indent = leadingSpaces(first_line);
+    var output: std.ArrayList(u8) = .empty;
+    var cursor: usize = 0;
+    while (cursor < source_item.len) {
+        const relative_lf = std.mem.indexOfScalar(u8, source_item[cursor..], '\n');
+        const end = if (relative_lf) |line_index| cursor + line_index else source_item.len;
+        const raw_line = source_item[cursor..end];
+        const line = std.mem.trimEnd(u8, raw_line, "\r");
+        const indent = leadingSpaces(line);
+        if (line.len != 0 and indent < source_indent) return error.UnsupportedStructure;
+        if (line.len != 0) {
+            try output.appendNTimes(arena, ' ', destination_indent + indent - source_indent);
+            try output.appendSlice(arena, line[indent..]);
+        }
+        if (relative_lf != null) try output.appendSlice(arena, line_ending);
+        cursor = if (relative_lf != null) end + 1 else end;
+    }
+    return output.toOwnedSlice(arena);
+}
 
 test "collection YAML flow keeps quoted punctuation and object references" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);

--- a/core/src/model.zig
+++ b/core/src/model.zig
@@ -19,6 +19,30 @@ pub const Node = union(enum) {
     scalar: []const u8,
     ref: Ref,
 
+    pub fn get(node: ?*const Node, key: []const u8) ?*Node {
+        const value = node orelse return null;
+        return switch (value.*) {
+            .map => |entries| findValue(entries, key),
+            else => null,
+        };
+    }
+
+    pub fn asScalar(node: ?*const Node) ?[]const u8 {
+        const value = node orelse return null;
+        return switch (value.*) {
+            .scalar => |scalar| scalar,
+            else => null,
+        };
+    }
+
+    pub fn asRef(node: ?*const Node) ?Ref {
+        const value = node orelse return null;
+        return switch (value.*) {
+            .ref => |reference| reference,
+            else => null,
+        };
+    }
+
     pub fn eql(a: *const Node, b: *const Node) bool {
         if (std.meta.activeTag(a.*) != std.meta.activeTag(b.*)) return false;
         return switch (a.*) {

--- a/core/src/prefab.zig
+++ b/core/src/prefab.zig
@@ -10,14 +10,6 @@ pub fn isTransformClass(class_id: u32) bool {
     return class_id == 4 or class_id == 224;
 }
 
-pub fn reference(node: ?*const model.Node) ?model.Ref {
-    const value = node orelse return null;
-    return switch (value.*) {
-        .ref => |ref_value| ref_value,
-        else => null,
-    };
-}
-
 pub const Modification = struct {
     target: ?model.Ref,
     property_path: []const u8,
@@ -54,21 +46,13 @@ pub const ModificationIterator = struct {
         while (self.index < self.items.len) {
             const item = self.items[self.index];
             self.index += 1;
-            if (item.* != .map) continue;
-            const path = model.findValue(item.map, "propertyPath") orelse continue;
-            if (path.* != .scalar) continue;
-            const target = if (model.findValue(item.map, "target")) |node|
-                switch (node.*) {
-                    .ref => |value| value,
-                    else => null,
-                }
-            else
-                null;
+            const path = Node.asScalar(item.get("propertyPath")) orelse continue;
+            const target = Node.asRef(item.get("target"));
             return Modification.init(
                 target,
-                path.scalar,
-                model.findValue(item.map, "value"),
-                model.findValue(item.map, "objectReference"),
+                path,
+                item.get("value"),
+                item.get("objectReference"),
             );
         }
         return null;
@@ -76,9 +60,9 @@ pub const ModificationIterator = struct {
 };
 
 pub fn modifications(doc: *const model.Document) ModificationIterator {
-    const modification = model.findValue(doc.body.map, "m_Modification") orelse return .{ .items = &.{} };
+    const modification = doc.body.get("m_Modification") orelse return .{ .items = &.{} };
     if (modification.* != .map) return .{ .items = &.{} };
-    const list = model.findValue(modification.map, "m_Modifications") orelse return .{ .items = &.{} };
+    const list = modification.get("m_Modifications") orelse return .{ .items = &.{} };
     if (list.* != .seq) return .{ .items = &.{} };
     return .{ .items = list.seq };
 }
@@ -118,7 +102,7 @@ pub const OverrideIterator = struct {
 };
 
 pub fn overrides(doc: *const model.Document) OverrideIterator {
-    const modification = model.findValue(doc.body.map, "m_Modification") orelse
+    const modification = doc.body.get("m_Modification") orelse
         return .{ .fields = &.{} };
     if (modification.* != .map) return .{ .fields = &.{} };
     return .{ .fields = modification.map };
@@ -135,30 +119,23 @@ fn overrideKind(field: []const u8) ?merge_model.PrefabOverrideKind {
 
 pub fn overrideItem(kind: merge_model.PrefabOverrideKind, item: *const model.Node) Override {
     if (kind == .removed_component or kind == .removed_game_object) {
-        const removed = reference(item);
+        const removed = Node.asRef(item);
         return .{ .kind = kind, .target = removed, .object = removed, .item = item };
     }
-    const entries = switch (item.*) {
-        .map => |value| value,
-        else => &.{},
-    };
     if (kind == .property) {
-        const path = model.findValue(entries, "propertyPath");
+        const path = item.get("propertyPath");
         return .{
             .kind = kind,
-            .target = reference(model.findValue(entries, "target")),
-            .property_path = if (path) |value| switch (value.*) {
-                .scalar => |scalar| scalar,
-                else => "",
-            } else "",
-            .object = reference(setObjectReference(model.findValue(entries, "objectReference"))),
+            .target = Node.asRef(item.get("target")),
+            .property_path = Node.asScalar(path) orelse "",
+            .object = Node.asRef(setObjectReference(item.get("objectReference"))),
             .item = item,
         };
     }
     return .{
         .kind = kind,
-        .target = reference(model.findValue(entries, "targetCorrespondingSourceObject")),
-        .object = reference(model.findValue(entries, "addedObject")),
+        .target = Node.asRef(item.get("targetCorrespondingSourceObject")),
+        .object = Node.asRef(item.get("addedObject")),
         .item = item,
     };
 }
@@ -172,11 +149,8 @@ fn setObjectReference(node: ?*Node) ?*Node {
 }
 
 pub fn sourceGuid(doc: *const model.Document) ?[]const u8 {
-    const source = model.findValue(doc.body.map, "m_SourcePrefab") orelse return null;
-    return switch (source.*) {
-        .ref => |value| value.guid,
-        else => null,
-    };
+    const source = Node.asRef(doc.body.get("m_SourcePrefab")) orelse return null;
+    return source.guid;
 }
 
 pub fn scalarModificationValue(doc: *const model.Document, property_path: []const u8) ?[]const u8 {
@@ -184,10 +158,7 @@ pub fn scalarModificationValue(doc: *const model.Document, property_path: []cons
     while (iterator.next()) |modification| {
         if (!std.mem.eql(u8, modification.property_path, property_path)) continue;
         const value = modification.value orelse continue;
-        return switch (value.*) {
-            .scalar => |scalar| scalar,
-            else => null,
-        };
+        return value.asScalar();
     }
     return null;
 }
@@ -240,9 +211,9 @@ test "prefab: merge helpers classify transforms and references" {
     try testing.expect(isTransformClass(4));
     try testing.expect(isTransformClass(224));
     try testing.expect(!isTransformClass(1));
-    try testing.expectEqual(@as(i64, 42), reference(&ref_node).?.file_id);
-    try testing.expect(reference(&scalar_node) == null);
-    try testing.expect(reference(null) == null);
+    try testing.expectEqual(@as(i64, 42), Node.asRef(&ref_node).?.file_id);
+    try testing.expect(Node.asRef(&scalar_node) == null);
+    try testing.expect(Node.asRef(null) == null);
 }
 
 test "prefab: source and scalar lookups keep serialized values" {

--- a/core/src/source.zig
+++ b/core/src/source.zig
@@ -47,6 +47,15 @@ pub const ParsedFile = struct {
         return span.bytes(self.bytes);
     }
 
+    pub fn completeEntrySpan(self: ParsedFile, node: *const model.Node) ?Span {
+        const entry = self.entry_spans.get(node) orelse return null;
+        const span = self.node_spans.get(node) orelse return entry.whole;
+        return .{
+            .start = @min(entry.whole.start, span.start),
+            .end = @max(entry.whole.end, span.end),
+        };
+    }
+
     pub fn sequenceItemBytes(self: ParsedFile, node: *const model.Node) ?[]const u8 {
         const span = self.sequence_item_spans.get(node) orelse return null;
         return span.bytes(self.bytes);

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -24,23 +24,7 @@ fn instanceName(idx: *Index, pi_id: i64) []const u8 {
 
 fn goName(idx: *Index, go_id: i64) []const u8 {
     const go = idx.structuralDoc(go_id) orelse return "";
-    const n = model.findValue(go.body.map, "m_Name") orelse return "";
-    return switch (n.*) {
-        .scalar => |s| s,
-        else => "",
-    };
-}
-
-fn makeComponent(dd: diffmod.DocDiff) ComponentDiff {
-    return .{
-        .file_id = dd.file_id,
-        .class_id = dd.class_id,
-        .type_name = dd.type_name,
-        .script_guid = dd.script_guid,
-        .class_name = dd.class_name,
-        .status = dd.status,
-        .fields = dd.fields,
-    };
+    return model.Node.asScalar(go.body.get("m_Name")) orelse "";
 }
 
 fn goFieldsToOverrides(arena: std.mem.Allocator, fields: []const model.FieldDiff) ![]model.OverrideDiff {
@@ -64,7 +48,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         .diff_by_id = std.AutoHashMap(i64, diffmod.DocDiff).init(arena),
         .doc_by_id = std.AutoHashMap(i64, *model.Document).init(arena),
     };
-    for (fd.docs) |d| try idx.diff_by_id.put(d.file_id, d);
+    for (fd.docs) |d| try idx.diff_by_id.put(d.component.file_id, d);
     // Structural-resolution docs: after preferred, removed objects fall back to before.
     for (fd.before) |*d| try idx.doc_by_id.put(d.file_id, d);
     for (fd.after) |*d| try idx.doc_by_id.put(d.file_id, d); // overwrite makes after win
@@ -76,7 +60,8 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
     var comps_by_owner = std.AutoHashMap(i64, std.ArrayList(ComponentDiff)).init(arena);
     var loose: std.ArrayList(ComponentDiff) = .empty;
 
-    for (fd.docs) |d| {
+    for (fd.docs) |document| {
+        const d = document.component;
         if (d.class_id == 1) {
             try go_ids.append(arena, d.file_id);
             continue;
@@ -99,7 +84,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
             // be stripped (nested prefab), so walk the chain to the nearest instance that
             // gets materialized.
             const owner_id = if (go_doc.stripped) inner: {
-                const pi_id = tree_chain.refFileId(model.findValue(go_doc.body.map, "m_PrefabInstance")) orelse break :blk null;
+                const pi_id = tree_chain.refFileId(go_doc.body.get("m_PrefabInstance")) orelse break :blk null;
                 break :inner tree_chain.resolveInstanceChain(&idx, pi_id) orelse break :blk null;
             } else go_id;
             // A stripped doc is excluded from fd.docs and does not become a node.
@@ -110,10 +95,10 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
             const gop = try comps_by_owner.getOrPut(owner_id);
             if (!gop.found_existing) gop.value_ptr.* = .empty;
             // Collapse unchanged components that have no fields.
-            if (d.status != .unchanged) try gop.value_ptr.append(arena, makeComponent(d));
+            if (d.status != .unchanged) try gop.value_ptr.append(arena, d);
         } else {
             // No owning GameObject/PrefabInstance -> loose (ScriptableObject etc.).
-            if (d.status != .unchanged) try loose.append(arena, makeComponent(d));
+            if (d.status != .unchanged) try loose.append(arena, d);
         }
     }
 
@@ -125,8 +110,8 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
         try obj_by_id.put(go_id, .{
             .file_id = go_id,
             .name = goName(&idx, go_id),
-            .status = gd.status,
-            .overrides = try goFieldsToOverrides(arena, gd.fields),
+            .status = gd.component.status,
+            .overrides = try goFieldsToOverrides(arena, gd.component.fields),
             .components = comps,
             .children = &.{},
         });
@@ -140,7 +125,7 @@ pub fn build(arena: std.mem.Allocator, fd: diffmod.FlatDiff) !model.DiffResult {
             .file_id = pi_id,
             .name = instanceName(&idx, pi_id),
             .source_guid = if (doc) |value| prefab.sourceGuid(value) else null,
-            .status = dd.status,
+            .status = dd.component.status,
             .overrides = dd.overrides,
             .components = comps,
             .children = &.{},

--- a/core/src/tree_chain.zig
+++ b/core/src/tree_chain.zig
@@ -23,24 +23,21 @@ pub const Index = struct {
 };
 
 pub fn refFileId(node: ?*model.Node) ?i64 {
-    const n = node orelse return null;
-    return switch (n.*) {
-        .ref => |r| r.file_id,
-        else => null,
-    };
+    const reference = model.Node.asRef(node) orelse return null;
+    return reference.file_id;
 }
 
 pub fn gameObjectIdOfComponent(doc: *model.Document) ?i64 {
-    return refFileId(model.findValue(doc.body.map, "m_GameObject"));
+    return refFileId(doc.body.get("m_GameObject"));
 }
 
 pub fn transformOf(idx: *Index, go_id: i64) ?*model.Document {
     // Find the Transform/RectTransform among the components the GameObject lists.
     const go = idx.structuralDoc(go_id) orelse return null;
-    const comps = model.findValue(go.body.map, "m_Component") orelse return null;
+    const comps = go.body.get("m_Component") orelse return null;
     if (comps.* != .seq) return null;
     for (comps.seq) |item| {
-        const cref = if (item.* == .map) model.findValue(item.map, "component") else null;
+        const cref = item.get("component");
         const cid = refFileId(cref) orelse continue;
         const cdoc = idx.structuralDoc(cid) orelse continue;
         if (isTransformClass(cdoc.class_id)) return cdoc;
@@ -67,7 +64,7 @@ pub fn resolveInstanceChain(idx: *Index, start_id: i64) ?i64 {
         const doc = idx.structuralDoc(id) orelse return null;
         if (doc.class_id != 1001) return null;
         if (!doc.stripped) return id;
-        id = refFileId(model.findValue(doc.body.map, "m_PrefabInstance")) orelse return null;
+        id = refFileId(doc.body.get("m_PrefabInstance")) orelse return null;
     }
     return null;
 }
@@ -79,7 +76,7 @@ pub fn ownerNodeIdOfTransform(idx: *Index, tr_id: i64) ?i64 {
     const tr = idx.structuralDoc(tr_id) orelse return null;
     if (!isTransformClass(tr.class_id)) return null;
     if (tr.stripped) {
-        const pi_id = refFileId(model.findValue(tr.body.map, "m_PrefabInstance")) orelse return null;
+        const pi_id = refFileId(tr.body.get("m_PrefabInstance")) orelse return null;
         return resolveInstanceChain(idx, pi_id);
     }
     return gameObjectIdOfComponent(tr);
@@ -87,15 +84,15 @@ pub fn ownerNodeIdOfTransform(idx: *Index, tr_id: i64) ?i64 {
 
 pub fn instanceParentId(idx: *Index, pi_id: i64) ?i64 {
     const doc = idx.structuralDoc(pi_id) orelse return null;
-    const m = model.findValue(doc.body.map, "m_Modification") orelse return null;
+    const m = doc.body.get("m_Modification") orelse return null;
     if (m.* != .map) return null;
-    const tp = refFileId(model.findValue(m.map, "m_TransformParent")) orelse return null;
+    const tp = refFileId(m.get("m_TransformParent")) orelse return null;
     return ownerNodeIdOfTransform(idx, tp);
 }
 
 pub fn parentGoId(idx: *Index, go_id: i64) ?i64 {
     const tr = transformOf(idx, go_id) orelse return null;
-    const father_id = refFileId(model.findValue(tr.body.map, "m_Father")) orelse return null;
+    const father_id = refFileId(tr.body.get("m_Father")) orelse return null;
     return ownerNodeIdOfTransform(idx, father_id);
 }
 

--- a/core/src/tree_order.zig
+++ b/core/src/tree_order.zig
@@ -51,7 +51,7 @@ pub fn orderChildren(arena: std.mem.Allocator, idx: *Index, parent_id: i64, list
     const parent = idx.structuralDoc(parent_id) orelse return;
     if (parent.class_id != 1) return;
     const tr = tree_chain.transformOf(idx, parent_id) orelse return;
-    const kids = model.findValue(tr.body.map, "m_Children") orelse return;
+    const kids = tr.body.get("m_Children") orelse return;
     if (kids.* != .seq) return;
     try orderByTransformRefs(arena, idx, kids.seq, list);
 }
@@ -63,11 +63,8 @@ fn rootOrderOf(idx: *Index, id: i64) ?i64 {
         return std.fmt.parseInt(i64, s, 10) catch null;
     }
     const tr = tree_chain.transformOf(idx, id) orelse return null;
-    const v = model.findValue(tr.body.map, "m_RootOrder") orelse return null;
-    return switch (v.*) {
-        .scalar => |s| std.fmt.parseInt(i64, s, 10) catch null,
-        else => null,
-    };
+    const value = model.Node.asScalar(tr.body.get("m_RootOrder")) orelse return null;
+    return std.fmt.parseInt(i64, value, 10) catch null;
 }
 
 // Scene root order: SceneRoots.m_Roots when present, else the per-transform
@@ -75,7 +72,7 @@ fn rootOrderOf(idx: *Index, id: i64) ?i64 {
 // so they fall through untouched.
 pub fn orderRoots(arena: std.mem.Allocator, idx: *Index, fd: diffmod.FlatDiff, roots_ids: *std.ArrayList(i64)) !void {
     if (sceneRootsDoc(fd)) |doc| {
-        const roots = model.findValue(doc.body.map, "m_Roots") orelse return;
+        const roots = doc.body.get("m_Roots") orelse return;
         if (roots.* != .seq) return;
         try orderByTransformRefs(arena, idx, roots.seq, roots_ids);
         return;


### PR DESCRIPTION
## Summary

Remove duplicate diff data and share value lookup and YAML editing helpers across the core.
Preserve the public API, JSON schema, and WASM ABI.

## Motivation

Duplicate structs required field copying, and merge application depended on the planner for YAML editing.
Keeping these operations with their data makes the code easier to follow and maintain.

The existing duplicate name override bug is tracked separately in #358.

## Changes

- Embed `ComponentDiff` in `DocDiff` and consolidate document diff construction.
- Move node accessors, source span calculation, and side selection to their owning models.
- Keep sequence keys in `SequenceItemId` and YAML editing helpers in `merge_yaml.zig`.
- Remove the production dependency from `merge_apply.zig` to `merge_planner.zig`.

## Testing

- `zig build test --summary all`: 593/593 tests passed, including native Git and collection integrations.
- `zig build lint wasm --summary all`: passed.
- `node --test core/tests/*.test.mjs`: 7/7 passed.
- `zig build perf --summary all`: passed; 50,000 objects in 201 ms and 50,000 metadata files in 506 ms.
- Compared baseline and refactored WASM on 135 fixture files: all 539 JSON comparisons matched.

A [comparison on the same Ubuntu CI runner](https://github.com/hashiiiii/PrefabLens/actions/runs/34141714621/job/101804942016) measured the base at 562/571/580 ms and this refactor at 552/545/585 ms, with no consistent slowdown. The normal performance gate passed at 544 ms. Intermittent failures with unchanged code are tracked in #368. The workload and 600 ms ceiling remain unchanged.
