### PR TITLE
fix: retry failed WASM initialization

### DIFF
--- a/extension/src/infrastructure/clients/wasm-differ-client.ts
+++ b/extension/src/infrastructure/clients/wasm-differ-client.ts
@@ -47,7 +47,12 @@ export function createDifferLoader(
   let differ: Promise<DifferGateway> | undefined;
   return () => {
     // Each JS context shares one WASM instance, including concurrent first requests.
-    differ ??= fetchBytes(wasmUrl).then(createDifferGateway);
+    differ ??= fetchBytes(wasmUrl)
+      .then(createDifferGateway)
+      .catch((error) => {
+        differ = undefined;
+        throw error;
+      });
     return differ;
   };
 }

--- a/extension/test/infrastructure/clients/wasm-differ-client.test.ts
+++ b/extension/test/infrastructure/clients/wasm-differ-client.test.ts
@@ -1,7 +1,12 @@
 /// <reference types="node" />
 import { readFileSync } from "node:fs";
-import { beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { DifferGateway } from "../../../src/application/gateway/differ";
+import { createFixturesGateway } from "../../../src/infrastructure/clients/fixture-client";
 import { createDifferGateway, createDifferLoader } from "../../../src/infrastructure/clients/wasm-differ-client";
 import { must } from "../../../src/internal/must";
 
@@ -14,27 +19,105 @@ const AFTER = enc.encode(`--- !u!114 &11400000
 MonoBehaviour:
   m_Script: {fileID: 0, guid: def, type: 3}
   volume: 0.8`);
+const wasmBytes = readFileSync(new URL("../../../../zig-out/bin/prefablens.wasm", import.meta.url));
 
 let differ: DifferGateway;
 beforeAll(async () => {
-  const bytes = readFileSync(new URL("../../../../zig-out/bin/prefablens.wasm", import.meta.url));
-  differ = await createDifferGateway(bytes);
+  differ = await createDifferGateway(wasmBytes);
 });
 
 describe("createDifferLoader", () => {
+  let server: Server;
+  let directory: string;
+  let wasmPath: string;
+  let wasmUrl: string;
+  let requests: number;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), "prefablens-wasm-"));
+    wasmPath = join(directory, "prefablens.wasm");
+    requests = 0;
+    // Real file replacements exercise recovery through fetch and WASM instantiation.
+    server = createServer(async (_request, response) => {
+      requests++;
+      try {
+        const bytes = await readFile(wasmPath);
+        response.writeHead(200, { "content-type": "application/wasm" }).end(bytes);
+      } catch {
+        response.writeHead(404).end("Not found");
+      }
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (address === null || typeof address === "string") throw new Error("Expected a TCP server address");
+    wasmUrl = `http://127.0.0.1:${address.port}/prefablens.wasm`;
+  });
+
+  afterEach(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    await rm(directory, { recursive: true, force: true });
+  });
+
   it("returns one real differ for repeated loads", async () => {
-    const wasmBytes = readFileSync(new URL("../../../../zig-out/bin/prefablens.wasm", import.meta.url));
-    const fetchBytes = async (url: string): Promise<BufferSource> => {
-      if (url !== "prefablens.wasm") throw new Error(`Unexpected URL: ${url}`);
-      return wasmBytes;
-    };
-    const loadDiffer = createDifferLoader("prefablens.wasm", fetchBytes);
+    await writeFile(wasmPath, wasmBytes);
+    const loadDiffer = createDifferLoader(wasmUrl);
 
     const first = await loadDiffer();
     const second = await loadDiffer();
 
     expect(second).toBe(first);
+    expect(requests).toBe(1);
     expect(first.diff(BEFORE, AFTER).ok).toBe(true);
+  });
+
+  it("shares one pending initialization between concurrent calls", async () => {
+    await writeFile(wasmPath, wasmBytes);
+    const loadDiffer = createDifferLoader(wasmUrl);
+
+    // Both callers arrive before fetch can finish, so they must share initialization.
+    const [first, second] = await Promise.all([loadDiffer(), loadDiffer()]);
+
+    expect(second).toBe(first);
+    expect(requests).toBe(1);
+    expect(first.diff(BEFORE, AFTER).ok).toBe(true);
+  });
+
+  it("retries a failed fetch after the asset becomes available", async () => {
+    // The demo fetcher rejects HTTP errors before WASM instantiation starts.
+    const loadDiffer = createDifferLoader(wasmUrl, createFixturesGateway().fetchBytes);
+    const [first, second] = await Promise.allSettled([loadDiffer(), loadDiffer()]);
+
+    expect(first.status).toBe("rejected");
+    expect(second.status).toBe("rejected");
+    if (first.status !== "rejected" || second.status !== "rejected") return;
+    expect(first.reason).toBeInstanceOf(Error);
+    expect(first.reason.message).toContain("HTTP 404");
+    expect(second.reason).toBe(first.reason);
+    expect(requests).toBe(1);
+
+    await writeFile(wasmPath, wasmBytes);
+    const [recovered, concurrent] = await Promise.all([loadDiffer(), loadDiffer()]);
+
+    expect(concurrent).toBe(recovered);
+    expect(await loadDiffer()).toBe(recovered);
+    expect(requests).toBe(2);
+    expect(recovered.diff(BEFORE, AFTER).ok).toBe(true);
+  });
+
+  it("retries after invalid WASM bytes are replaced", async () => {
+    await writeFile(wasmPath, "Invalid WASM");
+    const loadDiffer = createDifferLoader(wasmUrl);
+
+    await expect(loadDiffer()).rejects.toBeInstanceOf(WebAssembly.CompileError);
+    expect(requests).toBe(1);
+
+    await writeFile(wasmPath, wasmBytes);
+    const recovered = await loadDiffer();
+
+    expect(await loadDiffer()).toBe(recovered);
+    expect(requests).toBe(2);
+    expect(recovered.diff(BEFORE, AFTER).ok).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Allow the shared WASM loader to retry after initialization fails. Pending and successful loads still share one differ instance.

## Motivation

A temporary fetch failure or invalid WASM file leaves a rejected promise cached for the lifetime of the loader. Later calls cannot recover even after the asset becomes available.

Closes #362

## Changes

- Clear the cached initialization promise on failure and rethrow the original error.
- Test fetch and instantiation recovery, concurrent initialization, successful reuse, and shared errors with real HTTP, temporary files, and compiled WASM.

## Testing

The two recovery tests failed before the fix and passed afterward. All commands below passed; pnpm commands ran from `extension/`.

- `mise exec -- pnpm exec vitest run test/infrastructure/clients/wasm-differ-client.test.ts`: 14 tests passed.
- `mise exec -- pnpm test`: 29 test files and 239 tests passed.
- `mise exec -- pnpm run e2e`: 28 Chromium tests passed.
- `mise exec -- node --test core/tests/*.test.mjs`: 7 WASM tests passed.
- `mise exec -- pnpm run lint`: 101 files checked, no fixes applied.
- `mise exec -- pnpm run typecheck`: passed.
- `mise exec -- pnpm run build` and `mise exec -- pnpm run demo`: passed.
- `mise exec -- pnpm run size`: WASM gzip size 49.2 KB, within the 80 KB target.
- `git diff --check`: passed.
