### PR TITLE
fix: correct nested project paths and prefab names

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -258,10 +258,9 @@ pub fn build(b: *std.Build) void {
     });
     const run_perf = b.addRunArtifact(perf_exe);
     const perf_step = b.step("perf", "Run the performance budget gate (ReleaseFast)");
-    perf_step.dependOn(&run_perf.step);
 
-    // The CLI's guid-resolution scan has its own budget: it must stay
-    // concurrent (see cli/src/perf_scan_main.zig).
+    // The CLI's GUID scan has a separate budget to catch regressions in its
+    // concurrent file reads (see cli/src/perf_scan_main.zig).
     const perf_scan_exe = b.addExecutable(.{
         .name = "perf-scan",
         .root_module = b.createModule(.{
@@ -273,7 +272,12 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    perf_step.dependOn(&b.addRunArtifact(perf_scan_exe).step);
+    // Finish both builds before measuring, then run the benchmarks sequentially
+    // so compilation and the GUID scan cannot contend with the diff samples.
+    run_perf.step.dependOn(&perf_scan_exe.step);
+    const run_perf_scan = b.addRunArtifact(perf_scan_exe);
+    run_perf_scan.step.dependOn(&run_perf.step);
+    perf_step.dependOn(&run_perf_scan.step);
 
     const wasm = b.addExecutable(.{
         .name = "prefablens",

--- a/cli/src/diff.zig
+++ b/cli/src/diff.zig
@@ -41,7 +41,7 @@ const help_text = usage_line ++ "\nGit merge setup: " ++ merge_setup.usage ++ "\
     \\  --json         prefablens.diff.v2 JSON ({path, diff} array in bulk mode)
     \\  --html         self-contained HTML report on stdout
     \\  --open         write the HTML report to a temp file and open it in a browser
-    \\  --project DIR  Unity project root for guid resolution (and git repo dir);
+    \\  --project DIR  Unity project root; git uses its containing repository;
     \\                 git mode resolves against the repository root by default
     \\  --no-project   skip the default guid-resolution scan
     \\  --color        force ANSI colors when stdout is not a TTY (e.g. piping)
@@ -161,7 +161,7 @@ fn collectFileDiffs(
     f: @FieldType(Target, "files"),
     resolver: ?*core.json.Resolver,
     assets: *core.Assets,
-    repo_dir: []const u8,
+    project_root: []const u8,
     stderr: *std.Io.Writer,
 ) !Collected {
     const before = readFile(io, arena, f.before) catch {
@@ -172,7 +172,7 @@ fn collectFileDiffs(
         try stderr.print("error: cannot read file '{s}'\n", .{f.after});
         return .{ .exit = 1 };
     };
-    const res = diffOne(io, arena, before, after, resolver, assets, repo_dir) catch |err| return .{ .exit = try diffError(stderr, err) };
+    const res = diffOne(io, arena, before, after, resolver, assets, project_root) catch |err| return .{ .exit = try diffError(stderr, err) };
     var diffs: std.ArrayList(NamedDiff) = .empty;
     try diffs.append(arena, .{ .path = null, .before = before, .after = after, .res = res });
     return .{ .diffs = diffs.items };
@@ -189,6 +189,7 @@ fn collectGitDiffs(
     resolver: ?*core.json.Resolver,
     assets: *core.Assets,
     repo_dir: []const u8,
+    project_root: []const u8,
     stdout: *std.Io.Writer,
     stderr: *std.Io.Writer,
 ) !Collected {
@@ -223,7 +224,7 @@ fn collectGitDiffs(
         // are binary regardless of Force Text and would render as an
         // empty diff. An explicit path operand is never second-guessed.
         if (g.path == null and !core.isUnityYaml(before) and !core.isUnityYaml(after)) continue;
-        const res = diffOne(io, arena, before, after, resolver, assets, repo_dir) catch |err| return .{ .exit = try diffError(stderr, err) };
+        const res = diffOne(io, arena, before, after, resolver, assets, project_root) catch |err| return .{ .exit = try diffError(stderr, err) };
         // Single explicit path keeps the headerless single-file output.
         try diffs.append(arena, .{ .path = if (g.path != null) null else p, .before = before, .after = after, .res = res });
     }
@@ -333,15 +334,14 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
         return 0;
     }
 
-    // --project doubles as the guid-resolution base and the git repo dir.
-    // Without it, git mode anchors at the repository root: git reports changed
-    // paths relative to that root, so reading them against a subdirectory cwd
-    // would silently misreport every file as deleted. Failure falls back to
-    // "." so the not-a-repository error surfaces through git itself below.
-    const repo_dir = opt.project_root orelse switch (opt.target) {
-        .git => input.repoRoot(io, arena, ".", input.default_git_timeout) catch ".",
-        .files => ".",
+    // Git paths are repository-relative even when --project selects a nested Unity project.
+    // Keep source loading relative to that project and preserve Git's errors if discovery fails.
+    const start_dir = opt.project_root orelse ".";
+    const repo_dir = switch (opt.target) {
+        .git => input.repoRoot(io, arena, start_dir, input.default_git_timeout) catch start_dir,
+        .files => start_dir,
     };
+    const project_root = opt.project_root orelse repo_dir;
     var resolver_ptr: ?*core.json.Resolver = null;
     var idx: core.json.Resolver = undefined;
     if (opt.project_root) |proj| {
@@ -355,8 +355,8 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, stdou
 
     // Collect (path, before, after) triples for every diff target.
     const collected = switch (opt.target) {
-        .files => |f| try collectFileDiffs(io, arena, f, resolver_ptr, &assets, repo_dir, stderr),
-        .git => |g| try collectGitDiffs(io, arena, g, opt.format, resolver_ptr, &assets, repo_dir, stdout, stderr),
+        .files => |f| try collectFileDiffs(io, arena, f, resolver_ptr, &assets, project_root, stderr),
+        .git => |g| try collectGitDiffs(io, arena, g, opt.format, resolver_ptr, &assets, repo_dir, project_root, stdout, stderr),
     };
     const diffs = switch (collected) {
         .diffs => |d| d,

--- a/cli/src/diff_options.zig
+++ b/cli/src/diff_options.zig
@@ -15,7 +15,7 @@ pub const Target = union(enum) {
 pub const Options = struct {
     target: Target = .{ .git = .{ .before_ref = "HEAD", .after_ref = "", .path = null } },
     format: Format = .tree,
-    project_root: ?[]const u8 = null, // guid-resolution base and the git repo dir
+    project_root: ?[]const u8 = null, // GUID resolution base; Git uses the containing repository.
     no_project: bool = false, // skip the default guid-resolution scan
     no_color: bool = false,
     force_color: bool = false,

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -143,6 +143,34 @@ const windows_job = struct {
     extern "kernel32" fn CreateJobObjectW(?*windows.SECURITY_ATTRIBUTES, ?windows.LPCWSTR) callconv(.winapi) ?windows.HANDLE;
     extern "kernel32" fn AssignProcessToJobObject(windows.HANDLE, windows.HANDLE) callconv(.winapi) windows.BOOL;
     extern "kernel32" fn TerminateJobObject(windows.HANDLE, windows.UINT) callconv(.winapi) windows.BOOL;
+    extern "kernel32" fn QueryInformationJobObject(windows.HANDLE, c_int, *anyopaque, windows.DWORD, ?*windows.DWORD) callconv(.winapi) windows.BOOL;
+
+    const Accounting = extern struct {
+        total_user_time: i64,
+        total_kernel_time: i64,
+        period_user_time: i64,
+        period_kernel_time: i64,
+        page_faults: u32,
+        total_processes: u32,
+        active_processes: u32,
+        terminated_processes: u32,
+    };
+
+    fn terminateAndWait(job: windows.HANDLE, child: *std.process.Child, io: std.Io) void {
+        if (!TerminateJobObject(job, 1).toBool())
+            std.debug.panic("Could not terminate Git job: {t}", .{windows.GetLastError()});
+        child.kill(io);
+        // Termination is asynchronous. Waiting for the whole job also releases
+        // files held by the real Git behind the Windows launcher.
+        while (true) {
+            var accounting: Accounting = undefined;
+            if (!QueryInformationJobObject(job, 1, &accounting, @sizeOf(Accounting), null).toBool())
+                std.debug.panic("Could not query Git job: {t}", .{windows.GetLastError()});
+            if (accounting.active_processes == 0) return;
+            const interval: windows.LARGE_INTEGER = -10 * 10_000;
+            _ = windows.ntdll.NtDelayExecution(.FALSE, &interval);
+        }
+    }
 };
 
 // Zig 0.16 cancels the output readers before killing the child. On Windows,
@@ -188,9 +216,7 @@ fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) s
     defer multi_reader.deinit();
     // A silent child must exit before Windows waits for pending pipe reads.
     defer if (child.id != null) {
-        const terminated = windows_job.TerminateJobObject(job, 1);
-        std.debug.assert(terminated.toBool());
-        child.kill(io);
+        windows_job.terminateAndWait(job, &child, io);
     };
     const resumed = windows.ntdll.NtResumeThread(child.thread_handle, null);
     if (resumed != .SUCCESS) return windows.unexpectedStatus(resumed);
@@ -350,10 +376,8 @@ test "showAtRef kills git and errors when the timeout passes" {
     }
 
     // Releasing the blocked read must leave the same repository usable.
-    if (builtin.os.tag != .windows) {
-        try tmp.dir.deleteFile(testing.io, include_name);
-        try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
-    }
+    try tmp.dir.deleteFile(testing.io, include_name);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
     try testing.expectEqualStrings("v1\n", try showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", default_git_timeout));
 }
 

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -1,5 +1,51 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
+
+const timeout_test = struct {
+    const windows = std.os.windows;
+
+    extern "kernel32" fn CreateNamedPipeW(
+        lpName: windows.LPCWSTR,
+        dwOpenMode: windows.DWORD,
+        dwPipeMode: windows.DWORD,
+        nMaxInstances: windows.DWORD,
+        nOutBufferSize: windows.DWORD,
+        nInBufferSize: windows.DWORD,
+        nDefaultTimeOut: windows.DWORD,
+        lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
+    ) callconv(.winapi) windows.HANDLE;
+
+    extern "kernel32" fn ConnectNamedPipe(
+        hNamedPipe: windows.HANDLE,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) windows.BOOL;
+
+    fn createPipe(arena: std.mem.Allocator, path: []const u8) !windows.HANDLE {
+        if (builtin.os.tag != .windows) unreachable;
+        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, path);
+        const handle = CreateNamedPipeW(
+            path_w.ptr,
+            0x00000002, // PIPE_ACCESS_OUTBOUND: the Git client reads this pipe.
+            0x00000001, // PIPE_NOWAIT: leave the server listening while Git starts.
+            1,
+            4096,
+            4096,
+            0,
+            null,
+        );
+        if (handle == windows.INVALID_HANDLE_VALUE) return error.CreateTimeoutPipeFailed;
+        const connected = ConnectNamedPipe(handle, null);
+        if (!connected.toBool()) switch (windows.GetLastError()) {
+            .PIPE_LISTENING, .PIPE_CONNECTED => {},
+            else => {
+                windows.CloseHandle(handle);
+                return error.ConnectTimeoutPipeFailed;
+            },
+        };
+        return handle;
+    }
+};
 
 /// Shared input-size ceiling for both file reads (diff.zig) and `git show`
 /// output (here), so the two acquisition paths reject oversized input the
@@ -202,10 +248,32 @@ test "showAtRef kills git and errors when the timeout passes" {
     try git(testing.io, arena, dir, &.{ "add", "Foo.prefab" });
     try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
 
-    // Even real git can't finish in 1µs (spawn alone takes ms). Confirm that the cutoff
-    // protecting a long-lived caller from a hung git returns as a clear error.
-    const tiny: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromMicroseconds(1) } };
-    try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", tiny));
+    var random: [16]u8 = undefined;
+    testing.io.random(&random);
+    const include_path = if (builtin.os.tag == .windows)
+        try std.fmt.allocPrint(arena, "\\\\.\\pipe\\prefablens-show-timeout-{x}", .{random})
+    else
+        try std.fs.path.join(arena, &.{ dir, "prefablens-show-timeout" });
+
+    // Git reads included configuration before resolving the requested object. Keep
+    // this real Git read pending so timeout coverage does not depend on process startup.
+    if (builtin.os.tag != .windows) {
+        const result = try std.process.run(arena, testing.io, .{ .argv = &.{ "mkfifo", include_path } });
+        if (result.term != .exited or result.term.exited != 0) return error.MkfifoFailed;
+    }
+    try git(testing.io, arena, dir, &.{ "config", "--local", "include.path", include_path });
+
+    if (builtin.os.tag == .windows) {
+        const pipe = try timeout_test.createPipe(arena, include_path);
+        defer timeout_test.windows.CloseHandle(pipe);
+        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
+        try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
+    } else {
+        const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{ .mode = .read_write });
+        defer include_file.close(testing.io);
+        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
+        try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
+    }
 }
 
 test "showAtRef does not let a dash-prefixed ref be parsed as a git option" {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -2,51 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
 
-const timeout_test = struct {
-    const windows = std.os.windows;
-
-    extern "kernel32" fn CreateNamedPipeW(
-        lpName: windows.LPCWSTR,
-        dwOpenMode: windows.DWORD,
-        dwPipeMode: windows.DWORD,
-        nMaxInstances: windows.DWORD,
-        nOutBufferSize: windows.DWORD,
-        nInBufferSize: windows.DWORD,
-        nDefaultTimeOut: windows.DWORD,
-        lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
-    ) callconv(.winapi) windows.HANDLE;
-
-    extern "kernel32" fn ConnectNamedPipe(
-        hNamedPipe: windows.HANDLE,
-        lpOverlapped: ?*anyopaque,
-    ) callconv(.winapi) windows.BOOL;
-
-    fn createPipe(arena: std.mem.Allocator, path: []const u8) !windows.HANDLE {
-        if (builtin.os.tag != .windows) unreachable;
-        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, path);
-        const handle = CreateNamedPipeW(
-            path_w.ptr,
-            0x00000002, // PIPE_ACCESS_OUTBOUND: the Git client reads this pipe.
-            0x00000001, // PIPE_NOWAIT: leave the server listening while Git starts.
-            1,
-            4096,
-            4096,
-            0,
-            null,
-        );
-        if (handle == windows.INVALID_HANDLE_VALUE) return error.CreateTimeoutPipeFailed;
-        const connected = ConnectNamedPipe(handle, null);
-        if (!connected.toBool()) switch (windows.GetLastError()) {
-            .PIPE_LISTENING, .PIPE_CONNECTED => {},
-            else => {
-                windows.CloseHandle(handle);
-                return error.ConnectTimeoutPipeFailed;
-            },
-        };
-        return handle;
-    }
-};
-
 /// Shared input-size ceiling for both file reads (diff.zig) and `git show`
 /// output (here), so the two acquisition paths reject oversized input the
 /// same way instead of diverging on an arbitrary limit.
@@ -61,7 +16,7 @@ pub const default_git_timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awak
 /// git reports changed paths relative to this root, so anchoring reads here
 /// keeps subdirectory invocations correct.
 pub fn repoRoot(io: std.Io, arena: std.mem.Allocator, dir: []const u8, timeout: std.Io.Timeout) ![]const u8 {
-    const res = std.process.run(arena, io, .{
+    const res = runGit(arena, io, .{
         .argv = &.{ "git", "rev-parse", "--show-toplevel" },
         .cwd = .{ .path = dir },
         .stdout_limit = .limited(64 * 1024),
@@ -104,14 +59,14 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     var env = std.process.Environ.Map.init(arena);
     try env.put("LC_ALL", "C");
     try env.put("LANG", "C");
-    const res = std.process.run(arena, io, .{
+    const res = runGit(arena, io, .{
         .argv = &.{ "git", "show", "--end-of-options", spec },
         .cwd = .{ .path = repo_dir },
         .stdout_limit = .limited(max_input_bytes),
         .environ_map = &env,
         .timeout = timeout,
     }) catch |err| switch (err) {
-        // std.process.run kills the child on deadline overrun and returns error.Timeout.
+        // runGit kills the child on deadline overrun and returns error.Timeout.
         error.Timeout => return error.GitTimeout,
         else => return err,
     };
@@ -163,7 +118,7 @@ pub fn changedPaths(
     // have git silently reinterpret it as a pathspec instead of failing. The explicit "--"
     // forces every operand before it to be resolved strictly as a revision.
     try argv.append(arena, "--");
-    const res = std.process.run(arena, io, .{
+    const res = runGit(arena, io, .{
         .argv = argv.items,
         .cwd = .{ .path = repo_dir },
         .stdout_limit = .limited(max_input_bytes),
@@ -180,6 +135,98 @@ pub fn changedPaths(
         if (entry.len != 0) try out.append(arena, entry);
     }
     return out.items;
+}
+
+const windows_job = struct {
+    const windows = std.os.windows;
+
+    extern "kernel32" fn CreateJobObjectW(?*windows.SECURITY_ATTRIBUTES, ?windows.LPCWSTR) callconv(.winapi) ?windows.HANDLE;
+    extern "kernel32" fn AssignProcessToJobObject(windows.HANDLE, windows.HANDLE) callconv(.winapi) windows.BOOL;
+    extern "kernel32" fn TerminateJobObject(windows.HANDLE, windows.UINT) callconv(.winapi) windows.BOOL;
+};
+
+// Zig 0.16 cancels the output readers before killing the child. On Windows,
+// reader cancellation can wait for output first, so a hung Git also hangs its
+// timeout cleanup. Keep the same collection behavior but reverse that order.
+fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) std.process.RunError!std.process.RunResult {
+    if (builtin.os.tag != .windows) return std.process.run(gpa, io, options);
+    const windows = std.os.windows;
+    const job = windows_job.CreateJobObjectW(null, null) orelse return windows.unexpectedError(windows.GetLastError());
+    defer windows.CloseHandle(job);
+    var child = try std.process.spawn(io, .{
+        .argv = options.argv,
+        .cwd = options.cwd,
+        .environ_map = options.environ_map,
+        .expand_arg0 = options.expand_arg0,
+        .progress_node = options.progress_node,
+        .create_no_window = options.create_no_window,
+        .disable_aslr = options.disable_aslr,
+        // Git for Windows launches the real Git as a child. Assign the launcher
+        // to a job before it runs so timeout cleanup includes its descendants.
+        .start_suspended = true,
+
+        .stdin = .ignore,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
+    errdefer child.kill(io);
+    if (!windows_job.AssignProcessToJobObject(job, child.id.?).toBool())
+        return windows.unexpectedError(windows.GetLastError());
+
+    // Child.kill and Child.wait normally close these handles. The readers own
+    // them here so cancellation never operates on already-closed handles.
+    const stdout = child.stdout.?;
+    const stderr = child.stderr.?;
+    child.stdout = null;
+    child.stderr = null;
+    defer stdout.close(io);
+    defer stderr.close(io);
+
+    var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(gpa, io, multi_reader_buffer.toStreams(), &.{ stdout, stderr });
+    defer multi_reader.deinit();
+    // A silent child must exit before Windows waits for pending pipe reads.
+    defer if (child.id != null) {
+        const terminated = windows_job.TerminateJobObject(job, 1);
+        std.debug.assert(terminated.toBool());
+        child.kill(io);
+    };
+    const resumed = windows.ntdll.NtResumeThread(child.thread_handle, null);
+    if (resumed != .SUCCESS) return windows.unexpectedStatus(resumed);
+
+    const stdout_reader = multi_reader.reader(0);
+    const stderr_reader = multi_reader.reader(1);
+
+    while (multi_reader.fill(options.reserve_amount, options.timeout)) |_| {
+        if (options.stdout_limit.toInt()) |limit| {
+            if (stdout_reader.buffered().len > limit)
+                return error.StreamTooLong;
+        }
+        if (options.stderr_limit.toInt()) |limit| {
+            if (stderr_reader.buffered().len > limit)
+                return error.StreamTooLong;
+        }
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        else => |e| return e,
+    }
+
+    try multi_reader.checkAnyError();
+
+    const term = try child.wait(io);
+
+    const stdout_slice = try multi_reader.toOwnedSlice(0);
+    errdefer gpa.free(stdout_slice);
+
+    const stderr_slice = try multi_reader.toOwnedSlice(1);
+    errdefer gpa.free(stderr_slice);
+
+    return .{
+        .stdout = stdout_slice,
+        .stderr = stderr_slice,
+        .term = term,
+    };
 }
 
 fn git(io: std.Io, arena: std.mem.Allocator, dir: []const u8, argv: []const []const u8) !void {
@@ -248,32 +295,66 @@ test "showAtRef kills git and errors when the timeout passes" {
     try git(testing.io, arena, dir, &.{ "add", "Foo.prefab" });
     try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
 
-    var random: [16]u8 = undefined;
-    testing.io.random(&random);
-    const include_path = if (builtin.os.tag == .windows)
-        try std.fmt.allocPrint(arena, "\\\\.\\pipe\\prefablens-show-timeout-{x}", .{random})
-    else
-        try std.fs.path.join(arena, &.{ dir, "prefablens-show-timeout" });
+    const include_name = "prefablens-show-timeout";
+    const include_path = try std.fs.path.join(arena, &.{ dir, include_name });
 
     // Git reads included configuration before resolving the requested object. Keep
     // this real Git read pending so timeout coverage does not depend on process startup.
-    if (builtin.os.tag != .windows) {
+    if (builtin.os.tag == .windows) {
+        try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
+    } else {
         const result = try std.process.run(arena, testing.io, .{ .argv = &.{ "mkfifo", include_path } });
         if (result.term != .exited or result.term.exited != 0) return error.MkfifoFailed;
     }
     try git(testing.io, arena, dir, &.{ "config", "--local", "include.path", include_path });
 
+    const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
     if (builtin.os.tag == .windows) {
-        const pipe = try timeout_test.createPipe(arena, include_path);
-        defer timeout_test.windows.CloseHandle(pipe);
-        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
+        const windows = std.os.windows;
+        // Git's access check rejects named pipes. An exclusive oplock on a regular
+        // file lets that check succeed, but blocks Git's open until we release it.
+        // Disabling symlink following gives this fixture an asynchronous handle,
+        // which Windows requires for an oplock request.
+        const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{
+            .mode = .read_write,
+            .follow_symlinks = false,
+        });
+        defer include_file.close(testing.io);
+        var oplock: windows.IO_STATUS_BLOCK = undefined;
+        const request_level_one: windows.CTL_CODE = @bitCast(@as(u32, 0x00090000));
+        try testing.expectEqual(windows.NTSTATUS.PENDING, windows.ntdll.NtFsControlFile(
+            include_file.handle,
+            null,
+            null,
+            null,
+            &oplock,
+            request_level_one,
+            null,
+            0,
+            null,
+            0,
+        ));
+        defer {
+            // Even a spawn failure must finish the asynchronous request before
+            // its status block goes out of scope.
+            var cancelled: windows.IO_STATUS_BLOCK = undefined;
+            const status = windows.ntdll.NtCancelIoFileEx(include_file.handle, &oplock, &cancelled);
+            std.debug.assert(status == .SUCCESS or status == .NOT_FOUND);
+            std.debug.assert(windows.ntdll.NtWaitForSingleObject(include_file.handle, .FALSE, null) == .SUCCESS);
+        }
         try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
     } else {
         const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{ .mode = .read_write });
         defer include_file.close(testing.io);
-        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
         try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
     }
+
+    // Releasing the blocked read must leave the same repository usable.
+    if (builtin.os.tag != .windows) {
+        try tmp.dir.deleteFile(testing.io, include_name);
+        try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
+    }
+    try testing.expectEqualStrings("v1\n", try showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", default_git_timeout));
 }
 
 test "showAtRef does not let a dash-prefixed ref be parsed as a git option" {

--- a/cli/src/testing/diff.zig
+++ b/cli/src/testing/diff.zig
@@ -591,3 +591,124 @@ test "run: --project points git mode at a repo outside the cwd" {
     try testing.expectEqual(@as(u8, 0), code);
     try testing.expect(std.mem.indexOf(u8, output.items, "\"after\":\"2\"") != null);
 }
+
+test "run: nested --project reads modified and deleted files from the repository root" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(testing.io, "Game/Assets");
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    const project = try tmp.dir.realPathFileAlloc(testing.io, "Game", arena);
+
+    // Git reports repository-relative paths even when the selected Unity project is nested.
+    const before = "--- !u!114 &1\nMonoBehaviour:\n  hp: 1\n";
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Foo.prefab", .data = before });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Gone.prefab", .data = before });
+    try gitInit(arena, dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Foo.prefab", .data = "--- !u!114 &1\nMonoBehaviour:\n  hp: 2\n" });
+    try tmp.dir.deleteFile(testing.io, "Game/Assets/Gone.prefab");
+
+    const cases = .{
+        .{ "Game/Assets/Foo.prefab", "modified", @as(?[]const u8, "2") },
+        .{ "Game/Assets/Gone.prefab", "removed", @as(?[]const u8, null) },
+    };
+    for ([_][]const u8{ dir, project }) |selected| {
+        var out = std.Io.Writer.Allocating.init(arena);
+        var err = std.Io.Writer.Allocating.init(arena);
+        const code = try run(testing.io, arena, &.{ "--json", "--project", selected }, &out.writer, &err.writer, false, null);
+        try testing.expectEqual(@as(u8, 0), code);
+        try testing.expectEqualStrings("", err.toArrayList().items);
+        const bulk = try std.json.parseFromSlice(std.json.Value, arena, out.toArrayList().items, .{});
+        try testing.expectEqual(@as(usize, 2), bulk.value.array.items.len);
+
+        inline for (cases, 0..) |case, i| {
+            const entry = bulk.value.array.items[i].object;
+            try testing.expectEqualStrings(case[0], entry.get("path").?.string);
+            try expectHpDiff(entry.get("diff").?, case[1], case[2]);
+
+            // Explicit paths must share the same root as paths returned by bulk discovery.
+            var single = std.Io.Writer.Allocating.init(arena);
+            var single_err = std.Io.Writer.Allocating.init(arena);
+            const single_code = try run(testing.io, arena, &.{ "--json", "--project", selected, "HEAD", case[0] }, &single.writer, &single_err.writer, false, null);
+            try testing.expectEqual(@as(u8, 0), single_code);
+            try testing.expectEqualStrings("", single_err.toArrayList().items);
+            const parsed = try std.json.parseFromSlice(std.json.Value, arena, single.toArrayList().items, .{});
+            try expectHpDiff(parsed.value, case[1], case[2]);
+        }
+    }
+}
+
+fn expectHpDiff(value: std.json.Value, status: []const u8, after: ?[]const u8) !void {
+    const components = value.object.get("loose").?.array.items;
+    try testing.expectEqual(@as(usize, 1), components.len);
+    try testing.expectEqualStrings(status, components[0].object.get("status").?.string);
+    const fields = components[0].object.get("fields").?.array.items;
+    try testing.expectEqual(@as(usize, 1), fields.len);
+    const field = fields[0].object;
+    try testing.expectEqualStrings("Hp", field.get("path").?.string);
+    try testing.expectEqualStrings(status, field.get("status").?.string);
+    try testing.expectEqualStrings("1", field.get("before").?.string);
+    if (after) |expected| {
+        try testing.expectEqualStrings(expected, field.get("after").?.string);
+    } else {
+        try testing.expect(field.get("after").? == .null);
+    }
+}
+
+test "run: nested --project keeps GUID resolution and source loading relative to the project" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(testing.io, "Game/Assets");
+    const dir = try tmp.dir.realPathFileAlloc(testing.io, ".", arena);
+    const project = try tmp.dir.realPathFileAlloc(testing.io, "Game", arena);
+
+    // Source paths in the GUID index are relative to Game, while Git paths include Game/.
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Cylinder.prefab", .data =
+        \\--- !u!1 &10
+        \\GameObject:
+        \\  m_Name: Cyl
+        \\  m_Component:
+        \\  - component: {fileID: 40}
+        \\--- !u!4 &40
+        \\Transform:
+        \\  m_GameObject: {fileID: 10}
+        \\  m_LocalScale: {x: 1, y: 1, z: 1}
+    });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Cylinder.prefab.meta", .data = "fileFormatVersion: 2\nguid: 0123456789abcdef0123456789abcdef\n" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Variant.prefab", .data = "" });
+    try gitInit(arena, dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "Game/Assets/Variant.prefab", .data =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 40, guid: 0123456789abcdef0123456789abcdef, type: 3}
+        \\      propertyPath: m_LocalScale.y
+        \\      value: 2
+        \\  m_SourcePrefab: {fileID: 100100000, guid: 0123456789abcdef0123456789abcdef, type: 3}
+    });
+
+    var out = std.Io.Writer.Allocating.init(arena);
+    var err = std.Io.Writer.Allocating.init(arena);
+    const code = try run(testing.io, arena, &.{ "--json", "--project", project, "HEAD", "Game/Assets/Variant.prefab" }, &out.writer, &err.writer, false, null);
+    try testing.expectEqual(@as(u8, 0), code);
+    try testing.expectEqualStrings("", err.toArrayList().items);
+    const parsed = try std.json.parseFromSlice(std.json.Value, arena, out.toArrayList().items, .{});
+    const resolved = parsed.value.object.get("resolved").?.object;
+    try testing.expect(resolved.contains("0123456789abcdef0123456789abcdef"));
+    try testing.expectEqualStrings("Assets/Cylinder.prefab", resolved.get("0123456789abcdef0123456789abcdef").?.string);
+    try testing.expect(parsed.value.object.get("neededSources") == null);
+
+    // Combining the recorded y override with source x/z values requires loading the actual source file.
+    var tree = std.Io.Writer.Allocating.init(arena);
+    var tree_err = std.Io.Writer.Allocating.init(arena);
+    const tree_code = try run(testing.io, arena, &.{ "--no-color", "--project", project }, &tree.writer, &tree_err.writer, false, null);
+    try testing.expectEqual(@as(u8, 0), tree_code);
+    try testing.expectEqualStrings("", tree_err.toArrayList().items);
+    try testing.expect(std.mem.indexOf(u8, tree.toArrayList().items, "Scale: (1, 2, 1)") != null);
+}

--- a/cli/src/testing/diff.zig
+++ b/cli/src/testing/diff.zig
@@ -701,7 +701,9 @@ test "run: nested --project keeps GUID resolution and source loading relative to
     const parsed = try std.json.parseFromSlice(std.json.Value, arena, out.toArrayList().items, .{});
     const resolved = parsed.value.object.get("resolved").?.object;
     try testing.expect(resolved.contains("0123456789abcdef0123456789abcdef"));
-    try testing.expectEqualStrings("Assets/Cylinder.prefab", resolved.get("0123456789abcdef0123456789abcdef").?.string);
+    // The resolver preserves the native separators returned by the filesystem walker.
+    const expected_source = try std.fs.path.join(arena, &.{ "Assets", "Cylinder.prefab" });
+    try testing.expectEqualStrings(expected_source, resolved.get("0123456789abcdef0123456789abcdef").?.string);
     try testing.expect(parsed.value.object.get("neededSources") == null);
 
     // Combining the recorded y override with source x/z values requires loading the actual source file.

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -530,6 +530,55 @@ test "instantiate: outer overrides push down through nested instances" {
     try testing.expectEqualStrings("(9, 0, 0)", inst.components[0].fields[0].after.?.scalar);
 }
 
+test "instantiate: outer name wins after pushing into a nested instance" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const base =
+        \\--- !u!1 &10
+        \\GameObject:
+        \\  m_Name: Base
+    ;
+    const variant =
+        \\--- !u!1001 &100
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 10, guid: baseguid, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Inner
+        \\  m_SourcePrefab: {fileID: 100100000, guid: baseguid, type: 3}
+        \\--- !u!1 &20
+        \\GameObject:
+        \\  m_Name: Sibling
+    ;
+    const outer =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 110, guid: varguid, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Outer
+        \\  m_SourcePrefab: {fileID: 100100000, guid: varguid, type: 3}
+    ;
+    var assets: Assets = .empty;
+    try assets.put(arena, "varguid", variant);
+    try assets.put(arena, "baseguid", base);
+
+    // 110 XOR nested instance 100 targets base object 10, appending Outer after Inner.
+    const res = try root.diffBytesWithAssets(arena, "", outer, &assets);
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    try testing.expectEqualStrings("Outer", res.roots[0].name);
+    var saw_nested = false;
+    for (res.roots[0].children) |child| {
+        if (child.file_id != 100) continue;
+        saw_nested = true;
+        try testing.expectEqualStrings("Outer", child.name);
+    }
+    try testing.expect(saw_nested);
+}
+
 test "instantiate: pushed-down overrides win in the degraded view" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -836,19 +836,23 @@ fn tokenize(arena: std.mem.Allocator, source_bytes: []const u8, join_folded_line
 }
 
 fn shouldContinueLine(prev: Line, indent: usize) bool {
+    // Sibling and parent lines cannot continue the previous scalar.
+    if (indent <= prev.indent) return false;
     if (std.mem.startsWith(u8, prev.text, "- ")) {
         const text = std.mem.trimStart(u8, prev.text[1..], " ");
         const kv = splitKeyValue(text);
         const value = if (kv.has_colon) kv.value else text;
         if (value.len == 0) return false;
         if (looksLikeMapEntry(text)) return indent > prev.indent + 2;
-        return indent > prev.indent;
+        return true;
     }
     const kv = splitKeyValue(prev.text);
-    return kv.has_colon and kv.value.len > 0 and indent > prev.indent;
+    return kv.has_colon and kv.value.len > 0;
 }
 
 fn withoutComment(line: []const u8) []const u8 {
+    // Most Unity YAML lines have no comment marker and need no quote-state scan.
+    if (std.mem.indexOfScalar(u8, line, '#') == null) return line;
     var quote: ?u8 = null;
     var scalar_start = true;
     var flow_depth: usize = 0;

--- a/core/src/perf.zig
+++ b/core/src/perf.zig
@@ -43,6 +43,12 @@ pub fn timeDiff(io: std.Io, arena: std.mem.Allocator, n: usize) !u64 {
     return @intCast(start.durationTo(end).raw.toNanoseconds());
 }
 
+pub fn medianSample(samples: [5]u64) u64 {
+    var sorted = samples;
+    std.mem.sort(u64, &sorted, {}, std.sort.asc(u64));
+    return sorted[sorted.len / 2];
+}
+
 test "perf: small scene diff completes well under budget" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -50,4 +56,14 @@ test "perf: small scene diff completes well under budget" {
     const ns = try timeDiff(std.testing.io, arena, 200); // 200 objects ≈ a smallish prefab
     // A loose ceiling for the debug-build test (the real budget is enforced by `zig build perf`).
     try std.testing.expect(ns < 500 * std.time.ns_per_ms);
+}
+
+test "perf: budget median tolerates isolated slow samples" {
+    // These CI timings cross the ceiling despite unchanged diff code.
+    try std.testing.expectEqual(@as(u64, 585), medianSample(.{ 648, 552, 843, 545, 585 }));
+}
+
+test "perf: budget median retains sustained slowdowns" {
+    // A fast outlier must not hide a majority of samples above the budget.
+    try std.testing.expectEqual(@as(u64, 648), medianSample(.{ 552, 843, 648, 614, 700 }));
 }

--- a/core/src/perf_main.zig
+++ b/core/src/perf_main.zig
@@ -1,26 +1,35 @@
 const std = @import("std");
 const perf = @import("perf.zig");
 
-// The budget is loosened above the nominal value to allow for CI-runner noise. Nominal
-// values are the performance targets (typically < 5ms, ~10MB scene < 150ms). Generate a scene of
-// ~10MB and verify it diffs within the CI ceiling.
-const big_objects = 50_000; // at ~200 bytes per object, ~10 MB of YAML
-const ci_ceiling_ms = 600; // 4x the nominal 150ms. Fails only on a true regression
+// Keep the workload and ceiling stable so changes remain comparable across revisions.
+const big_objects = 50_000;
+const ci_ceiling_ms = 600;
 
 pub fn main(init: std.process.Init) !void {
-    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
+    // Warm up before sampling to keep one-time startup costs out of the budget.
+    _ = try measure(init.io);
 
-    const ns = try perf.timeDiff(init.io, arena, big_objects);
-    const ms = @divTrunc(ns, std.time.ns_per_ms);
-
+    var samples: [5]u64 = undefined;
     var buf: [128]u8 = undefined;
-    const msg = try std.fmt.bufPrint(&buf, "perf: {d} objects diffed in {d} ms (ceiling {d} ms)\n", .{ big_objects, ms, ci_ceiling_ms });
+    for (&samples, 0..) |*sample, i| {
+        sample.* = try measure(init.io);
+        const msg = try std.fmt.bufPrint(&buf, "perf: sample {d}/{d}: {d} ms\n", .{ i + 1, samples.len, @divTrunc(sample.*, std.time.ns_per_ms) });
+        try std.Io.File.stdout().writeStreamingAll(init.io, msg);
+    }
+
+    const ms = @divTrunc(perf.medianSample(samples), std.time.ns_per_ms);
+    const msg = try std.fmt.bufPrint(&buf, "perf: {d} objects diffed in {d} ms median (ceiling {d} ms)\n", .{ big_objects, ms, ci_ceiling_ms });
     try std.Io.File.stdout().writeStreamingAll(init.io, msg);
 
     if (ms > ci_ceiling_ms) {
         try std.Io.File.stdout().writeStreamingAll(init.io, "PERF BUDGET EXCEEDED\n");
         std.process.exit(1);
     }
+}
+
+fn measure(io: std.Io) !u64 {
+    // Each diff needs its own arena so samples do not accumulate hundreds of megabytes.
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    return perf.timeDiff(io, arena_state.allocator(), big_objects);
 }

--- a/core/src/prefab.zig
+++ b/core/src/prefab.zig
@@ -154,13 +154,16 @@ pub fn sourceGuid(doc: *const model.Document) ?[]const u8 {
 }
 
 pub fn scalarModificationValue(doc: *const model.Document, property_path: []const u8) ?[]const u8 {
+    var target_file_id: ?i64 = null;
+    var result: ?[]const u8 = null;
     var iterator = modifications(doc);
     while (iterator.next()) |modification| {
         if (!std.mem.eql(u8, modification.property_path, property_path)) continue;
         const value = modification.value orelse continue;
-        return value.asScalar();
+        if (target_file_id == null) target_file_id = modification.targetFileId();
+        if (modification.targetFileId() == target_file_id.?) result = value.asScalar();
     }
-    return null;
+    return result;
 }
 
 test "prefab: modifications skip malformed entries in source order" {
@@ -232,6 +235,29 @@ test "prefab: source and scalar lookups keep serialized values" {
 
     try testing.expectEqualStrings("source-guid", sourceGuid(&docs[0]).?);
     try testing.expectEqualStrings("Cylinder", scalarModificationValue(&docs[0], "m_Name").?);
+}
+
+test "prefab: scalar lookup keeps the first target and its last duplicate" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const docs = try @import("parser.zig").parse(arena_state.allocator(),
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 8, guid: source-guid, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: First
+        \\    - target: {fileID: 8, guid: source-guid, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Last
+        \\    - target: {fileID: 9, guid: source-guid, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Other target
+    );
+
+    // The first target identifies the instance. Only its later duplicate may replace the name.
+    try testing.expectEqualStrings("Last", scalarModificationValue(&docs[0], "m_Name").?);
 }
 
 test "prefab: override iterator keeps source order for all kinds" {

--- a/core/src/tree.zig
+++ b/core/src/tree.zig
@@ -498,6 +498,35 @@ test "tree: prefab instance with root transform parent becomes a root" {
     try testing.expectEqualStrings("Cylinder Variant", res.roots[0].name);
 }
 
+test "tree: duplicate prefab instance names use the effective override value" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const after =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 1, guid: 0123456789abcdef0123456789abcdef, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: First
+        \\      objectReference: {fileID: 0}
+        \\    - target: {fileID: 1, guid: 0123456789abcdef0123456789abcdef, type: 3}
+        \\      propertyPath: m_Name
+        \\      value: Last
+        \\      objectReference: {fileID: 0}
+        \\  m_SourcePrefab: {fileID: 100100000, guid: 0123456789abcdef0123456789abcdef, type: 3}
+    ;
+
+    const res = try root.diffBytes(arena, "", after);
+    try testing.expectEqual(@as(usize, 1), res.roots.len);
+    const instance = res.roots[0];
+    try testing.expectEqualStrings("Last", instance.name);
+    try testing.expectEqual(@as(usize, 1), instance.overrides.len);
+    try testing.expectEqualStrings("Name", instance.overrides[0].label);
+    try testing.expectEqualStrings("Last", instance.overrides[0].after.?.scalar);
+}
+
 test "tree: component whose m_GameObject resolves to a non-GameObject document becomes loose, not dropped" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -354,6 +354,11 @@ zig build perf
 zig build run -- before.prefab after.prefab
 ```
 
+The performance gate builds both benchmarks before running them sequentially.
+The diff benchmark warms up once, then reports five samples and checks their median against the 600 ms ceiling.
+Each sample diffs 50,000 objects with a fresh arena to keep memory usage bounded.
+The GUID scan retains its 50,000-file workload and 1,200 ms ceiling.
+
 Build the native CLI and Git strategy script before running the package test:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -259,12 +259,15 @@ Recognized UnityYAML extensions:
 | `--json` | Emit `prefablens.diff.v2` JSON. Bulk mode emits a `[{path, diff}]` array. On exit 0, it always emits valid JSON and never prose. |
 | `--html` | Emit a self-contained HTML report on stdout. |
 | `--open` | Implies `--html`. Writes a temp report, prints its path, and opens a browser. Conflicts with `--json`. |
-| `--project DIR` | Unity project root for GUID resolution and the Git repository directory. An unreadable DIR is an error (exit 1). |
+| `--project DIR` | Unity project root for GUID resolution and source prefabs. Git uses the repository containing DIR. An unreadable DIR is an error (exit 1). |
 | `--no-project` | Skip the default GUID resolution scan. Conflicts with `--project`. |
 | `--color` | Force ANSI colors when stdout is not a TTY (for example a pipe). |
 | `--no-color` | Disable ANSI colors. Overrides TTY detection and `--color`. |
 | `--version` | Print `prefablens X.Y.Z` on stdout and exit 0. Ignores other work. |
 | `-h`, `--help` | Print usage on stdout and exit 0. Ignores other work. |
+
+In Git mode, paths are relative to the repository root, including when `--project` selects a nested Unity project.
+For example, use `prefablens --project Game Game/Assets/Foo.prefab` from the repository root.
 
 #### Output formats
 


### PR DESCRIPTION
## Summary

Keep Git file reads relative to the repository root when `--project` selects a nested Unity project.
Use the final duplicate name override for prefab instance names.

## Motivation

Modified files could appear deleted because file reads duplicated the nested project directory.
Prefab instance names could disagree with their effective Name override.

Closes #354
Closes #358

## Changes

- Separate the Git root from the Unity project root while preserving GUID resolution and source prefab loading.
- Preserve the first override target and use its last matching name value.
- Add real Git and public diff API regression tests, including nested prefab expansion, and document Git path handling.
- Match the resolver's native path separators in the nested-project regression test.
- Include the shared performance and Git timeout fixes from #373, covering faster YAML parsing, Windows process cleanup, and a deterministic timeout test that checks file release after termination.

## Testing

- `zig build test --summary all`: 32/32 steps succeeded; 602/602 tests passed.
- `zig build lint`, `zig build`, and `zig build wasm`: passed.
- `node --test core/tests/*.test.mjs`: 7 passed, 0 failed.
- Latest Ubuntu CI performance gate: 50,000 objects diffed in 405 ms median (600 ms ceiling); 50,000 `.meta` files scanned in 114 ms (1,200 ms ceiling).
- Real Git and native CLI checks: 72 comparisons passed across bulk and explicit paths, modifications and deletions, worktree and commit comparisons, and different working directories. Both absolute and relative project paths were checked.
- Reproduced #358 with the native CLI and WASM: both returned the same JSON, with instance name `Last` and one Name override containing `Last`.
- New regression tests failed before the fixes and passed afterward. `git diff --check` passed.

- [Latest GitHub CI](https://github.com/hashiiiii/PrefabLens/actions/runs/34180703549) passed all 15 jobs at `b8455a4`.
