### PR TITLE
feat: add git external diff driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ prefablens --open main                  # write the report to a temp file and op
 Operands with a UnityYAML extension (`.prefab`, `.unity`, `.asset`, and more) are paths.
 All other operands are Git references (refs).
 
+### Git diff
+
+PrefabLens can render UnityYAML semantically during `git diff`.
+Other files keep Git's unified diff.
+
+```bash
+prefablens setup-diff
+```
+
+Use `prefablens setup-diff --user` to register the driver in your global Git configuration.
+Use `prefablens setup-diff --project` to write shared `.gitattributes`.
+Without a flag, setup uses `--local` for the current repository.
+
+Then run the normal diff command:
+
+```bash
+git diff
+git diff --cached
+git diff HEAD~1 HEAD
+```
+
+`git log -p` and `git show` need `--ext-diff` to use the driver.
+
+The driver prints PrefabLens's tree, not a unified diff. If your pager is `delta`, the tree and `.cs` diffs share one stream and `delta` may mangle the tree. Use `git --no-pager diff` or `git -c core.pager='less -R' diff` to inspect the raw driver output.
+
 ### Git merge
 
 PrefabLens uses Git **2.39** or later to resolve UnityYAML conflicts during `git merge`.

--- a/build.zig
+++ b/build.zig
@@ -85,6 +85,21 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_cli_tests.step);
     test_step.dependOn(&run_merge_driver_cwd_tests.step);
 
