### PR TITLE
refactor: simplify extension code

### DIFF
--- a/docs/extension.md
+++ b/docs/extension.md
@@ -144,6 +144,11 @@ infrastructure/
   (for example `fetch-queue.ts`, `merge-store.ts`, `storage-area.ts`).
 - Only infrastructure files can import `internal/` (the internal rule in Overview).
 
+`createGithubGateway(base, token, fetchFn)` creates one GitHub client.
+`createQueuedGithubGateway(concurrency, fetchFn, sleep)` creates a factory whose clients share one queue.
+`createDifferGateway(wasmBytes)` instantiates WASM, while `createDifferLoader(wasmUrl, fetchBytes)` loads one instance lazily.
+Each function has one input contract; callers do not select behavior by changing an argument's type.
+
 #### Presentation (`src/presentation/`)
 
 ```
@@ -189,6 +194,7 @@ presentation/
 - Put layer rules under `test/architecture/`.
 - Put browser tests and their HTML files under `test/e2e/`.
 - `test/fixtures/` contains shared static test data.
+- `test/support/` contains shared test implementations, such as storage with a configurable capacity.
 - Keep test-only helpers in test files when one file uses them.
 - Do not put test-only helpers in `src/`.
 - An in-memory storage implementation derives failures from its complete state and capacity.

--- a/extension/src/application/gateway/github.ts
+++ b/extension/src/application/gateway/github.ts
@@ -6,7 +6,7 @@ export type GithubFailure =
   | { kind: "fetch-failed" };
 
 export function isRateLimited(e: unknown): e is Extract<GithubFailure, { kind: "rate-limited" }> {
-  return typeof e === "object" && e !== null && (e as { kind?: string }).kind === "rate-limited";
+  return typeof e === "object" && e !== null && "kind" in e && e.kind === "rate-limited";
 }
 
 // The pipeline branches only on added/removed. The gateway folds the other

--- a/extension/src/container.ts
+++ b/extension/src/container.ts
@@ -13,9 +13,9 @@ import { createChromeGuidRepository } from "./infrastructure/clients/chrome-guid
 import { createChromeMessengerGateway } from "./infrastructure/clients/chrome-messenger-client";
 import { createChromeRepoIndexRepository } from "./infrastructure/clients/chrome-repo-index-client";
 import { createFixturesGateway as createHttpFixturesGateway } from "./infrastructure/clients/fixture-client";
-import { createGithubGateway as createQueuedGithubGateway } from "./infrastructure/clients/github-client";
+import { createQueuedGithubGateway } from "./infrastructure/clients/github-client";
 import { createGithubDeviceFlowGateway } from "./infrastructure/clients/github-device-flow-client";
-import { createDifferGateway as createWasmDifferGateway } from "./infrastructure/clients/wasm-differ-client";
+import { createDifferLoader } from "./infrastructure/clients/wasm-differ-client";
 
 export function createAuthRepository(): AuthRepository {
   return createChromeAuthRepository(chrome.storage.local);
@@ -46,11 +46,11 @@ export function createGithubGateway(concurrency: number): MakeGithubGateway {
 }
 
 export function createDifferGateway(): () => Promise<DifferGateway> {
-  return createWasmDifferGateway(chrome.runtime.getURL("prefablens.wasm"));
+  return createDifferLoader(chrome.runtime.getURL("prefablens.wasm"));
 }
 
 export function createDemoDifferGateway(fetchBytes: FixturesGateway["fetchBytes"]): () => Promise<DifferGateway> {
-  return createWasmDifferGateway("prefablens.wasm", fetchBytes);
+  return createDifferLoader("prefablens.wasm", fetchBytes);
 }
 
 export function createFixturesGateway(): FixturesGateway {

--- a/extension/src/domain/auth/token.ts
+++ b/extension/src/domain/auth/token.ts
@@ -1,1 +1,5 @@
 export type AccessToken = string;
+
+export function isAccessToken(value: unknown): value is AccessToken {
+  return typeof value === "string";
+}

--- a/extension/src/domain/diff/types.ts
+++ b/extension/src/domain/diff/types.ts
@@ -4,6 +4,10 @@ export type Status = "added" | "removed" | "modified" | "unchanged";
 export type RefValue = { ref: { fileId: string; guid: string | null; type: number | null } };
 export type FieldValue = string | RefValue | null;
 
+export function isRefValue(value: FieldValue): value is RefValue {
+  return value !== null && typeof value === "object";
+}
+
 export type FieldDiff = { path: string; status: Status; before: FieldValue; after: FieldValue };
 
 export type OverrideDiff = {

--- a/extension/src/infrastructure/clients/chrome-auth-client.ts
+++ b/extension/src/infrastructure/clients/chrome-auth-client.ts
@@ -1,17 +1,19 @@
 import type { AuthRepository } from "../../domain/auth/auth-repository";
 import type { PendingSignIn } from "../../domain/auth/pending-sign-in";
+import { isAccessToken } from "../../domain/auth/token";
 import type { StorageAreaWithRemove } from "../internal/storage-area";
 
 export function createChromeAuthRepository(storage: StorageAreaWithRemove): AuthRepository {
   return {
     loadAccessToken: async () => {
       const stored = await storage.get(["accessToken"]);
-      return typeof stored.accessToken === "string" ? stored.accessToken : undefined;
+      return isAccessToken(stored.accessToken) ? stored.accessToken : undefined;
     },
     saveAccessToken: (token) => storage.set({ accessToken: token }),
     savePendingSignIn: (pending) => storage.set({ signin: pending }),
     loadPendingSignIn: async () => {
       const stored = await storage.get(["signin"]);
+      // savePendingSignIn owns the signin key and writes PendingSignIn values.
       return stored.signin as PendingSignIn | undefined;
     },
     clearPendingSignIn: () => storage.remove("signin"),

--- a/extension/src/infrastructure/clients/chrome-diff-client.ts
+++ b/extension/src/infrastructure/clients/chrome-diff-client.ts
@@ -11,6 +11,7 @@ export function createChromeDiffRepository(area: StorageAreaWithRemove): DiffRep
   return {
     async load(key) {
       const stored = await area.get(PREFIX + key);
+      // This repository owns diff: keys and writes DiffV2 values to session storage.
       return stored[PREFIX + key] as DiffV2 | undefined;
     },
     async save(key, json) {

--- a/extension/src/infrastructure/clients/chrome-messenger-client.ts
+++ b/extension/src/infrastructure/clients/chrome-messenger-client.ts
@@ -11,12 +11,12 @@ import type {
 export function createChromeMessengerGateway(): MessengerGateway {
   return {
     semanticDiff: (req: SemanticDiffRequest) =>
-      (chrome.runtime.sendMessage(req) as Promise<SemanticDiffResponse>).catch(() => ({
+      chrome.runtime.sendMessage<SemanticDiffRequest, SemanticDiffResponse>(req).catch(() => ({
         ok: false as const,
         error: "fetch-failed" as const,
       })),
     prefetch: (req: PrefetchRequest) =>
-      (chrome.runtime.sendMessage(req) as Promise<unknown>).then(
+      chrome.runtime.sendMessage(req).then(
         () => undefined,
         () => undefined,
       ),

--- a/extension/src/infrastructure/clients/chrome-repo-index-client.ts
+++ b/extension/src/infrastructure/clients/chrome-repo-index-client.ts
@@ -11,6 +11,7 @@ export function createChromeRepoIndexRepository(area: StorageArea): RepoIndexRep
     saveGuids: (repo, entries) => metaGuids.save(repo, entries).catch(() => {}),
     async loadIndex(repo) {
       const stored = await area.get([indexKey(repo)]);
+      // saveIndex owns guidIndex: keys and writes RepoGuidIndex values.
       return stored[indexKey(repo)] as RepoGuidIndex | undefined;
     },
     async saveIndex(repo, index) {

--- a/extension/src/infrastructure/clients/fixture-client.ts
+++ b/extension/src/infrastructure/clients/fixture-client.ts
@@ -11,7 +11,7 @@ export function createFixturesGateway(): FixturesGateway {
     fetchBytes,
     // A missing source fixture degrades to the unmerged diff, like the extension does.
     fetchSource: (side, path) => fetchBytes(`fixtures/${side}/${path}`).catch(() => new Uint8Array()),
-    // build.mjs generates this guid → asset path map from the fixture .meta files.
+    // site/build.mjs generates this GUID → asset path map from the fixture .meta files.
     async loadGuidIndex() {
       const body = (await (await fetch("fixtures/guids.json")).json()) as Record<string, string>;
       return new Map(Object.entries(body));

--- a/extension/src/infrastructure/clients/github-client.ts
+++ b/extension/src/infrastructure/clients/github-client.ts
@@ -113,6 +113,7 @@ class GithubClient implements GithubGateway {
     const res = await this.request(path, "application/vnd.github+json");
     if (!res.ok) return res;
     if (!res.value.ok) return FETCH_FAILED;
+    // Each caller specifies the GitHub response contract for its fixed REST endpoint.
     return readOr(() => res.value.json() as Promise<T>);
   }
 
@@ -214,6 +215,7 @@ class GithubClient implements GithubGateway {
     if (!res.ok) return res;
     if (!res.value.ok) return ok(null);
     return readOr(async () => {
+      // GitHub's code search endpoint returns file paths in items[].
       const body = (await res.value.json()) as { items?: Array<{ path?: string }> };
       const path = body.items?.[0]?.path;
       return path?.endsWith(".meta") ? assetPathFromMeta(path) : null;
@@ -297,6 +299,7 @@ class GithubClient implements GithubGateway {
       data?: { repository?: Record<string, { text?: string | null } | null> } | null;
       errors?: Array<{ type?: string }>;
     };
+    // The query requests repository blob text; GitHub may return nullable data and GraphQL errors.
     const parsed = await readOr(() => res.value.json() as Promise<GraphqlBody>);
     if (!parsed.ok) return parsed;
     const body = parsed.value;
@@ -312,32 +315,16 @@ class GithubClient implements GithubGateway {
 const defaultFetch: typeof fetch = (input, init) => fetch(input, init);
 const defaultSleep = (milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
-function githubGateway(base: string, token: string, fetchFn: typeof fetch): GithubGateway {
+export function createGithubGateway(base: string, token: string, fetchFn: typeof fetch = defaultFetch): GithubGateway {
   return new GithubClient(base, token, fetchFn);
 }
 
-export function createGithubGateway(base: string, token: string, fetchFn?: typeof fetch): GithubGateway;
-export function createGithubGateway(
+export function createQueuedGithubGateway(
   concurrency: number,
-  fetchFn?: typeof fetch,
-  sleep?: (milliseconds: number) => Promise<void>,
-): MakeGithubGateway;
-export function createGithubGateway(
-  baseOrConcurrency: string | number,
-  tokenOrFetch?: string | typeof fetch,
-  fetchOrSleep?: typeof fetch | ((milliseconds: number) => Promise<void>),
-): GithubGateway | MakeGithubGateway {
-  if (typeof baseOrConcurrency === "number") {
-    const fetchFn = typeof tokenOrFetch === "function" ? tokenOrFetch : defaultFetch;
-    const sleep =
-      typeof fetchOrSleep === "function" ? (fetchOrSleep as (milliseconds: number) => Promise<void>) : defaultSleep;
-    // One shared queue: the user lane has priority over the prefetch traffic.
-    const queue = createQueue(baseOrConcurrency, sleep);
-    return (base, token, lane) => githubGateway(base, token, createQueuedFetch(queue, fetchFn, lane === "user"));
-  }
-  return githubGateway(
-    baseOrConcurrency,
-    tokenOrFetch as string,
-    typeof fetchOrSleep === "function" ? (fetchOrSleep as typeof fetch) : defaultFetch,
-  );
+  fetchFn: typeof fetch = defaultFetch,
+  sleep: (milliseconds: number) => Promise<void> = defaultSleep,
+): MakeGithubGateway {
+  // One shared queue keeps user requests ahead of prefetch traffic across clients.
+  const queue = createQueue(concurrency, sleep);
+  return (base, token, lane) => createGithubGateway(base, token, createQueuedFetch(queue, fetchFn, lane === "user"));
 }

--- a/extension/src/infrastructure/clients/github-device-flow-client.ts
+++ b/extension/src/infrastructure/clients/github-device-flow-client.ts
@@ -25,6 +25,7 @@ async function requestDeviceCode(fetchFn: typeof fetch): Promise<Result<DeviceCo
     credentials: "omit",
   });
   if (!res.ok) return failed(`device code request failed (HTTP ${res.status})`);
+  // GitHub's device-code endpoint returns the requested code fields or its documented OAuth error response.
   const body = (await res.json()) as DeviceCodeResponse;
   if ("error" in body) return failed(body.error_description ?? body.error);
   return ok({
@@ -55,6 +56,7 @@ async function pollForToken(
       credentials: "omit",
     });
     if (!res.ok) return { status: "failed" };
+    // GitHub's token endpoint returns an access token or a documented polling error.
     const body = (await res.json()) as TokenResponse;
     if ("access_token" in body) return { status: "ok", token: body.access_token };
     switch (body.error) {

--- a/extension/src/infrastructure/clients/wasm-differ-client.ts
+++ b/extension/src/infrastructure/clients/wasm-differ-client.ts
@@ -2,7 +2,7 @@ import type { DifferGateway, DiffFailure } from "../../application/gateway/diffe
 import type { DiffErrorV1, DiffV2 } from "../../domain/diff/types";
 import { err, ok, type Result } from "../../domain/result";
 
-type Exports = {
+type Exports = WebAssembly.Exports & {
   memory: WebAssembly.Memory;
   alloc(len: number): number;
   free(ptr: number, len: number): void;
@@ -40,26 +40,22 @@ function encodeAssets(assets: Map<string, Uint8Array>): Uint8Array {
 
 const defaultFetchBytes: FetchBytes = async (url) => (await fetch(url)).arrayBuffer();
 
-export function createDifferGateway(wasmUrl: string, fetchBytes?: FetchBytes): () => Promise<DifferGateway>;
-export function createDifferGateway(wasmBytes: BufferSource): Promise<DifferGateway>;
-export function createDifferGateway(
-  wasmUrlOrBytes: string | BufferSource,
+export function createDifferLoader(
+  wasmUrl: string,
   fetchBytes: FetchBytes = defaultFetchBytes,
-): (() => Promise<DifferGateway>) | Promise<DifferGateway> {
-  if (typeof wasmUrlOrBytes === "string") {
-    let differ: Promise<DifferGateway> | undefined;
-    return () => {
-      // A lazy singleton. An SW restart causes a re-fetch.
-      differ ??= fetchBytes(wasmUrlOrBytes).then(instantiateDifferGateway);
-      return differ;
-    };
-  }
-  return instantiateDifferGateway(wasmUrlOrBytes);
+): () => Promise<DifferGateway> {
+  let differ: Promise<DifferGateway> | undefined;
+  return () => {
+    // Each JS context shares one WASM instance, including concurrent first requests.
+    differ ??= fetchBytes(wasmUrl).then(createDifferGateway);
+    return differ;
+  };
 }
 
-async function instantiateDifferGateway(wasmBytes: BufferSource): Promise<DifferGateway> {
+export async function createDifferGateway(wasmBytes: BufferSource): Promise<DifferGateway> {
   const { instance } = await WebAssembly.instantiate(wasmBytes);
-  const exp = instance.exports as unknown as Exports;
+  // The bundled core/src/wasm.zig exports this ABI; gateway tests instantiate the same compiled artifact.
+  const exp = instance.exports as Exports;
 
   function call(before: Uint8Array, after: Uint8Array, assets?: Uint8Array): Result<DiffV2, DiffFailure> {
     const alloc = (b: Uint8Array): number => (b.length ? exp.alloc(b.length) : 0);
@@ -82,9 +78,10 @@ async function instantiateDifferGateway(wasmBytes: BufferSource): Promise<Differ
       const len = new DataView(exp.memory.buffer).getUint32(rp, true);
       const text = utf8.decode(new Uint8Array(exp.memory.buffer, rp + 4, len));
       exp.free(rp, 4 + len);
+      // core/src/wasm.zig emits only these two schemas through core/src/json.zig.
       const parsed = JSON.parse(text) as DiffV2 | DiffErrorV1;
       if (parsed.schema !== "prefablens.diff.v2") {
-        return err({ kind: "diff-failed", message: (parsed as DiffErrorV1).error });
+        return err({ kind: "diff-failed", message: parsed.error });
       }
       return ok(parsed);
     } finally {

--- a/extension/src/infrastructure/internal/fetch-queue.ts
+++ b/extension/src/infrastructure/internal/fetch-queue.ts
@@ -2,11 +2,8 @@ import { isRateLimited } from "../../application/gateway/github";
 import { must } from "../../internal/must";
 
 type Job = {
-  run: () => Promise<unknown>;
-  resolve: (v: unknown) => void;
-  reject: (e: unknown) => void;
+  run(): void;
   front: boolean;
-  retries: number;
 };
 
 export type Queue = <T>(task: () => Promise<T>, opts?: { front?: boolean }) => Promise<T>;
@@ -43,39 +40,40 @@ export function createQueue(
     while (!paused && active < limit && pending.length) {
       const job = must(pending.shift());
       active++;
-      // Normalize sync throws into rejections: a leak here jams the queue forever
-      Promise.resolve()
-        .then(job.run)
-        .then(
-          (v) => {
-            active--;
-            job.resolve(v);
-            pump();
-          },
-          (e: unknown) => {
-            active--;
-            if (isRateLimited(e) && job.retries < MAX_RATE_LIMIT_RETRIES) {
-              job.retries++;
-              enqueue(job);
-              pauseFor(Math.min(e.retryAfterMs ?? BACKOFF_FALLBACK_MS, BACKOFF_CAP_MS));
-            } else {
-              job.reject(e);
-            }
-            pump();
-          },
-        );
+      job.run();
     }
   };
 
   return <T>(task: () => Promise<T>, opts?: { front?: boolean }) =>
     new Promise<T>((resolve, reject) => {
-      enqueue({
-        run: task,
-        resolve: resolve as (v: unknown) => void,
-        reject,
+      let retries = 0;
+      const job: Job = {
         front: opts?.front === true,
-        retries: 0,
-      });
+        run() {
+          // The closure preserves T. Normalize sync throws so a task cannot leak an active slot.
+          void Promise.resolve()
+            .then(task)
+            .then(
+              (value) => {
+                active--;
+                resolve(value);
+                pump();
+              },
+              (cause: unknown) => {
+                active--;
+                if (isRateLimited(cause) && retries < MAX_RATE_LIMIT_RETRIES) {
+                  retries++;
+                  enqueue(job);
+                  pauseFor(Math.min(cause.retryAfterMs ?? BACKOFF_FALLBACK_MS, BACKOFF_CAP_MS));
+                } else {
+                  reject(cause);
+                }
+                pump();
+              },
+            );
+        },
+      };
+      enqueue(job);
       pump();
     });
 }

--- a/extension/src/infrastructure/internal/merge-store.ts
+++ b/extension/src/infrastructure/internal/merge-store.ts
@@ -9,16 +9,16 @@ export type MergeStore = {
 // Failures propagate. Each call site decides if a lost write is fatal or if the code continues past it.
 export function createMergeStore(area: StorageArea, prefix: string): MergeStore {
   const keyOf = (id: string): string => `${prefix}:${id}`;
+  const load = async (id: string): Promise<Record<string, string>> => {
+    const key = keyOf(id);
+    const stored = await area.get([key]);
+    // This store owns its prefixed keys and saves only GUID or metadata maps with string values.
+    return (stored[key] as Record<string, string> | undefined) ?? {};
+  };
   return {
-    async load(id) {
-      const key = keyOf(id);
-      const stored = await area.get([key]);
-      return (stored[key] as Record<string, string> | undefined) ?? {};
-    },
+    load,
     async save(id, entries) {
-      const key = keyOf(id);
-      const stored = await area.get([key]);
-      await area.set({ [key]: { ...(stored[key] as Record<string, string> | undefined), ...entries } });
+      await area.set({ [keyOf(id)]: { ...(await load(id)), ...entries } });
     },
   };
 }

--- a/extension/src/infrastructure/internal/storage-area.ts
+++ b/extension/src/infrastructure/internal/storage-area.ts
@@ -1,6 +1,11 @@
+import type { JsonValue } from "../../internal/json";
+
+// Chrome storage serializes values as JSON; undefined object fields are omitted.
+export type StorageEntries = Record<string, JsonValue | undefined>;
+
 export type StorageArea = {
-  get(keys: string | string[] | null): Promise<Record<string, unknown>>;
-  set(items: Record<string, unknown>): Promise<void>;
+  get(keys: string | string[] | null): Promise<StorageEntries>;
+  set(items: StorageEntries): Promise<void>;
 };
 
 export type StorageAreaWithRemove = StorageArea & {

--- a/extension/src/internal/json.ts
+++ b/extension/src/internal/json.ts
@@ -1,0 +1,1 @@
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue | undefined };

--- a/extension/src/presentation/content/detect.ts
+++ b/extension/src/presentation/content/detect.ts
@@ -160,7 +160,7 @@ function scanReact(root: ParentNode): FileEntry[] {
         const block = headerBlock();
         for (const child of region.children) {
           if (child === block || child.hasAttribute("data-prefablens-view")) continue;
-          (child as HTMLElement).style.display = hidden ? "none" : "";
+          if (child instanceof HTMLElement) child.style.display = hidden ? "none" : "";
         }
       },
       // Chevron octicon swap + DiffFileHeader-module__collapsed class

--- a/extension/src/presentation/content/index.ts
+++ b/extension/src/presentation/content/index.ts
@@ -1,6 +1,7 @@
 import { type SignInFailure, signIn } from "../../application/auth/sign-in";
 import type { AuthError, GuidResolvedPush } from "../../application/gateway/messenger";
 import { createAuthRepository, createGithubAuthGateway, createMessengerGateway } from "../../container";
+import { isAccessToken } from "../../domain/auth/token";
 import { targetKey } from "../../domain/diff/fn/target-key";
 import { renderSignIn, renderSignInPending } from "../internal/render";
 import { mountGlobalBar, type Toggle } from "../internal/toggle";
@@ -144,7 +145,7 @@ async function init(): Promise<void> {
     if (area !== "local") return;
     const next = changes.viewMode?.newValue;
     if (next === "raw" || next === "semantic") viewState.setPage(next);
-    if (typeof changes.accessToken?.newValue === "string") {
+    if (isAccessToken(changes.accessToken?.newValue)) {
       for (const file of updateFiles().values()) {
         if (file.status === "auth-blocked" && viewState.getFile(file.path) === "semantic") {
           void file.loadDiff();

--- a/extension/src/presentation/internal/builtin-refs.ts
+++ b/extension/src/presentation/internal/builtin-refs.ts
@@ -12,11 +12,12 @@ export const BUILTIN_EXTRA_GUID = "0000000000000000f000000000000000";
 // when the guid is not one of the two built-in files or the fileID is unknown.
 // fileId is the decimal string the diff JSON carries (int64-safe).
 export function builtinName(guid: string, fileId: string): string | null {
-  return BUILTIN_REFS[guid]?.[fileId] ?? null;
+  if (guid !== DEFAULT_RESOURCES_GUID && guid !== BUILTIN_EXTRA_GUID) return null;
+  return BUILTIN_REFS[guid][fileId] ?? null;
 }
 
 // Exported for the parity test against cli/src/builtin_refs.zig.
-export const BUILTIN_REFS: Record<string, Record<string, string>> = {
+export const BUILTIN_REFS: Record<typeof DEFAULT_RESOURCES_GUID | typeof BUILTIN_EXTRA_GUID, Record<string, string>> = {
   "0000000000000000e000000000000000": {
     "17": "Hidden/InternalErrorShader",
     "68": "Hidden/InternalClear",

--- a/extension/src/presentation/internal/file-view-controller.ts
+++ b/extension/src/presentation/internal/file-view-controller.ts
@@ -17,26 +17,22 @@ export function createFileViewController(
   attachHost: (host: HTMLDivElement) => void,
   semanticVisible: () => boolean,
 ): FileViewController {
-  let host: HTMLDivElement | undefined;
-  let root: ShadowRoot | undefined;
+  let viewHost: ReturnType<typeof createViewHost> | undefined;
   let started = false;
   const selectionListeners = new Set<(view: ViewMode) => void>();
   const semanticListeners = new Set<(root: ShadowRoot) => void>();
 
-  const ensureHost = (): { host: HTMLDivElement; root: ShadowRoot } => {
-    if (!host || !root) {
-      const created = createViewHost();
-      host = created.host;
-      root = created.root;
-    }
-    if (!host.isConnected) attachHost(host);
-    return { host, root };
+  const ensureHost = () => {
+    viewHost ??= createViewHost();
+    if (!viewHost.host.isConnected) attachHost(viewHost.host);
+    return viewHost;
   };
 
   const update = (view: ViewMode): void => {
     if (view === "raw") {
       setRawHidden(false);
-      if (host) {
+      if (viewHost) {
+        const { host } = viewHost;
         if (!host.isConnected) attachHost(host);
         host.style.display = "none";
       }

--- a/extension/src/presentation/internal/render.ts
+++ b/extension/src/presentation/internal/render.ts
@@ -1,4 +1,12 @@
-import type { ComponentDiff, DiffV2, FieldValue, NodeDiff, OverrideDiff, Status } from "../../domain/diff/types";
+import {
+  type ComponentDiff,
+  type DiffV2,
+  type FieldValue,
+  isRefValue,
+  type NodeDiff,
+  type OverrideDiff,
+  type Status,
+} from "../../domain/diff/types";
 import { builtinName } from "./builtin-refs";
 import { ALERT, CHECK, CHEVRON, CUBE, GEAR } from "./icons";
 import { STYLES } from "./styles";
@@ -15,7 +23,7 @@ export function detectTheme(doc: Document): "light" | "dark" {
 
 // data-prefablens-view marks semantic hosts. detect.ts skips them when it hides
 // raw children. The content script and the demo must agree on the attribute.
-export function createViewHost(): { host: HTMLDivElement; root: ShadowRoot } {
+export function createViewHost() {
   const host = document.createElement("div");
   host.setAttribute("data-prefablens-view", "");
   return { host, root: host.attachShadow({ mode: "open" }) };
@@ -330,7 +338,7 @@ function valueSpan(className: string, value: FieldValue, diff: DiffV2): HTMLElem
 
 function formatValue(value: FieldValue, diff: DiffV2): string {
   if (value === null) return "—";
-  if (typeof value === "string") return value;
+  if (!isRefValue(value)) return value;
   const { fileId, guid } = value.ref;
   if (guid === null) return fileId === "0" ? "None" : `#${fileId}`; // {fileID: 0} is Unity's null reference
   const path = diff.resolved?.[guid];

