### PR TITLE
feat: integrate Git difftool with diffnav

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,50 @@ prefablens --open main                  # write the report to a temp file and op
 Operands with a UnityYAML extension (`.prefab`, `.unity`, `.asset`, and more) are paths.
 All other operands are Git references (refs).
 
+### Git diff
+
+PrefabLens can provide semantic views inside the [PrefabLens diffnav fork](https://github.com/hashiiiii/diffnav).
+Git, `diffnav`, `delta`, and `prefablens` must be on `PATH` when the difftool runs.
+Build the fork from its checkout before setup:
+
+```bash
+go build -o ./diffnav .
+```
+
+Place the resulting `diffnav` executable on `PATH`.
+The required direct comparison and external renderer options are specific to this fork.
+
+Register the integration for the current repository:
+
+```bash
+prefablens setup-diff
+```
+
+Use `prefablens setup-diff --user` to register it in your global Git configuration.
+Setup only registers the Git configuration. It does not install or verify the required executables.
+
+Open all changed files in one directory comparison:
+
+```bash
+git difftool --dir-diff --no-symlinks
+git difftool --dir-diff --no-symlinks --cached
+git difftool --dir-diff --no-symlinks HEAD~1 HEAD
+```
+
+Directory mode asks Git to prepare temporary before and after directories.
+`--no-symlinks` asks Git to copy working tree files into them.
+See the [Git difftool documentation](https://git-scm.com/docs/git-difftool) for its revision and directory options.
+
+Open one session for a specific file:
+
+```bash
+git difftool --no-prompt --tool=prefablens -- Assets/Player.prefab
+```
+
+Press **v** in `diffnav` to switch between semantic and raw views.
+Unsupported files and renderer errors stay available as raw diffs.
+For malformed UnityYAML, the raw view also shows the renderer diagnostic.
+
 ### Git merge
 
 PrefabLens uses Git **2.39** or later to resolve UnityYAML conflicts during `git merge`.

--- a/build.zig
+++ b/build.zig
@@ -121,6 +121,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "build_options", .module = build_options_mod },
+                .{ .name = "vaxis", .module = vaxis_mod },
             },
         }),
     });
@@ -149,6 +150,36 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_setup_tests.step);
     const setup_test_step = b.step("test-merge-setup", "Run merge setup scope integration tests");
     setup_test_step.dependOn(&run_setup_tests.step);
+
+    const diff_integration_tests = b.addExecutable(.{
+        .name = "diff-integration-tests",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("cli/src/diff_integration_test_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_diff_integration_tests = b.addRunArtifact(diff_integration_tests);
+    run_diff_integration_tests.addArtifactArg(exe);
+    test_step.dependOn(&run_diff_integration_tests.step);
+    const diff_test_step = b.step("test-diff", "Run Git difftool and renderer integration tests");
+    diff_test_step.dependOn(&run_diff_integration_tests.step);
+
+    const diffnav_tests = b.addExecutable(.{
+        .name = "diffnav-tests",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("cli/src/diffnav_test_main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{.{ .name = "vaxis", .module = vaxis_mod }},
+        }),
+    });
+    const run_diffnav_tests = b.addRunArtifact(diffnav_tests);
+    run_diffnav_tests.addArtifactArg(exe);
+    run_diffnav_tests.addArg(b.option([]const u8, "diffnav", "Path to the diffnav fork executable") orelse "diffnav");
+    run_diffnav_tests.addArg(b.pathFromRoot("core/src/testdata"));
+    const diffnav_test_step = b.step("test-diffnav", "Run optional diffnav integration tests in a real terminal");
+    diffnav_test_step.dependOn(&run_diffnav_tests.step);
 
     // Real alternate-release commands expose mixed installations without a runtime version override.
     const alternate_opts = b.addOptions();
@@ -196,6 +227,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("cli/src/git_structural_test_main.zig"),
             .target = target,
             .optimize = optimize,
+            .imports = &.{.{ .name = "vaxis", .module = vaxis_mod }},
         }),
     });
     const run_structural_tests = b.addRunArtifact(structural_tests);
@@ -212,6 +244,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("cli/src/pty_smoke_test_main.zig"),
             .target = target,
             .optimize = optimize,
+            .imports = &.{.{ .name = "vaxis", .module = vaxis_mod }},
         }),
     });
     const run_pty_smoke = b.addRunArtifact(pty_smoke);
