### PR TITLE
fix: preserve site Raw diffs with forced color

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,4 +160,5 @@ jobs:
         working-directory: site
         run: |
           pnpm install --frozen-lockfile
+          pnpm test
           pnpm run build

--- a/site/build.mjs
+++ b/site/build.mjs
@@ -48,7 +48,8 @@ function prepareDemoRepo(repo) {
 }
 
 function createFileEntry(repo, path, index) {
-  const { table, added, removed } = createDiffTable(runGit(repo, "diff", "-M", "main", "--", path));
+  const { table, added, removed } = createDiffTable(runGit(repo, "diff", "--no-color", "-M", "main", "--", path));
+  assert(added + removed > 0, `${path} has no Raw diff changes`);
   const fragment = `diffs/${index}.html`;
   writeFileSync(join(RAW_HTML, fragment), table);
   return {

--- a/site/build.test.mjs
+++ b/site/build.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+function buildWithColor(color) {
+  // Per-command settings keep the real Git comparison independent of the user's configuration.
+  execFileSync(process.execPath, ["build.mjs"], {
+    cwd: import.meta.dirname,
+    env: {
+      ...process.env,
+      GIT_CONFIG_COUNT: "2",
+      GIT_CONFIG_KEY_0: "color.ui",
+      GIT_CONFIG_VALUE_0: color,
+      GIT_CONFIG_KEY_1: "color.diff",
+      GIT_CONFIG_VALUE_1: color,
+    },
+  });
+  const generated = join(import.meta.dirname, "generated");
+  const pullRequest = JSON.parse(readFileSync(join(generated, "pull-request.json"), "utf8"));
+  const readRawHtml = (path) => readFileSync(join(generated, "raw-html", path), "utf8");
+  return {
+    pullRequest,
+    tables: pullRequest.files.map((file) => readRawHtml(file.table)),
+    hero: readRawHtml("hero-diff.html"),
+    terminal: readRawHtml("terminal.html"),
+  };
+}
+
+test("Raw diffs retain fixture changes when Git forces color", () => {
+  const plain = buildWithColor("never");
+  const colored = buildWithColor("always");
+
+  // Equality alone could pass if both builds silently lost the fixture changes.
+  for (const result of [plain, colored]) {
+    for (const file of result.pullRequest.files) {
+      assert(file.added + file.removed > 0, `${file.path} has no Raw diff changes`);
+    }
+    assert.match(result.hero, /<tr class="add">/);
+    assert.match(result.hero, /<tr class="del">/);
+    assert.equal(result.hero, result.tables[0]);
+    assert.match(result.terminal, /<span class="[^"]*\b(?:red|green|yellow)\b[^"]*">/);
+  }
+  assert.deepEqual(colored, plain);
+});

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,8 @@
   "packageManager": "pnpm@12.2.1",
   "scripts": {
     "dev": "node build.mjs && eleventy --serve",
-    "build": "node build.mjs && eleventy"
+    "build": "node build.mjs && eleventy",
+    "test": "node --test build.test.mjs"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.1.6",


### PR DESCRIPTION
## Summary

Keep generated Raw diffs and file statistics intact when Git forces color.

## Motivation

With `color.ui=always`, ANSI codes prevented hunk parsing. The build succeeded with empty Raw diffs and `+0 -0` statistics.

Closes #352

## Changes

- Pass `--no-color` when collecting unified diffs.
- Fail the build if a changed fixture produces no additions or deletions.
- Compare real Git builds with color disabled and forced, and run this regression test in site CI.

## Testing

- Built the real CLI, WASM, and extension demo inputs with `mise exec -- zig build`, `mise exec -- zig build wasm`, and `mise exec -- pnpm run demo`.
- `mise exec -- pnpm test` in `site/`: 1 passed, 0 failed. The regression test failed before the fix.
- `mise exec -- pnpm run build` in `site/`: passed with default settings and `color.ui=always`; all 42 output files were identical.
- Verified Robot retains 100 Raw diff rows and `+29 -27` in both demos. The CLI terminal retains its colors.
- `git diff --check`: passed.
- GitHub CI and CodeQL: passed on `cf52c8f`.
