### PR TITLE
fix: label demo counts as changed files

### DIFF
--- a/site/extension.liquid
+++ b/site/extension.liquid
@@ -14,7 +14,7 @@ layout: layout.liquid
   <div class="gh-page">
     <h1 class="pr-header">Rebalance robot physics and rework the playground scene <span class="pr-number">#1</span></h1>
     <p class="pr-meta">
-      {{ pullRequest.files.size }} commits into <span class="branch">{{ pullRequest.base }}</span> from
+      {{ pullRequest.files.size }} files changed between <span class="branch">{{ pullRequest.base }}</span> and
       <span class="branch">{{ pullRequest.head }}</span>
     </p>
     {% comment %} Files changed: one file-card per changed path {% endcomment %}


### PR DESCRIPTION
## Summary

Label the extension demo count as changed files and identify the two compared branches.

## Motivation

The metadata used the file count as a commit count, although the demo has no commit-count data.

Closes #353

## Changes

- Replace `4 commits into main from feat/robot-rebalance` with `4 files changed between main and feat/robot-rebalance`.
- Keep the count derived from `pullRequest.files.size` and retain both branch names and all file cards.

## Testing

- Built the real CLI, WASM, and extension demo inputs with `mise exec -- zig build`, `mise exec -- zig build wasm`, and `mise exec -- pnpm run demo`.
- `mise exec -- pnpm run build` in `site/`: passed and wrote six pages.
- Inspected the generated HTML: the count matches all four fixture cards, both branch names remain, and the metadata no longer mentions commits.
- `git diff --check`: passed.
- GitHub CI and CodeQL: passed on `0cc44b5`.