--- a/extension/src/presentation/internal/toggle.ts
+++ b/extension/src/presentation/internal/toggle.ts
@@ -85,7 +85,7 @@ export function mountToggle(initial: ViewMode = "raw"): Toggle {
 // The bar DOM matches the [data-prefablens-global] page styles that this module
 // owns. The content script and the demo must build the bar in the same way.
 // Callers position the element.
-export function mountGlobalBar(initial: ViewMode): { element: HTMLElement; toggle: Toggle } {
+export function mountGlobalBar(initial: ViewMode) {
   const bar = document.createElement("div");
   bar.setAttribute("data-prefablens-global", "");
   const label = document.createElement("span");

--- a/extension/test/application/auth/sign-in.test.ts
+++ b/extension/test/application/auth/sign-in.test.ts
@@ -2,36 +2,11 @@ import { describe, expect, it } from "vitest";
 import { type SignInEvent, signIn } from "../../../src/application/auth/sign-in";
 import { createChromeAuthRepository } from "../../../src/infrastructure/clients/chrome-auth-client";
 import { createGithubDeviceFlowGateway } from "../../../src/infrastructure/clients/github-device-flow-client";
+import type { JsonValue } from "../../../src/internal/json";
+import { MemoryStorageArea } from "../../support/memory-storage-area";
 
-const json = (body: unknown, status = 200) =>
+const json = (body: JsonValue, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
-
-class MemoryStorageArea {
-  private values: Record<string, unknown>;
-
-  constructor(
-    initial: Record<string, unknown> = {},
-    private readonly capacity = Number.POSITIVE_INFINITY,
-  ) {
-    this.values = { ...initial };
-  }
-
-  async get(keys: string | string[] | null): Promise<Record<string, unknown>> {
-    const selected = keys === null ? Object.keys(this.values) : Array.isArray(keys) ? keys : [keys];
-    return Object.fromEntries(selected.filter((key) => key in this.values).map((key) => [key, this.values[key]]));
-  }
-
-  async set(items: Record<string, unknown>): Promise<void> {
-    const next = { ...this.values, ...items };
-    if (JSON.stringify(next).length > this.capacity) throw new Error("quota exceeded");
-    this.values = next;
-  }
-
-  async remove(keys: string | string[]): Promise<void> {
-    const removed = new Set(Array.isArray(keys) ? keys : [keys]);
-    this.values = Object.fromEntries(Object.entries(this.values).filter(([key]) => !removed.has(key)));
-  }
-}
 
 class VirtualClock {
   now = 0;
@@ -52,7 +27,7 @@ describe("signIn", () => {
     const area = new MemoryStorageArea();
     const authRepository = createChromeAuthRepository(area);
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "https://github.com/login/device/code") {
         return json({
@@ -67,7 +42,7 @@ describe("signIn", () => {
         return json({ access_token: "tok123" });
       }
       throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url} at ${clock.now}`);
-    }) as typeof fetch;
+    };
     const auth = createGithubDeviceFlowGateway(route, clock.sleep);
     const state = { inFlight: false };
     const events = signIn(auth, authRepository, () => 1_000, state);
@@ -90,11 +65,11 @@ describe("signIn", () => {
 
   it("emits a request failure and clears in-flight state", async () => {
     const authRepository = createChromeAuthRepository(new MemoryStorageArea());
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "https://github.com/login/device/code") return json({}, 500);
       throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
-    }) as typeof fetch;
+    };
     const state = { inFlight: false };
 
     const events = await collect(signIn(createGithubDeviceFlowGateway(route), authRepository, () => 1_000, state));
@@ -106,7 +81,7 @@ describe("signIn", () => {
   it("emits one terminal denied result", async () => {
     const authRepository = createChromeAuthRepository(new MemoryStorageArea());
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "https://github.com/login/device/code") {
         return json({
@@ -121,7 +96,7 @@ describe("signIn", () => {
         return json({ error: "access_denied" });
       }
       throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url} at ${clock.now}`);
-    }) as typeof fetch;
+    };
     const state = { inFlight: false };
 
     const events = await collect(
@@ -139,7 +114,7 @@ describe("signIn", () => {
   it("clears pending sign-in data after an unexpected token request rejection", async () => {
     const authRepository = createChromeAuthRepository(new MemoryStorageArea());
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "https://github.com/login/device/code") {
         return json({
@@ -154,7 +129,7 @@ describe("signIn", () => {
         throw new Error("token request rejected");
       }
       throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url} at ${clock.now}`);
-    }) as typeof fetch;
+    };
     const state = { inFlight: false };
     const events = signIn(createGithubDeviceFlowGateway(route, clock.sleep), authRepository, () => 1_000, state);
 
@@ -179,14 +154,14 @@ describe("signIn", () => {
     const authRepository = createChromeAuthRepository(new MemoryStorageArea());
     const clock = new VirtualClock();
     const codeRequest = Promise.withResolvers<Response>();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url === "https://github.com/login/device/code") return codeRequest.promise;
       if (url === "https://github.com/login/oauth/access_token" && clock.now === 5_000) {
         return json({ access_token: "tok123" });
       }
       throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url} at ${clock.now}`);
-    }) as typeof fetch;
+    };
     const auth = createGithubDeviceFlowGateway(route, clock.sleep);
     const state = { inFlight: false };
 

--- a/extension/test/application/diff/get-semantic-diff.test.ts
+++ b/extension/test/application/diff/get-semantic-diff.test.ts
@@ -123,8 +123,7 @@ describe("getSemanticDiff", () => {
       },
     );
 
-    expect(typeof (stream as unknown as AsyncIterable<unknown>)[Symbol.asyncIterator]).toBe("function");
-    expect(await collect(stream as unknown as AsyncIterable<unknown>)).toEqual([
+    expect(await collect(stream)).toEqual([
       { type: "response", response: { ok: false, error: "access-token-missing" } },
     ]);
     expect(requests).toHaveLength(0);

--- a/extension/test/application/internal/github-source-merge.test.ts
+++ b/extension/test/application/internal/github-source-merge.test.ts
@@ -38,11 +38,11 @@ class MemoryGuidRepository implements GuidRepository {
 
 function githubRoutes(respond: (request: URL) => Response) {
   const requests: URL[] = [];
-  const fetchRoute = (async (input: RequestInfo | URL) => {
+  const fetchRoute: typeof fetch = async (input: RequestInfo | URL) => {
     const request = new URL(String(input));
     requests.push(request);
     return respond(request);
-  }) as typeof fetch;
+  };
   return { requests, client: createGithubGateway(API_BASE, "token", fetchRoute) };
 }
 
@@ -155,13 +155,13 @@ describe("mergeGithubSources", () => {
   });
 
   it("stops after three source rounds", async () => {
-    const sources: Record<string, Uint8Array> = {
-      "/repos/o/r/contents/Assets/S0.prefab": nestedSource(100, "src1"),
-      "/repos/o/r/contents/Assets/S1.prefab": nestedSource(200, "src2"),
-      "/repos/o/r/contents/Assets/S2.prefab": nestedSource(300, "src3"),
-    };
+    const sources = new Map([
+      ["/repos/o/r/contents/Assets/S0.prefab", nestedSource(100, "src1")],
+      ["/repos/o/r/contents/Assets/S1.prefab", nestedSource(200, "src2")],
+      ["/repos/o/r/contents/Assets/S2.prefab", nestedSource(300, "src3")],
+    ]);
     const { client, requests } = githubRoutes((request) => {
-      const source = sources[request.pathname];
+      const source = sources.get(request.pathname);
       return source ? raw(source) : new Response(null, { status: 404 });
     });
     const first = firstDiff(differ, new Uint8Array(), VARIANT_PREFAB, { src0: "Assets/S0.prefab" });

--- a/extension/test/application/internal/guid-resolution.test.ts
+++ b/extension/test/application/internal/guid-resolution.test.ts
@@ -18,11 +18,11 @@ class MemoryGuidRepository implements GuidRepository {
 
 function searchRoutes(respond: (request: URL) => Response | Promise<Response>) {
   const requests: URL[] = [];
-  const fetchRoute = (async (input: RequestInfo | URL) => {
+  const fetchRoute: typeof fetch = async (input: RequestInfo | URL) => {
     const request = new URL(String(input));
     requests.push(request);
     return respond(request);
-  }) as typeof fetch;
+  };
   return { requests, client: createGithubGateway("https://api.github.test", "token", fetchRoute) };
 }
 

--- a/extension/test/application/internal/raw-diff.test.ts
+++ b/extension/test/application/internal/raw-diff.test.ts
@@ -9,6 +9,7 @@ import type { DiffRepository } from "../../../src/domain/diff/diff-repository";
 import type { DiffV2 } from "../../../src/domain/diff/types";
 import { createGithubGateway } from "../../../src/infrastructure/clients/github-client";
 import { createDifferGateway } from "../../../src/infrastructure/clients/wasm-differ-client";
+import type { JsonValue } from "../../../src/internal/json";
 import { AFTER_PREFAB, BEFORE_PREFAB } from "../../fixtures/unity";
 
 const API_BASE = "https://api.github.test";
@@ -30,11 +31,11 @@ class MemoryDiffRepository implements DiffRepository {
 }
 
 function githubClient(respond: (request: URL) => Response | Promise<Response>): GithubGateway {
-  const fetchRoute = (async (input: RequestInfo | URL) => respond(new URL(String(input)))) as typeof fetch;
+  const fetchRoute: typeof fetch = async (input: RequestInfo | URL) => respond(new URL(String(input)));
   return createGithubGateway(API_BASE, "token", fetchRoute);
 }
 
-function json(value: unknown, status = 200, headers?: HeadersInit): Response {
+function json(value: JsonValue, status = 200, headers?: HeadersInit): Response {
   return new Response(JSON.stringify(value), {
     status,
     headers: { "content-type": "application/json", ...headers },

--- a/extension/test/application/internal/repo-index.test.ts
+++ b/extension/test/application/internal/repo-index.test.ts
@@ -90,6 +90,7 @@ describe("getRepoIndex", () => {
         });
       }
       if (request.pathname === "/graphql") {
+        // The body comes from the GitHub client's JSON.stringify({ query }) call.
         const body = JSON.parse(String(init?.body)) as { query: string };
         graphqlQueries.push(body.query);
         return Response.json({ data: { repository: { b0: { text: "guid: gB\n" } } } });
@@ -119,6 +120,7 @@ describe("getRepoIndex", () => {
         return Response.json({ truncated: false, tree: metas });
       }
       if (request.pathname === "/graphql") {
+        // The body comes from the GitHub client's JSON.stringify({ query }) call.
         const body = JSON.parse(String(init?.body)) as { query: string };
         graphqlBatchSizes.push(body.query.match(/object\(oid:/g)?.length ?? 0);
         return Response.json({ data: { repository: {} } });

--- a/extension/test/application/internal/resolve-semantic-diff.test.ts
+++ b/extension/test/application/internal/resolve-semantic-diff.test.ts
@@ -10,6 +10,7 @@ import type { RepoGuidIndex } from "../../../src/domain/guid/repo-guid-index";
 import type { RepoIndexRepository } from "../../../src/domain/guid/repo-index-repository";
 import { createGithubGateway } from "../../../src/infrastructure/clients/github-client";
 import { createDifferGateway } from "../../../src/infrastructure/clients/wasm-differ-client";
+import type { JsonValue } from "../../../src/internal/json";
 import { SOURCE_PREFAB, VARIANT_PREFAB } from "../../fixtures/unity";
 
 const API_BASE = "https://api.github.test";
@@ -60,15 +61,15 @@ type RoutedRequest = { url: URL; init?: RequestInit };
 
 function githubRoutes(respond: (request: RoutedRequest) => Response | Promise<Response>) {
   const requests: RoutedRequest[] = [];
-  const fetchRoute = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const fetchRoute: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = { url: new URL(String(input)), init };
     requests.push(request);
     return respond(request);
-  }) as typeof fetch;
+  };
   return { requests, client: createGithubGateway(API_BASE, "token", fetchRoute) };
 }
 
-function json(value: unknown, status = 200): Response {
+function json(value: JsonValue, status = 200): Response {
   return new Response(JSON.stringify(value), {
     status,
     headers: { "content-type": "application/json" },
@@ -138,7 +139,6 @@ describe("resolveSemanticDiff", () => {
       },
     );
 
-    expect(typeof (operation as unknown as AsyncIterable<unknown>)[Symbol.asyncIterator]).toBe("function");
     const messages = await collect(operation);
 
     expect(messages).toHaveLength(2);

--- a/extension/test/architecture/presentation-types.test.ts
+++ b/extension/test/architecture/presentation-types.test.ts
@@ -139,7 +139,7 @@ function presentationSources(): Array<{ file: string; source: string }> {
   });
 }
 
-function collect(source: string): { types: ExportedType[]; fns: ExportedFn[] } {
+function collect(source: string) {
   source = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
   const types: ExportedType[] = [];
   const fns: ExportedFn[] = [];

--- a/extension/test/e2e/full.spec.ts
+++ b/extension/test/e2e/full.spec.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from "../../src/internal/json";
+import type { ViewMode } from "../../src/presentation/internal/view-mode";
 /// <reference types="node" />
 // This suite runs detection, background work, WASM, and rendering through the loaded extension.
 // The local server replaces GitHub. The E2E build uses its fixed port for both origins.
@@ -89,7 +91,7 @@ function startServer(): Promise<Server> {
       res.writeHead(200, { "content-type": type });
       res.end(body);
     };
-    const json = (body: unknown): void => send(JSON.stringify(body), "application/json");
+    const json = (body: JsonValue): void => send(JSON.stringify(body), "application/json");
     // Empty trees make each ref pair use the contents API.
     if (url.pathname.startsWith("/repos/o/r/git/trees/")) return json({ truncated: false, tree: [] });
     switch (url.pathname) {
@@ -246,7 +248,7 @@ function startServer(): Promise<Server> {
 let context: BrowserContext;
 let server: Server;
 
-async function setLocalStorage(values: Record<string, unknown>): Promise<void> {
+async function setLocalStorage(values: { accessToken?: string; viewMode?: ViewMode }): Promise<void> {
   const worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
   await worker.evaluate((next) => chrome.storage.local.set(next), values);
 }
@@ -362,6 +364,31 @@ test("renders a real WASM diff with Code Search GUID resolution", async () => {
   await expect(view).toContainText("0.8");
   await expect.poll(() => state.requests.join("\n")).toContain("GET /repos/o/r/contents/Assets/Foo.prefab?ref=MB");
   await expect.poll(() => state.requests.join("\n")).toContain("GET /repos/o/r/contents/Assets/Foo.prefab?ref=H");
+  await page.close();
+});
+
+test("uses the operating-system dark theme in automatic mode", async () => {
+  const page = await context.newPage();
+  await page.emulateMedia({ colorScheme: "dark" });
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/1/files`);
+  await page.evaluate(() => document.documentElement.setAttribute("data-color-mode", "auto"));
+
+  // Real matchMedia behavior must reach the rendered view through the loaded content script.
+  const header = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await header.getByRole("button", { name: "Semantic" }).click();
+  await expect(page.locator("[data-prefablens-view] .pl-root")).toHaveCSS("color", "rgb(240, 246, 252)");
+  await page.close();
+});
+
+test("uses the operating-system light theme in automatic mode", async () => {
+  const page = await context.newPage();
+  await page.emulateMedia({ colorScheme: "light" });
+  await page.goto(`http://127.0.0.1:${PORT}/o/r/pull/1/files`);
+  await page.evaluate(() => document.documentElement.setAttribute("data-color-mode", "auto"));
+
+  const header = page.locator('.file-header[data-path="Assets/Foo.prefab"]');
+  await header.getByRole("button", { name: "Semantic" }).click();
+  await expect(page.locator("[data-prefablens-view] .pl-root")).toHaveCSS("color", "rgb(31, 35, 40)");
   await page.close();
 });
 
@@ -656,6 +683,7 @@ test("restores a fully remounted React file before the next paint", async () => 
       new Promise<{ rawDisplay: string; semanticView: boolean }>((resolve) => {
         const entry = document.querySelector("#diff-aaa111")?.parentElement;
         if (!entry) throw new Error("diff region missing");
+        // cloneNode preserves the HTML element type of entry.
         const clone = entry.cloneNode(true) as HTMLElement;
         // GitHub rebuilds this node from React state. The new node has no PrefabLens attributes or styles.
         clone.querySelector("[data-prefablens-view]")?.remove();
@@ -786,6 +814,7 @@ test("reattaches a fully remounted file with the semantic default", async () => 
   await page.evaluate(() => {
     const entry = document.querySelector("#diff-aaa111")?.parentElement;
     if (!entry) throw new Error("diff region missing");
+    // cloneNode preserves the HTML element type of entry.
     const clone = entry.cloneNode(true) as HTMLElement;
     clone.querySelector("[data-prefablens-view]")?.remove();
     clone.querySelector("[data-prefablens-toggle]")?.remove();

--- a/extension/test/infrastructure/clients/chrome-auth-client.test.ts
+++ b/extension/test/infrastructure/clients/chrome-auth-client.test.ts
@@ -1,27 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createChromeAuthRepository } from "../../../src/infrastructure/clients/chrome-auth-client";
-import type { StorageAreaWithRemove } from "../../../src/infrastructure/internal/storage-area";
-
-class MemoryStorageArea implements StorageAreaWithRemove {
-  private readonly values: Record<string, unknown>;
-
-  constructor(initial: Record<string, unknown> = {}) {
-    this.values = { ...initial };
-  }
-
-  async get(keys: string | string[] | null): Promise<Record<string, unknown>> {
-    const selected = keys === null ? Object.keys(this.values) : Array.isArray(keys) ? keys : [keys];
-    return Object.fromEntries(selected.filter((key) => key in this.values).map((key) => [key, this.values[key]]));
-  }
-
-  async set(items: Record<string, unknown>): Promise<void> {
-    Object.assign(this.values, items);
-  }
-
-  async remove(keys: string | string[]): Promise<void> {
-    for (const key of Array.isArray(keys) ? keys : [keys]) delete this.values[key];
-  }
-}
+import { MemoryStorageArea } from "../../support/memory-storage-area";
 
 describe("createChromeAuthRepository", () => {
   it("round-trips the access token", async () => {

--- a/extension/test/infrastructure/clients/chrome-diff-client.test.ts
+++ b/extension/test/infrastructure/clients/chrome-diff-client.test.ts
@@ -1,36 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { type DiffV2, emptyDiff } from "../../../src/domain/diff/types";
 import { createChromeDiffRepository } from "../../../src/infrastructure/clients/chrome-diff-client";
-import type { StorageAreaWithRemove } from "../../../src/infrastructure/internal/storage-area";
+import { MemoryStorageArea } from "../../support/memory-storage-area";
 
 const DIFF: DiffV2 = emptyDiff();
-
-class MemoryStorageArea implements StorageAreaWithRemove {
-  private values: Record<string, unknown>;
-
-  constructor(
-    initial: Record<string, unknown> = {},
-    private readonly capacity = Number.POSITIVE_INFINITY,
-  ) {
-    this.values = { ...initial };
-  }
-
-  async get(keys: string | string[] | null): Promise<Record<string, unknown>> {
-    const selected = keys === null ? Object.keys(this.values) : Array.isArray(keys) ? keys : [keys];
-    return Object.fromEntries(selected.filter((key) => key in this.values).map((key) => [key, this.values[key]]));
-  }
-
-  async set(items: Record<string, unknown>): Promise<void> {
-    const next = { ...this.values, ...items };
-    if (JSON.stringify(next).length > this.capacity) throw new Error("quota exceeded");
-    this.values = next;
-  }
-
-  async remove(keys: string | string[]): Promise<void> {
-    const removed = new Set(Array.isArray(keys) ? keys : [keys]);
-    this.values = Object.fromEntries(Object.entries(this.values).filter(([key]) => !removed.has(key)));
-  }
-}
 
 describe("createChromeDiffRepository", () => {
   it("returns no diff for a missing key", async () => {

--- a/extension/test/infrastructure/clients/chrome-guid-client.test.ts
+++ b/extension/test/infrastructure/clients/chrome-guid-client.test.ts
@@ -1,28 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createChromeGuidRepository } from "../../../src/infrastructure/clients/chrome-guid-client";
-import type { StorageArea } from "../../../src/infrastructure/internal/storage-area";
-
-class MemoryStorageArea implements StorageArea {
-  private values: Record<string, unknown>;
-
-  constructor(
-    initial: Record<string, unknown> = {},
-    private readonly capacity = Number.POSITIVE_INFINITY,
-  ) {
-    this.values = { ...initial };
-  }
-
-  async get(keys: string | string[] | null): Promise<Record<string, unknown>> {
-    const selected = keys === null ? Object.keys(this.values) : Array.isArray(keys) ? keys : [keys];
-    return Object.fromEntries(selected.filter((key) => key in this.values).map((key) => [key, this.values[key]]));
-  }
-
-  async set(items: Record<string, unknown>): Promise<void> {
-    const next = { ...this.values, ...items };
-    if (JSON.stringify(next).length > this.capacity) throw new Error("quota exceeded");
-    this.values = next;
-  }
-}
+import { MemoryStorageArea } from "../../support/memory-storage-area";
 
 describe("createChromeGuidRepository", () => {
   it("returns an empty map for a repository without stored GUIDs", async () => {

--- a/extension/test/infrastructure/clients/chrome-repo-index-client.test.ts
+++ b/extension/test/infrastructure/clients/chrome-repo-index-client.test.ts
@@ -1,29 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { RepoGuidIndex } from "../../../src/domain/guid/repo-guid-index";
 import { createChromeRepoIndexRepository } from "../../../src/infrastructure/clients/chrome-repo-index-client";
-import type { StorageArea } from "../../../src/infrastructure/internal/storage-area";
-
-class MemoryStorageArea implements StorageArea {
-  private values: Record<string, unknown>;
-
-  constructor(
-    initial: Record<string, unknown> = {},
-    private readonly capacity = Number.POSITIVE_INFINITY,
-  ) {
-    this.values = { ...initial };
-  }
-
-  async get(keys: string | string[] | null): Promise<Record<string, unknown>> {
-    const selected = keys === null ? Object.keys(this.values) : Array.isArray(keys) ? keys : [keys];
-    return Object.fromEntries(selected.filter((key) => key in this.values).map((key) => [key, this.values[key]]));
-  }
-
-  async set(items: Record<string, unknown>): Promise<void> {
-    const next = { ...this.values, ...items };
-    if (JSON.stringify(next).length > this.capacity) throw new Error("quota exceeded");
-    this.values = next;
-  }
-}
+import { MemoryStorageArea } from "../../support/memory-storage-area";
 
 describe("createChromeRepoIndexRepository", () => {
   it("returns an empty metadata map for an unknown repository", async () => {

--- a/extension/test/infrastructure/clients/github-client.test.ts
+++ b/extension/test/infrastructure/clients/github-client.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { isRateLimited } from "../../../src/application/gateway/github";
 import { err, ok } from "../../../src/domain/result";
-import { createGithubGateway } from "../../../src/infrastructure/clients/github-client";
+import { createGithubGateway, createQueuedGithubGateway } from "../../../src/infrastructure/clients/github-client";
+import type { JsonValue } from "../../../src/internal/json";
 import { must } from "../../../src/internal/must";
 
 const API = "https://api.github.test";
 
-const json = (body: unknown, status = 200, headers?: HeadersInit) =>
+const json = (body: JsonValue, status = 200, headers?: HeadersInit) =>
   new Response(JSON.stringify(body), {
     status,
     headers: { "content-type": "application/json", ...Object.fromEntries(new Headers(headers)) },
@@ -30,7 +31,7 @@ class VirtualClock {
 
 describe("createGithubGateway", () => {
   it("returns the merge base", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       switch (requestKey(input, init)) {
         case `GET ${API}/repos/o/r/pulls/7`:
           return json({ base: { sha: "base-tip" }, head: { sha: "head-sha" } });
@@ -39,7 +40,7 @@ describe("createGithubGateway", () => {
         default:
           return unexpectedRequest(input, init);
       }
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 7);
 
@@ -47,7 +48,7 @@ describe("createGithubGateway", () => {
   });
 
   it("sends the required REST headers", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1/files?per_page=100&page=1`) {
         return unexpectedRequest(input, init);
       }
@@ -56,7 +57,7 @@ describe("createGithubGateway", () => {
       expect(headers.get("accept")).toBe("application/vnd.github+json");
       expect(headers.get("x-github-api-version")).toBe("2022-11-28");
       return json([]);
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).listPrFiles("o", "r", 1);
 
@@ -68,7 +69,7 @@ describe("createGithubGateway", () => {
       filename: `f${index}.cs`,
       status: "modified",
     }));
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       switch (requestKey(input, init)) {
         case `GET ${API}/repos/o/r/pulls/1/files?per_page=100&page=1`:
           return json(firstPage);
@@ -84,7 +85,7 @@ describe("createGithubGateway", () => {
         default:
           return unexpectedRequest(input, init);
       }
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).listPrFiles("o", "r", 1);
 
@@ -100,7 +101,7 @@ describe("createGithubGateway", () => {
   });
 
   it("returns the first commit parent and maps its files", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) === `GET ${API}/repos/o/r/commits/abc1234?per_page=300&page=1`) {
         return json({
           sha: "abc1234full",
@@ -109,7 +110,7 @@ describe("createGithubGateway", () => {
         });
       }
       return unexpectedRequest(input, init);
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getCommit("o", "r", "abc1234");
 
@@ -128,7 +129,7 @@ describe("createGithubGateway", () => {
         requestKey(`${API}/repos/o/r/commits/root?per_page=300&page=${index + 1}`),
       ),
     );
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (!accepted.has(requestKey(input, init))) return unexpectedRequest(input, init);
       const page = new URL(String(input)).searchParams.get("page");
       return json({
@@ -139,7 +140,7 @@ describe("createGithubGateway", () => {
           status: "added",
         })),
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getCommit("o", "r", "root");
 
@@ -151,7 +152,7 @@ describe("createGithubGateway", () => {
   });
 
   it("encodes compare refs and maps removed files", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) === `GET ${API}/repos/o/r/compare/feat%2Fx...main`) {
         return json({
           merge_base_commit: { sha: "merge-base" },
@@ -159,7 +160,7 @@ describe("createGithubGateway", () => {
         });
       }
       return unexpectedRequest(input, init);
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).compareRefs("o", "r", "feat/x", "main");
 
@@ -172,13 +173,13 @@ describe("createGithubGateway", () => {
   });
 
   it("requests the SHA media type and trims the response", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/commits/feat%2Fx`) {
         return unexpectedRequest(input, init);
       }
       expect(new Headers(init?.headers).get("accept")).toBe("application/vnd.github.sha");
       return new Response("full-head-sha\n");
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).resolveRefSha("o", "r", "feat/x");
 
@@ -186,13 +187,13 @@ describe("createGithubGateway", () => {
   });
 
   it("requests raw file content with encoded path segments", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/contents/Assets/My%20Prefab%231.prefab?ref=sha1`) {
         return unexpectedRequest(input, init);
       }
       expect(new Headers(init?.headers).get("accept")).toBe("application/vnd.github.raw+json");
       return new Response(new Uint8Array([1, 2, 3]));
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getFileAtRef(
       "o",
@@ -207,12 +208,12 @@ describe("createGithubGateway", () => {
   });
 
   it("returns null when file content is absent", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/contents/gone.prefab?ref=sha1`) {
         return unexpectedRequest(input, init);
       }
       return new Response("not found", { status: 404 });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getFileAtRef("o", "r", "gone.prefab", "sha1");
 
@@ -220,13 +221,13 @@ describe("createGithubGateway", () => {
   });
 
   it("requests raw bytes by blob SHA", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/git/blobs/blob1`) {
         return unexpectedRequest(input, init);
       }
       expect(new Headers(init?.headers).get("accept")).toBe("application/vnd.github.raw+json");
       return new Response(new Uint8Array([1, 2, 3]));
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getBlobRaw("o", "r", "blob1");
 
@@ -237,10 +238,10 @@ describe("createGithubGateway", () => {
 
   it("returns the asset path from metadata search", async () => {
     const url = `${API}/search/code?q=${encodeURIComponent('"abc123" repo:o/r extension:meta')}&per_page=1`;
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${url}`) return unexpectedRequest(input, init);
       return json({ items: [{ path: "Assets/Scripts/Player.cs.meta" }] });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).searchMetaByGuid("o", "r", "abc123");
 
@@ -250,7 +251,7 @@ describe("createGithubGateway", () => {
   it("returns null for empty and non-metadata search results", async () => {
     const emptyUrl = `${API}/search/code?q=${encodeURIComponent('"empty" repo:o/r extension:meta')}&per_page=1`;
     const nonMetaUrl = `${API}/search/code?q=${encodeURIComponent('"odd" repo:o/r extension:meta')}&per_page=1`;
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       switch (requestKey(input, init)) {
         case `GET ${emptyUrl}`:
           return json({ items: [] });
@@ -259,7 +260,7 @@ describe("createGithubGateway", () => {
         default:
           return unexpectedRequest(input, init);
       }
-    }) as typeof fetch;
+    };
     const client = createGithubGateway(API, "tok", fetchFn);
 
     expect(await client.searchMetaByGuid("o", "r", "empty")).toEqual(ok(null));
@@ -269,7 +270,7 @@ describe("createGithubGateway", () => {
   it("keeps the residual metadata search fallback", async () => {
     const unindexedUrl = `${API}/search/code?q=${encodeURIComponent('"unindexed" repo:o/r extension:meta')}&per_page=1`;
     const failedUrl = `${API}/search/code?q=${encodeURIComponent('"failed" repo:o/r extension:meta')}&per_page=1`;
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       switch (requestKey(input, init)) {
         case `GET ${unindexedUrl}`:
           return json({ message: "Validation Failed" }, 422);
@@ -278,7 +279,7 @@ describe("createGithubGateway", () => {
         default:
           return unexpectedRequest(input, init);
       }
-    }) as typeof fetch;
+    };
     const client = createGithubGateway(API, "tok", fetchFn);
 
     expect(await client.searchMetaByGuid("o", "r", "unindexed")).toEqual(ok(null));
@@ -286,7 +287,7 @@ describe("createGithubGateway", () => {
   });
 
   it("returns metadata blobs with the truncation state", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/git/trees/H?recursive=1`) {
         return unexpectedRequest(input, init);
       }
@@ -299,7 +300,7 @@ describe("createGithubGateway", () => {
           { path: "Assets", type: "tree", sha: "sha4" },
         ],
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).listMetaTree("o", "r", "H");
 
@@ -315,7 +316,7 @@ describe("createGithubGateway", () => {
   });
 
   it("maps every blob path with the truncation state", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/git/trees/merge-base?recursive=1`) {
         return unexpectedRequest(input, init);
       }
@@ -327,7 +328,7 @@ describe("createGithubGateway", () => {
           { path: "Assets", type: "tree", sha: "sha3" },
         ],
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).listBlobShas("o", "r", "merge-base");
 
@@ -341,17 +342,18 @@ describe("createGithubGateway", () => {
   });
 
   it("posts a GraphQL query and maps blob text", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `POST ${API}/graphql`) return unexpectedRequest(input, init);
       const headers = new Headers(init?.headers);
       expect(headers.get("authorization")).toBe("Bearer tok");
       expect(headers.get("accept")).toBe("application/json");
       expect(headers.get("content-type")).toBe("application/json");
+      // The body comes from the GitHub client's JSON.stringify({ query }) call.
       const body = JSON.parse(String(init?.body)) as { query: string };
       expect(body.query).toContain('b0: object(oid: "sha1")');
       expect(body.query).toContain('b1: object(oid: "sha2")');
       return json({ data: { repository: { b0: { text: "guid: g1\n" }, b1: null } } });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).batchBlobTexts("o", "r", ["sha1", "sha2"]);
 
@@ -359,10 +361,10 @@ describe("createGithubGateway", () => {
   });
 
   it("classifies an HTTP 429 response as rate-limited", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       return new Response("", { status: 429 });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 1);
 
@@ -372,10 +374,10 @@ describe("createGithubGateway", () => {
   });
 
   it("classifies Retry-After on HTTP 403 as rate-limited", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       return new Response("", { status: 403, headers: { "retry-after": "60" } });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 1);
 
@@ -385,10 +387,10 @@ describe("createGithubGateway", () => {
   });
 
   it("classifies an exhausted REST quota as rate-limited", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       return new Response("", { status: 403, headers: { "x-ratelimit-remaining": "0" } });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 1);
 
@@ -398,13 +400,13 @@ describe("createGithubGateway", () => {
   });
 
   it("classifies a secondary rate-limit message as rate-limited", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       return new Response('{"message":"Secondary rate limit"}', {
         status: 403,
         headers: { "x-ratelimit-remaining": "4999" },
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 1);
 
@@ -414,13 +416,13 @@ describe("createGithubGateway", () => {
   });
 
   it("maps a permission response to auth-failed", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       return new Response('{"message":"Resource not accessible by personal access token"}', {
         status: 403,
         headers: { "x-ratelimit-remaining": "4999" },
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 1);
 
@@ -428,10 +430,10 @@ describe("createGithubGateway", () => {
   });
 
   it("maps a non-success response to fetch-failed", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       return new Response("server error", { status: 500 });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 1);
 
@@ -440,13 +442,13 @@ describe("createGithubGateway", () => {
 
   it("uses Retry-After before the reset time", async () => {
     const reset = Math.floor(Date.now() / 1000) + 30;
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/7`) return unexpectedRequest(input, init);
       return new Response("slow down", {
         status: 403,
         headers: { "retry-after": "12", "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(reset) },
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 7);
 
@@ -455,13 +457,13 @@ describe("createGithubGateway", () => {
 
   it("converts the reset time to a relative wait", async () => {
     const reset = Math.floor(Date.now() / 1000) + 30;
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/7`) return unexpectedRequest(input, init);
       return new Response("", {
         status: 403,
         headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(reset) },
       });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 7);
 
@@ -472,10 +474,10 @@ describe("createGithubGateway", () => {
   });
 
   it("omits advice when a rate-limit response has no advice header", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/7`) return unexpectedRequest(input, init);
       return new Response('{"message":"Secondary rate limit"}', { status: 403 });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).getPrRefs("o", "r", 7);
 
@@ -483,10 +485,10 @@ describe("createGithubGateway", () => {
   });
 
   it("maps GraphQL RATE_LIMITED and keeps header advice", async () => {
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `POST ${API}/graphql`) return unexpectedRequest(input, init);
       return json({ errors: [{ type: "RATE_LIMITED" }] }, 200, { "retry-after": "4" });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubGateway(API, "tok", fetchFn).batchBlobTexts("o", "r", ["sha1"]);
 
@@ -494,17 +496,17 @@ describe("createGithubGateway", () => {
   });
 });
 
-describe("createGithubGateway", () => {
+describe("createQueuedGithubGateway", () => {
   it("returns rate-limited after two queue backoffs", async () => {
     const clock = new VirtualClock();
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       if (![0, 30_000, 60_000].includes(clock.now)) {
         throw new Error(`Unexpected clock state: ${clock.now}`);
       }
       return new Response("limited", { status: 429 });
-    }) as typeof fetch;
-    const client = createGithubGateway(1, fetchFn, clock.sleep)(API, "tok", "user");
+    };
+    const client = createQueuedGithubGateway(1, fetchFn, clock.sleep)(API, "tok", "user");
 
     const result = await client.getPrRefs("o", "r", 1);
 
@@ -514,12 +516,12 @@ describe("createGithubGateway", () => {
 
   it("does not retry an authentication response", async () => {
     const clock = new VirtualClock();
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       if (requestKey(input, init) !== `GET ${API}/repos/o/r/pulls/1`) return unexpectedRequest(input, init);
       if (clock.now !== 0) throw new Error(`Unexpected clock state: ${clock.now}`);
       return new Response("unauthorized", { status: 401 });
-    }) as typeof fetch;
-    const client = createGithubGateway(1, fetchFn, clock.sleep)(API, "tok", "user");
+    };
+    const client = createQueuedGithubGateway(1, fetchFn, clock.sleep)(API, "tok", "user");
 
     const result = await client.getPrRefs("o", "r", 1);
 
@@ -530,7 +532,7 @@ describe("createGithubGateway", () => {
   it("shares one queue and runs the user lane first", async () => {
     const activeResponse = Promise.withResolvers<Response>();
     const order: string[] = [];
-    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const fetchFn: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       switch (requestKey(input, init)) {
         case `GET ${API}/repos/o/r/commits/active`:
           order.push("active");
@@ -544,8 +546,8 @@ describe("createGithubGateway", () => {
         default:
           return unexpectedRequest(input, init);
       }
-    }) as typeof fetch;
-    const makeGithubGateway = createGithubGateway(1, fetchFn, async () => {});
+    };
+    const makeGithubGateway = createQueuedGithubGateway(1, fetchFn, async () => {});
     const prefetch = makeGithubGateway(API, "tok", "prefetch");
     const user = makeGithubGateway(API, "tok", "user");
     const active = prefetch.resolveRefSha("o", "r", "active");

--- a/extension/test/infrastructure/clients/github-device-flow-client.test.ts
+++ b/extension/test/infrastructure/clients/github-device-flow-client.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { err, ok } from "../../../src/domain/result";
 import { createGithubDeviceFlowGateway } from "../../../src/infrastructure/clients/github-device-flow-client";
+import type { JsonValue } from "../../../src/internal/json";
 
-const json = (body: unknown, status = 200) =>
+const json = (body: JsonValue, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 
 class VirtualClock {
@@ -15,7 +16,7 @@ class VirtualClock {
 
 describe("createGithubDeviceFlowGateway", () => {
   it("maps a successful device-code response", async () => {
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/device/code") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
@@ -33,7 +34,7 @@ describe("createGithubDeviceFlowGateway", () => {
         interval: 5,
         expires_in: 900,
       });
-    }) as typeof fetch;
+    };
 
     const auth = createGithubDeviceFlowGateway(route);
 
@@ -49,13 +50,13 @@ describe("createGithubDeviceFlowGateway", () => {
   });
 
   it("returns a failure for a device-code HTTP error", async () => {
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/device/code") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
       }
       return json({}, 500);
-    }) as typeof fetch;
+    };
 
     await expect(createGithubDeviceFlowGateway(route).requestDeviceCode()).resolves.toEqual(
       err({ kind: "device-flow-failed", message: "device code request failed (HTTP 500)" }),
@@ -63,13 +64,13 @@ describe("createGithubDeviceFlowGateway", () => {
   });
 
   it("returns the device-code error description", async () => {
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/device/code") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
       }
       return json({ error: "invalid_client", error_description: "bad client id" });
-    }) as typeof fetch;
+    };
 
     await expect(createGithubDeviceFlowGateway(route).requestDeviceCode()).resolves.toEqual(
       err({ kind: "device-flow-failed", message: "bad client id" }),
@@ -78,7 +79,7 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("returns the token from the first poll", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
@@ -92,7 +93,7 @@ describe("createGithubDeviceFlowGateway", () => {
       expect(form.get("device_code")).toBe("dc1");
       expect(form.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:device_code");
       return json({ access_token: "tok123" });
-    }) as typeof fetch;
+    };
 
     const result = await createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
       deviceCode: "dc1",
@@ -108,7 +109,7 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("repeats with the same interval after authorization_pending", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
@@ -116,7 +117,7 @@ describe("createGithubDeviceFlowGateway", () => {
       if (clock.now === 5_000 || clock.now === 10_000) return json({ error: "authorization_pending" });
       if (clock.now === 15_000) return json({ access_token: "tok123" });
       throw new Error(`Unexpected poll time: ${clock.now}`);
-    }) as typeof fetch;
+    };
 
     const result = await createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
       deviceCode: "dc1",
@@ -132,7 +133,7 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("uses the response interval after slow_down", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
@@ -140,7 +141,7 @@ describe("createGithubDeviceFlowGateway", () => {
       if (clock.now === 5_000) return json({ error: "slow_down", interval: 8 });
       if (clock.now === 13_000) return json({ access_token: "tok123" });
       throw new Error(`Unexpected poll time: ${clock.now}`);
-    }) as typeof fetch;
+    };
 
     await expect(
       createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
@@ -156,7 +157,7 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("adds five seconds when slow_down has no interval", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
@@ -164,7 +165,7 @@ describe("createGithubDeviceFlowGateway", () => {
       if (clock.now === 5_000) return json({ error: "slow_down" });
       if (clock.now === 15_000) return json({ access_token: "tok123" });
       throw new Error(`Unexpected poll time: ${clock.now}`);
-    }) as typeof fetch;
+    };
 
     await expect(
       createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
@@ -180,14 +181,14 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("maps expired_token to expired", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
       }
       expect(clock.now).toBe(5_000);
       return json({ error: "expired_token" });
-    }) as typeof fetch;
+    };
 
     await expect(
       createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
@@ -202,14 +203,14 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("maps access_denied to denied", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
       }
       expect(clock.now).toBe(5_000);
       return json({ error: "access_denied" });
-    }) as typeof fetch;
+    };
 
     await expect(
       createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
@@ -224,14 +225,14 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("maps incorrect_client_credentials to failed", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
       }
       expect(clock.now).toBe(5_000);
       return json({ error: "incorrect_client_credentials" });
-    }) as typeof fetch;
+    };
 
     await expect(
       createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({
@@ -246,14 +247,14 @@ describe("createGithubDeviceFlowGateway", () => {
 
   it("maps a token HTTP error to failed", async () => {
     const clock = new VirtualClock();
-    const route = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const route: typeof fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url !== "https://github.com/login/oauth/access_token") {
         throw new Error(`Unexpected request: ${init?.method ?? "GET"} ${url}`);
       }
       expect(clock.now).toBe(5_000);
       return json({}, 500);
-    }) as typeof fetch;
+    };
 
     await expect(
       createGithubDeviceFlowGateway(route, clock.sleep).pollForToken({

--- a/extension/test/infrastructure/clients/wasm-differ-client.test.ts
+++ b/extension/test/infrastructure/clients/wasm-differ-client.test.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from "node:fs";
 import { beforeAll, describe, expect, it } from "vitest";
 import type { DifferGateway } from "../../../src/application/gateway/differ";
-import { createDifferGateway } from "../../../src/infrastructure/clients/wasm-differ-client";
+import { createDifferGateway, createDifferLoader } from "../../../src/infrastructure/clients/wasm-differ-client";
 import { must } from "../../../src/internal/must";
 
 const enc = new TextEncoder();
@@ -21,14 +21,14 @@ beforeAll(async () => {
   differ = await createDifferGateway(bytes);
 });
 
-describe("createDifferGateway", () => {
+describe("createDifferLoader", () => {
   it("returns one real differ for repeated loads", async () => {
     const wasmBytes = readFileSync(new URL("../../../../zig-out/bin/prefablens.wasm", import.meta.url));
     const fetchBytes = async (url: string): Promise<BufferSource> => {
       if (url !== "prefablens.wasm") throw new Error(`Unexpected URL: ${url}`);
       return wasmBytes;
     };
-    const loadDiffer = createDifferGateway("prefablens.wasm", fetchBytes);
+    const loadDiffer = createDifferLoader("prefablens.wasm", fetchBytes);
 
     const first = await loadDiffer();
     const second = await loadDiffer();

--- a/extension/test/infrastructure/internal/fetch-queue.test.ts
+++ b/extension/test/infrastructure/internal/fetch-queue.test.ts
@@ -3,7 +3,7 @@ import { isRateLimited } from "../../../src/application/gateway/github";
 import { createQueue } from "../../../src/infrastructure/internal/fetch-queue";
 
 // Manual deferreds expose the task order and concurrency.
-function deferred(): { promise: Promise<void>; resolve: () => void } {
+function deferred() {
   let resolve!: () => void;
   const promise = new Promise<void>((r) => {
     resolve = r;
@@ -71,9 +71,9 @@ describe("createQueue", () => {
     // A synchronous throw can occur before task() returns a Promise.
     // The next task runs only when the active slot returns to the queue.
     const queue = createQueue(1);
-    const syncThrow = (() => {
+    const syncThrow = () => {
       throw new Error("sync boom");
-    }) as () => Promise<never>;
+    };
     await expect(queue(syncThrow)).rejects.toThrow("sync boom");
     await expect(queue(async () => "next")).resolves.toBe("next");
   });
@@ -86,9 +86,9 @@ describe("createQueue", () => {
     const first = queue(async () => {
       await gate.promise;
     });
-    const syncThrow = (() => {
+    const syncThrow = () => {
       throw new Error("boom");
-    }) as () => Promise<never>;
+    };
     const bad = queue(syncThrow);
     const good = queue(async () => "ok");
     gate.resolve();

--- a/extension/test/presentation/internal/builtin-refs.parity.test.ts
+++ b/extension/test/presentation/internal/builtin-refs.parity.test.ts
@@ -11,7 +11,7 @@ import {
 // All three tables are generated from the same Unity dump (issue #104). This
 // test fails when someone regenerates or edits one side without the others.
 
-function zigEntries(section: string): Record<string, string> {
+function zigEntries(section: string) {
   const out: Record<string, string> = {};
   for (const m of section.matchAll(/\.\{ \.file_id = (\d+), \.name = "([^"]*)" \}/g)) {
     out[must(m[1])] = must(m[2]);
@@ -36,7 +36,7 @@ it("GUID constants match between the Zig and TS tables", () => {
   expect(zig).toContain(`pub const builtin_extra_guid = "${BUILTIN_EXTRA_GUID}";`);
 });
 
-function csEntries(section: string): Record<string, string> {
+function csEntries(section: string) {
   const out: Record<string, string> = {};
   for (const m of section.matchAll(/\{ "(\d+)", "([^"]*)" \},/g)) {
     out[must(m[1])] = must(m[2]);

--- a/extension/test/presentation/internal/render.test.ts
+++ b/extension/test/presentation/internal/render.test.ts
@@ -359,18 +359,9 @@ describe("detectTheme", () => {
     expect(detectTheme(document)).toBe("light");
   });
 
-  it("uses the operating-system theme for automatic mode", () => {
+  it("defaults to light when the browser has no media-query API", () => {
     document.documentElement.setAttribute("data-color-mode", "auto");
     expect(detectTheme(document)).toBe("light");
-    const win = must(document.defaultView);
-    win.matchMedia = ((query: string) => ({
-      matches: query === "(prefers-color-scheme: dark)",
-    })) as unknown as typeof win.matchMedia;
-    try {
-      expect(detectTheme(document)).toBe("dark");
-    } finally {
-      delete (win as { matchMedia?: unknown }).matchMedia;
-    }
   });
 });
 

--- a/extension/test/support/memory-storage-area.ts
+++ b/extension/test/support/memory-storage-area.ts
@@ -1,0 +1,30 @@
+import type { StorageAreaWithRemove, StorageEntries } from "../../src/infrastructure/internal/storage-area";
+
+// Capacity applies to the complete state so quota failures reflect the repository's writes.
+export class MemoryStorageArea implements StorageAreaWithRemove {
+  private values: StorageEntries;
+
+  constructor(
+    initial: StorageEntries = {},
+    private readonly capacity = Number.POSITIVE_INFINITY,
+  ) {
+    this.values = { ...initial };
+  }
+
+  async get(keys: string | string[] | null): Promise<StorageEntries> {
+    const selected = keys === null ? Object.keys(this.values) : Array.isArray(keys) ? keys : [keys];
+    return Object.fromEntries(
+      selected.filter((key) => Object.hasOwn(this.values, key)).map((key) => [key, this.values[key]]),
+    );
+  }
+
+  async set(items: StorageEntries): Promise<void> {
+    const next = { ...this.values, ...items };
+    if (JSON.stringify(next).length > this.capacity) throw new Error("quota exceeded");
+    this.values = next;
+  }
+
+  async remove(keys: string | string[]): Promise<void> {
+    for (const key of Array.isArray(keys) ? keys : [keys]) delete this.values[key];
+  }
+}


### PR DESCRIPTION
## Summary

Simplify extension factories, queue result handling, and shared test storage. Separate factory contracts and remove unnecessary type assertions.

## Motivation

The GitHub and WASM factories select behavior through argument types, while several tests repeat storage implementations and fetch casts. Separate entry points and precise types make those contracts easier to follow.

Bugs found during the review are tracked separately in #360, #361, and #362 and remain open.

## Changes

- Separate GitHub client creation from the shared queue factory, and WASM instantiation from lazy loading.
- Keep queue results in typed job closures, consolidate storage test implementations, and replace unnecessary assertions with domain guards or inferred types.
- Simplify view host state and verify automatic dark and light themes in real Chromium.
- Document the factory contracts and shared test storage.

## Testing

Run in an isolated worktree based on `origin/main`, using `mise exec --`:

- `pnpm install --frozen-lockfile`: passed.
- `pnpm run lint`: Biome passed with no findings.
- `pnpm run typecheck`: passed.
- `pnpm test`: 29 files and 236 tests passed.
- `pnpm run e2e`: 28 tests passed in Chromium with the real WASM module, including dark and light theme coverage.
- `pnpm run build` and `pnpm run demo`: passed.
- `pnpm run size`: 49.7 KB gzip, below the 80 KB target and 150 KB hard limit.
- `git diff --check`: passed.