+    const diff_driver_tests = b.addExecutable(.{
+        .name = "git-diff-driver-tests",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("cli/src/diff_driver_test_main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_diff_driver_tests = b.addRunArtifact(diff_driver_tests);
+    run_diff_driver_tests.addArtifactArg(exe);
+    run_diff_driver_tests.addArg(b.pathFromRoot("core/src/testdata"));
+    test_step.dependOn(&run_diff_driver_tests.step);
+    const diff_driver_test_step = b.step("test-diff-driver", "Run Git external diff driver integration tests");
+    diff_driver_test_step.dependOn(&run_diff_driver_tests.step);
+
     const git_merge_tests = b.addExecutable(.{
         .name = "git-merge-tests",
         .root_module = b.createModule(.{
@@ -228,6 +243,7 @@ pub fn build(b: *std.Build) void {
         run_installation_tests,
         run_structural_tests,
         run_pty_smoke,
+        run_diff_driver_tests,
     }) |run| {
         // Independent scratch directories let these checks share the build without inherited stdio.
         run.expectExitCode(0);

--- a/cli/src/command.zig
+++ b/cli/src/command.zig
@@ -16,12 +16,26 @@ pub const MergetoolArgs = struct {
     merged: []const u8,
 };
 
+pub const DiffDriverCompare = struct {
+    path: []const u8,
+    old_file: []const u8,
+    new_file: []const u8,
+};
+
+pub const DiffDriverArgs = union(enum) {
+    help,
+    skip,
+    compare: DiffDriverCompare,
+};
+
 pub const Command = union(enum) {
     diff: []const []const u8,
+    diff_driver: DiffDriverArgs,
     merge_strategy: []const []const u8,
     merge_driver: MergeDriverArgs,
     mergetool: MergetoolArgs,
     setup_merge: []const []const u8,
+    setup_diff: []const []const u8,
 };
 
 pub const Error = error{
@@ -31,7 +45,9 @@ pub const Error = error{
 
 pub fn parse(args: []const []const u8) Error!Command {
     if (args.len == 0) return .{ .diff = args };
+    if (std.mem.eql(u8, args[0], "setup-diff")) return .{ .setup_diff = args[1..] };
     if (std.mem.eql(u8, args[0], "setup-merge")) return .{ .setup_merge = args[1..] };
+    if (std.mem.eql(u8, args[0], "diff-driver")) return .{ .diff_driver = try parseDiffDriver(args[1..]) };
     if (std.mem.eql(u8, args[0], "merge-strategy")) return .{ .merge_strategy = args[1..] };
     if (std.mem.eql(u8, args[0], "merge-driver")) {
         if (args.len != 5 and args.len != 6) return error.InvalidArguments;
@@ -57,9 +73,21 @@ pub fn parse(args: []const []const u8) Error!Command {
             .merged = args[4],
         } };
     }
-    if (std.mem.eql(u8, args[0], "diff-driver") or
-        std.mem.eql(u8, args[0], "difftool")) return error.ReservedSubcommand;
+    if (std.mem.eql(u8, args[0], "difftool")) return error.ReservedSubcommand;
     return .{ .diff = args };
+}
+
+fn parseDiffDriver(args: []const []const u8) Error!DiffDriverArgs {
+    if (args.len == 0) return .help;
+    if (args.len == 1 and (std.mem.eql(u8, args[0], "--help") or std.mem.eql(u8, args[0], "-h"))) return .help;
+    // Unmerged paths reach GIT_EXTERNAL_DIFF with only the repository path.
+    if (args.len == 1) return .skip;
+    if (args.len < 7) return error.InvalidArguments;
+    return .{ .compare = .{
+        .path = args[0],
+        .old_file = args[1],
+        .new_file = args[4],
+    } };
 }
 
 test "command: parses both merge adapters without changing diff arguments" {
@@ -69,8 +97,44 @@ test "command: parses both merge adapters without changing diff arguments" {
     try testing.expectEqualStrings("merged", tool.mergetool.merged);
     const diff = try parse(&.{ "HEAD", "Assets/A.prefab" });
     try testing.expectEqual(@as(usize, 2), diff.diff.len);
-    try testing.expectError(error.ReservedSubcommand, parse(&.{"diff-driver"}));
     try testing.expectError(error.ReservedSubcommand, parse(&.{"difftool"}));
+}
+
+test "command: maps git external diff operands onto two file paths" {
+    const seven = try parse(&.{
+        "diff-driver",
+        "Assets/A.prefab",
+        "/tmp/old",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "100644",
+        "/tmp/new",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "100644",
+    });
+    try testing.expectEqualStrings("Assets/A.prefab", seven.diff_driver.compare.path);
+    try testing.expectEqualStrings("/tmp/old", seven.diff_driver.compare.old_file);
+    try testing.expectEqualStrings("/tmp/new", seven.diff_driver.compare.new_file);
+
+    const renamed = try parse(&.{
+        "diff-driver",
+        "Assets/B.prefab",
+        "/tmp/old",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "100644",
+        "/tmp/new",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "100644",
+        "Assets/A.prefab",
+        "similarity index 95%",
+    });
+    try testing.expectEqualStrings("Assets/B.prefab", renamed.diff_driver.compare.path);
+    try testing.expectEqualStrings("/tmp/new", renamed.diff_driver.compare.new_file);
+
+    try testing.expect((try parse(&.{ "diff-driver", "Assets/Conflict.prefab" })).diff_driver == .skip);
+    try testing.expect((try parse(&.{"diff-driver"})).diff_driver == .help);
+    try testing.expectError(error.InvalidArguments, parse(&.{ "diff-driver", "path", "old" }));
+    const setup = try parse(&.{ "setup-diff", "--user" });
+    try testing.expectEqualStrings("--user", setup.setup_diff[0]);
 }
 
 test "command: merge adapters reject missing or invalid operands" {

--- a/cli/src/diff_driver.zig
+++ b/cli/src/diff_driver.zig
@@ -1,0 +1,211 @@
+const std = @import("std");
+const core = @import("core");
+const testing = std.testing;
+
+const command = @import("command.zig");
+const input = @import("input.zig");
+const render_tree = @import("render_tree.zig");
+
+pub const usage = "prefablens diff-driver <path> <old-file> <old-hex> <old-mode> <new-file> <new-hex> <new-mode> [<old-path> <xfrm-msg>]";
+
+pub const help = usage ++
+    \\
+    \\
+    \\Render a semantic diff from Git's external diff arguments.
+    \\Git appends seven operands for a changed path, or nine for a rename.
+    \\An unmerged path arrives as the repository path alone and is skipped.
+    \\/dev/null means that side is absent.
+    \\
+;
+
+const Side = struct {
+    bytes: []const u8,
+    present: bool,
+};
+
+fn isAbsent(path: []const u8) bool {
+    return path.len == 0 or
+        std.mem.eql(u8, path, "/dev/null") or
+        std.ascii.eqlIgnoreCase(path, "nul");
+}
+
+fn readSide(io: std.Io, arena: std.mem.Allocator, path: []const u8) !Side {
+    if (isAbsent(path)) return .{ .bytes = "", .present = false };
+    return .{
+        .bytes = try std.Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(input.max_input_bytes)),
+        .present = true,
+    };
+}
+
+fn noColorRequested(environ: ?*const std.process.Environ.Map) bool {
+    const env = environ orelse return false;
+    const value = env.get("NO_COLOR") orelse return false;
+    return value.len != 0;
+}
+
+fn reportSkip(stderr: *std.Io.Writer, path: []const u8, reason: []const u8) !u8 {
+    try stderr.print("prefablens: Skipping '{s}': {s}.\n", .{ path, reason });
+    // Non-zero status aborts the rest of `git diff`.
+    return 0;
+}
+
+pub fn run(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    args: command.DiffDriverArgs,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+    environ: ?*const std.process.Environ.Map,
+) !u8 {
+    switch (args) {
+        .help => {
+            try stdout.writeAll(help);
+            return 0;
+        },
+        .skip => return 0,
+        .compare => |compare| return renderCompare(io, arena, compare, stdout, stderr, environ),
+    }
+}
+
+fn renderCompare(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    compare: command.DiffDriverCompare,
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+    environ: ?*const std.process.Environ.Map,
+) !u8 {
+    const before = readSide(io, arena, compare.old_file) catch
+        return reportSkip(stderr, compare.path, "cannot read the old file");
+    const after = readSide(io, arena, compare.new_file) catch
+        return reportSkip(stderr, compare.path, "cannot read the new file");
+    if (!before.present and !after.present)
+        return reportSkip(stderr, compare.path, "both sides are absent");
+    if (before.present and !core.isUnityYaml(before.bytes))
+        return reportSkip(stderr, compare.path, "the old file is not Unity YAML");
+    if (after.present and !core.isUnityYaml(after.bytes))
+        return reportSkip(stderr, compare.path, "the new file is not Unity YAML");
+
+    const result = core.diffBytes(arena, before.bytes, after.bytes) catch
+        return reportSkip(stderr, compare.path, "cannot parse Unity YAML");
+    try stdout.print("{s}\n", .{compare.path});
+    if (result.roots.len == 0 and result.loose.len == 0) {
+        try stdout.writeAll("No semantic changes\n");
+        return 0;
+    }
+    const color = !noColorRequested(environ);
+    try render_tree.render(arena, stdout, result, null, color);
+    return 0;
+}
+
+const Invocation = struct {
+    code: u8,
+    stdout: []const u8,
+    stderr: []const u8,
+};
+
+fn invoke(
+    arena: std.mem.Allocator,
+    args: command.DiffDriverArgs,
+    environ: ?*const std.process.Environ.Map,
+) !Invocation {
+    var out: std.ArrayList(u8) = .empty;
+    var out_writer = std.Io.Writer.Allocating.fromArrayList(arena, &out);
+    var err: std.ArrayList(u8) = .empty;
+    var err_writer = std.Io.Writer.Allocating.fromArrayList(arena, &err);
+    const code = try run(testing.io, arena, args, &out_writer.writer, &err_writer.writer, environ);
+    return .{
+        .code = code,
+        .stdout = out_writer.toArrayList().items,
+        .stderr = err_writer.toArrayList().items,
+    };
+}
+
+fn writeFixturePair(tmp: *testing.TmpDir, arena: std.mem.Allocator) !struct { before: []const u8, after: []const u8 } {
+    const before_fixture = try std.Io.Dir.cwd().readFileAlloc(testing.io, "core/src/testdata/cylinder_before.prefab", arena, .limited(1024 * 1024));
+    const after_fixture = try std.Io.Dir.cwd().readFileAlloc(testing.io, "core/src/testdata/cylinder_after.prefab", arena, .limited(1024 * 1024));
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "old", .data = before_fixture });
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "new", .data = after_fixture });
+    return .{
+        .before = try tmp.dir.realPathFileAlloc(testing.io, "old", arena),
+        .after = try tmp.dir.realPathFileAlloc(testing.io, "new", arena),
+    };
+}
+
+fn compareArgs(path: []const u8, old_file: []const u8, new_file: []const u8) command.DiffDriverArgs {
+    return .{ .compare = .{ .path = path, .old_file = old_file, .new_file = new_file } };
+}
+
+test "diff-driver: renders git's seven operands from the cylinder fixture" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    var env = std.process.Environ.Map.init(arena);
+    try env.put("NO_COLOR", "1");
+    const result = try invoke(arena, compareArgs("Assets/Cylinder.prefab", paths.before, paths.after), &env);
+
+    try testing.expectEqual(@as(u8, 0), result.code);
+    try testing.expectEqualStrings("", result.stderr);
+    try testing.expect(std.mem.startsWith(u8, result.stdout, "Assets/Cylinder.prefab\n"));
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "Position.x: 0.64596 → 1") != null);
+    try testing.expect(std.mem.indexOf(u8, result.stdout, "\x1b[") == null);
+}
+
+test "diff-driver: treats /dev/null as an added or deleted side" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    var env = std.process.Environ.Map.init(arena);
+    try env.put("NO_COLOR", "1");
+    const added = try invoke(arena, compareArgs("Assets/Added.prefab", "/dev/null", paths.after), &env);
+    try testing.expectEqual(@as(u8, 0), added.code);
+    try testing.expect(std.mem.indexOf(u8, added.stdout, "Cylinder") != null);
+
+    const deleted = try invoke(arena, compareArgs("Assets/Removed.prefab", paths.before, "/dev/null"), &env);
+    try testing.expectEqual(@as(u8, 0), deleted.code);
+    try testing.expect(std.mem.startsWith(u8, deleted.stdout, "Assets/Removed.prefab\n"));
+}
+
+test "diff-driver: skips unmerged paths and non-Unity input without failing" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "notes.cs", .data = "class A {}\n" });
+    const cs = try tmp.dir.realPathFileAlloc(testing.io, "notes.cs", arena);
+
+    const skipped = try invoke(arena, .skip, null);
+    try testing.expectEqual(@as(u8, 0), skipped.code);
+    try testing.expectEqualStrings("", skipped.stdout);
+
+    const unsupported = try invoke(arena, compareArgs("Assets/Notes.cs", cs, cs), null);
+    try testing.expectEqual(@as(u8, 0), unsupported.code);
+    try testing.expectEqualStrings("", unsupported.stdout);
+    try testing.expect(unsupported.stderr.len != 0);
+}
+
+test "diff-driver: colors through a pipe unless NO_COLOR is set" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const paths = try writeFixturePair(&tmp, arena);
+
+    const colored = try invoke(arena, compareArgs("Assets/Cylinder.prefab", paths.before, paths.after), null);
+    try testing.expectEqual(@as(u8, 0), colored.code);
+    try testing.expect(std.mem.indexOf(u8, colored.stdout, "\x1b[") != null);
+
+    const help_text = try invoke(arena, .help, null);
+    try testing.expectEqual(@as(u8, 0), help_text.code);
+    try testing.expect(std.mem.indexOf(u8, help_text.stdout, "external diff") != null);
+}

