### PR TITLE
fix: stabilize CI and Windows Git timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,6 @@ jobs:
         uses: ./.github/actions/setup-zig-cache
       - name: Lint
         run: zig build lint
-      - name: Diagnose Windows timeout fixture
-        if: matrix.os == 'windows-latest'
-        timeout-minutes: 2
-        run: |
-          1..10 | ForEach-Object {
-            zig test cli/src/input.zig --test-filter "showAtRef kills git"
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          }
       - name: Test
         run: zig build test --summary all
       - name: Performance budget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         uses: ./.github/actions/setup-zig-cache
       - name: Lint
         run: zig build lint
+      - name: Diagnose Windows timeout fixture
+        if: matrix.os == 'windows-latest'
+        run: zig test cli/src/input.zig --test-filter "showAtRef kills git"
       - name: Test
         run: zig build test --summary all
       - name: Performance budget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
       - name: Diagnose Windows timeout fixture
         if: matrix.os == 'windows-latest'
         timeout-minutes: 2
-        run: zig test cli/src/input.zig --test-filter "showAtRef kills git"
+        run: |
+          1..10 | ForEach-Object {
+            zig test cli/src/input.zig --test-filter "showAtRef kills git"
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
       - name: Test
         run: zig build test --summary all
       - name: Performance budget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         run: zig build lint
       - name: Diagnose Windows timeout fixture
         if: matrix.os == 'windows-latest'
+        timeout-minutes: 2
         run: zig test cli/src/input.zig --test-filter "showAtRef kills git"
       - name: Test
         run: zig build test --summary all

--- a/build.zig
+++ b/build.zig
@@ -258,10 +258,9 @@ pub fn build(b: *std.Build) void {
     });
     const run_perf = b.addRunArtifact(perf_exe);
     const perf_step = b.step("perf", "Run the performance budget gate (ReleaseFast)");
-    perf_step.dependOn(&run_perf.step);
 
