### PR TITLE
fix: preserve concurrent cache saves

### DIFF
--- a/extension/src/infrastructure/internal/merge-store.ts
+++ b/extension/src/infrastructure/internal/merge-store.ts
@@ -5,9 +5,14 @@ export type MergeStore = {
   save(id: string, entries: Record<string, string>): Promise<void>;
 };
 
+// Repository instances can share storage keys, so their writes must share a queue.
+const pendingWrites = new WeakMap<StorageArea, Map<string, Promise<void>>>();
+
 // `prefix:id` slot: save merges into stored instead of replacing (writers only add keys).
 // Failures propagate. Each call site decides if a lost write is fatal or if the code continues past it.
 export function createMergeStore(area: StorageArea, prefix: string): MergeStore {
+  const pending = pendingWrites.get(area) ?? new Map<string, Promise<void>>();
+  pendingWrites.set(area, pending);
   const keyOf = (id: string): string => `${prefix}:${id}`;
   const load = async (id: string): Promise<Record<string, string>> => {
     const key = keyOf(id);
@@ -18,7 +23,20 @@ export function createMergeStore(area: StorageArea, prefix: string): MergeStore 
   return {
     load,
     async save(id, entries) {
-      await area.set({ [keyOf(id)]: { ...(await load(id)), ...entries } });
+      const key = keyOf(id);
+      const write = (pending.get(key) ?? Promise.resolve())
+        // A failed save still releases the key; its caller receives the original error below.
+        .catch(() => {})
+        .then(async () => {
+          await area.set({ [key]: { ...(await load(id)), ...entries } });
+        });
+      pending.set(key, write);
+      try {
+        await write;
+      } finally {
+        // An older save must not remove a newer save's place in the queue.
+        if (pending.get(key) === write) pending.delete(key);
+      }
     },
   };
 }

--- a/extension/test/e2e/merge-store.spec.ts
+++ b/extension/test/e2e/merge-store.spec.ts
@@ -1,0 +1,89 @@
+import { fileURLToPath } from "node:url";
+import { type BrowserContext, chromium, expect, test, type Worker } from "@playwright/test";
+import { build } from "esbuild";
+import type { MergeStore } from "../../src/infrastructure/internal/merge-store";
+import type { StorageArea } from "../../src/infrastructure/internal/storage-area";
+import { must } from "../../src/internal/must";
+
+declare const cacheRepositories: Record<"guids" | "metaGuids", (area: StorageArea) => MergeStore>;
+
+const DIST = fileURLToPath(new URL("../../dist", import.meta.url));
+let repositoryScript: string;
+let context: BrowserContext;
+let worker: Worker;
+
+test.beforeAll(async () => {
+  // Bundle the real repositories into the worker without adding test hooks to the shipped extension.
+  const result = await build({
+    stdin: {
+      contents: `
+        export { createChromeGuidRepository as guids } from "./src/infrastructure/clients/chrome-guid-client";
+        import { createChromeRepoIndexRepository } from "./src/infrastructure/clients/chrome-repo-index-client";
+        export function metaGuids(area) {
+          const repo = createChromeRepoIndexRepository(area);
+          return { load: repo.loadGuids, save: repo.saveGuids };
+        }
+      `,
+      resolveDir: fileURLToPath(new URL("../../", import.meta.url)),
+    },
+    bundle: true,
+    format: "iife",
+    globalName: "cacheRepositories",
+    write: false,
+  });
+  repositoryScript = must(result.outputFiles[0]).text;
+});
+
+test.beforeEach(async () => {
+  context = await chromium.launchPersistentContext("", {
+    channel: "chromium",
+    args: [`--disable-extensions-except=${DIST}`, `--load-extension=${DIST}`],
+  });
+  worker = context.serviceWorkers()[0] ?? (await context.waitForEvent("serviceworker"));
+  await worker.evaluate(repositoryScript);
+});
+
+test.afterEach(async () => {
+  await context?.close();
+});
+
+for (const prefix of ["guids", "metaGuids"] as const) {
+  test(`preserves concurrent ${prefix} saves after a Chrome storage failure`, async () => {
+    const result = await worker.evaluate(async (prefix) => {
+      const area = chrome.storage.local;
+      const first = cacheRepositories[prefix](area);
+      const second = cacheRepositories[prefix](area);
+      await first.save("repro", { stored: "initial" });
+
+      await Promise.all([
+        first.save("repro", { a: "first" }),
+        first.save("repro", { b: "second" }),
+        second.save("repro", { c: "third" }),
+      ]);
+      const concurrent = await first.load("repro");
+
+      // Exceed Chrome's actual quota so repository error handling runs against a real rejected write.
+      const saves = await Promise.allSettled([
+        first.save("repro", { oversized: "x".repeat(area.QUOTA_BYTES) }),
+        first.save("repro", { d: "after failure" }),
+        second.save("repro", { e: "last" }),
+      ]);
+      return {
+        concurrent,
+        statuses: saves.map((save) => save.status),
+        recovered: await first.load("repro"),
+      };
+    }, prefix);
+
+    expect(result.concurrent).toEqual({ stored: "initial", a: "first", b: "second", c: "third" });
+    expect(result.statuses).toEqual([prefix === "guids" ? "rejected" : "fulfilled", "fulfilled", "fulfilled"]);
+    expect(result.recovered).toEqual({
+      stored: "initial",
+      a: "first",
+      b: "second",
+      c: "third",
+      d: "after failure",
+      e: "last",
+    });
+  });
+}

--- a/extension/test/infrastructure/clients/chrome-guid-client.test.ts
+++ b/extension/test/infrastructure/clients/chrome-guid-client.test.ts
@@ -21,6 +21,41 @@ describe("createChromeGuidRepository", () => {
     });
   });
 