--- a/cli/src/diff_driver_test_main.zig
+++ b/cli/src/diff_driver_test_main.zig
@@ -1,0 +1,168 @@
+const std = @import("std");
+const t = @import("testing/git.zig");
+
+const Context = struct {
+    io: std.Io,
+    arena: std.mem.Allocator,
+    root: []const u8,
+    repo: []const u8,
+    env: *std.process.Environ.Map,
+    before: []const u8,
+    after: []const u8,
+
+    fn run(self: Context, argv: []const []const u8) !std.process.RunResult {
+        return std.process.run(self.arena, self.io, .{
+            .argv = argv,
+            .cwd = .{ .path = self.repo },
+            .environ_map = self.env,
+            .stdout_limit = .limited(1024 * 1024),
+            .stderr_limit = .limited(1024 * 1024),
+            .timeout = .{ .duration = .{ .clock = .awake, .raw = .fromSeconds(30) } },
+        });
+    }
+
+    fn git(self: Context, args: []const []const u8) !std.process.RunResult {
+        return self.run(try std.mem.concat(self.arena, []const u8, &.{ &.{"git"}, args }));
+    }
+
+    fn gitOk(self: Context, args: []const []const u8) !void {
+        try t.expectCode(try self.git(args), 0, args[0]);
+    }
+
+    fn write(self: Context, path: []const u8, bytes: []const u8) !void {
+        try t.writeFile(self.io, self.arena, self.repo, path, bytes);
+    }
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    var arena_state = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const args = try init.minimal.args.toSlice(arena);
+    try t.require(args.len == 3, "expected the prefablens executable and fixture directory");
+    const prefablens = try std.Io.Dir.cwd().realPathFileAlloc(init.io, args[1], arena);
+    const fixtures = try std.Io.Dir.cwd().realPathFileAlloc(init.io, args[2], arena);
+    const scratch = try t.scratchDirectory(init.io, arena, "diff-driver space 日本語");
+    defer std.Io.Dir.cwd().deleteTree(init.io, scratch) catch {};
+    const repo = try std.fs.path.join(arena, &.{ scratch, "repository" });
+    const user = try std.fs.path.join(arena, &.{ scratch, "user" });
+    try std.Io.Dir.cwd().createDirPath(init.io, repo);
+    try std.Io.Dir.cwd().createDirPath(init.io, user);
+
+    var env = try init.environ_map.clone(arena);
+    var inherited = init.environ_map.iterator();
+    while (inherited.next()) |entry| {
+        if (std.mem.startsWith(u8, entry.key_ptr.*, "GIT_")) _ = env.swapRemove(entry.key_ptr.*);
+    }
+    try env.put("HOME", user);
+    try env.put("XDG_CONFIG_HOME", user);
+    try env.put("GIT_CONFIG_GLOBAL", try std.fs.path.join(arena, &.{ user, "gitconfig" }));
+    try env.put("GIT_CONFIG_NOSYSTEM", "1");
+    try env.put("GIT_ATTR_NOSYSTEM", "1");
+    try env.put("GIT_CONFIG_COUNT", "0");
+    try env.put("GIT_CEILING_DIRECTORIES", scratch);
+    try env.put("GIT_PAGER", "cat");
+    try env.put("NO_COLOR", "1");
+    try env.put("PATH", try std.fmt.allocPrint(arena, "{s}{c}{s}", .{
+        std.fs.path.dirname(prefablens).?,
+        std.fs.path.delimiter,
+        env.get("PATH") orelse "",
+    }));
+
+    const ctx: Context = .{
+        .io = init.io,
+        .arena = arena,
+        .root = scratch,
+        .repo = repo,
+        .env = &env,
+        .before = try t.readFile(init.io, arena, fixtures, "cylinder_before.prefab"),
+        .after = try t.readFile(init.io, arena, fixtures, "cylinder_after.prefab"),
+    };
+    try prepare(ctx, prefablens);
+    try testMixedWorkingTree(ctx);
+    try testAddedAndDeleted(ctx);
+    try testRename(ctx);
+    try testUnmergedDoesNotAbort(ctx);
+    try std.Io.File.stdout().writeStreamingAll(init.io, "diff driver integration: passed\n");
+    return 0;
+}
+
+fn prepare(ctx: Context, prefablens: []const u8) !void {
+    try std.Io.Dir.cwd().createDirPath(ctx.io, try std.fs.path.join(ctx.arena, &.{ ctx.repo, "Assets" }));
+    try ctx.gitOk(&.{ "init", "-q", "-b", "main" });
+    try t.configureHermeticRepository(ctx.io, ctx.arena, ctx.repo);
+    try ctx.gitOk(&.{ "config", "user.name", "PrefabLens tests" });
+    try ctx.gitOk(&.{ "config", "user.email", "prefablens-tests@example.invalid" });
+    try ctx.gitOk(&.{ "config", "color.ui", "never" });
+    try ctx.write("Assets/Cylinder.prefab", ctx.before);
+    try ctx.write("Assets/Movement.cs", "public float speed = 1;\n");
+    try ctx.gitOk(&.{ "add", "--all" });
+    try ctx.gitOk(&.{ "commit", "-qm", "base" });
+    try t.expectCode(try ctx.run(&.{ prefablens, "setup-diff" }), 0, "register the diff driver");
+    const attr = try t.readFile(ctx.io, ctx.arena, ctx.repo, ".git/info/attributes");
+    try t.require(std.mem.indexOf(u8, attr, "*.prefab diff=prefablens\n") != null, "setup omitted the prefab diff rule");
+    try t.require(std.mem.indexOf(u8, attr, "*.cs diff=prefablens") == null, "setup selected C# files");
+    const command = try ctx.git(&.{ "config", "--local", "--get", "diff.prefablens.command" });
+    try t.expectCode(command, 0, "read diff driver command");
+    try t.require(
+        std.mem.eql(u8, std.mem.trim(u8, command.stdout, " \t\r\n"), "prefablens diff-driver"),
+        "setup wrote the wrong driver command",
+    );
+}
+
+fn testMixedWorkingTree(ctx: Context) !void {
+    try ctx.gitOk(&.{ "reset", "-q", "--hard", "HEAD" });
+    try ctx.write("Assets/Cylinder.prefab", ctx.after);
+    try ctx.write("Assets/Movement.cs", "public float speed = 3;\n");
+    const result = try ctx.git(&.{ "--no-pager", "diff" });
+    try t.expectCode(result, 0, "mixed git diff");
+    try t.require(std.mem.indexOf(u8, result.stderr, "external diff died") == null, "driver aborted git diff");
+    try t.require(std.mem.indexOf(u8, result.stdout, "Assets/Cylinder.prefab") != null, "missing prefab path");
+    try t.require(std.mem.indexOf(u8, result.stdout, "Position.x: 0.64596 → 1") != null, "missing semantic prefab diff");
+    try t.require(std.mem.indexOf(u8, result.stdout, "diff --git") != null, "missing unified diff header for C#");
+    try t.require(std.mem.indexOf(u8, result.stdout, "speed = 3") != null, "missing C# unified diff");
+}
+
+fn testAddedAndDeleted(ctx: Context) !void {
+    try ctx.gitOk(&.{ "reset", "-q", "--hard", "HEAD" });
+    try ctx.write("Assets/Added.prefab", ctx.after);
+    try ctx.gitOk(&.{ "rm", "-q", "Assets/Cylinder.prefab" });
+    try ctx.gitOk(&.{ "add", "Assets/Added.prefab" });
+    const result = try ctx.git(&.{ "--no-pager", "diff", "--cached", "--no-renames" });
+    try t.expectCode(result, 0, "added and deleted git diff");
+    try t.require(std.mem.indexOf(u8, result.stderr, "external diff died") == null, "driver aborted git diff");
+    try t.require(std.mem.indexOf(u8, result.stdout, "Assets/Added.prefab") != null, "missing added prefab");
+    try t.require(std.mem.indexOf(u8, result.stdout, "Assets/Cylinder.prefab") != null, "missing deleted prefab");
+}
+
+fn testRename(ctx: Context) !void {
+    try ctx.gitOk(&.{ "reset", "-q", "--hard", "HEAD" });
+    try ctx.gitOk(&.{ "mv", "Assets/Cylinder.prefab", "Assets/Renamed.prefab" });
+    const mutated = try std.fmt.allocPrint(ctx.arena, "{s}# renamed\n", .{ctx.after});
+    try ctx.write("Assets/Renamed.prefab", mutated);
+    const result = try ctx.git(&.{ "--no-pager", "diff", "-M", "HEAD" });
+    try t.expectCode(result, 0, "renamed git diff");
+    try t.require(
+        std.mem.indexOf(u8, result.stdout, "Assets/Renamed.prefab") != null or
+            std.mem.indexOf(u8, result.stdout, "Assets/Cylinder.prefab") != null,
+        "missing rename path",
+    );
+}
+
+fn testUnmergedDoesNotAbort(ctx: Context) !void {
+    try ctx.gitOk(&.{ "reset", "-q", "--hard", "HEAD" });
+    try ctx.gitOk(&.{ "checkout", "-qb", "theirs" });
+    const theirs = try std.mem.replaceOwned(u8, ctx.arena, ctx.after, "x: 1,", "x: 2,");
+    try ctx.write("Assets/Cylinder.prefab", theirs);
+    try ctx.gitOk(&.{ "add", "--all" });
+    try ctx.gitOk(&.{ "commit", "-qm", "theirs" });
+    try ctx.gitOk(&.{ "checkout", "-q", "main" });
+    try ctx.write("Assets/Cylinder.prefab", ctx.after);
+    try ctx.gitOk(&.{ "add", "--all" });
+    try ctx.gitOk(&.{ "commit", "-qm", "ours" });
+    const merge = try ctx.git(&.{ "merge", "--no-edit", "theirs" });
+    try t.expectNonzero(merge, "prepare unmerged prefab");
+    const result = try ctx.git(&.{ "--no-pager", "diff" });
+    try t.expectCode(result, 0, "git diff during conflict");
+    try t.require(std.mem.indexOf(u8, result.stderr, "external diff died") == null, "unmerged path aborted git diff");
+}