@@ -225,6 +258,8 @@ pub fn build(b: *std.Build) void {
         run_collection_fixture_tests,
         run_strategy_tests,
         run_setup_tests,
+        run_diff_integration_tests,
+        run_diffnav_tests,
         run_installation_tests,
         run_structural_tests,
         run_pty_smoke,

--- a/cli/src/command.zig
+++ b/cli/src/command.zig
@@ -18,10 +18,12 @@ pub const MergetoolArgs = struct {
 
 pub const Command = union(enum) {
     diff: []const []const u8,
+    render_diff: []const []const u8,
     merge_strategy: []const []const u8,
     merge_driver: MergeDriverArgs,
     mergetool: MergetoolArgs,
     setup_merge: []const []const u8,
+    setup_diff: []const []const u8,
 };
 
 pub const Error = error{
@@ -31,6 +33,8 @@ pub const Error = error{
 
 pub fn parse(args: []const []const u8) Error!Command {
     if (args.len == 0) return .{ .diff = args };
+    if (std.mem.eql(u8, args[0], "render-diff")) return .{ .render_diff = args[1..] };
+    if (std.mem.eql(u8, args[0], "setup-diff")) return .{ .setup_diff = args[1..] };
     if (std.mem.eql(u8, args[0], "setup-merge")) return .{ .setup_merge = args[1..] };
     if (std.mem.eql(u8, args[0], "merge-strategy")) return .{ .merge_strategy = args[1..] };
     if (std.mem.eql(u8, args[0], "merge-driver")) {
@@ -60,6 +64,13 @@ pub fn parse(args: []const []const u8) Error!Command {
     if (std.mem.eql(u8, args[0], "diff-driver") or
         std.mem.eql(u8, args[0], "difftool")) return error.ReservedSubcommand;
     return .{ .diff = args };
+}
+
+test "command: routes diff integration commands with literal arguments" {
+    const rendered = try parse(&.{ "render-diff", "--", "--before", "after", "Assets/A.prefab" });
+    try testing.expectEqualStrings("--before", rendered.render_diff[1]);
+    const setup = try parse(&.{ "setup-diff", "--user" });
+    try testing.expectEqualStrings("--user", setup.setup_diff[0]);
 }
 
 test "command: parses both merge adapters without changing diff arguments" {

--- a/cli/src/diff.zig
+++ b/cli/src/diff.zig
@@ -10,6 +10,7 @@ const render_html = @import("render_html.zig");
 const unity_path = @import("unity_path.zig");
 const builtin_refs = @import("builtin_refs.zig");
 const merge_setup = @import("merge_setup.zig");
+const diff_setup = @import("diff_setup.zig");
 const version = @import("build_options").version;
 const Format = options.Format;
 const Target = options.Target;
@@ -23,7 +24,11 @@ test {
 
 const usage_line = "usage: prefablens [--json|--html] [--open] [--project DIR|--no-project] [--color|--no-color] [<ref>] [<ref>] [<path>] | <before> <after>\n";
 
-const help_text = usage_line ++ "\nGit merge setup: " ++ merge_setup.usage ++ "\n" ++
+const help_text = usage_line ++ "\nGit diff setup: " ++ diff_setup.usage ++ "\n" ++
+    \\  --local                Configure the current repository (default)
+    \\  --user                 Configure your global Git settings
+    \\
+++ "Git merge setup: " ++ merge_setup.usage ++ "\n" ++
     \\  --project              Share .gitattributes; configure the current clone
     \\  --local                Configure the current clone (default)
     \\  --user                 Configure all your repositories with global settings

--- a/cli/src/diff_integration_test_main.zig
+++ b/cli/src/diff_integration_test_main.zig
@@ -1,0 +1,220 @@
+const std = @import("std");
+const t = @import("testing/git.zig");
+
+const expected_command = "diffnav --compare --renderer prefablens --renderer-arg=render-diff --renderer-arg=--color --renderer-arg=-- -- \"$LOCAL\" \"$REMOTE\" \"$MERGED\"";
+const before_yaml = "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 1\n";
+const after_yaml = "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 2\n";
+
+const Context = struct {
+    io: std.Io,
+    arena: std.mem.Allocator,
+    root: []const u8,
+    prefablens: []const u8,
+    env: *std.process.Environ.Map,
+
+    fn run(self: Context, cwd: []const u8, args: []const []const u8) !std.process.RunResult {
+        return std.process.run(self.arena, self.io, .{
+            .argv = try std.mem.concat(self.arena, []const u8, &.{ &.{self.prefablens}, args }),
+            .cwd = .{ .path = cwd },
+            .environ_map = self.env,
+            .stdout_limit = .limited(1024 * 1024),
+            .stderr_limit = .limited(1024 * 1024),
+            .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(30) } },
+        });
+    }
+
+    fn git(self: Context, cwd: []const u8, args: []const []const u8) !std.process.RunResult {
+        return std.process.run(self.arena, self.io, .{
+            .argv = try std.mem.concat(self.arena, []const u8, &.{ &.{"git"}, args }),
+            .cwd = .{ .path = cwd },
+            .environ_map = self.env,
+            .stdout_limit = .limited(1024 * 1024),
+            .stderr_limit = .limited(1024 * 1024),
+            .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(30) } },
+        });
+    }
+
+    fn gitOk(self: Context, cwd: []const u8, args: []const []const u8) !void {
+        try t.expectCode(try self.git(cwd, args), 0, args[0]);
+    }
+
+    fn repository(self: Context, name: []const u8) ![]const u8 {
+        const path = try std.fs.path.join(self.arena, &.{ self.root, name });
+        try std.Io.Dir.cwd().createDirPath(self.io, path);
+        try self.gitOk(path, &.{ "init", "-q", "-b", "main" });
+        try self.gitOk(path, &.{ "config", "user.name", "PrefabLens tests" });
+        try self.gitOk(path, &.{ "config", "user.email", "prefablens-tests@example.invalid" });
+        return path;
+    }
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const args = try init.minimal.args.toSlice(arena);
+    const root = try t.scratchDirectory(init.io, arena, "diff setup space 日本語");
+    defer std.Io.Dir.cwd().deleteTree(init.io, root) catch {};
+    const outside = try std.fs.path.join(arena, &.{ root, "outside" });
+    const home = try std.fs.path.join(arena, &.{ root, "home" });
+    try std.Io.Dir.cwd().createDirPath(init.io, outside);
+    try std.Io.Dir.cwd().createDirPath(init.io, home);
+
+    var env = try init.environ_map.clone(arena);
+    for ([_][]const u8{ "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE", "GIT_CONFIG", "GIT_CONFIG_PARAMETERS", "XDG_CONFIG_HOME" }) |key| _ = env.swapRemove(key);
+    try env.put("HOME", home);
+    try env.put("GIT_CONFIG_GLOBAL", try std.fs.path.join(arena, &.{ home, ".gitconfig" }));
+    try env.put("GIT_CONFIG_NOSYSTEM", "1");
+    try env.put("GIT_CONFIG_COUNT", "0");
+    try env.put("GIT_CEILING_DIRECTORIES", root);
+
+    const ctx: Context = .{
+        .io = init.io,
+        .arena = arena,
+        .root = root,
+        .prefablens = try std.Io.Dir.cwd().realPathFileAlloc(init.io, args[1], arena),
+        .env = &env,
+    };
+    const cases = .{ help, repositoryScopes, linkedWorktree, userScope, outsideRepository, invalidArguments, renderer };
+    var failures: usize = 0;
+    inline for (cases) |case| {
+        case(ctx, outside) catch |err| {
+            std.debug.print("diff integration case failed: {s}\n", .{@errorName(err)});
+            failures += 1;
+        };
+    }
+    if (failures != 0) return 1;
+    try std.Io.File.stdout().writeStreamingAll(init.io, "diff integration: passed\n");
+    return 0;
+}
+
+fn requireContains(haystack: []const u8, needle: []const u8, message: []const u8) !void {
+    try t.require(std.mem.indexOf(u8, haystack, needle) != null, message);
+}
+
+fn read(ctx: Context, path: []const u8) ![]const u8 {
+    return std.Io.Dir.cwd().readFileAlloc(ctx.io, path, ctx.arena, .limited(1024 * 1024));
+}
+
+fn expectAbsent(ctx: Context, path: []const u8) !void {
+    std.Io.Dir.cwd().access(ctx.io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+    return error.UnexpectedFile;
+}
+
+fn config(ctx: Context, cwd: []const u8, scope: []const u8, key: []const u8) ![]const u8 {
+    const result = try ctx.git(cwd, &.{ "config", scope, "--get", key });
+    try t.expectCode(result, 0, key);
+    return std.mem.trimEnd(u8, result.stdout, "\r\n");
+}
+
+fn expectConfiguration(ctx: Context, cwd: []const u8, scope: []const u8) !void {
+    try t.require(std.mem.eql(u8, try config(ctx, cwd, scope, "diff.tool"), "prefablens"), "setup wrote the wrong diff.tool value");
+    try t.require(std.mem.eql(u8, try config(ctx, cwd, scope, "difftool.prefablens.cmd"), expected_command), "setup wrote the wrong difftool command");
+}
+
+fn help(ctx: Context, outside: []const u8) !void {
+    for ([_][]const []const u8{ &.{ "render-diff", "--help" }, &.{ "render-diff", "-h" }, &.{ "setup-diff", "--help" }, &.{ "setup-diff", "-h" } }) |args| {
+        const result = try ctx.run(outside, args);
+        try t.expectCode(result, 0, "help outside a repository");
+        try t.require(result.stderr.len == 0, "help wrote stderr");
+        try requireContains(result.stdout, args[0], "help omitted its command name");
+    }
+    const top_level = try ctx.run(outside, &.{"--help"});
+    try t.expectCode(top_level, 0, "top-level help");
+    try requireContains(top_level.stdout, "prefablens setup-diff [--local|--user]", "top-level help omitted diff setup");
+    try expectAbsent(ctx, ctx.env.get("GIT_CONFIG_GLOBAL").?);
+}
+
+fn repositoryScopes(ctx: Context, _: []const u8) !void {
+    const cases = [_]struct { name: []const u8, args: []const []const u8 }{
+        .{ .name = "default", .args = &.{} },
+        .{ .name = "explicit-local", .args = &.{"--local"} },
+    };
+    for (cases) |case| {
+        const repo = try ctx.repository(case.name);
+        const nested = try std.fs.path.join(ctx.arena, &.{ repo, "Assets", "Nested" });
+        try std.Io.Dir.cwd().createDirPath(ctx.io, nested);
+        const attributes = try std.fs.path.join(ctx.arena, &.{ repo, ".gitattributes" });
+        const info_attributes = try std.fs.path.join(ctx.arena, &.{ repo, ".git", "info", "attributes" });
+        try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = attributes, .data = "*.prefab diff=keep\n" });
+        try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = info_attributes, .data = "*.asset -diff\n" });
+        try ctx.gitOk(repo, &.{ "config", "prefablens.test.keep", "yes" });
+        for (0..2) |_| {
+            const result = try ctx.run(nested, try std.mem.concat(ctx.arena, []const u8, &.{ &.{"setup-diff"}, case.args }));
+            try t.expectCode(result, 0, case.name);
+            try requireContains(result.stdout, "registered", "setup did not describe configuration registration");
+        }
+        try expectConfiguration(ctx, nested, "--local");
+        try t.require(std.mem.eql(u8, try config(ctx, repo, "--local", "prefablens.test.keep"), "yes"), "setup changed unrelated local configuration");
+        try t.require(std.mem.eql(u8, try read(ctx, attributes), "*.prefab diff=keep\n"), "setup changed repository attributes");
+        try t.require(std.mem.eql(u8, try read(ctx, info_attributes), "*.asset -diff\n"), "setup changed local attributes");
+    }
+    try expectAbsent(ctx, ctx.env.get("GIT_CONFIG_GLOBAL").?);
+}
+
+fn linkedWorktree(ctx: Context, _: []const u8) !void {
+    const repo = try ctx.repository("worktree-source");
+    try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = try std.fs.path.join(ctx.arena, &.{ repo, "tracked" }), .data = "base\n" });
+    try ctx.gitOk(repo, &.{ "add", "tracked" });
+    try ctx.gitOk(repo, &.{ "commit", "-qm", "base" });
+    const linked = try std.fs.path.join(ctx.arena, &.{ ctx.root, "linked worktree" });
+    try ctx.gitOk(repo, &.{ "worktree", "add", "-q", "-b", "linked", linked });
+    const nested = try std.fs.path.join(ctx.arena, &.{ linked, "Assets" });
+    try std.Io.Dir.cwd().createDirPath(ctx.io, nested);
+    try t.expectCode(try ctx.run(nested, &.{ "setup-diff", "--local" }), 0, "linked worktree setup");
+    try expectConfiguration(ctx, linked, "--local");
+}
+
+fn userScope(ctx: Context, outside: []const u8) !void {
+    try ctx.gitOk(outside, &.{ "config", "--global", "prefablens.test.keep", "yes" });
+    for (0..2) |_| try t.expectCode(try ctx.run(outside, &.{ "setup-diff", "--user" }), 0, "user setup");
+    try expectConfiguration(ctx, outside, "--global");
+    try t.require(std.mem.eql(u8, try config(ctx, outside, "--global", "prefablens.test.keep"), "yes"), "setup changed unrelated global configuration");
+}
+
+fn outsideRepository(ctx: Context, outside: []const u8) !void {
+    const result = try ctx.run(outside, &.{"setup-diff"});
+    try t.expectCode(result, 2, "local setup outside a repository");
+    try requireContains(result.stderr, "setup-diff --user", "outside-repository error omitted user setup guidance");
+}
+
+fn invalidArguments(ctx: Context, _: []const u8) !void {
+    const repo = try ctx.repository("invalid");
+    try ctx.gitOk(repo, &.{ "config", "prefablens.test.keep", "yes" });
+    const local_path = try std.fs.path.join(ctx.arena, &.{ repo, ".git", "config" });
+    const local_before = try ctx.arena.dupe(u8, try read(ctx, local_path));
+    const global_path = ctx.env.get("GIT_CONFIG_GLOBAL").?;
+    const global_before = try ctx.arena.dupe(u8, try read(ctx, global_path));
+    const attributes = try std.fs.path.join(ctx.arena, &.{ repo, ".gitattributes" });
+    try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = attributes, .data = "keep\n" });
+    for ([_][]const []const u8{ &.{ "setup-diff", "--project" }, &.{ "setup-diff", "--local", "--user" }, &.{ "setup-diff", "--unknown" }, &.{ "setup-diff", "extra" } }) |args| {
+        const result = try ctx.run(repo, args);
+        try t.expectCode(result, 2, "invalid setup arguments");
+        try requireContains(result.stderr, "usage:", "invalid setup arguments omitted usage");
+        try t.require(std.mem.eql(u8, local_before, try read(ctx, local_path)), "invalid setup changed local configuration");
+        try t.require(std.mem.eql(u8, global_before, try read(ctx, global_path)), "invalid setup changed global configuration");
+        try t.require(std.mem.eql(u8, try read(ctx, attributes), "keep\n"), "invalid setup changed attributes");
+    }
+}
+
+fn renderer(ctx: Context, outside: []const u8) !void {
+    const before_path = try std.fs.path.join(ctx.arena, &.{ outside, "before $(printf wrong)" });
+    const after_path = try std.fs.path.join(ctx.arena, &.{ outside, "after 空 白" });
+    try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = before_path, .data = before_yaml });
+    try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = after_path, .data = after_yaml });
+    const rendered = try ctx.run(outside, &.{ "render-diff", "--no-color", "--", before_path, after_path, "Assets/Literal.prefab" });
+    try t.expectCode(rendered, 0, "literal renderer inputs");
+    try t.require(rendered.stderr.len == 0, "renderer wrote stderr for valid inputs");
+    try requireContains(rendered.stdout, "1 → 2", "renderer did not compare literal input files");
+    try t.require(std.mem.indexOf(u8, rendered.stdout, "\x1b[") == null, "--no-color emitted ANSI escapes");
+
+    const malformed_path = try std.fs.path.join(ctx.arena, &.{ outside, "malformed" });
+    try std.Io.Dir.cwd().writeFile(ctx.io, .{ .sub_path = malformed_path, .data = "--- !u!114 &1\nMonoBehaviour:\n  values: [1, 2\n" });
+    const malformed = try ctx.run(outside, &.{ "render-diff", before_path, malformed_path, "Assets/Literal.prefab" });
+    try t.expectCode(malformed, 2, "malformed renderer input");
+    try t.require(malformed.stdout.len == 0, "malformed renderer input wrote stdout");
+    try requireContains(malformed.stderr, "invalid_flow_value", "malformed renderer input omitted syntax diagnostic");
+}