+  it("keeps all GUID paths from concurrent saves", async () => {
+    const area = new MemoryStorageArea({ "guids:api/o/r": { g0: "Assets/Stored.cs" } });
+    const guids = createChromeGuidRepository(area);
+
+    // Separate repository instances still write the same persisted map.
+    await Promise.all([
+      guids.save("api/o/r", { g1: "Assets/A.cs" }),
+      guids.save("api/o/r", { g2: "Assets/B.cs" }),
+      createChromeGuidRepository(area).save("api/o/r", { g3: "Assets/C.cs" }),
+    ]);
+
+    expect(await guids.load("api/o/r")).toEqual({
+      g0: "Assets/Stored.cs",
+      g1: "Assets/A.cs",
+      g2: "Assets/B.cs",
+      g3: "Assets/C.cs",
+    });
+  });
+
+  it("saves queued GUID paths after a write exceeds capacity", async () => {
+    const guids = createChromeGuidRepository(new MemoryStorageArea({}, 100));
+
+    // A real capacity failure must reject its caller without poisoning the next save.
+    const results = await Promise.allSettled([
+      guids.save("api/o/r", { oversized: "x".repeat(100) }),
+      guids.save("api/o/r", { g1: "Assets/A.cs" }),
+    ]);
+
+    expect(results).toEqual([
+      { status: "rejected", reason: expect.objectContaining({ message: "quota exceeded" }) },
+      { status: "fulfilled", value: undefined },
+    ]);
+    expect(await guids.load("api/o/r")).toEqual({ g1: "Assets/A.cs" });
+  });
+
   it("keeps GUID paths in separate repository maps", async () => {
     const guids = createChromeGuidRepository(new MemoryStorageArea());
 

--- a/extension/test/infrastructure/clients/chrome-repo-index-client.test.ts
+++ b/extension/test/infrastructure/clients/chrome-repo-index-client.test.ts
@@ -19,6 +19,33 @@ describe("createChromeRepoIndexRepository", () => {
     expect(await repoIndex.loadGuids("api/o/r")).toEqual({ sha1: "g1", sha2: "g2" });
   });
 
+  it("keeps all metadata GUIDs from concurrent saves", async () => {
+    const area = new MemoryStorageArea({ "metaGuids:api/o/r": { sha0: "g0" } });
+    const repoIndex = createChromeRepoIndexRepository(area);
+
+    // Concurrent diffs can discover different metadata entries for the same repository.
+    await Promise.all([
+      repoIndex.saveGuids("api/o/r", { sha1: "g1" }),
+      repoIndex.saveGuids("api/o/r", { sha2: "g2" }),
+      createChromeRepoIndexRepository(area).saveGuids("api/o/r", { sha3: "g3" }),
+    ]);
+
+    expect(await repoIndex.loadGuids("api/o/r")).toEqual({ sha0: "g0", sha1: "g1", sha2: "g2", sha3: "g3" });
+  });
+
+  it("saves queued metadata GUIDs after an ignored capacity failure", async () => {
+    const repoIndex = createChromeRepoIndexRepository(new MemoryStorageArea({}, 100));
+
+    // Metadata caching stays best effort, but a failed write must not discard later additions.
+    await expect(
+      Promise.all([
+        repoIndex.saveGuids("api/o/r", { oversized: "x".repeat(100) }),
+        repoIndex.saveGuids("api/o/r", { sha1: "g1" }),
+      ]),
+    ).resolves.toEqual([undefined, undefined]);
+    expect(await repoIndex.loadGuids("api/o/r")).toEqual({ sha1: "g1" });
+  });
+
   it("stores index data separately from metadata GUIDs", async () => {
     const repoIndex = createChromeRepoIndexRepository(new MemoryStorageArea());
 

--- a/extension/test/infrastructure/internal/merge-store.test.ts
+++ b/extension/test/infrastructure/internal/merge-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { createMergeStore } from "../../../src/infrastructure/internal/merge-store";
+import { MemoryStorageArea } from "../../support/memory-storage-area";
+
+describe("createMergeStore", () => {
+  it.each(["repository IDs", "prefixes", "storage areas"])("keeps different %s independent", async (difference) => {
+    const area = new MemoryStorageArea();
+    const busy = createMergeStore(area, "guids");
+    const independent = createMergeStore(
+      difference === "storage areas" ? new MemoryStorageArea() : area,
+      difference === "prefixes" ? "metaGuids" : "guids",
+    );
+    const independentId = difference === "repository IDs" ? "api/o/second" : "api/o/r";
+    const completed: string[] = [];
+
+    // One busy map must not make an unrelated save wait for its whole backlog.
+    const backlog = Array.from({ length: 5 }, (_, index) =>
+      busy.save("api/o/r", { [`g${index}`]: `Assets/${index}.cs` }).then(() => completed.push("busy")),
+    );
+    await Promise.all([
+      ...backlog,
+      independent.save(independentId, { other: "Assets/Other.cs" }).then(() => completed.push("independent")),
+    ]);
+
+    expect(completed.indexOf("independent")).toBeLessThan(completed.lastIndexOf("busy"));
+    expect(await independent.load(independentId)).toEqual({ other: "Assets/Other.cs" });
+  });
+
+  it("keeps a later save behind writes that are still pending", async () => {
+    const store = createMergeStore(new MemoryStorageArea(), "guids");
+    const first = store.save("api/o/r", { g1: "Assets/A.cs" });
+    const second = store.save("api/o/r", { g2: "Assets/B.cs" });
+    await first;
+
+    // Completing an older save must not release the key while a newer save still owns it.
+    await Promise.all([second, store.save("api/o/r", { g3: "Assets/C.cs" })]);
+
+    expect(await store.load("api/o/r")).toEqual({ g1: "Assets/A.cs", g2: "Assets/B.cs", g3: "Assets/C.cs" });
+  });
+});


### PR DESCRIPTION
## Summary

Concurrent GUID and metadata cache saves now retain every successful addition to the same storage key.
GUID write errors still propagate, and metadata writes remain best effort.

## Motivation

Concurrent read-merge-write operations could overwrite entries found by other diffs and trigger repeated GitHub requests.

Closes #361

## Changes

- Serialize saves by storage area and full key, including across repository instances.
- Keep unrelated keys independent and release failed writes without discarding queued saves.
- Add regression tests for concurrent additions, queue cleanup, and recovery from real Chrome storage quota failures.

## Testing

The new concurrent-save tests failed before the fix in both Vitest and Chromium, with earlier additions missing from storage.
All checks below passed after rebasing onto the latest `main`.

From `extension/`:

- `mise exec -- pnpm run lint`: checked 104 files, no issues.
- `mise exec -- pnpm run typecheck`: exited with code 0.
- `mise exec -- pnpm test`: 31 test files and 253 tests passed.
- `mise exec -- pnpm run e2e`: 30 tests passed.
- `mise exec -- pnpm run build`: exited with code 0.
- `mise exec -- pnpm run demo`: exited with code 0.
- `mise exec -- pnpm run size`: WASM gzip size 49.2 KB, within the 80 KB target.

From the worktree root:

- `git diff origin/main...HEAD --check`: no whitespace errors.