--- a/cli/src/diff_setup.zig
+++ b/cli/src/diff_setup.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const merge_git = @import("merge_git.zig");
+const atomic_file = @import("atomic_file.zig");
+const unity_path = @import("unity_path.zig");
+
+const Scope = enum { project, local, user };
+pub const usage = "prefablens setup-diff [--project|--local|--user]";
+pub const help = usage ++
+    \\
+    \\
+    \\Register PrefabLens as a Git external diff driver for UnityYAML files.
+    \\Other paths keep Git's unified diff.
+    \\prefablens must be on PATH when git diff runs.
+    \\
+;
+
+fn parseScope(args: []const []const u8) !?Scope {
+    if (args.len == 0) return .local;
+    if (args.len != 1) return error.InvalidSetupArguments;
+    if (std.mem.eql(u8, args[0], "--help") or std.mem.eql(u8, args[0], "-h")) return null;
+    if (std.mem.eql(u8, args[0], "--project")) return .project;
+    if (std.mem.eql(u8, args[0], "--local")) return .local;
+    if (std.mem.eql(u8, args[0], "--user")) return .user;
+    return error.InvalidSetupArguments;
+}
+
+const UserAttributes = struct {
+    path: []const u8,
+    default_path: ?[]const u8,
+};
+
+fn userAttributes(git: merge_git.Git) !UserAttributes {
+    const xdg = git.env.get("XDG_CONFIG_HOME") orelse "";
+    const default = if (xdg.len == 0) "~/.config/git/attributes" else try std.fs.path.join(git.arena, &.{ xdg, "git/attributes" });
+    const configured = try git.run(&.{ "config", "--global", "--includes", "--path", "--null", "--get", "core.attributesFile" });
+    const missing = merge_git.exitCode(configured) == 1;
+    if (!missing and merge_git.exitCode(configured) != 0) {
+        try std.Io.File.stderr().writeStreamingAll(git.io, configured.stderr);
+        return error.GitFailed;
+    }
+    const output = if (missing)
+        try git.output(&.{ "config", "--global", "--includes", "--path", "--null", "--get", "--default", default, "core.attributesFile" })
+    else
+        configured.stdout;
+    const path = std.mem.trimEnd(u8, output, "\x00");
+    if (!std.fs.path.isAbsolute(path)) return error.InvalidUserAttributesPath;
+    const resolved = std.Io.Dir.cwd().realPathFileAlloc(git.io, path, git.arena) catch |err| switch (err) {
+        error.FileNotFound => path,
+        else => return err,
+    };
+    return .{ .path = resolved, .default_path = if (missing) default else null };
+}
+
+pub fn run(
+    io: std.Io,
+    arena: std.mem.Allocator,
+    args: []const []const u8,
+    env: *std.process.Environ.Map,
+    stdout: *std.Io.Writer,
+) !void {
+    const scope = (try parseScope(args)) orelse {
+        try stdout.writeAll(help);
+        return;
+    };
+    var git: merge_git.Git = .{ .io = io, .arena = arena, .env = env };
+    if (scope != .user) {
+        const root = git.output(&.{ "rev-parse", "--show-toplevel" }) catch |err| {
+            return if (err == error.GitFailed) error.SetupRequiresRepository else err;
+        };
+        git.cwd = merge_git.trim(root);
+    }
+    var default_user_path: ?[]const u8 = null;
+    const path = switch (scope) {
+        .project => try git.path(".gitattributes"),
+        .local => merge_git.trim(try git.output(&.{ "rev-parse", "--git-path", "info/attributes" })),
+        .user => blk: {
+            const attributes = try userAttributes(git);
+            default_user_path = attributes.default_path;
+            break :blk attributes.path;
+        },
+    };
+    const absolute = if (std.fs.path.isAbsolute(path)) path else try git.path(path);
+    const old = std.Io.Dir.cwd().readFileAlloc(io, absolute, arena, .limited(1024 * 1024)) catch |err| switch (err) {
+        error.FileNotFound => "",
+        else => return err,
+    };
+    var attributes: std.ArrayList(u8) = .empty;
+    try attributes.appendSlice(arena, old);
+    if (old.len != 0 and old[old.len - 1] != '\n') try attributes.append(arena, '\n');
+    for (unity_path.extensions) |extension| {
+        const line = try std.fmt.allocPrint(arena, "*{s} diff=prefablens\n", .{extension});
+        var lines = std.mem.splitScalar(u8, old, '\n');
+        var found = false;
+        while (lines.next()) |existing| {
+            if (std.mem.eql(u8, std.mem.trim(u8, existing, " \t\r"), std.mem.trimEnd(u8, line, "\n"))) found = true;
+        }
+        if (!found) try attributes.appendSlice(arena, line);
+    }
+    try std.Io.Dir.cwd().createDirPath(io, std.fs.path.dirname(absolute).?);
+    if (!std.mem.eql(u8, old, attributes.items)) try atomic_file.replace(io, arena, absolute, if (old.len == 0) null else old, attributes.items);
+    if (default_user_path) |default| try git.ok(&.{ "config", "--global", "core.attributesFile", default });
+    const config_scope = if (scope == .user) "--global" else "--local";
+    try git.ok(&.{ "config", config_scope, "--replace-all", "diff.prefablens.command", "prefablens diff-driver" });
+    try stdout.print(
+        "PrefabLens diff is ready for {s}. Run git diff as usual.\n",
+        .{if (scope == .user) "your repositories" else "this repository"},
+    );
+    if (scope == .project) try stdout.writeAll("Commit .gitattributes to share the rules. Each clone needs setup unless your user configuration already provides it.\n");
+}