--- a/cli/src/diff_setup.zig
+++ b/cli/src/diff_setup.zig
@@ -1,0 +1,46 @@
+const std = @import("std");
+const merge_git = @import("merge_git.zig");
+
+const Scope = enum { local, user };
+
+pub const usage = "prefablens setup-diff [--local|--user]";
+pub const help = usage ++
+    "\n\nRegister PrefabLens as a Git difftool for this repository or your user configuration.\n" ++
+    "Git, diffnav, delta, and prefablens must be on PATH when the difftool runs.\n";
+
+const command = "diffnav --compare --renderer prefablens --renderer-arg=render-diff --renderer-arg=--color --renderer-arg=-- -- \"$LOCAL\" \"$REMOTE\" \"$MERGED\"";
+
+fn parseScope(args: []const []const u8) !?Scope {
+    if (args.len == 0) return .local;
+    if (args.len != 1) return error.InvalidSetupArguments;
+    if (std.mem.eql(u8, args[0], "--help") or std.mem.eql(u8, args[0], "-h")) return null;
+    if (std.mem.eql(u8, args[0], "--local")) return .local;
+    if (std.mem.eql(u8, args[0], "--user")) return .user;
+    return error.InvalidSetupArguments;
+}
+
+pub fn run(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    args: []const []const u8,
+    env: *std.process.Environ.Map,
+    stdout: *std.Io.Writer,
+) !void {
+    const scope = (try parseScope(args)) orelse {
+        try stdout.writeAll(help);
+        return;
+    };
+    var git: merge_git.Git = .{ .io = io, .arena = arena, .env = env };
+    if (scope == .local) {
+        const root_result = try git.run(&.{ "rev-parse", "--show-toplevel" });
+        if (merge_git.exitCode(root_result) != 0) return error.SetupRequiresRepository;
+        git.cwd = merge_git.trim(root_result.stdout);
+    }
+    const config_scope = if (scope == .user) "--global" else "--local";
+    try git.ok(&.{ "config", config_scope, "--replace-all", "diff.tool", "prefablens" });
+    try git.ok(&.{ "config", config_scope, "--replace-all", "difftool.prefablens.cmd", command });
+    try stdout.print(
+        "PrefabLens diff configuration was registered for {s}.\nGit, diffnav, delta, and prefablens must be on PATH when the difftool runs.\n",
+        .{if (scope == .user) "your user account" else "this repository"},
+    );
+}

