### PR TITLE
fix: preserve refreshed cache entries

### DIFF
--- a/extension/src/application/diff/create-diff-session.ts
+++ b/extension/src/application/diff/create-diff-session.ts
@@ -32,11 +32,14 @@ function createPromiseCache<V>(options: PromiseCacheOptions<V>, now: () => numbe
         return hit.promise;
       }
       const promise = compute();
+      // Expiration or eviction may replace this request before it settles.
       promise.then(
         (value) => {
-          if (retain && !retain(value)) entries.delete(key);
+          if (retain && !retain(value) && entries.get(key)?.promise === promise) entries.delete(key);
         },
-        () => entries.delete(key), // never cache failures
+        () => {
+          if (entries.get(key)?.promise === promise) entries.delete(key);
+        },
       );
       entries.set(key, { at: now(), promise });
       if (max !== undefined && entries.size > max) {

--- a/extension/test/application/diff/create-diff-session.test.ts
+++ b/extension/test/application/diff/create-diff-session.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { createDiffSession, type DiffContext } from "../../../src/application/diff/create-diff-session";
+import type { GithubFailure } from "../../../src/application/gateway/github";
+import { err, ok, type Result } from "../../../src/domain/result";
+
+const failures = ["rejects", "returns a failure"] as const;
+
+async function failRequest<T>(
+  request: PromiseWithResolvers<Result<T, GithubFailure>>,
+  failure: (typeof failures)[number],
+) {
+  if (failure === "rejects") {
+    request.reject(new Error("fetch failed"));
+    await expect(request.promise).rejects.toThrow("fetch failed");
+  } else {
+    request.resolve(err({ kind: "fetch-failed" }));
+    await expect(request.promise).resolves.toEqual({ ok: false, error: { kind: "fetch-failed" } });
+  }
+}
+
+const context: DiffContext = {
+  refs: { baseSha: "base", headSha: "head" },
+  files: [],
+  guidIndex: new Map(),
+  baseShas: new Map(),
+};
+
+describe("createDiffSession", () => {
+  it.each(failures)("preserves the refreshed context when an expired request %s", async (failure) => {
+    let now = 0;
+    const session = createDiffSession(() => now);
+    const request = Promise.withResolvers<Result<DiffContext, GithubFailure>>();
+    const expired = session.contexts.get("context", () => request.promise);
+
+    // A refresh can finish while the expired request still waits on the network.
+    now = 60_001;
+    const refreshed = session.contexts.get("context", async () => ok(context));
+    expect(refreshed).not.toBe(expired);
+    await expect(refreshed).resolves.toEqual({ ok: true, value: context });
+
+    await failRequest(request, failure);
+
+    expect(session.contexts.get("context", async () => ok(context))).toBe(refreshed);
+  });
+
+  it.each(failures)("preserves the replacement blob when an evicted request %s", async (failure) => {
+    const session = createDiffSession();
+    const request = Promise.withResolvers<Result<Uint8Array | null, GithubFailure>>();
+    const evicted = session.blobs.get("blob", () => request.promise);
+
+    // Filling the 32-entry cache evicts the pending request without settling it.
+    for (let index = 0; index < 32; index++) {
+      await session.blobs.get(`other-${index}`, async () => ok(null));
+    }
+    const bytes = new Uint8Array([1, 2, 3]);
+    const replacement = session.blobs.get("blob", async () => ok(bytes));
+    expect(replacement).not.toBe(evicted);
+    await expect(replacement).resolves.toEqual({ ok: true, value: bytes });
+
+    await failRequest(request, failure);
+
+    expect(session.blobs.get("blob", async () => ok(null))).toBe(replacement);
+  });
+
+  it.each(failures)("retries when the current request %s", async (failure) => {
+    const session = createDiffSession();
+    const request = Promise.withResolvers<Result<DiffContext, GithubFailure>>();
+    const failed = session.contexts.get("context", () => request.promise);
+
+    // The ownership check must still remove a failure that has no replacement.
+    await failRequest(request, failure);
+
+    const retry = session.contexts.get("context", async () => ok(context));
+    expect(retry).not.toBe(failed);
+    await expect(retry).resolves.toEqual({ ok: true, value: context });
+    expect(session.contexts.get("context", async () => ok(context))).toBe(retry);
+  });
+});


### PR DESCRIPTION
## Summary

Preserve a replacement cache entry when an older request rejects or returns a failure.

## Motivation

An expired or evicted request can finish after its replacement and discard a successful refresh. Later callers then repeat work that was already cached.

Closes #360

## Changes

- Delete a failed cache entry only when it still stores the promise that settled.
- Add six deterministic tests covering expiration, eviction, and retries for both failure modes.

## Testing

Before the fix, all four stale-entry cases failed. All six regression tests pass with the fix.

From `extension/`:

- `mise exec -- pnpm run lint`: 102 files checked, no errors.
- `mise exec -- pnpm run typecheck`: passed.
- `mise exec -- pnpm test`: 30 files and 242 tests passed.
- `mise exec -- pnpm run build`: passed.
- `mise exec -- pnpm run size`: WASM gzip size 49.2 KB, within the 80 KB target.
- `mise exec -- pnpm run e2e`: 28 Chromium tests passed.

From the repository root:

- `git diff origin/main...HEAD --check`: passed.