-    // The CLI's guid-resolution scan has its own budget: it must stay
-    // concurrent (see cli/src/perf_scan_main.zig).
+    // The CLI's GUID scan has a separate budget to catch regressions in its
+    // concurrent file reads (see cli/src/perf_scan_main.zig).
     const perf_scan_exe = b.addExecutable(.{
         .name = "perf-scan",
         .root_module = b.createModule(.{
@@ -273,7 +272,12 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    perf_step.dependOn(&b.addRunArtifact(perf_scan_exe).step);
+    // Finish both builds before measuring, then run the benchmarks sequentially
+    // so compilation and the GUID scan cannot contend with the diff samples.
+    run_perf.step.dependOn(&perf_scan_exe.step);
+    const run_perf_scan = b.addRunArtifact(perf_scan_exe);
+    run_perf_scan.step.dependOn(&run_perf.step);
+    perf_step.dependOn(&run_perf_scan.step);
 
     const wasm = b.addExecutable(.{
         .name = "prefablens",

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -16,7 +16,7 @@ pub const default_git_timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awak
 /// git reports changed paths relative to this root, so anchoring reads here
 /// keeps subdirectory invocations correct.
 pub fn repoRoot(io: std.Io, arena: std.mem.Allocator, dir: []const u8, timeout: std.Io.Timeout) ![]const u8 {
-    const res = std.process.run(arena, io, .{
+    const res = runGit(arena, io, .{
         .argv = &.{ "git", "rev-parse", "--show-toplevel" },
         .cwd = .{ .path = dir },
         .stdout_limit = .limited(64 * 1024),
@@ -59,7 +59,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
     var env = std.process.Environ.Map.init(arena);
     try env.put("LC_ALL", "C");
     try env.put("LANG", "C");
-    const res = std.process.run(arena, io, .{
+    const res = runGit(arena, io, .{
         .argv = &.{ "git", "show", "--end-of-options", spec },
         .cwd = .{ .path = repo_dir },
         .stdout_limit = .limited(max_input_bytes),
@@ -119,7 +119,7 @@ pub fn changedPaths(
     // have git silently reinterpret it as a pathspec instead of failing. The explicit "--"
     // forces every operand before it to be resolved strictly as a revision.
     try argv.append(arena, "--");
-    const res = std.process.run(arena, io, .{
+    const res = runGit(arena, io, .{
         .argv = argv.items,
         .cwd = .{ .path = repo_dir },
         .stdout_limit = .limited(max_input_bytes),
@@ -136,6 +136,66 @@ pub fn changedPaths(
         if (entry.len != 0) try out.append(arena, entry);
     }
     return out.items;
+}
+
+// Zig 0.16 cancels the output readers before killing the child. On Windows,
+// reader cancellation can wait for output first, so a hung Git also hangs its
+// timeout cleanup. Keep the same collection behavior but reverse that order.
+fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) std.process.RunError!std.process.RunResult {
+    if (builtin.os.tag != .windows) return std.process.run(gpa, io, options);
+    var child = try std.process.spawn(io, .{
+        .argv = options.argv,
+        .cwd = options.cwd,
+        .environ_map = options.environ_map,
+        .expand_arg0 = options.expand_arg0,
+        .progress_node = options.progress_node,
+        .create_no_window = options.create_no_window,
+        .disable_aslr = options.disable_aslr,
+
+        .stdin = .ignore,
+        .stdout = .pipe,
+        .stderr = .pipe,
+    });
+
+    var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
+    var multi_reader: std.Io.File.MultiReader = undefined;
+    multi_reader.init(gpa, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    defer multi_reader.deinit();
+    // A silent child must exit before Windows waits for pending pipe reads.
+    defer child.kill(io);
+
+    const stdout_reader = multi_reader.reader(0);
+    const stderr_reader = multi_reader.reader(1);
+
+    while (multi_reader.fill(options.reserve_amount, options.timeout)) |_| {
+        if (options.stdout_limit.toInt()) |limit| {
+            if (stdout_reader.buffered().len > limit)
+                return error.StreamTooLong;
+        }
+        if (options.stderr_limit.toInt()) |limit| {
+            if (stderr_reader.buffered().len > limit)
+                return error.StreamTooLong;
+        }
+    } else |err| switch (err) {
+        error.EndOfStream => {},
+        else => |e| return e,
+    }
+
+    try multi_reader.checkAnyError();
+
+    const term = try child.wait(io);
+
+    const stdout_slice = try multi_reader.toOwnedSlice(0);
+    errdefer gpa.free(stdout_slice);
+
+    const stderr_slice = try multi_reader.toOwnedSlice(1);
+    errdefer gpa.free(stderr_slice);
+
+    return .{
+        .stdout = stdout_slice,
+        .stderr = stderr_slice,
+        .term = term,
+    };
 }
 
 fn git(io: std.Io, arena: std.mem.Allocator, dir: []const u8, argv: []const []const u8) !void {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -66,7 +66,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
         .environ_map = &env,
         .timeout = timeout,
     }) catch |err| switch (err) {
-        // std.process.run kills the child on deadline overrun and returns error.Timeout.
+        // runGit kills the child on deadline overrun and returns error.Timeout.
         error.Timeout => return error.GitTimeout,
         else => return err,
     };
@@ -138,11 +138,22 @@ pub fn changedPaths(
     return out.items;
 }
 
+const windows_job = struct {
+    const windows = std.os.windows;
+
+    extern "kernel32" fn CreateJobObjectW(?*windows.SECURITY_ATTRIBUTES, ?windows.LPCWSTR) callconv(.winapi) ?windows.HANDLE;
+    extern "kernel32" fn AssignProcessToJobObject(windows.HANDLE, windows.HANDLE) callconv(.winapi) windows.BOOL;
+    extern "kernel32" fn TerminateJobObject(windows.HANDLE, windows.UINT) callconv(.winapi) windows.BOOL;
+};
+
 // Zig 0.16 cancels the output readers before killing the child. On Windows,
 // reader cancellation can wait for output first, so a hung Git also hangs its
 // timeout cleanup. Keep the same collection behavior but reverse that order.
 fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) std.process.RunError!std.process.RunResult {
     if (builtin.os.tag != .windows) return std.process.run(gpa, io, options);
+    const windows = std.os.windows;
+    const job = windows_job.CreateJobObjectW(null, null) orelse return windows.unexpectedError(windows.GetLastError());
+    defer windows.CloseHandle(job);
     var child = try std.process.spawn(io, .{
         .argv = options.argv,
         .cwd = options.cwd,
@@ -151,18 +162,38 @@ fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) s
         .progress_node = options.progress_node,
         .create_no_window = options.create_no_window,
         .disable_aslr = options.disable_aslr,
+        // Git for Windows launches the real Git as a child. Assign the launcher
+        // to a job before it runs so timeout cleanup includes its descendants.
+        .start_suspended = true,
 
         .stdin = .ignore,
         .stdout = .pipe,
         .stderr = .pipe,
     });
+    errdefer child.kill(io);
+    if (!windows_job.AssignProcessToJobObject(job, child.id.?).toBool())
+        return windows.unexpectedError(windows.GetLastError());
+
+    // Child.kill and Child.wait normally close these handles. The readers own
+    // them here so cancellation never operates on already-closed handles.
+    const stdout = child.stdout.?;
+    const stderr = child.stderr.?;
+    child.stdout = null;
+    child.stderr = null;
+    defer stdout.close(io);
+    defer stderr.close(io);
 
     var multi_reader_buffer: std.Io.File.MultiReader.Buffer(2) = undefined;
     var multi_reader: std.Io.File.MultiReader = undefined;
-    multi_reader.init(gpa, io, multi_reader_buffer.toStreams(), &.{ child.stdout.?, child.stderr.? });
+    multi_reader.init(gpa, io, multi_reader_buffer.toStreams(), &.{ stdout, stderr });
     defer multi_reader.deinit();
     // A silent child must exit before Windows waits for pending pipe reads.
-    defer child.kill(io);
+    defer if (child.id != null) {
+        std.debug.assert(windows_job.TerminateJobObject(job, 1).toBool());
+        child.kill(io);
+    };
+    const resumed = windows.ntdll.NtResumeThread(child.thread_handle, null);
+    if (resumed != .SUCCESS) return windows.unexpectedStatus(resumed);
 
     const stdout_reader = multi_reader.reader(0);
     const stderr_reader = multi_reader.reader(1);
@@ -325,8 +356,10 @@ test "showAtRef kills git and errors when the timeout passes" {
     }
 
     // Releasing the blocked read must leave the same repository usable.
-    try tmp.dir.deleteFile(testing.io, include_name);
-    try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
+    if (builtin.os.tag != .windows) {
+        try tmp.dir.deleteFile(testing.io, include_name);
+        try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
+    }
     try testing.expectEqualStrings("v1\n", try showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", default_git_timeout));
 }
 

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -123,6 +123,7 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
                 std.mem.indexOf(u8, res.stderr, "exists on disk, but not in") != null)
                 return &[_]u8{};
             // Anything else (bad revision, not a git repository, ...) is a real failure.
+            if (builtin.is_test) std.debug.print("git show failed: {s}\n", .{res.stderr});
             return error.GitShowFailed;
         },
         else => return error.GitShowFailed,

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -231,6 +231,7 @@ test "showAtRef kills git and errors when the timeout passes" {
         defer include_file.close(testing.io);
         var oplock: windows.IO_STATUS_BLOCK = undefined;
         const request_level_one: windows.CTL_CODE = @bitCast(@as(u32, 0x00090000));
+        std.debug.print("timeout fixture: requesting oplock\n", .{});
         try testing.expectEqual(windows.NTSTATUS.PENDING, windows.ntdll.NtFsControlFile(
             include_file.handle,
             null,
@@ -243,15 +244,20 @@ test "showAtRef kills git and errors when the timeout passes" {
             null,
             0,
         ));
+        std.debug.print("timeout fixture: oplock granted\n", .{});
         defer {
             // Even a spawn failure must finish the asynchronous request before
             // its status block goes out of scope.
             var cancelled: windows.IO_STATUS_BLOCK = undefined;
             const status = windows.ntdll.NtCancelIoFileEx(include_file.handle, &oplock, &cancelled);
+            std.debug.print("timeout fixture: cancellation {t}\n", .{status});
             std.debug.assert(status == .SUCCESS or status == .NOT_FOUND);
             std.debug.assert(windows.ntdll.NtWaitForSingleObject(include_file.handle, .FALSE, null) == .SUCCESS);
+            std.debug.print("timeout fixture: cleanup complete\n", .{});
         }
+        std.debug.print("timeout fixture: running Git\n", .{});
         try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
+        std.debug.print("timeout fixture: Git timed out\n", .{});
     } else {
         const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{ .mode = .read_write });
         defer include_file.close(testing.io);

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -143,6 +143,34 @@ const windows_job = struct {
     extern "kernel32" fn CreateJobObjectW(?*windows.SECURITY_ATTRIBUTES, ?windows.LPCWSTR) callconv(.winapi) ?windows.HANDLE;
     extern "kernel32" fn AssignProcessToJobObject(windows.HANDLE, windows.HANDLE) callconv(.winapi) windows.BOOL;
     extern "kernel32" fn TerminateJobObject(windows.HANDLE, windows.UINT) callconv(.winapi) windows.BOOL;
+    extern "kernel32" fn QueryInformationJobObject(windows.HANDLE, c_int, *anyopaque, windows.DWORD, ?*windows.DWORD) callconv(.winapi) windows.BOOL;
+
+    const Accounting = extern struct {
+        total_user_time: i64,
+        total_kernel_time: i64,
+        period_user_time: i64,
+        period_kernel_time: i64,
+        page_faults: u32,
+        total_processes: u32,
+        active_processes: u32,
+        terminated_processes: u32,
+    };
+
+    fn terminateAndWait(job: windows.HANDLE, child: *std.process.Child, io: std.Io) void {
+        if (!TerminateJobObject(job, 1).toBool())
+            std.debug.panic("Could not terminate Git job: {t}", .{windows.GetLastError()});
+        child.kill(io);
+        // Termination is asynchronous. Waiting for the whole job also releases
+        // files held by the real Git behind the Windows launcher.
+        while (true) {
+            var accounting: Accounting = undefined;
+            if (!QueryInformationJobObject(job, 1, &accounting, @sizeOf(Accounting), null).toBool())
+                std.debug.panic("Could not query Git job: {t}", .{windows.GetLastError()});
+            if (accounting.active_processes == 0) return;
+            const interval: windows.LARGE_INTEGER = -10 * 10_000;
+            _ = windows.ntdll.NtDelayExecution(.FALSE, &interval);
+        }
+    }
 };
 
 // Zig 0.16 cancels the output readers before killing the child. On Windows,
@@ -188,9 +216,7 @@ fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) s
     defer multi_reader.deinit();
     // A silent child must exit before Windows waits for pending pipe reads.
     defer if (child.id != null) {
-        const terminated = windows_job.TerminateJobObject(job, 1);
-        std.debug.assert(terminated.toBool());
-        child.kill(io);
+        windows_job.terminateAndWait(job, &child, io);
     };
     const resumed = windows.ntdll.NtResumeThread(child.thread_handle, null);
     if (resumed != .SUCCESS) return windows.unexpectedStatus(resumed);
@@ -350,10 +376,8 @@ test "showAtRef kills git and errors when the timeout passes" {
     }
 
     // Releasing the blocked read must leave the same repository usable.
-    if (builtin.os.tag != .windows) {
-        try tmp.dir.deleteFile(testing.io, include_name);
-        try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
-    }
+    try tmp.dir.deleteFile(testing.io, include_name);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
     try testing.expectEqualStrings("v1\n", try showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", default_git_timeout));
 }
 

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -1,5 +1,51 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
+
+const timeout_test = struct {
+    const windows = std.os.windows;
+
+    extern "kernel32" fn CreateNamedPipeW(
+        lpName: windows.LPCWSTR,
+        dwOpenMode: windows.DWORD,
+        dwPipeMode: windows.DWORD,
+        nMaxInstances: windows.DWORD,
+        nOutBufferSize: windows.DWORD,
+        nInBufferSize: windows.DWORD,
+        nDefaultTimeOut: windows.DWORD,
+        lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
+    ) callconv(.winapi) windows.HANDLE;
+
+    extern "kernel32" fn ConnectNamedPipe(
+        hNamedPipe: windows.HANDLE,
+        lpOverlapped: ?*anyopaque,
+    ) callconv(.winapi) windows.BOOL;
+
+    fn createPipe(arena: std.mem.Allocator, path: []const u8) !windows.HANDLE {
+        if (builtin.os.tag != .windows) unreachable;
+        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, path);
+        const handle = CreateNamedPipeW(
+            path_w.ptr,
+            0x00000002, // PIPE_ACCESS_OUTBOUND: the Git client reads this pipe.
+            0x00000001, // PIPE_NOWAIT: leave the server listening while Git starts.
+            1,
+            4096,
+            4096,
+            0,
+            null,
+        );
+        if (handle == windows.INVALID_HANDLE_VALUE) return error.CreateTimeoutPipeFailed;
+        const connected = ConnectNamedPipe(handle, null);
+        if (!connected.toBool()) switch (windows.GetLastError()) {
+            .PIPE_LISTENING, .PIPE_CONNECTED => {},
+            else => {
+                windows.CloseHandle(handle);
+                return error.ConnectTimeoutPipeFailed;
+            },
+        };
+        return handle;
+    }
+};
 
 /// Shared input-size ceiling for both file reads (diff.zig) and `git show`
 /// output (here), so the two acquisition paths reject oversized input the
@@ -202,10 +248,32 @@ test "showAtRef kills git and errors when the timeout passes" {
     try git(testing.io, arena, dir, &.{ "add", "Foo.prefab" });
     try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
 
-    // Even real git can't finish in 1µs (spawn alone takes ms). Confirm that the cutoff
-    // protecting a long-lived caller from a hung git returns as a clear error.
-    const tiny: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromMicroseconds(1) } };
-    try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", tiny));
+    var random: [16]u8 = undefined;
+    testing.io.random(&random);
+    const include_path = if (builtin.os.tag == .windows)
+        try std.fmt.allocPrint(arena, "\\\\.\\pipe\\prefablens-show-timeout-{x}", .{random})
+    else
+        try std.fs.path.join(arena, &.{ dir, "prefablens-show-timeout" });
+
+    // Git reads included configuration before resolving the requested object. Keep
+    // this real Git read pending so timeout coverage does not depend on process startup.
+    if (builtin.os.tag != .windows) {
+        const result = try std.process.run(arena, testing.io, .{ .argv = &.{ "mkfifo", include_path } });
+        if (result.term != .exited or result.term.exited != 0) return error.MkfifoFailed;
+    }
+    try git(testing.io, arena, dir, &.{ "config", "--local", "include.path", include_path });
+
+    if (builtin.os.tag == .windows) {
+        const pipe = try timeout_test.createPipe(arena, include_path);
+        defer timeout_test.windows.CloseHandle(pipe);
+        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
+        try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
+    } else {
+        const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{ .mode = .read_write });
+        defer include_file.close(testing.io);
+        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
+        try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
+    }
 }
 
 test "showAtRef does not let a dash-prefixed ref be parsed as a git option" {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -2,51 +2,6 @@ const std = @import("std");
 const builtin = @import("builtin");
 const testing = std.testing;
 
-const timeout_test = struct {
-    const windows = std.os.windows;
-
-    extern "kernel32" fn CreateNamedPipeW(
-        lpName: windows.LPCWSTR,
-        dwOpenMode: windows.DWORD,
-        dwPipeMode: windows.DWORD,
-        nMaxInstances: windows.DWORD,
-        nOutBufferSize: windows.DWORD,
-        nInBufferSize: windows.DWORD,
-        nDefaultTimeOut: windows.DWORD,
-        lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
-    ) callconv(.winapi) windows.HANDLE;
-
-    extern "kernel32" fn ConnectNamedPipe(
-        hNamedPipe: windows.HANDLE,
-        lpOverlapped: ?*anyopaque,
-    ) callconv(.winapi) windows.BOOL;
-
-    fn createPipe(arena: std.mem.Allocator, path: []const u8) !windows.HANDLE {
-        if (builtin.os.tag != .windows) unreachable;
-        const path_w = try std.unicode.utf8ToUtf16LeAllocZ(arena, path);
-        const handle = CreateNamedPipeW(
-            path_w.ptr,
-            0x00000002, // PIPE_ACCESS_OUTBOUND: the Git client reads this pipe.
-            0x00000001, // PIPE_NOWAIT: leave the server listening while Git starts.
-            1,
-            4096,
-            4096,
-            0,
-            null,
-        );
-        if (handle == windows.INVALID_HANDLE_VALUE) return error.CreateTimeoutPipeFailed;
-        const connected = ConnectNamedPipe(handle, null);
-        if (!connected.toBool()) switch (windows.GetLastError()) {
-            .PIPE_LISTENING, .PIPE_CONNECTED => {},
-            else => {
-                windows.CloseHandle(handle);
-                return error.ConnectTimeoutPipeFailed;
-            },
-        };
-        return handle;
-    }
-};
-
 /// Shared input-size ceiling for both file reads (diff.zig) and `git show`
 /// output (here), so the two acquisition paths reject oversized input the
 /// same way instead of diverging on an arbitrary limit.
@@ -249,32 +204,64 @@ test "showAtRef kills git and errors when the timeout passes" {
     try git(testing.io, arena, dir, &.{ "add", "Foo.prefab" });
     try git(testing.io, arena, dir, &.{ "commit", "-q", "-m", "first" });
 
-    var random: [16]u8 = undefined;
-    testing.io.random(&random);
-    const include_path = if (builtin.os.tag == .windows)
-        try std.fmt.allocPrint(arena, "\\\\.\\pipe\\prefablens-show-timeout-{x}", .{random})
-    else
-        try std.fs.path.join(arena, &.{ dir, "prefablens-show-timeout" });
+    const include_name = "prefablens-show-timeout";
+    const include_path = try std.fs.path.join(arena, &.{ dir, include_name });
 
     // Git reads included configuration before resolving the requested object. Keep
     // this real Git read pending so timeout coverage does not depend on process startup.
-    if (builtin.os.tag != .windows) {
+    if (builtin.os.tag == .windows) {
+        try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
+    } else {
         const result = try std.process.run(arena, testing.io, .{ .argv = &.{ "mkfifo", include_path } });
         if (result.term != .exited or result.term.exited != 0) return error.MkfifoFailed;
     }
     try git(testing.io, arena, dir, &.{ "config", "--local", "include.path", include_path });
 
+    const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
     if (builtin.os.tag == .windows) {
-        const pipe = try timeout_test.createPipe(arena, include_path);
-        defer timeout_test.windows.CloseHandle(pipe);
-        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
+        const windows = std.os.windows;
+        // Git's access check rejects named pipes. An exclusive oplock on a regular
+        // file lets that check succeed, but blocks Git's open until we release it.
+        // Disabling symlink following gives this fixture an asynchronous handle,
+        // which Windows requires for an oplock request.
+        const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{
+            .mode = .read_write,
+            .follow_symlinks = false,
+        });
+        defer include_file.close(testing.io);
+        var oplock: windows.IO_STATUS_BLOCK = undefined;
+        const request_level_one: windows.CTL_CODE = @bitCast(@as(u32, 0x00090000));
+        try testing.expectEqual(windows.NTSTATUS.PENDING, windows.ntdll.NtFsControlFile(
+            include_file.handle,
+            null,
+            null,
+            null,
+            &oplock,
+            request_level_one,
+            null,
+            0,
+            null,
+            0,
+        ));
+        defer {
+            // Even a spawn failure must finish the asynchronous request before
+            // its status block goes out of scope.
+            var cancelled: windows.IO_STATUS_BLOCK = undefined;
+            const status = windows.ntdll.NtCancelIoFileEx(include_file.handle, &oplock, &cancelled);
+            std.debug.assert(status == .SUCCESS or status == .NOT_FOUND);
+            std.debug.assert(windows.ntdll.NtWaitForSingleObject(include_file.handle, .FALSE, null) == .SUCCESS);
+        }
         try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
     } else {
         const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{ .mode = .read_write });
         defer include_file.close(testing.io);
-        const timeout: std.Io.Timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(1) } };
         try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
     }
+
+    // Releasing the blocked read must leave the same repository usable.
+    try tmp.dir.deleteFile(testing.io, include_name);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = include_name, .data = "" });
+    try testing.expectEqualStrings("v1\n", try showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", default_git_timeout));
 }
 
 test "showAtRef does not let a dash-prefixed ref be parsed as a git option" {

--- a/cli/src/input.zig
+++ b/cli/src/input.zig
@@ -78,7 +78,6 @@ pub fn showAtRef(io: std.Io, arena: std.mem.Allocator, repo_dir: []const u8, ref
                 std.mem.indexOf(u8, res.stderr, "exists on disk, but not in") != null)
                 return &[_]u8{};
             // Anything else (bad revision, not a git repository, ...) is a real failure.
-            if (builtin.is_test) std.debug.print("git show failed: {s}\n", .{res.stderr});
             return error.GitShowFailed;
         },
         else => return error.GitShowFailed,
@@ -189,7 +188,8 @@ fn runGit(gpa: std.mem.Allocator, io: std.Io, options: std.process.RunOptions) s
     defer multi_reader.deinit();
     // A silent child must exit before Windows waits for pending pipe reads.
     defer if (child.id != null) {
-        std.debug.assert(windows_job.TerminateJobObject(job, 1).toBool());
+        const terminated = windows_job.TerminateJobObject(job, 1);
+        std.debug.assert(terminated.toBool());
         child.kill(io);
     };
     const resumed = windows.ntdll.NtResumeThread(child.thread_handle, null);
@@ -322,7 +322,6 @@ test "showAtRef kills git and errors when the timeout passes" {
         defer include_file.close(testing.io);
         var oplock: windows.IO_STATUS_BLOCK = undefined;
         const request_level_one: windows.CTL_CODE = @bitCast(@as(u32, 0x00090000));
-        std.debug.print("timeout fixture: requesting oplock\n", .{});
         try testing.expectEqual(windows.NTSTATUS.PENDING, windows.ntdll.NtFsControlFile(
             include_file.handle,
             null,
@@ -335,20 +334,15 @@ test "showAtRef kills git and errors when the timeout passes" {
             null,
             0,
         ));
-        std.debug.print("timeout fixture: oplock granted\n", .{});
         defer {
             // Even a spawn failure must finish the asynchronous request before
             // its status block goes out of scope.
             var cancelled: windows.IO_STATUS_BLOCK = undefined;
             const status = windows.ntdll.NtCancelIoFileEx(include_file.handle, &oplock, &cancelled);
-            std.debug.print("timeout fixture: cancellation {t}\n", .{status});
             std.debug.assert(status == .SUCCESS or status == .NOT_FOUND);
             std.debug.assert(windows.ntdll.NtWaitForSingleObject(include_file.handle, .FALSE, null) == .SUCCESS);
-            std.debug.print("timeout fixture: cleanup complete\n", .{});
         }
-        std.debug.print("timeout fixture: running Git\n", .{});
         try testing.expectError(error.GitTimeout, showAtRef(testing.io, arena, dir, "HEAD", "Foo.prefab", timeout));
-        std.debug.print("timeout fixture: Git timed out\n", .{});
     } else {
         const include_file = try std.Io.Dir.openFileAbsolute(testing.io, include_path, .{ .mode = .read_write });
         defer include_file.close(testing.io);

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -836,19 +836,23 @@ fn tokenize(arena: std.mem.Allocator, source_bytes: []const u8, join_folded_line
 }
 
 fn shouldContinueLine(prev: Line, indent: usize) bool {
+    // Sibling and parent lines cannot continue the previous scalar.
+    if (indent <= prev.indent) return false;
     if (std.mem.startsWith(u8, prev.text, "- ")) {
         const text = std.mem.trimStart(u8, prev.text[1..], " ");
         const kv = splitKeyValue(text);
         const value = if (kv.has_colon) kv.value else text;
         if (value.len == 0) return false;
         if (looksLikeMapEntry(text)) return indent > prev.indent + 2;
-        return indent > prev.indent;
+        return true;
     }
     const kv = splitKeyValue(prev.text);
-    return kv.has_colon and kv.value.len > 0 and indent > prev.indent;
+    return kv.has_colon and kv.value.len > 0;
 }
 
 fn withoutComment(line: []const u8) []const u8 {
+    // Most Unity YAML lines have no comment marker and need no quote-state scan.
+    if (std.mem.indexOfScalar(u8, line, '#') == null) return line;
     var quote: ?u8 = null;
     var scalar_start = true;
     var flow_depth: usize = 0;

--- a/core/src/perf.zig
+++ b/core/src/perf.zig
@@ -43,6 +43,12 @@ pub fn timeDiff(io: std.Io, arena: std.mem.Allocator, n: usize) !u64 {
     return @intCast(start.durationTo(end).raw.toNanoseconds());
 }
 
+pub fn medianSample(samples: [5]u64) u64 {
+    var sorted = samples;
+    std.mem.sort(u64, &sorted, {}, std.sort.asc(u64));
+    return sorted[sorted.len / 2];
+}
+
 test "perf: small scene diff completes well under budget" {
     var arena_state = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena_state.deinit();
@@ -50,4 +56,14 @@ test "perf: small scene diff completes well under budget" {
     const ns = try timeDiff(std.testing.io, arena, 200); // 200 objects ≈ a smallish prefab
     // A loose ceiling for the debug-build test (the real budget is enforced by `zig build perf`).
     try std.testing.expect(ns < 500 * std.time.ns_per_ms);
+}
+
+test "perf: budget median tolerates isolated slow samples" {
+    // These CI timings cross the ceiling despite unchanged diff code.
+    try std.testing.expectEqual(@as(u64, 585), medianSample(.{ 648, 552, 843, 545, 585 }));
+}
+
+test "perf: budget median retains sustained slowdowns" {
+    // A fast outlier must not hide a majority of samples above the budget.
+    try std.testing.expectEqual(@as(u64, 648), medianSample(.{ 552, 843, 648, 614, 700 }));
 }

--- a/core/src/perf_main.zig
+++ b/core/src/perf_main.zig
@@ -1,26 +1,35 @@
 const std = @import("std");
 const perf = @import("perf.zig");
 
-// The budget is loosened above the nominal value to allow for CI-runner noise. Nominal
-// values are the performance targets (typically < 5ms, ~10MB scene < 150ms). Generate a scene of
-// ~10MB and verify it diffs within the CI ceiling.
-const big_objects = 50_000; // at ~200 bytes per object, ~10 MB of YAML
-const ci_ceiling_ms = 600; // 4x the nominal 150ms. Fails only on a true regression
+// Keep the workload and ceiling stable so changes remain comparable across revisions.
+const big_objects = 50_000;
+const ci_ceiling_ms = 600;
 
 pub fn main(init: std.process.Init) !void {
-    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
+    // Warm up before sampling to keep one-time startup costs out of the budget.
+    _ = try measure(init.io);
 
-    const ns = try perf.timeDiff(init.io, arena, big_objects);
-    const ms = @divTrunc(ns, std.time.ns_per_ms);
-
+    var samples: [5]u64 = undefined;
     var buf: [128]u8 = undefined;
-    const msg = try std.fmt.bufPrint(&buf, "perf: {d} objects diffed in {d} ms (ceiling {d} ms)\n", .{ big_objects, ms, ci_ceiling_ms });
+    for (&samples, 0..) |*sample, i| {
+        sample.* = try measure(init.io);
+        const msg = try std.fmt.bufPrint(&buf, "perf: sample {d}/{d}: {d} ms\n", .{ i + 1, samples.len, @divTrunc(sample.*, std.time.ns_per_ms) });
+        try std.Io.File.stdout().writeStreamingAll(init.io, msg);
+    }
+
+    const ms = @divTrunc(perf.medianSample(samples), std.time.ns_per_ms);
+    const msg = try std.fmt.bufPrint(&buf, "perf: {d} objects diffed in {d} ms median (ceiling {d} ms)\n", .{ big_objects, ms, ci_ceiling_ms });
     try std.Io.File.stdout().writeStreamingAll(init.io, msg);
 
     if (ms > ci_ceiling_ms) {
         try std.Io.File.stdout().writeStreamingAll(init.io, "PERF BUDGET EXCEEDED\n");
         std.process.exit(1);
     }
+}
+
+fn measure(io: std.Io) !u64 {
+    // Each diff needs its own arena so samples do not accumulate hundreds of megabytes.
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    return perf.timeDiff(io, arena_state.allocator(), big_objects);
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -351,6 +351,11 @@ zig build perf
 zig build run -- before.prefab after.prefab
 ```
 
+The performance gate builds both benchmarks before running them sequentially.
+The diff benchmark warms up once, then reports five samples and checks their median against the 600 ms ceiling.
+Each sample diffs 50,000 objects with a fresh arena to keep memory usage bounded.
+The GUID scan retains its 50,000-file workload and 1,200 ms ceiling.
+
 Build the native CLI and Git strategy script before running the package test:
 
 ```bash


### PR DESCRIPTION
## Summary

Prevent Windows Git reads from hanging during timeout cleanup and reduce the parsing cost behind repeated performance-gate failures.
Keep the 50,000-object workload, 600 ms ceiling, output limits, and default Git timeout.

## Motivation

Closes #368
Closes #369

Unchanged core code failed the Ubuntu performance gate at 648 ms on `main` and 651 ms on PR #370.
The gate relied on one sample and allowed benchmark execution to overlap with other benchmark builds and runs.
A later runner measured 632–641 ms across all five samples, so sampling alone was insufficient. Profiling found unnecessary scans in YAML comment and continuation handling.
The Git timeout test also failed intermittently because a successful read could beat its one-microsecond timeout.
A controlled read exposed a Windows cleanup deadlock: Zig 0.16 waits for pending output reads before terminating the child process.

## Changes

- Complete both benchmark builds before measuring, then run the diff and GUID scan sequentially.
- Warm up the diff once, measure five samples with separate arenas, and log each sample plus their median.
- Cover isolated outliers and sustained slowdowns, and document the measurement method.
- Skip quote-state scans for lines without a comment marker and continuation scans for sibling or parent lines. Preserve YAML parsing and source spans.
- On Windows, start Git in a job object so timeout cleanup terminates the launcher and its descendants before cancelling the output readers. Wait for every process in the job to exit, and keep the pipe handles open until reader cancellation completes. Preserve subprocess options and output limits.
- Block a real Git configuration read with a POSIX FIFO or Windows file oplock so the timeout assertion does not depend on process startup speed. Verify that the included file can be deleted immediately and that normal reads work after releasing the fixture.

## Testing

- `mise exec -- zig build lint test --summary all`: 597/597 tests passed.
- Focused timeout test: 10 consecutive runs passed on macOS, Linux x64, and the Windows CI runner.
- The blocked Windows read hung before the runner fix and returned `GitTimeout` after it; normal reads passed after releasing the fixture.
- Linux x64 and Windows x64 timeout test executables cross-compiled successfully.
- `mise exec -- zig build perf --summary all`: diff median 174 ms; GUID scan 199 ms.
- Linux ARM64 parser comparison, alternating before/after on the same host: median times fell from 201/191/201 ms to 182/175/169 ms.
- `mise exec -- zig build wasm` and `mise exec -- node --test core/tests/*.test.mjs`: 7/7 passed.
- Pausing the disposable Linux container during one sample produced a 1,260 ms outlier; the 354 ms median passed.
- Sustained CPU throttling produced a 905 ms median and exit code 1 with `PERF BUDGET EXCEEDED`.
- `git diff --check`: passed.

- [Latest GitHub CI](https://github.com/hashiiiii/PrefabLens/actions/runs/34180670932) passed all 15 jobs at `bdc410b`. Ubuntu diff samples were 470/464/472/493/466 ms; median 470 ms. Windows passed 596 tests with one existing platform skip.