--- a/cli/src/diffnav_test_main.zig
+++ b/cli/src/diffnav_test_main.zig
@@ -1,0 +1,266 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const t = @import("testing/git.zig");
+const pty = @import("testing/pty.zig");
+const Session = @import("testing/pty_session.zig");
+
+const Context = struct {
+    io: std.Io,
+    arena: std.mem.Allocator,
+    root: []const u8,
+    repo: []const u8,
+    env: *std.process.Environ.Map,
+
+    fn run(self: Context, argv: []const []const u8) !std.process.RunResult {
+        return std.process.run(self.arena, self.io, .{
+            .argv = argv,
+            .cwd = .{ .path = self.repo },
+            .environ_map = self.env,
+            .stdout_limit = .limited(1024 * 1024),
+            .stderr_limit = .limited(1024 * 1024),
+            .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(30) } },
+        });
+    }
+
+    fn git(self: Context, args: []const []const u8) !void {
+        try t.expectCode(try self.run(try std.mem.concat(self.arena, []const u8, &.{ &.{"git"}, args })), 0, args[0]);
+    }
+
+    fn write(self: Context, path: []const u8, bytes: []const u8) !void {
+        try t.writeFile(self.io, self.arena, self.repo, path, bytes);
+    }
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    if (builtin.os.tag != .macos and builtin.os.tag != .linux) {
+        try std.Io.File.stdout().writeStreamingAll(init.io, "diffnav integration: skipped on unsupported OS\n");
+        return 0;
+    }
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const args = try init.minimal.args.toSlice(arena);
+    try t.require(args.len == 4, "expected PrefabLens, diffnav, and fixture paths");
+    const root = try t.scratchDirectory(init.io, arena, "diffnav space 日本語");
+    defer std.Io.Dir.cwd().deleteTree(init.io, root) catch {};
+    const repo = try std.fs.path.join(arena, &.{ root, "repository" });
+    const bin = try std.fs.path.join(arena, &.{ root, "bin" });
+    const user = try std.fs.path.join(arena, &.{ root, "user" });
+    for ([_][]const u8{ repo, bin, user }) |directory| try std.Io.Dir.cwd().createDirPath(init.io, directory);
+
+    var env = try init.environ_map.clone(arena);
+    // The fixture must not inherit a caller's worktree, Git configuration, or diffnav theme.
+    var inherited = init.environ_map.iterator();
+    while (inherited.next()) |entry| {
+        if (std.mem.startsWith(u8, entry.key_ptr.*, "GIT_")) _ = env.swapRemove(entry.key_ptr.*);
+    }
+    _ = env.swapRemove("NO_COLOR");
+    try env.put("HOME", user);
+    try env.put("XDG_CONFIG_HOME", user);
+    try env.put("GIT_CONFIG_GLOBAL", try std.fs.path.join(arena, &.{ user, "gitconfig" }));
+    try env.put("GIT_CONFIG_NOSYSTEM", "1");
+    try env.put("GIT_ATTR_NOSYSTEM", "1");
+    try env.put("GIT_CONFIG_COUNT", "0");
+    try env.put("GIT_CEILING_DIRECTORIES", root);
+    try env.put("TERM", "xterm-256color");
+    try env.put("COLORTERM", "truecolor");
+    try env.put("DIFFNAV_CONFIG_DIR", user);
+    try std.Io.Dir.cwd().writeFile(init.io, .{
+        .sub_path = try std.fs.path.join(arena, &.{ user, "config.yml" }),
+        .data = "ui:\n  theme: tokyo_night\n  showFileTree: true\n  showDiffStats: false\n  startFoldersOpenDepth: -1\n  fileTreeWidth: 24\n",
+    });
+    const ctx: Context = .{ .io = init.io, .arena = arena, .root = root, .repo = repo, .env = &env };
+    for ([_][]const u8{ "prefablens", "diffnav" }, args[1..3]) |name, executable| {
+        const path = if (std.mem.indexOfScalar(u8, executable, '/') != null) executable else path: {
+            const resolved = try ctx.run(&.{ "sh", "-c", "command -v \"$1\"", "resolve-executable", executable });
+            try t.expectCode(resolved, 0, name);
+            break :path std.mem.trim(u8, resolved.stdout, "\r\n");
+        };
+        const absolute = try std.Io.Dir.cwd().realPathFileAlloc(init.io, path, arena);
+        try std.Io.Dir.cwd().symLink(init.io, absolute, try std.fs.path.join(arena, &.{ bin, name }), .{});
+    }
+    try env.put("PATH", try std.fmt.allocPrint(arena, "{s}:{s}", .{ bin, env.get("PATH") orelse "" }));
+    try t.expectCode(try ctx.run(&.{ "delta", "--version" }), 0, "delta is required for test-diffnav");
+
+    try testScreenAssertions();
+    try prepare(ctx, args[3]);
+    try testSnapshotAssertions(ctx);
+    // Zig resolves argv[0] against the parent's PATH, so setup must name the supplied executable.
+    try t.expectCode(try ctx.run(&.{ try std.fs.path.join(arena, &.{ bin, "prefablens" }), "setup-diff" }), 0, "register the actual difftool");
+    try compare(ctx, "working-tree", "git difftool --dir-diff --no-symlinks", true);
+    try compare(ctx, "per-file", "git difftool --no-prompt -- Assets/'00 Cylinder.prefab'", false);
+    try ctx.git(&.{ "add", "--all" });
+    try compare(ctx, "staged", "git difftool --dir-diff --no-symlinks --cached", false);
+    try ctx.git(&.{ "commit", "-qm", "fixture changes" });
+    try compare(ctx, "revisions", "git difftool --dir-diff --no-symlinks HEAD~1 HEAD", false);
+    try std.Io.File.stdout().writeStreamingAll(init.io, "diffnav integration: passed\n");
+    return 0;
+}
+
+fn prepare(ctx: Context, fixtures: []const u8) !void {
+    const before = try t.readFile(ctx.io, ctx.arena, fixtures, "cylinder_before.prefab");
+    const after = try t.readFile(ctx.io, ctx.arena, fixtures, "cylinder_after.prefab");
+    try std.Io.Dir.cwd().createDirPath(ctx.io, try std.fs.path.join(ctx.arena, &.{ ctx.repo, "Assets" }));
+    try ctx.git(&.{ "init", "-q", "-b", "main" });
+    try ctx.git(&.{ "config", "core.autocrlf", "false" });
+    try ctx.git(&.{ "config", "commit.gpgSign", "false" });
+    try ctx.git(&.{ "config", "core.hooksPath", try std.fs.path.join(ctx.arena, &.{ ctx.root, "no-hooks" }) });
+    try ctx.git(&.{ "config", "user.name", "PrefabLens tests" });
+    try ctx.git(&.{ "config", "user.email", "prefablens-tests@example.invalid" });
+    const files = [_]struct { path: []const u8, before: ?[]const u8, after: ?[]const u8 }{
+        .{ .path = "Assets/00 Cylinder.prefab", .before = before, .after = after },
+        .{ .path = "Assets/01 Movement.cs", .before = "public float speed = 1;\r\n", .after = "public float speed = 3;\r\n" },
+        .{ .path = "Assets/02 Cylinder.prefab.meta", .before = "userData: before\n", .after = "userData: after\n" },
+        .{ .path = "Assets/03 Added.prefab", .before = null, .after = after },
+        .{ .path = "Assets/04 Removed.prefab", .before = before, .after = null },
+        .{ .path = "Assets/05 Formatting.prefab", .before = before, .after = try std.mem.concat(ctx.arena, u8, &.{ before, "# Formatting-only change.\n" }) },
+        .{ .path = "Assets/06 Damaged.asset", .before = before, .after = "--- !u!114 &1\nMonoBehaviour:\n  values: [1, 2\n" },
+        .{ .path = "Assets/07 LightingData.asset", .before = "\x00binary before\n", .after = "\x00binary after\n" },
+        .{ .path = "Assets/08 空 白.prefab", .before = before, .after = after },
+    };
+    for (files) |file| if (file.before) |bytes| try ctx.write(file.path, bytes);
+    try ctx.git(&.{ "add", "--all" });
+    try ctx.git(&.{ "commit", "-qm", "fixture baseline" });
+    for (files) |file| {
+        if (file.after) |bytes| {
+            try ctx.write(file.path, bytes);
+        } else {
+            try std.Io.Dir.cwd().deleteFile(ctx.io, try std.fs.path.join(ctx.arena, &.{ ctx.repo, file.path }));
+        }
+        if (file.before == null) try ctx.git(&.{ "add", "-N", "--", file.path });
+    }
+    try std.Io.Dir.cwd().createDirPath(ctx.io, try std.fs.path.join(ctx.arena, &.{ ctx.repo, "Notes", "Nested" }));
+    try ctx.write("Notes/Nested/untracked.txt", "Keep this untracked file.\n");
+    try std.Io.Dir.cwd().symLink(ctx.io, "missing target", try std.fs.path.join(ctx.arena, &.{ ctx.repo, "untracked-link" }), .{});
+}
+
+fn compare(ctx: Context, name: []const u8, command: []const u8, mixed: bool) !void {
+    const before = try snapshot(ctx);
+    var session = try Session.start(ctx.io, ctx.arena, ctx.repo, ctx.env, try std.fs.path.join(ctx.arena, &.{ ctx.root, name }), command);
+    defer session.deinit();
+    try session.waitFor(&.{"F1/"});
+    if (mixed) try session.waitFor(&.{"GameObject:"});
+    try select(&session, "00 Cylinder.prefab", &.{ "Position.x: 0.64596", "v: raw" });
+    if (mixed) {
+        try session.send("v");
+        try session.waitFor(&.{ "v: semantic", "component: {fileID:" });
+        // Side-by-side output repeats unchanged context on the same visible row.
+        try session.waitForLineCount("component: {fileID:", 2);
+        try session.send("s");
+        try session.waitForLineCount("component: {fileID:", 1);
+        try session.send("s");
+        try session.waitForLineCount("component: {fileID:", 2);
+        try session.send("s");
+        try session.waitFor(&.{ "v: semantic", "m_Name: Cylinder" });
+        try session.resize(80, 20);
+        try session.send("v");
+        try session.waitFor(&.{ "Position.x: 0.64596", "v: raw" });
+        try session.resize(100, 24);
+        try select(&session, "01 Movement.cs", &.{ "[raw]", "public float speed" });
+        try select(&session, "02 Cylinder.prefab.meta", &.{ "[raw]", "userData" });
+        try select(&session, "03 Added.prefab", &.{ "[semantic", "Position" });
+        try select(&session, "04 Removed.prefab", &.{ "[semantic", "Position" });
+        try select(&session, "05 Formatting.prefab", &.{"No semantic changes"});
+        try session.send("v");
+        try session.waitFor(&.{ "[raw", "Formatting-only change" });
+        try select(&session, "06 Damaged.asset", &.{ "[raw]", "[renderer] renderer failed" });
+        try session.send("G");
+        try session.waitFor(&.{"values: [1, 2"});
+        try select(&session, "07 LightingData.asset", &.{ "[raw]", "binary" });
+        try select(&session, "08 空 白.prefab", &.{ "[semantic", "Position.x: 0.64596" });
+    }
+    try session.finish();
+    const after = try snapshot(ctx);
+    try t.require(snapshotsEqual(before, after), "difftool changed file bytes, permissions, links, index, or configuration");
+    try std.Io.File.stdout().writeStreamingAll(ctx.io, try std.fmt.allocPrint(ctx.arena, "diffnav {s}: passed\n", .{name}));
+}
+
+fn snapshotsEqual(before: std.StringHashMap([32]u8), after: std.StringHashMap([32]u8)) bool {
+    if (before.count() != after.count()) return false;
+    var iterator = before.iterator();
+    while (iterator.next()) |entry| {
+        const current = after.get(entry.key_ptr.*) orelse return false;
+        if (!std.mem.eql(u8, entry.value_ptr, &current)) return false;
+    }
+    return true;
+}
+
+fn select(session: *Session, name: []const u8, needles: []const []const u8) !void {
+    try session.send(try std.fmt.allocPrint(session.arena, "t{s}\r", .{name}));
+    // Only the selected pane includes the path prefix; the sidebar also lists every basename.
+    const header = try std.fmt.allocPrint(session.arena, "Assets/{s}", .{name[0..2]});
+    try session.waitFor(try std.mem.concat(session.arena, []const u8, &.{ &.{header}, needles }));
+}
+
+fn snapshot(ctx: Context) !std.StringHashMap([32]u8) {
+    var result = std.StringHashMap([32]u8).init(ctx.arena);
+    var dir = try std.Io.Dir.cwd().openDir(ctx.io, ctx.repo, .{ .iterate = true });
+    defer dir.close(ctx.io);
+    var walker = try dir.walkSelectively(ctx.arena);
+    defer {
+        while (walker.stack.items.len != 0) walker.leave(ctx.io);
+        walker.deinit();
+    }
+    try snapshotEntry(ctx, dir, &result, ".");
+    try snapshotEntry(ctx, dir, &result, ".git/index");
+    try snapshotEntry(ctx, dir, &result, ".git/config");
+    while (try walker.next(ctx.io)) |entry| {
+        if (std.mem.eql(u8, entry.path, ".git")) continue;
+        try snapshotEntry(ctx, dir, &result, entry.path);
+        if (entry.kind == .directory) try walker.enter(ctx.io, entry);
+    }
+    return result;
+}
+
+fn snapshotEntry(ctx: Context, dir: std.Io.Dir, result: *std.StringHashMap([32]u8), path: []const u8) !void {
+    const stat = try dir.statFile(ctx.io, path, .{ .follow_symlinks = false });
+    var hash = std.crypto.hash.sha2.Sha256.init(.{});
+    hash.update(try std.fmt.allocPrint(ctx.arena, "{s}:{d}:", .{ @tagName(stat.kind), @intFromEnum(stat.permissions) }));
+    switch (stat.kind) {
+        .file => hash.update(try dir.readFileAlloc(ctx.io, path, ctx.arena, .limited(1024 * 1024))),
+        .sym_link => {
+            var buffer: [std.fs.max_path_bytes]u8 = undefined;
+            hash.update(buffer[0..try dir.readLink(ctx.io, path, &buffer)]);
+        },
+        else => {},
+    }
+    try result.put(try ctx.arena.dupe(u8, path), hash.finalResult());
+}
+
+fn testScreenAssertions() !void {
+    // Historical captures must not make a cleared view satisfy a later interaction.
+    const capture = "\x1b[?1049h\x1b[Hsemantic\x1b[H\x1b[2Kraw\x1b[K";
+    try t.require(pty.terminalCaptureContains(capture, "semantic"), "lost historical terminal assertions");
+    try t.require(!pty.terminalScreenContains(capture, "semantic"), "a cleared semantic view remained visible");
+    try t.require(pty.terminalScreenContains(capture, "raw"), "erase-to-end removed the new raw label");
+    try t.require(!pty.terminalScreenContains(capture ++ "\x1b[?1049l", "raw"), "an exited TUI remained visible");
+    const header = "\x1b[?1049h\u{25cf} Assets/01 Movement.cs [semantic]\x1b[1;25H[raw]\x1b[K";
+    try t.require(pty.terminalScreenContains(header, "Assets/01 Movement.cs [raw]"), "a Unicode icon shifted the updated header");
+    const shortened = "\x1b[?1049hsemantic [raw]\x1b[H\x1b[9P";
+    try t.require(!pty.terminalScreenContains(shortened, "semantic"), "deleted header characters remained visible");
+}
+
+fn testSnapshotAssertions(ctx: Context) !void {
+    // Read-only guarantees include untracked files outside Assets and symlink targets.
+    const before = try snapshot(ctx);
+    const path = "Notes/Nested/untracked.txt";
+    const original = try t.readFile(ctx.io, ctx.arena, ctx.repo, path);
+    try ctx.write(path, "Changed outside Assets.\n");
+    try t.require(!snapshotsEqual(before, try snapshot(ctx)), "snapshot missed a nested untracked write");
+    try ctx.write(path, original);
+
+    const file = try std.Io.Dir.cwd().openFile(ctx.io, try std.fs.path.join(ctx.arena, &.{ ctx.repo, path }), .{});
+    defer file.close(ctx.io);
+    const permissions = (try file.stat(ctx.io)).permissions;
+    try file.setPermissions(ctx.io, .fromMode(@intFromEnum(permissions) ^ 0o100));
+    try t.require(!snapshotsEqual(before, try snapshot(ctx)), "snapshot missed an executable-bit change");
+    try file.setPermissions(ctx.io, permissions);
+
+    const link = try std.fs.path.join(ctx.arena, &.{ ctx.repo, "untracked-link" });
+    try std.Io.Dir.cwd().deleteFile(ctx.io, link);
+    try std.Io.Dir.cwd().symLink(ctx.io, "another missing target", link, .{});
+    try t.require(!snapshotsEqual(before, try snapshot(ctx)), "snapshot missed a changed symlink target");
+    try std.Io.Dir.cwd().deleteFile(ctx.io, link);
+    try std.Io.Dir.cwd().symLink(ctx.io, "missing target", link, .{});
+    try t.require(snapshotsEqual(before, try snapshot(ctx)), "restoring fixture bytes did not restore the snapshot");
+}

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -5,6 +5,8 @@ const merge_driver = @import("merge_driver.zig");
 const mergetool = @import("mergetool.zig");
 const merge_strategy = @import("git_merge_strategy.zig");
 const merge_setup = @import("merge_setup.zig");