--- a/cli/src/main.zig
+++ b/cli/src/main.zig
@@ -1,6 +1,8 @@
 const std = @import("std");
 const command = @import("command.zig");
 const diff = @import("diff.zig");
+const diff_driver = @import("diff_driver.zig");
+const diff_setup = @import("diff_setup.zig");
 const merge_driver = @import("merge_driver.zig");
 const mergetool = @import("mergetool.zig");
 const merge_strategy = @import("git_merge_strategy.zig");
@@ -12,6 +14,8 @@ test {
     std.testing.refAllDecls(@This());
     _ = command;
     _ = diff;
+    _ = diff_driver;
+    _ = diff_setup;
     _ = merge_driver;
     _ = mergetool;
     _ = merge_strategy;
@@ -77,6 +81,27 @@ pub fn main(init: std.process.Init) !u8 {
             };
             break :blk @as(u8, 0);
         },
+        .setup_diff => |setup_args| blk: {
+            diff_setup.run(init.io, arena, setup_args, init.environ_map, stdout) catch |err| switch (err) {
+                error.InvalidSetupArguments => {
+                    try stderr.writeAll("usage: " ++ diff_setup.usage ++ "\n");
+                    break :blk @as(u8, 2);
+                },
+                error.SetupRequiresRepository => {
+                    try stderr.writeAll("prefablens: Diff setup requires a Git working tree.\nRun this command inside a repository, or use: prefablens setup-diff --user\n");
+                    break :blk @as(u8, 2);
+                },
+                error.InvalidUserAttributesPath => {
+                    try stderr.writeAll("prefablens: Global core.attributesFile must name an absolute path or start with ~/.\nSet it with git config --global core.attributesFile <path>, then run setup again.\n");
+                    break :blk @as(u8, 2);
+                },
+                else => {
+                    try stderr.print("prefablens: Diff setup failed: {s}.\n", .{@errorName(err)});
+                    break :blk @as(u8, 2);
+                },
+            };
+            break :blk @as(u8, 0);
+        },
         .diff => |diff_args| try diff.run(
             init.io,
             arena,
@@ -84,6 +109,14 @@ pub fn main(init: std.process.Init) !u8 {
             stdout,
             stderr,
             color,
+            init.environ_map,
+        ),
+        .diff_driver => |driver_args| try diff_driver.run(
+            init.io,
+            arena,
+            driver_args,
+            stdout,
+            stderr,
             init.environ_map,
         ),
         .merge_driver => |driver_args| try merge_driver.runWithGit(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,6 +40,8 @@ The schema remains stable unless a release documents a breaking change.
 | `core/src/` | Parse, diff, tree, JSON (`prefablens.diff.v2`), WASM export |
 | `cli/src/main.zig`, `command.zig` | Process setup and command dispatch |
 | `cli/src/diff.zig` | Diff input collection, GUID resolution, and output selection |
+| `cli/src/diff_driver.zig` | Git external diff driver |
+| `cli/src/diff_setup.zig` | Git diff driver configuration |
 | `cli/src/diff_options.zig` | Diff options and operand parsing |
 | `cli/src/input.zig` | Git subprocess I/O and file reads |
 | `cli/src/resolve.zig` | `.meta` GUID index scan |
@@ -207,8 +209,34 @@ The mergetool requires both standard input and standard output to be TTYs.
 Without them, it returns 2 and keeps `$MERGED` unchanged. The automatic strategy instead leaves the merge unresolved.
 PrefabLens writes completed output with atomic file replacement and retains existing permissions.
 
-`diff-driver` and `difftool` remain reserved for Issue #227.
+`difftool` remains reserved for Issue #227.
 libvaxis is a CLI dependency. The core and WASM targets do not import it.
+
+#### Git diff driver
+
+```text
+prefablens setup-diff [--project|--local|--user]
+prefablens diff-driver <path> <old-file> <old-hex> <old-mode> <new-file> <new-hex> <new-mode> [<old-path> <xfrm-msg>]
+```
+
+Setup writes `diff=prefablens` for UnityYAML extensions and registers:
+
+```ini
+[diff "prefablens"]
+    command = prefablens diff-driver
+```
+
+`git diff` then renders UnityYAML semantically. Other paths keep Git's unified diff.
+Git invokes the driver with seven operands, or nine for a rename. `/dev/null` marks an added or deleted side.
+An unmerged path arrives as the repository path alone; the driver exits 0 without output so `git diff` can show `diff --cc`.
+A driver failure also exits 0. A non-zero status would abort the rest of `git diff`.
+
+The driver prints the repository path, then the semantic tree. It does not scan a Unity project.
+Color is on unless `NO_COLOR` is nonempty, because Git pipes driver output to the pager.
+
+`git log -p` and `git show` do not run external diff drivers unless you pass `--ext-diff`.
+
+The pager still sees one combined stream. A pager that expects unified diffs, such as `delta`, may mangle the tree.
 
 ### CLI contract
 


### PR DESCRIPTION
## Summary

Add a Git external diff driver so `git diff` renders UnityYAML semantically while other files keep Git's unified diff.

## Motivation

`git difftool` needs a manual invocation. A custom diff driver hooks plain `git diff` for UnityYAML paths through `.gitattributes`.

Related to #227.

This trial does not emit unified diffs, so a pager such as `delta` may mangle the tree when it sits next to `.cs` hunks.

## Changes

- Add `prefablens diff-driver` to accept Git's seven (or nine, for a rename) operands and print the semantic tree.
- Treat `/dev/null` as an added or deleted side. Skip unmerged 1-argument calls with exit 0 so `git diff` is not aborted.
- Add `prefablens setup-diff [--project|--local|--user]` to write `diff=prefablens` attributes and `diff.prefablens.command`.
- Keep `difftool` reserved.

## Testing

```sh
mise exec -- zig build test lint --summary all
# Build Summary: 34/34 steps succeeded; 607/607 tests passed
# lint success
```

The integration test runs the registered driver through Git with mixed UnityYAML and `.cs` files, plus added, deleted, renamed, and unmerged paths.