### PR TITLE
fix: wrap long inline code on narrow screens

### DIFF
--- a/site/public/site.css
+++ b/site/public/site.css
@@ -54,6 +54,7 @@ a:hover {
 code {
   font-family: var(--mono);
   font-size: 0.9em;
+  overflow-wrap: anywhere;
   background: var(--code-bg);
   padding: 1px 5px;
   border-radius: 4px;
@@ -68,6 +69,7 @@ pre {
 }
 
 pre code {
+  overflow-wrap: normal;
   background: none;
   padding: 0;
 }


### PR DESCRIPTION
## Summary

Keep long inline code, including the Unity Package Manager Git URL, within the page on narrow screens.

## Motivation

At a 390 px viewport width, the Git URL widened the landing page to 405 px and caused horizontal scrolling.

Closes #359

## Changes

- Allow long inline code to wrap with `overflow-wrap: anywhere`.
- Preserve the existing wrapping and scrolling behavior of code inside `pre` blocks.

## Testing

- `mise exec -- zig build` and `mise exec -- zig build wasm`: passed.
- `mise exec -- pnpm -C extension run demo`: passed.
- `mise exec -- pnpm -C site run build`: passed; Eleventy copied 36 files and wrote 6 pages.
- Chromium 151.0.7922.34: checked the landing and CLI pages at 390 px and 1280 px in light and dark themes (8 combinations).
  The landing page width changed from 405 px to 390 px at the narrow viewport. The complete URL remained selectable.
  Code blocks, diff panes, terminal output, and iframe dimensions and scrolling matched the baseline.
- `git diff --check`: passed.