+const diff_setup = @import("diff_setup.zig");
+const render_diff = @import("render_diff.zig");
 const installation = @import("installation.zig");
 const version = @import("build_options").version;
 
@@ -15,6 +17,8 @@ test {
     _ = merge_driver;
     _ = mergetool;
     _ = merge_strategy;
+    _ = diff_setup;
+    _ = render_diff;
     _ = @import("atomic_file.zig");
     _ = @import("merge_io.zig");
     _ = @import("merge_tree.zig");
@@ -77,10 +81,30 @@ pub fn main(init: std.process.Init) !u8 {
             };
             break :blk @as(u8, 0);
         },
+        .setup_diff => |setup_args| blk: {
+            diff_setup.run(init.io, arena, setup_args, init.environ_map, stdout) catch |err| {
+                switch (err) {
+                    error.InvalidSetupArguments => try stderr.writeAll("usage: " ++ diff_setup.usage ++ "\n"),
+                    error.SetupRequiresRepository => try stderr.writeAll("prefablens: Diff setup requires a Git working tree.\nRun this command inside a repository, or use: prefablens setup-diff --user\n"),
+                    else => try stderr.print("prefablens: Diff setup failed: {s}.\n", .{@errorName(err)}),
+                }
+                break :blk @as(u8, 2);
+            };
+            break :blk @as(u8, 0);
+        },
         .diff => |diff_args| try diff.run(
             init.io,
             arena,
             diff_args,
+            stdout,
+            stderr,
+            color,
+            init.environ_map,
+        ),
+        .render_diff => |render_args| try render_diff.run(
+            init.io,
+            arena,
+            render_args,
             stdout,
             stderr,
             color,

--- a/cli/src/render_diff.zig
+++ b/cli/src/render_diff.zig
@@ -1,0 +1,370 @@
+const std = @import("std");
+const core = @import("core");
+const testing = std.testing;
+
+const input = @import("input.zig");
+const render_tree = @import("render_tree.zig");
+const unity_path = @import("unity_path.zig");
+
+pub const usage = "prefablens render-diff [--color|--no-color] [--] BEFORE AFTER DISPLAY_PATH";
+
+pub const help = usage ++ "\n\nRender a semantic diff from two literal file paths.\nEmpty paths and /dev/null mean that side is absent.\n";
+
+const Args = struct {
+    before: []const u8,
+    after: []const u8,
+    display_path: []const u8,
+    force_color: bool = false,
+    no_color: bool = false,
+};
+
+const ArgError = error{InvalidArguments};
+
+fn parseArgs(args: []const []const u8) ArgError!Args {
+    var operands: [3][]const u8 = undefined;
+    var operand_count: usize = 0;
+    var force_color = false;
+    var no_color = false;
+    var parse_options = true;
+    for (args) |arg| {
+        if (parse_options and std.mem.eql(u8, arg, "--")) {
+            parse_options = false;
+        } else if (parse_options and std.mem.eql(u8, arg, "--color")) {
+            force_color = true;
+        } else if (parse_options and std.mem.eql(u8, arg, "--no-color")) {
+            no_color = true;
+        } else if (parse_options and std.mem.startsWith(u8, arg, "--")) {
+            return error.InvalidArguments;
+        } else {
+            if (operand_count == operands.len) return error.InvalidArguments;
+            operands[operand_count] = arg;
+            operand_count += 1;
+        }
+    }
+    if (operand_count != operands.len) return error.InvalidArguments;
+    return .{
+        .before = operands[0],
+        .after = operands[1],
+        .display_path = operands[2],
+        .force_color = force_color,
+        .no_color = no_color,
+    };
+}
+
+test "render-diff option sentinel preserves dash-prefixed literal operands" {
+    const parsed = try parseArgs(&.{ "--color", "--", "--before", "--after", "--display.prefab" });
+    try testing.expect(parsed.force_color);
+    try testing.expectEqualStrings("--before", parsed.before);
+    try testing.expectEqualStrings("--after", parsed.after);
+    try testing.expectEqualStrings("--display.prefab", parsed.display_path);
+}
+
+const Side = struct {
+    bytes: []const u8,
+    present: bool,
+    argument: []const u8,
+};
+
+fn isAbsent(path: []const u8) bool {
+    return path.len == 0 or std.mem.eql(u8, path, "/dev/null");
+}
+
+fn readSide(io: std.Io, arena: std.mem.Allocator, path: []const u8) !Side {
+    if (isAbsent(path)) return .{ .bytes = "", .present = false, .argument = path };
+    return .{
+        .bytes = try std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(input.max_input_bytes)),
+        .present = true,
+        .argument = path,
+    };
+}
+
+fn noColorRequested(environ: ?*const std.process.Environ.Map) bool {
+    const env = environ orelse return false;
+    const value = env.get("NO_COLOR") orelse return false;
+    return value.len != 0;
+}
+
+fn hasUnityDocumentHeader(bytes: []const u8) bool {
+    var lines = std.mem.splitScalar(u8, bytes, '\n');
+    var first = true;
+    while (lines.next()) |raw| {
+        var line = std.mem.trimEnd(u8, raw, "\r");
+        if (first and std.mem.startsWith(u8, line, "\xEF\xBB\xBF")) line = line[3..];
+        first = false;
+        if (std.mem.startsWith(u8, line, "--- !u!")) return true;
+    }
+    return false;
+}
+
+fn validateSide(arena: std.mem.Allocator, side: Side, stderr: *std.Io.Writer) !?u8 {
+    if (!side.present) return null;
+    if (!core.isUnityYaml(side.bytes)) {
+        try stderr.print("prefablens: Renderer input '{s}' is not Unity YAML.\n", .{side.argument});
+        return 3;
+    }
+    if (!hasUnityDocumentHeader(side.bytes)) {
+        try stderr.print("prefablens: Renderer input has no Unity document header ('{s}').\n", .{side.argument});
+        return 3;
+    }
+    const found = core.parseDiagnostics(arena, side.bytes) catch |err| {
+        if (err == error.NestingTooDeep) {
+            try stderr.print("prefablens: Cannot parse renderer input: input nested too deeply ('{s}').\n", .{side.argument});
+            return 2;
+        }
+        return err;
+    };
+    if (found.len != 0) {
+        try stderr.print("prefablens: Cannot parse renderer input: {s} ('{s}').\n", .{ @tagName(found[0]), side.argument });
+        return 2;
+    }
+    return null;
+}
+
+pub fn run(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    args: []const []const u8,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+    tty_color: bool,
+    environ: ?*const std.process.Environ.Map,
+) !u8 {
+    if (args.len == 1 and (std.mem.eql(u8, args[0], "--help") or std.mem.eql(u8, args[0], "-h"))) {
+        try stdout.writeAll(help);
+        return 0;
+    }
+    const parsed = parseArgs(args) catch {
+        try stderr.writeAll("usage: " ++ usage ++ "\n");
+        return 2;
+    };
+    if (!unity_path.isUnityPath(parsed.display_path)) {
+        try stderr.print("prefablens: Unsupported renderer path '{s}'.\n", .{parsed.display_path});
+        return 3;
+    }
+
+    const before = readSide(io, arena, parsed.before) catch {
+        try stderr.print("prefablens: Cannot read renderer input '{s}'.\n", .{parsed.before});
+        return 2;
+    };
+    const after = readSide(io, arena, parsed.after) catch {
+        try stderr.print("prefablens: Cannot read renderer input '{s}'.\n", .{parsed.after});
+        return 2;
+    };
+    if (!before.present and !after.present) {
+        try stderr.writeAll("prefablens: Renderer inputs do not contain Unity YAML.\n");
+        return 3;
+    }
+    if (try validateSide(arena, before, stderr)) |code| return code;
+    if (try validateSide(arena, after, stderr)) |code| return code;
+
+    const result = core.diffBytes(arena, before.bytes, after.bytes) catch |err| {
+        if (err == error.NestingTooDeep) {
+            try stderr.writeAll("prefablens: Cannot parse renderer input: input nested too deeply.\n");
+            return 2;
+        }
+        return err;
+    };
+    if (result.roots.len == 0 and result.loose.len == 0) {
+        try stdout.writeAll("No semantic changes\n");
+        return 0;
+    }
+    const use_color = (tty_color or parsed.force_color) and !parsed.no_color and !noColorRequested(environ);
+    try render_tree.renderWithOptions(arena, stdout, result, null, .{
+        .color = use_color,
+        .project_hint = false,
+    });
+    return 0;
+}
+
+const Invocation = struct {
+    code: u8,
+    stdout: []const u8,
+    stderr: []const u8,
+};
+
+fn invoke(
+    arena: std.mem.Allocator,
+    args: []const []const u8,
+    tty_color: bool,
+    environ: ?*const std.process.Environ.Map,
+) !Invocation {
+    var out: std.ArrayList(u8) = .empty;
+    var out_writer = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err: std.ArrayList(u8) = .empty;
+    var err_writer = std.Io.Writer.Allocating.fromArrayList(arena, &err);
+    const code = try run(testing.io, arena, args, &out_writer.writer, &err_writer.writer, tty_color, environ);
+    return .{
+        .code = code,
+        .stdout = out_writer.toArrayList().items,
+        .stderr = err_writer.toArrayList().items,
+    };
+}
+
+fn writeFixturePair(tmp: *testing.TmpDir, arena: std.mem.Allocator) !struct { before: []const u8, after: []const u8 } {
+    const before_fixture = try std.Io.Dir.cwd().readFileAlloc(testing.io, "core/src/testdata/cylinder_before.prefab", arena, .limited(1024 * 1024));
+    const after_fixture = try std.Io.Dir.cwd().readFileAlloc(testing.io, "core/src/testdata/cylinder_after.prefab", arena, .limited(1024 * 1024));
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "before literal $(echo wrong)", .data = before_fixture });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "after 空 白", .data = after_fixture });
+    return .{
+        .before = try tmp.dir.realPathFileAlloc(testing.io, "before literal $(echo wrong)", arena),
+        .after = try tmp.dir.realPathFileAlloc(testing.io, "after 空 白", arena),
+    };
+}
+
+test "render-diff reads literal paths and renders the actual Unity fixture" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    const result = try invoke(arena, &.{ paths.before, paths.after, "Assets/Cylinder.prefab" }, false, null);
+
+    try testing.expectEqual(@as(u8, 0), result.code);
+    try testing.expectEqualStrings("", result.stderr);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "Position.x: 0.64596 → 1") != null);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "(1 unresolved guid reference(s))") != null);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "--project") == null);
+}
+
+test "render-diff treats only empty arguments and dev-null as absent" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    const empty_arg = try invoke(arena, &.{ "", paths.after, "Assets/Cylinder.prefab" }, false, null);
+    try testing.expectEqual(@as(u8, 0), empty_arg.code);
+    try testing.expect(std.mem.indexOf(u8, empty_arg.stdout, "Cylinder") != null);
+
+    const dev_null = try invoke(arena, &.{ paths.before, "/dev/null", "Assets/Cylinder.prefab" }, false, null);
+    try testing.expectEqual(@as(u8, 0), dev_null.code);
+
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "empty one", .data = "" });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "empty two", .data = "" });
+    const empty_one = try tmp.dir.realPathFileAlloc(testing.io, "empty one", arena);
+    const empty_two = try tmp.dir.realPathFileAlloc(testing.io, "empty two", arena);
+    const existing_empty = try invoke(arena, &.{ empty_one, empty_two, "Assets/Empty.asset" }, false, null);
+    try testing.expectEqual(@as(u8, 3), existing_empty.code);
+    try testing.expectEqualStrings("", existing_empty.stdout);
+    try testing.expect(existing_empty.stderr.len != 0);
+}
+
+test "render-diff returns separate unsupported and input failure exits without stdout" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    const unsupported = try invoke(arena, &.{ paths.before, paths.after, "Assets/Cylinder.cs" }, false, null);
+    try testing.expectEqual(@as(u8, 3), unsupported.code);
+    try testing.expectEqualStrings("", unsupported.stdout);
+    try testing.expect(unsupported.stderr.len != 0);
+
+    const missing_path = try std.fs.path.join(arena, &.{ paths.before, "missing" });
+    const missing = try invoke(arena, &.{ missing_path, paths.after, "Assets/Cylinder.prefab" }, false, null);
+    try testing.expectEqual(@as(u8, 2), missing.code);
+    try testing.expectEqualStrings("", missing.stdout);
+    try testing.expect(missing.stderr.len != 0);
+}
+
+test "render-diff rejects malformed Unity YAML before writing stdout" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "malformed", .data = "--- !u!114 &1\nMonoBehaviour:\n  values: [1, 2\n" });
+    const malformed_path = try tmp.dir.realPathFileAlloc(testing.io, "malformed", arena);
+
+    const result = try invoke(arena, &.{ paths.before, malformed_path, "Assets/Cylinder.prefab" }, false, null);
+
+    try testing.expectEqual(@as(u8, 2), result.code);
+    try testing.expectEqualStrings("", result.stdout);
+    try testing.expect(std.mem.startsWith(u8, result.stderr, "prefablens: Cannot parse renderer input: invalid_flow_value"));
+    try testing.expect(std.mem.indexOf(u8, result.stderr, malformed_path) != null);
+}
+
+test "render-diff rejects a directive-only real file as unsupported" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{
+        .sub_path = "only directive",
+        .data = "%TAG !u! tag:unity3d.com,2011:\n",
+    });
+    const directive_path = try tmp.dir.realPathFileAlloc(testing.io, "only directive", arena);
+
+    const result = try invoke(arena, &.{ "/dev/null", directive_path, "Assets/OnlyDirective.asset" }, false, null);
+
+    try testing.expectEqual(@as(u8, 3), result.code);
+    try testing.expectEqualStrings("", result.stdout);
+    try testing.expect(std.mem.indexOf(u8, result.stderr, "document header") != null);
+}
+
+test "render-diff reports a successful empty semantic result" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const before_fixture = try std.Io.Dir.cwd().readFileAlloc(testing.io, "core/src/testdata/cylinder_before.prefab", arena, .limited(1024 * 1024));
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "before", .data = before_fixture });
+    const after = try std.fmt.allocPrint(arena, "{s}# Only a comment changed.\n", .{before_fixture});
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "after", .data = after });
+    const before_path = try tmp.dir.realPathFileAlloc(testing.io, "before", arena);
+    const after_path = try tmp.dir.realPathFileAlloc(testing.io, "after", arena);
+
+    const result = try invoke(arena, &.{ before_path, after_path, "Assets/Cylinder.prefab" }, false, null);
+
+    try testing.expectEqual(@as(u8, 0), result.code);
+    try testing.expectEqualStrings("No semantic changes\n", result.stdout);
+    try testing.expectEqualStrings("", result.stderr);
+}
+
+test "render-diff no-color settings override forced and terminal color" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    const forced_color = try invoke(arena, &.{ "--color", paths.before, paths.after, "Assets/Cylinder.prefab" }, false, null);
+    try testing.expectEqual(@as(u8, 0), forced_color.code);
+    try testing.expect(std.mem.indexOf(u8, forced_color.stdout, "\x1b[") != null);
+
+    var env = std.process.Environ.Map.init(arena);
+    try env.put("NO_COLOR", "1");
+    const no_color_env = try invoke(arena, &.{ "--color", paths.before, paths.after, "Assets/Cylinder.prefab" }, false, &env);
+    try testing.expectEqual(@as(u8, 0), no_color_env.code);
+    try testing.expect(std.mem.indexOf(u8, no_color_env.stdout, "\x1b[") == null);
+
+    const no_color_flag = try invoke(arena, &.{ "--color", "--no-color", paths.before, paths.after, "Assets/Cylinder.prefab" }, true, null);
+    try testing.expectEqual(@as(u8, 0), no_color_flag.code);
+    try testing.expect(std.mem.indexOf(u8, no_color_flag.stdout, "\x1b[") == null);
+}
+
+test "render-diff rejects invalid arguments without stdout" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const missing = try invoke(arena, &.{ "before", "after" }, false, null);
+    try testing.expectEqual(@as(u8, 2), missing.code);
+    try testing.expectEqualStrings("", missing.stdout);
+    try testing.expect(missing.stderr.len != 0);
+
+    const unknown = try invoke(arena, &.{ "--json", "before", "after", "Assets/Foo.prefab" }, false, null);
+    try testing.expectEqual(@as(u8, 2), unknown.code);
+    try testing.expectEqualStrings("", unknown.stdout);
+    try testing.expect(unknown.stderr.len != 0);
+}

--- a/cli/src/render_tree.zig
+++ b/cli/src/render_tree.zig
@@ -426,6 +426,22 @@ pub fn render(
     resolved: ?*const core.json.Resolver,
     color: bool,
 ) !void {
+    return renderWithOptions(arena, w, res, resolved, .{ .color = color });
+}
+
+pub const RenderOptions = struct {
+    color: bool,
+    project_hint: bool = true,
+};
+
+pub fn renderWithOptions(
+    arena: std.mem.Allocator,
+    w: *std.Io.Writer,
+    res: model.DiffResult,
+    resolved: ?*const core.json.Resolver,
+    options: RenderOptions,
+) !void {
+    const color = options.color;
     var prefix: std.ArrayList(u8) = .empty;
     for (res.roots) |o| try renderObject(arena, w, o, resolved, color, &prefix, "");
     if (res.loose.len != 0) {
@@ -440,7 +456,12 @@ pub fn render(
         // Built-ins display by name (no .meta exists for them), so counting
         // them here would advertise a --project run that cannot help.
         const n = display.unresolvedCount(res);
-        if (n != 0) try w.print("\n({d} unresolved guid reference(s); pass --project DIR to resolve)\n", .{n});
+        if (n != 0) {
+            if (options.project_hint)
+                try w.print("\n({d} unresolved guid reference(s); pass --project DIR to resolve)\n", .{n})
+            else
+                try w.print("\n({d} unresolved guid reference(s))\n", .{n});
+        }
     }
 }
 

--- a/cli/src/testing/pty.zig
+++ b/cli/src/testing/pty.zig
@@ -1,11 +1,24 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const integration = @import("git.zig");
+const gwidth = @import("vaxis").gwidth;
 
 const capture_width = 100;
 const capture_height = 24;
 
 pub fn terminalCaptureContains(capture: []const u8, needle: []const u8) bool {
+    return captureCount(capture, needle, false) != 0;
+}
+
+pub fn terminalScreenContains(capture: []const u8, needle: []const u8) bool {
+    return terminalScreenLineCount(capture, needle) != 0;
+}
+
+pub fn terminalScreenLineCount(capture: []const u8, needle: []const u8) usize {
+    return captureCount(capture, needle, true);
+}
+
+fn captureCount(capture: []const u8, needle: []const u8, current_only: bool) usize {
     var cells: [capture_height][capture_width]u8 = undefined;
     for (&cells) |*screen_row| @memset(screen_row, ' ');
     var row: usize = 0;
@@ -19,21 +32,39 @@ pub fn terminalCaptureContains(capture: []const u8, needle: []const u8) bool {
             index = consumeEscape(capture, index, &row, &col, &cells, &alternate_active);
             continue;
         }
+        if (byte >= 0xc0) {
+            const length = std.unicode.utf8ByteSequenceLength(byte) catch 1;
+            if (index + length > capture.len) break;
+            const width = gwidth.gwidth(capture[index..][0..length], .wcwidth);
+            const end = @min(col + width, capture_width);
+            @memset(cells[row][col..end], ' ');
+            col = end;
+            index += length;
+            continue;
+        }
         index += 1;
         switch (byte) {
             '\r' => col = 0,
             '\n' => row = @min(row + 1, capture_height - 1),
+            '\x08' => col -|= 1,
+            '\t' => col = @min((col / 8 + 1) * 8, capture_width - 1),
             0x20...0x7e => {
                 if (col < capture_width) {
                     cells[row][col] = byte;
                     col += 1;
                 }
-                if (alternate_active and std.mem.indexOf(u8, &cells[row], needle) != null) return true;
+                if (!current_only and alternate_active and std.mem.indexOf(u8, &cells[row], needle) != null) return 1;
             },
             else => {},
         }
     }
-    return false;
+    var count: usize = 0;
+    if (current_only and alternate_active) {
+        for (cells) |screen_row| {
+            count = @max(count, std.mem.count(u8, &screen_row, needle));
+        }
+    }
+    return count;
 }
 
 fn consumeEscape(
@@ -119,8 +150,31 @@ fn applyCsi(
         'B' => row.* = @min(row.* + first, capture_height - 1),
         'C' => col.* = @min(col.* + first, capture_width - 1),
         'D' => col.* -|= first,
-        'J' => for (cells) |*screen_row| @memset(screen_row, ' '),
-        'K' => @memset(&cells[row.*], ' '),
+        'X' => @memset(cells[row.*][@min(col.*, capture_width)..@min(col.* + first, capture_width)], ' '),
+        'P' => {
+            const start = @min(col.*, capture_width);
+            const count = @min(first, capture_width - start);
+            std.mem.copyForwards(u8, cells[row.*][start .. capture_width - count], cells[row.*][start + count ..]);
+            @memset(cells[row.*][capture_width - count ..], ' ');
+        },
+        'J' => switch (params[0]) {
+            0 => {
+                @memset(cells[row.*][@min(col.*, capture_width)..], ' ');
+                for (cells[row.* + 1 ..]) |*screen_row| @memset(screen_row, ' ');
+            },
+            1 => {
+                for (cells[0..row.*]) |*screen_row| @memset(screen_row, ' ');
+                @memset(cells[row.*][0..@min(col.* + 1, capture_width)], ' ');
+            },
+            2, 3 => for (cells) |*screen_row| @memset(screen_row, ' '),
+            else => {},
+        },
+        'K' => switch (params[0]) {
+            0 => @memset(cells[row.*][@min(col.*, capture_width)..], ' '),
+            1 => @memset(cells[row.*][0..@min(col.* + 1, capture_width)], ' '),
+            2 => @memset(&cells[row.*], ' '),
+            else => {},
+        },
         'h' => if (private_mode and params[0] == 1049) {
             for (cells) |*screen_row| @memset(screen_row, ' ');
             row.* = 0;

--- a/cli/src/testing/pty_session.zig
+++ b/cli/src/testing/pty_session.zig
@@ -1,0 +1,156 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const git = @import("git.zig");
+const pty = @import("pty.zig");
+
+const Session = @This();
+const capture_allocator = std.heap.page_allocator;
+
+io: std.Io,
+arena: std.mem.Allocator,
+child: std.process.Child,
+capture_path: []const u8,
+status_path: []const u8,
+pid_path: []const u8,
+tty_path: []const u8,
+replies: [3]usize = .{ 0, 0, 0 },
+
+pub fn start(io: std.Io, arena: std.mem.Allocator, directory: []const u8, env: *const std.process.Environ.Map, prefix: []const u8, command: []const u8) !Session {
+    const capture_path = try std.fmt.allocPrint(arena, "{s}.ansi", .{prefix});
+    const status_path = try std.fmt.allocPrint(arena, "{s}.status", .{prefix});
+    const pid_path = try std.fmt.allocPrint(arena, "{s}.pid", .{prefix});
+    const tty_path = try std.fmt.allocPrint(arena, "{s}.tty", .{prefix});
+    const terminal_command = try std.fmt.allocPrint(
+        arena,
+        "stty cols 100 rows 24; printf '%s' \"$$\" > {s}; tty > {s}; {s}; printf '%s' \"$?\" > {s}",
+        .{ try git.shellQuote(arena, pid_path), try git.shellQuote(arena, tty_path), command, try git.shellQuote(arena, status_path) },
+    );
+    const argv: []const []const u8 = switch (builtin.os.tag) {
+        .linux => &.{ "script", "-qfec", terminal_command, capture_path },
+        .macos => &.{ "script", "-qF", capture_path, "sh", "-c", terminal_command },
+        else => return error.UnsupportedOperatingSystem,
+    };
+    return .{
+        .io = io,
+        .arena = arena,
+        .child = try std.process.spawn(io, .{
+            .argv = argv,
+            .cwd = .{ .path = directory },
+            .environ_map = env,
+            .stdin = .pipe,
+            .stdout = .ignore,
+            .stderr = .inherit,
+        }),
+        .capture_path = capture_path,
+        .status_path = status_path,
+        .pid_path = pid_path,
+        .tty_path = tty_path,
+    };
+}
+
+pub fn deinit(self: *Session) void {
+    if (self.child.id != null) {
+        // The shell inside script owns the PTY process group, including Git and its tools.
+        const pid_bytes = self.read(self.pid_path) catch "";
+        defer capture_allocator.free(pid_bytes);
+        const pid = std.fmt.parseInt(std.posix.pid_t, pid_bytes, 10) catch 0;
+        if (pid > 1) std.posix.kill(-pid, .KILL) catch {};
+        self.child.kill(self.io);
+    }
+    for ([_][]const u8{ self.capture_path, self.status_path, self.pid_path, self.tty_path }) |path| {
+        std.Io.Dir.cwd().deleteFile(self.io, path) catch {};
+    }
+}
+
+pub fn send(self: *Session, keys: []const u8) !void {
+    try self.child.stdin.?.writeStreamingAll(self.io, keys);
+}
+
+pub fn waitFor(self: *Session, needles: []const []const u8) !void {
+    return self.waitForMatches(needles, null);
+}
+
+pub fn waitForLineCount(self: *Session, needle: []const u8, count: usize) !void {
+    return self.waitForMatches(&.{needle}, count);
+}
+
+fn waitForMatches(self: *Session, needles: []const []const u8, expected_count: ?usize) !void {
+    const started = std.Io.Clock.awake.now(self.io);
+    while (started.durationTo(std.Io.Clock.awake.now(self.io)).toSeconds() < 10) {
+        const captured = try self.capture();
+        defer capture_allocator.free(captured);
+        // Inspect the current screen so an earlier semantic view cannot satisfy a later toggle.
+        const ready = for (needles) |needle| {
+            const count = pty.terminalScreenLineCount(captured, needle);
+            if (if (expected_count) |expected| count != expected else count == 0) break false;
+        } else true;
+        if (ready) return;
+        if (try self.exitCode() != null) break;
+        try std.Io.sleep(self.io, .fromMilliseconds(25), .awake);
+    }
+    const captured = try self.capture();
+    defer capture_allocator.free(captured);
+    for (needles) |needle| {
+        if (!pty.terminalScreenContains(captured, needle)) std.debug.print("PTY missing: {s}\n", .{needle});
+    }
+    std.debug.print("PTY capture:\n{s}\n", .{captured});
+    return error.TerminalExpectationFailed;
+}
+
+pub fn resize(self: *Session, columns: u16, rows: u16) !void {
+    const tty_bytes = try self.read(self.tty_path);
+    defer capture_allocator.free(tty_bytes);
+    const tty_path = std.mem.trim(u8, tty_bytes, "\r\n");
+    const result = try std.process.run(self.arena, self.io, .{
+        .argv = &.{
+            "stty",                                             if (builtin.os.tag == .macos) "-f" else "-F",          tty_path,
+            "cols",                                             try std.fmt.allocPrint(self.arena, "{d}", .{columns}), "rows",
+            try std.fmt.allocPrint(self.arena, "{d}", .{rows}),
+        },
+        .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(5) } },
+    });
+    try git.expectCode(result, 0, "resize difftool terminal");
+}
+
+pub fn finish(self: *Session) !void {
+    try self.send("q");
+    const started = std.Io.Clock.awake.now(self.io);
+    while (started.durationTo(std.Io.Clock.awake.now(self.io)).toSeconds() < 5) {
+        const captured = try self.capture();
+        capture_allocator.free(captured);
+        if (try self.exitCode()) |code| {
+            try git.require(code == 0, "Git difftool did not exit cleanly");
+            const term = try self.child.wait(self.io);
+            try git.require(term == .exited and term.exited == 0, "PTY did not exit cleanly");
+            return;
+        }
+        try std.Io.sleep(self.io, .fromMilliseconds(25), .awake);
+    }
+    return error.TerminalExitTimeout;
+}
+
+fn capture(self: *Session) ![]const u8 {
+    const bytes = try self.read(self.capture_path);
+    errdefer capture_allocator.free(bytes);
+    const queries = [_][]const u8{ "\x1b[6n", "\x1b]10;?", "\x1b]11;?" };
+    const responses = [_][]const u8{ "\x1b[1;1R", "\x1b]10;rgb:eeee/eeee/eeee\x1b\\", "\x1b]11;rgb:1111/1111/1111\x1b\\" };
+    for (queries, responses, &self.replies) |query, response, *replies| {
+        const count = std.mem.count(u8, bytes, query);
+        while (replies.* < count) : (replies.* += 1) try self.send(response);
+    }
+    return bytes;
+}
+
+fn read(self: Session, path: []const u8) ![]const u8 {
+    // Poll buffers must be released independently of the fixture's long-lived arena.
+    return std.Io.Dir.cwd().readFileAlloc(self.io, path, capture_allocator, .limited(4 * 1024 * 1024)) catch |err| switch (err) {
+        error.FileNotFound => "",
+        else => return err,
+    };
+}
+
+fn exitCode(self: Session) !?u8 {
+    const bytes = try self.read(self.status_path);
+    defer capture_allocator.free(bytes);
+    return if (bytes.len == 0) null else try std.fmt.parseInt(u8, bytes, 10);
+}

--- a/core/src/parser.zig
+++ b/core/src/parser.zig
@@ -88,6 +88,18 @@ test "parseSpanned: reports malformed syntax without changing parse" {
     try testing.expectEqual(@as(usize, 1), docs.len);
 }
 
+test "diagnostics: uses normal folded-line normalization" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    const folded = @embedFile("testdata/folded_quoted_array_after.asset");
+    try testing.expectEqual(@as(usize, 0), (try diagnostics(arena, folded)).len);
+
+    const malformed = "--- !u!114 &1\nMonoBehaviour:\n  values: [1, 2\n";
+    try testing.expect((try diagnostics(arena, malformed)).len != 0);
+}
+
 test "parseSpanned: records container and nested entry spans" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -899,6 +911,19 @@ pub fn parse(arena: std.mem.Allocator, source_bytes: []const u8) Error![]Documen
         .track_source = false,
     };
     return parseDocuments(&p);
+}
+
+/// Reports syntax diagnostics with the same folded-line normalization as `parse`.
+/// `parseSpanned` keeps physical lines for merge editing and has different semantics.
+pub fn diagnostics(arena: std.mem.Allocator, source_bytes: []const u8) Error![]source_map.Diagnostic {
+    var p = Parser{
+        .arena = arena,
+        .source_bytes = source_bytes,
+        .lines = try tokenize(arena, source_bytes, true),
+        .track_source = false,
+    };
+    _ = try parseDocuments(&p);
+    return p.diagnostics.toOwnedSlice(arena);
 }
 
 pub fn parseSpanned(arena: std.mem.Allocator, source_bytes: []const u8) Error!source_map.ParsedFile {

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -22,6 +22,7 @@ const prefab = @import("prefab.zig");
 pub const Assets = prefab.Assets;
 pub const displayPropertyPath = inspector.displayPath;
 pub const isUnityYaml = parser.isUnityYaml;
+pub const parseDiagnostics = parser.diagnostics;
 pub const DiffError = parser.Error;
 pub const JsonError = DiffError || std.Io.Writer.Error;
 const no_assets: Assets = .empty;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,8 @@ The schema remains stable unless a release documents a breaking change.
 | `cli/src/main.zig`, `command.zig` | Process setup and command dispatch |
 | `cli/src/diff.zig` | Diff input collection, GUID resolution, and output selection |
 | `cli/src/diff_options.zig` | Diff options and operand parsing |
+| `cli/src/render_diff.zig` | Independent semantic renderer for diffnav |
+| `cli/src/diff_setup.zig` | Git difftool configuration |
 | `cli/src/input.zig` | Git subprocess I/O and file reads |
 | `cli/src/resolve.zig` | `.meta` GUID index scan |
 | `cli/src/unity_path.zig` | UnityYAML extension detection |
@@ -64,6 +66,83 @@ Test executables share helpers from `testing/` without importing one another.
   Bulk Git mode skips binary candidates after a content sniff.
 - `.meta`, `.asmdef`, and other non-UnityYAML names are never path operands.
   The CLI treats them as Git refs intentionally.
+
+### Git diff integration
+
+The integration requires Git, the [PrefabLens diffnav fork](https://github.com/hashiiiii/diffnav), `delta`, and `prefablens` on `PATH` at run time.
+Build the fork from its checkout with `go build -o ./diffnav .`.
+Its `--compare`, `--renderer`, and repeatable `--renderer-arg` options are not part of an upstream diffnav release.
+PrefabLens setup registers configuration only. It does not install or verify these executables.
+
+```text
+prefablens setup-diff [--local|--user]
+```
+
+Without a flag, setup uses `--local` for the current repository.
+It also works from a repository subdirectory and from a linked worktree.
+Use `--user` to write the global Git configuration, including outside a repository.
+`--project`, multiple scopes, and other arguments exit with status 2 before changing configuration.
+Local setup outside a working tree exits with status 2 and suggests `prefablens setup-diff --user`.
+
+Setup preserves attributes and unrelated Git settings.
+Repeated setup replaces the two integration values without creating duplicate values:
+
+```ini
+[diff]
+    tool = prefablens
+[difftool "prefablens"]
+    cmd = diffnav --compare --renderer prefablens --renderer-arg=render-diff --renderer-arg=--color --renderer-arg=-- -- "$LOCAL" "$REMOTE" "$MERGED"
+```
+
+Run directory comparisons for working tree, staged, or revision changes:
+
+```sh
+git difftool --dir-diff --no-symlinks
+git difftool --dir-diff --no-symlinks --cached
+git difftool --dir-diff --no-symlinks HEAD~1 HEAD
+```
+
+Directory mode asks Git to prepare temporary before and after directories.
+`--no-symlinks` asks Git to copy working tree files instead of linking to them.
+See the [Git difftool documentation](https://git-scm.com/docs/git-difftool) for the complete Git interface.
+
+Run one comparison for a selected asset:
+
+```sh
+git difftool --no-prompt --tool=prefablens -- Assets/Player.prefab
+```
+
+`diffnav` starts `prefablens render-diff` directly and passes literal file paths.
+Press **v** to switch between the semantic and raw views when both are available.
+Unsupported inputs use the raw diff.
+Renderer errors also use the raw diff and show the diagnostic.
+
+#### Independent renderer
+
+```text
+prefablens render-diff [--color|--no-color] [--] BEFORE AFTER DISPLAY_PATH
+```
+
+The renderer reads `BEFORE` and `AFTER` as literal paths without invoking Git.
+An empty path or `/dev/null` means that side is absent.
+An existing empty file remains a real input and is rejected as unsupported.
+`DISPLAY_PATH` must have a recognized UnityYAML extension.
+Use `--` before operands that start with a dash.
+
+The renderer validates each present input before writing standard output.
+It does not scan a Unity project, so unresolved GUID references remain unresolved without a project hint.
+It does not generate a raw diff.
+`diffnav` owns the raw fallback.
+
+| Code | Renderer result |
+| --- | --- |
+| 0 | Semantic output, including `No semantic changes` for an empty semantic diff. |
+| 2 | Invalid arguments, unreadable input, or malformed UnityYAML. |
+| 3 | Unsupported display path, non-UnityYAML input, or no present input. |
+
+Color follows terminal detection or `--color`.
+`--no-color` takes precedence, and a nonempty `NO_COLOR` disables color.
+`-h` and `--help` alone print help and exit 0 without reading files or Git configuration.
 
 ### Git merge integration
 
@@ -207,7 +286,8 @@ The mergetool requires both standard input and standard output to be TTYs.
 Without them, it returns 2 and keeps `$MERGED` unchanged. The automatic strategy instead leaves the merge unresolved.
 PrefabLens writes completed output with atomic file replacement and retains existing permissions.
 
-`diff-driver` and `difftool` remain reserved for Issue #227.
+The `diff-driver` and `difftool` subcommand names remain reserved.
+The production adapters use `render-diff` and `setup-diff`.
 libvaxis is a CLI dependency. The core and WASM targets do not import it.
 
 ### CLI contract
@@ -349,6 +429,7 @@ Then run the core and CLI checks:
 
 ```bash
 zig build lint
+zig build test-diff
 zig build test
 zig build perf
 zig build run -- before.prefab after.prefab
@@ -358,6 +439,19 @@ The performance gate builds both benchmarks before running them sequentially.
 The diff benchmark warms up once, then reports five samples and checks their median against the 600 ms ceiling.
 Each sample diffs 50,000 objects with a fresh arena to keep memory usage bounded.
 The GUID scan retains its 50,000-file workload and 1,200 ms ceiling.
+
+Run the optional diffnav integration checks on macOS or Linux with the built fork and `delta` available:
+
+```sh
+zig build test-diffnav -Ddiffnav=/path/to/diffnav/diffnav
+```
+
+Without `-Ddiffnav`, the test finds `diffnav` on `PATH`.
+It uses Zig and the system `script` utility to exercise the real Git difftool in a PTY.
+Checks cover mixed files, semantic/raw switching, resizing, fallbacks, and working-tree, staged, and revision comparisons.
+The test verifies that input files, permissions, symlinks, index bytes, and Git configuration remain unchanged.
+Temporary repositories and terminal transcripts are removed after each run.
+This target runs separately from `zig build test`.
 
 Build the native CLI and Git strategy script before running the package test:
 


### PR DESCRIPTION
## Summary

Add a Git difftool integration that uses diffnav to browse mixed files and PrefabLens to render UnityYAML semantically.
Users can switch between semantic and raw views within the same session.

## Motivation

Mixed Git changes need a shared file list, with semantic views for UnityYAML and raw views for ordinary files.
The integration uses diffnav's existing TUI and delta rendering.

Related to #227. The external diff driver for plain `git diff` remains separate; this PR provides the interactive `git difftool` flow.

The runtime requires the fork changes in https://github.com/hashiiiii/diffnav/pull/1 and delta.
PrefabLens builds and default tests have no diffnav dependency.

## Changes

- Add `setup-diff [--local|--user]` to register the Git difftool command while preserving attributes and unrelated configuration.
- Add the Zig `render-diff` adapter for literal before, after, and display paths, including additions and deletions.
- Validate UnityYAML before writing semantic output. Return separate unsupported and error statuses so diffnav can show raw output and diagnostics.
- Add Zig tests for setup and rendering, plus an optional `test-diffnav` target using the existing mergetool PTY helpers.
- Document fork prerequisites, setup scopes, working-tree/staged/revision comparisons, view switching, and test commands.

The renderer does not scan Unity projects; unresolved GUID references remain unresolved.
Python validation scripts and screen recordings are excluded from this PR.

## Testing

Local validation on macOS after rebasing onto `main` at `e5edda8`:

```sh
mise exec -- zig build test lint test-diffnav -Ddiffnav=/Users/hashiiiii/workspace/diffnav/diffnav --summary all
# Build Summary: 37/37 steps succeeded; 613/613 tests passed

mise exec -- zig build --summary all
# Build Summary: 8/8 steps succeeded

git diff --check origin/main...HEAD
# Passed
```

The PTY test runs the actual registered difftool with Git, diffnav, delta, and PrefabLens. It uses no mocks or stubs.
It covers mixed files, semantic/raw and split/unified switching, resizing, fallbacks, and working-tree, staged, revision, and per-file comparisons.
Snapshots verify unchanged file contents, permissions, symlinks, index bytes, and Git configuration.
