### PR TITLE
fix: improve manual merge Result editing

### DIFF
--- a/cli/src/merge_result_text.zig
+++ b/cli/src/merge_result_text.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+
+const Position = struct { row: usize = 0, col: usize = 0 };
+
+fn advance(position: *Position, text: []const u8, width: usize) void {
+    if (std.mem.eql(u8, text, "\n")) {
+        position.row += 1;
+        position.col = 0;
+        return;
+    }
+    const cells = vaxis.gwidth.gwidth(text, .unicode);
+    if (position.col + cells > width) {
+        position.row += 1;
+        position.col = 0;
+    }
+    position.col += cells;
+}
+
+pub fn draw(editor: *vxfw.TextField, top: *usize, ctx: vxfw.DrawContext) !vxfw.Surface {
+    const size = vxfw.Size{ .width = ctx.max.width.?, .height = ctx.max.height.? };
+    var surface = try vxfw.Surface.init(ctx.arena, editor.widget(), size);
+    @memset(surface.buffer, .{ .style = editor.style });
+    if (size.width == 0 or size.height == 0) return surface;
+    const text = try editor.buf.dupe();
+    defer editor.buf.allocator.free(text);
+    var cursor: Position = .{};
+    var before = vaxis.unicode.graphemeIterator(text[0..editor.buf.cursor]);
+    while (before.next()) |g| advance(&cursor, g.bytes(text), size.width);
+    if (cursor.col == size.width) {
+        cursor.row += 1;
+        cursor.col = 0;
+    }
+    if (cursor.row < top.*) top.* = cursor.row;
+    if (cursor.row >= top.* + size.height) top.* = cursor.row - size.height + 1;
+    surface.cursor = .{ .row = @intCast(cursor.row - top.*), .col = @intCast(cursor.col) };
+
+    var position: Position = .{};
+    var iter = vaxis.unicode.graphemeIterator(text);
+    while (iter.next()) |g| {
+        const bytes = g.bytes(text);
+        if (std.mem.eql(u8, bytes, "\n")) {
+            advance(&position, bytes, size.width);
+            continue;
+        }
+        const cells = vaxis.gwidth.gwidth(bytes, .unicode);
+        if (position.col + cells > size.width) {
+            position.row += 1;
+            position.col = 0;
+        }
+        if (position.row >= top.* + size.height) break;
+        if (cells > 0 and cells <= size.width and position.row >= top.*) {
+            surface.writeCell(@intCast(position.col), @intCast(position.row - top.*), .{
+                .char = .{ .grapheme = try ctx.arena.dupe(u8, bytes), .width = @intCast(cells) },
+                .style = editor.style,
+            });
+        }
+        position.col += cells;
+    }
+    return surface;
+}
+
+pub fn moveLine(editor: *vxfw.TextField, key: vaxis.Key) !bool {
+    const up = key.matches(vaxis.Key.up, .{});
+    const down = key.matches(vaxis.Key.down, .{});
+    const home = key.matches(vaxis.Key.home, .{}) or key.matches('a', .{ .ctrl = true });
+    const end = key.matches(vaxis.Key.end, .{}) or key.matches('e', .{ .ctrl = true });
+    if (!up and !down and !home and !end) return false;
+    const text = try editor.buf.dupe();
+    defer editor.buf.allocator.free(text);
+    const cursor = editor.buf.cursor;
+    const start = if (std.mem.lastIndexOfScalar(u8, text[0..cursor], '\n')) |at| at + 1 else 0;
+    const stop = std.mem.indexOfScalarPos(u8, text, cursor, '\n') orelse text.len;
+    const target = if (home) start else if (end) stop else blk: {
+        if ((up and start == 0) or (down and stop == text.len)) return true;
+        const next_start = if (up)
+            (if (std.mem.lastIndexOfScalar(u8, text[0 .. start - 1], '\n')) |at| at + 1 else 0)
+        else
+            stop + 1;
+        const next_end = if (up) start - 1 else std.mem.indexOfScalarPos(u8, text, next_start, '\n') orelse text.len;
+        var column: usize = 0;
+        var before = vaxis.unicode.graphemeIterator(text[start..cursor]);
+        while (before.next()) |g| column += vaxis.gwidth.gwidth(g.bytes(text[start..cursor]), .unicode);
+        var next = vaxis.unicode.graphemeIterator(text[next_start..next_end]);
+        var offset = next_start;
+        var width: usize = 0;
+        while (next.next()) |g| {
+            width += vaxis.gwidth.gwidth(g.bytes(text[next_start..next_end]), .unicode);
+            if (width > column) break;
+            offset = next_start + g.start + g.len;
+        }
+        break :blk offset;
+    };
+    if (target < cursor) editor.buf.moveGapLeft(cursor - target) else editor.buf.moveGapRight(target - cursor);
+    return true;
+}

--- a/cli/src/merge_result_text.zig
+++ b/cli/src/merge_result_text.zig
@@ -3,6 +3,15 @@ const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 
 const Position = struct { row: usize = 0, col: usize = 0 };
+pub const Selection = struct { start: usize, end: usize };
+
+pub fn normalizeNewlines(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
+    const normalized = try std.mem.replaceOwned(u8, allocator, text, "\r\n", "\n");
+    for (normalized) |*byte| if (byte.* == '\r') {
+        byte.* = '\n';
+    };
+    return normalized;
+}
 
 fn advance(position: *Position, text: []const u8, width: usize) void {
     if (std.mem.eql(u8, text, "\n")) {
@@ -18,7 +27,7 @@ fn advance(position: *Position, text: []const u8, width: usize) void {
     position.col += cells;
 }
 
-pub fn draw(editor: *vxfw.TextField, top: *usize, ctx: vxfw.DrawContext) !vxfw.Surface {
+pub fn draw(editor: *vxfw.TextField, top: *usize, selection: ?Selection, ctx: vxfw.DrawContext) !vxfw.Surface {
     const size = vxfw.Size{ .width = ctx.max.width.?, .height = ctx.max.height.? };
     var surface = try vxfw.Surface.init(ctx.arena, editor.widget(), size);
     @memset(surface.buffer, .{ .style = editor.style });
@@ -40,7 +49,14 @@ pub fn draw(editor: *vxfw.TextField, top: *usize, ctx: vxfw.DrawContext) !vxfw.S
     var iter = vaxis.unicode.graphemeIterator(text);
     while (iter.next()) |g| {
         const bytes = g.bytes(text);
+        var style = editor.style;
+        if (selection) |range| style.reverse = g.start >= range.start and g.start < range.end;
         if (std.mem.eql(u8, bytes, "\n")) {
+            if (style.reverse and position.row >= top.* and position.row < top.* + size.height) {
+                for (position.col..size.width) |col| {
+                    surface.writeCell(@intCast(col), @intCast(position.row - top.*), .{ .style = style });
+                }
+            }
             advance(&position, bytes, size.width);
             continue;
         }
@@ -53,7 +69,7 @@ pub fn draw(editor: *vxfw.TextField, top: *usize, ctx: vxfw.DrawContext) !vxfw.S
         if (cells > 0 and cells <= size.width and position.row >= top.*) {
             surface.writeCell(@intCast(position.col), @intCast(position.row - top.*), .{
                 .char = .{ .grapheme = try ctx.arena.dupe(u8, bytes), .width = @intCast(cells) },
-                .style = editor.style,
+                .style = style,
             });
         }
         position.col += cells;
@@ -96,7 +112,7 @@ pub fn moveLine(editor: *vxfw.TextField, key: vaxis.Key) !bool {
     return true;
 }
 
-pub fn placeCursor(editor: *vxfw.TextField, width: usize, row: usize, col: usize) !void {
+pub fn cursorAt(editor: *vxfw.TextField, width: usize, row: usize, col: usize) !usize {
     const text = try editor.buf.dupe();
     defer editor.buf.allocator.free(text);
     var position: Position = .{};
@@ -117,6 +133,10 @@ pub fn placeCursor(editor: *vxfw.TextField, width: usize, row: usize, col: usize
         }
         advance(&position, bytes, width);
     }
+    return target;
+}
+
+pub fn setCursor(editor: *vxfw.TextField, target: usize) void {
     const cursor = editor.buf.cursor;
     if (target < cursor) editor.buf.moveGapLeft(cursor - target) else editor.buf.moveGapRight(target - cursor);
 }

--- a/cli/src/merge_result_text.zig
+++ b/cli/src/merge_result_text.zig
@@ -95,3 +95,28 @@ pub fn moveLine(editor: *vxfw.TextField, key: vaxis.Key) !bool {
     if (target < cursor) editor.buf.moveGapLeft(cursor - target) else editor.buf.moveGapRight(target - cursor);
     return true;
 }
+
+pub fn placeCursor(editor: *vxfw.TextField, width: usize, row: usize, col: usize) !void {
+    const text = try editor.buf.dupe();
+    defer editor.buf.allocator.free(text);
+    var position: Position = .{};
+    var target: usize = text.len;
+    var iter = vaxis.unicode.graphemeIterator(text);
+    while (iter.next()) |g| {
+        const bytes = g.bytes(text);
+        const newline = std.mem.eql(u8, bytes, "\n");
+        const cells = vaxis.gwidth.gwidth(bytes, .unicode);
+        if (!newline and position.col + cells > width) {
+            position.row += 1;
+            position.col = 0;
+        }
+        // Hit testing must use the same wrapping and grapheme boundaries as drawing.
+        if (position.row > row or (position.row == row and (newline or col < position.col + cells))) {
+            target = g.start;
+            break;
+        }
+        advance(&position, bytes, width);
+    }
+    const cursor = editor.buf.cursor;
+    if (target < cursor) editor.buf.moveGapLeft(cursor - target) else editor.buf.moveGapRight(target - cursor);
+}

--- a/cli/src/merge_result_text.zig
+++ b/cli/src/merge_result_text.zig
@@ -112,11 +112,10 @@ pub fn moveLine(editor: *vxfw.TextField, key: vaxis.Key) !bool {
     return true;
 }
 
-pub fn cursorAt(editor: *vxfw.TextField, width: usize, row: usize, col: usize) !usize {
+pub fn cellAt(editor: *vxfw.TextField, width: usize, row: usize, col: usize) !Selection {
     const text = try editor.buf.dupe();
     defer editor.buf.allocator.free(text);
     var position: Position = .{};
-    var target: usize = text.len;
     var iter = vaxis.unicode.graphemeIterator(text);
     while (iter.next()) |g| {
         const bytes = g.bytes(text);
@@ -127,13 +126,12 @@ pub fn cursorAt(editor: *vxfw.TextField, width: usize, row: usize, col: usize) !
             position.col = 0;
         }
         // Hit testing must use the same wrapping and grapheme boundaries as drawing.
-        if (position.row > row or (position.row == row and (newline or col < position.col + cells))) {
-            target = g.start;
-            break;
-        }
+        if (position.row > row) return .{ .start = g.start, .end = g.start };
+        if (position.row == row and (newline or col < position.col + cells))
+            return .{ .start = g.start, .end = g.start + if (newline) @as(usize, 0) else g.len };
         advance(&position, bytes, width);
     }
-    return target;
+    return .{ .start = text.len, .end = text.len };
 }
 
 pub fn setCursor(editor: *vxfw.TextField, target: usize) void {

--- a/cli/src/merge_tree.zig
+++ b/cli/src/merge_tree.zig
@@ -19,6 +19,7 @@ pub const Row = struct {
 pub const Model = struct {
     rows: []const Row,
     conflict_rows: []const usize,
+    visual_conflict_order: []const usize,
 
     pub fn rowForConflict(self: Model, conflict_index: usize) ?usize {
         if (conflict_index >= self.conflict_rows.len) return null;
@@ -211,9 +212,9 @@ const Builder = struct {
         try entry.value_ptr.append(self.arena, ordinal);
     }
 
-    fn emit(self: *Builder, conflict_count: usize) !Model {
+    fn emit(self: *Builder, conflict_indices: []const usize) !Model {
         var rows: std.ArrayList(Row) = .empty;
-        const conflict_rows = try self.arena.alloc(usize, conflict_count);
+        const conflict_rows = try self.arena.alloc(usize, conflict_indices.len);
         @memset(conflict_rows, 0);
         var loose_count: usize = 0;
         for (self.roots.items) |key| {
@@ -243,10 +244,40 @@ const Builder = struct {
                 );
             }
         }
+        const visual_conflict_order = try self.reorderConflicts(rows.items, conflict_rows, conflict_indices);
         return .{
             .rows = try rows.toOwnedSlice(self.arena),
             .conflict_rows = conflict_rows,
+            .visual_conflict_order = visual_conflict_order,
         };
+    }
+
+    fn reorderConflicts(
+        self: *Builder,
+        rows: []Row,
+        conflict_rows: []usize,
+        conflict_indices: []const usize,
+    ) ![]usize {
+        const visual_conflict_order = try self.arena.alloc(usize, conflict_indices.len);
+        if (conflict_indices.len == 0) return visual_conflict_order;
+
+        // Conflict discovery follows plan atomic order, while rows follow the tree order.
+        // Keep row lookup keyed by the rendered sequence and let State remap navigation.
+        const old_conflict_rows = try self.arena.dupe(usize, conflict_rows);
+        defer self.arena.free(old_conflict_rows);
+        var visual_index: usize = 0;
+        for (rows, 0..) |*row, row_index| {
+            row.conflict_index = null;
+            for (old_conflict_rows, 0..) |old_row_index, old_index| {
+                if (old_row_index != row_index) continue;
+                visual_conflict_order[visual_index] = old_index;
+                conflict_rows[visual_index] = row_index;
+                if (row.conflict_index == null) row.conflict_index = visual_index;
+                visual_index += 1;
+            }
+        }
+        std.debug.assert(visual_index == conflict_indices.len);
+        return visual_conflict_order;
     }
 
     fn emitNode(
@@ -342,7 +373,17 @@ pub fn build(
     try builder.addResult(try core.diffBytes(arena, "", plan.theirs.bytes));
     try builder.addResult(try core.diffBytes(arena, "", plan.base.bytes));
     try builder.addConflicts(plan, conflict_indices);
-    return builder.emit(conflict_indices.len);
+    return builder.emit(conflict_indices);
+}
+
+pub fn buildForState(
+    arena: std.mem.Allocator,
+    partial: []const u8,
+    state: *merge_ui_state.State,
+) !Model {
+    const tree = try build(arena, partial, state.plan, state.conflict_indices);
+    try state.reorderConflicts(tree.visual_conflict_order);
+    return tree;
 }
 
 const base =
@@ -474,4 +515,97 @@ test "merge TUI: prefab override conflict uses the Inspector property name" {
     const tree = try build(arena, built.partial, &built.plan, state.conflict_indices);
     const row_index = tree.rowForConflict(0).?;
     try testing.expectEqualStrings("Name", tree.rows[row_index].label);
+}
+
+test "merge TUI: conflict focus follows visual order across an edited component" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    // The component membership is collected from GameObject before later document fields,
+    // while the rendered tree shows Transform before the retained SphereCollider document.
+    const fixture_base =
+        "%YAML 1.1\n" ++
+        "%TAG !u! tag:unity3d.com,2011:\n" ++
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  - component: {fileID: 135}\n" ++
+        "  m_Name: Arm\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "  m_Children: []\n" ++
+        "  m_LocalPosition: {x: 0.5, y: 1, z: 0}\n" ++
+        "--- !u!135 &135\n" ++
+        "SphereCollider:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Radius: 0.25\n";
+    const ours =
+        "%YAML 1.1\n" ++
+        "%TAG !u! tag:unity3d.com,2011:\n" ++
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  m_Name: Arm\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "  m_Children: []\n" ++
+        "  m_LocalPosition: {x: 0.65, y: 1, z: 0}\n";
+    const theirs =
+        "%YAML 1.1\n" ++
+        "%TAG !u! tag:unity3d.com,2011:\n" ++
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  - component: {fileID: 135}\n" ++
+        "  m_Name: Arm\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "  m_Children: []\n" ++
+        "  m_LocalPosition: {x: 0.8, y: 1, z: 0}\n" ++
+        "--- !u!135 &135\n" ++
+        "SphereCollider:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Radius: 0.4\n";
+    var built = try core.merge.build(arena, fixture_base, ours, theirs);
+    var state = try merge_ui_state.State.init(arena, &built.plan);
+    const tree = try buildForState(arena, built.partial, &state);
+    try state.handle(.{ .select_conflict = 0 });
+
+    try testing.expectEqual(@as(usize, 2), state.conflict_indices.len);
+    const first = built.plan.operations[state.conflict_indices[0]];
+    try testing.expect(first.kind == .field);
+    try testing.expectEqualStrings("m_LocalPosition.x", first.property_path);
+    const first_row = tree.rowForConflict(0).?;
+    try testing.expectEqualStrings("Position.x", tree.rows[first_row].label);
+    const second_row = tree.rowForConflict(1).?;
+    try testing.expectEqualStrings("SphereCollider", tree.rows[second_row].label);
+
+    // Movement follows the same visual sequence, and applying the first row advances to the second.
+    try state.handle(.move_down);
+    try testing.expectEqual(@as(usize, 1), state.selected_conflict);
+    try state.handle(.move_up);
+    try testing.expectEqual(@as(usize, 0), state.selected_conflict);
+    try state.handle(.choose_theirs);
+    try state.handle(.apply_result);
+    try testing.expectEqual(@as(usize, 1), state.selected_conflict);
+
+    // Resolving the lower row first wraps auto-advance to the still-unresolved top row.
+    try state.handle(.{ .select_conflict = 0 });
+    try state.handle(.reopen_result);
+    try state.handle(.{ .select_conflict = 1 });
+    try state.handle(.choose_theirs);
+    try state.handle(.apply_result);
+    try testing.expectEqual(@as(usize, 0), state.selected_conflict);
+    try state.handle(.choose_theirs);
+    try state.handle(.apply_result);
+    try testing.expectEqual(merge_ui_state.Outcome.ready, state.outcome);
 }

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -190,6 +190,8 @@ pub const View = struct {
     editor: vxfw.TextField,
     editing: bool = false,
     editor_top: usize = 0,
+    editor_anchor: ?usize = null,
+    editor_drag_origin: ?usize = null,
     pasting: bool = false,
     paste_into_result: bool = false,
     paste_buffer: std.ArrayList(u8) = .empty,
@@ -342,14 +344,23 @@ pub const View = struct {
         ctx: *vxfw.EventContext,
         initial: []const u8,
     ) !void {
+        const normalized = try result_text.normalizeNewlines(self.editor.buf.allocator, initial);
+        defer self.editor.buf.allocator.free(normalized);
         self.editor.clearRetainingCapacity();
-        try self.editor.insertSliceAtCursor(initial);
-        const previous_val = try self.editor.buf.allocator.dupe(u8, initial);
+        try self.editor.insertSliceAtCursor(normalized);
+        const previous_val = try self.editor.buf.allocator.dupe(u8, normalized);
         self.editor.buf.allocator.free(self.editor.previous_val);
         self.editor.previous_val = previous_val;
         self.editing = true;
         self.editor_top = 0;
+        self.editor_anchor = null;
+        self.editor_drag_origin = null;
         self.editor_start_resolution = self.state.pending;
+        if (self.editor_start_resolution == null) {
+            if (self.selectedOperation()) |operation| {
+                if (operation.resolution != .unresolved) self.editor_start_resolution = operation.resolution;
+            }
+        }
         self.editor_changed = false;
         self.editor_reopened = false;
         try ctx.requestFocus(self.editor.widget());
@@ -366,13 +377,49 @@ pub const View = struct {
         try self.editor.handleEvent(ctx, .{ .key_press = key });
     }
 
+    fn editorSelection(self: *const View) ?result_text.Selection {
+        const anchor = self.editor_anchor orelse return null;
+        const cursor = self.editor.buf.cursor;
+        if (anchor == cursor) return null;
+        return .{ .start = @min(anchor, cursor), .end = @max(anchor, cursor) };
+    }
+
+    fn deleteEditorSelection(self: *View) bool {
+        const range = self.editorSelection() orelse return false;
+        result_text.setCursor(&self.editor, range.start);
+        self.editor.buf.growGapRight(range.end - range.start);
+        self.editor_anchor = null;
+        self.editor_drag_origin = null;
+        return true;
+    }
+
     fn handleEditorKey(self: *View, ctx: *vxfw.EventContext, key: vaxis.Key) !bool {
-        if (key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true })) {
+        self.editor_drag_origin = null;
+        const newline = key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true });
+        const deletion = key.matches(vaxis.Key.backspace, .{}) or key.matches(vaxis.Key.delete, .{}) or key.matches('d', .{ .ctrl = true });
+        const text_input = key.text != null and key.text.?.len != 0 and !key.mods.ctrl and !key.mods.alt and !key.mods.super;
+        if (self.editorSelection()) |range| {
+            if (deletion or newline or text_input) {
+                // Replacement is one edit, so deleting a selection must not reopen the conflict before insertion.
+                _ = self.deleteEditorSelection();
+                if (deletion) {
+                    try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = "" } });
+                    return true;
+                }
+            } else if (key.matches(vaxis.Key.left, .{}) or key.matches(vaxis.Key.right, .{})) {
+                result_text.setCursor(&self.editor, if (key.codepoint == vaxis.Key.left) range.start else range.end);
+                self.editor_anchor = null;
+                ctx.consumeAndRedraw();
+                return true;
+            }
+        }
+        self.editor_anchor = null;
+        if (newline) {
             const before = self.editor.buf.firstHalf();
             const start = if (std.mem.lastIndexOfScalar(u8, before, '\n')) |at| at + 1 else 0;
-            const newline = try std.mem.concat(self.editor.buf.allocator, u8, &.{ "\n", before[start .. start + lineIndent(before[start..])] });
-            defer self.editor.buf.allocator.free(newline);
-            try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = newline } });
+            const text = try std.mem.concat(self.editor.buf.allocator, u8, &.{ "\n", before[start .. start + lineIndent(before[start..])] });
+            defer self.editor.buf.allocator.free(text);
+            try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = text } });
             return true;
         }
         if (try result_text.moveLine(&self.editor, key)) {
@@ -386,11 +433,10 @@ pub const View = struct {
         if (text.len == 0) return;
         if (!self.editing) try self.beginResultEdit(ctx, self.selectedResultInput());
         // A paste is one edit; newline key events must never submit a partial value.
-        const normalized = try std.mem.replaceOwned(u8, self.editor.buf.allocator, text, "\r\n", "\n");
+        const normalized = try result_text.normalizeNewlines(self.editor.buf.allocator, text);
         defer self.editor.buf.allocator.free(normalized);
-        for (normalized) |*byte| if (byte.* == '\r') {
-            byte.* = '\n';
-        };
+        _ = self.deleteEditorSelection();
+        self.editor_drag_origin = null;
         try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = normalized } });
     }
 
@@ -476,12 +522,38 @@ pub const View = struct {
         ctx.consumeAndRedraw();
     }
 
+    fn editorCursorAt(self: *View, mouse: vaxis.Mouse, size: vxfw.Size) !usize {
+        const geometry = self.valueGeometry(size.width);
+        const body = BodyGeometry.init(size.height);
+        const col: usize = @intCast(@max(mouse.col, 0));
+        const row: usize = @intCast(@max(mouse.row, 0));
+        return result_text.cursorAt(
+            &self.editor,
+            geometry.result.end - geometry.result.start -| 2,
+            self.editor_top + std.math.clamp(row, body.inspector_rows.start, body.inspector_rows.end - 1) - body.inspector_rows.start,
+            col -| (geometry.result.start + 2),
+        );
+    }
+
     fn handleMouseWhileEditing(
         self: *View,
         ctx: *vxfw.EventContext,
         mouse: vaxis.Mouse,
         size: vxfw.Size,
     ) !void {
+        if (self.editor_drag_origin) |origin| {
+            if (mouse.type == .drag or mouse.type == .release) {
+                const body = BodyGeometry.init(size.height);
+                if (mouse.type == .drag) {
+                    if (mouse.row < body.inspector_rows.start) self.editor_top -|= 1;
+                    if (mouse.row >= body.inspector_rows.end) self.editor_top += 1;
+                    self.editor_anchor = origin;
+                }
+                if (self.editor_anchor != null) result_text.setCursor(&self.editor, try self.editorCursorAt(mouse, size));
+                if (mouse.type == .release) self.editor_drag_origin = null;
+                return ctx.consumeAndRedraw();
+            }
+        }
         if (self.handleHierarchyWheel(ctx, mouse, size)) return;
         if (mouse.type != .press or mouse.button != .left or mouse.col < 0 or mouse.row < 0) return;
         const col: u16 = @intCast(mouse.col);
@@ -491,12 +563,10 @@ pub const View = struct {
         if (self.canCombine() and row == body.inspector_heading_row and inRange(col, self.combineToggleRange(size.width)))
             return ctx.consumeEvent();
         if (row >= body.inspector_rows.start and row < body.inspector_rows.end and inRange(col, geometry.result)) {
-            try result_text.placeCursor(
-                &self.editor,
-                geometry.result.end - geometry.result.start -| 2,
-                self.editor_top + row - body.inspector_rows.start,
-                col -| (geometry.result.start + 2),
-            );
+            const cursor = try self.editorCursorAt(mouse, size);
+            result_text.setCursor(&self.editor, cursor);
+            self.editor_anchor = null;
+            self.editor_drag_origin = cursor;
             return ctx.consumeAndRedraw();
         }
         if (!try self.finishEditorForNavigation(ctx)) return;
@@ -507,6 +577,8 @@ pub const View = struct {
         self.editor.clearRetainingCapacity();
         self.editing = false;
         self.editor_top = 0;
+        self.editor_anchor = null;
+        self.editor_drag_origin = null;
         self.editor_start_resolution = null;
         self.editor_changed = false;
         self.editor_reopened = false;
@@ -897,7 +969,9 @@ pub const View = struct {
             self.selected_value = .result;
             self.horizontal_offset = 0;
             try self.state.handle(.pane_right);
-            return self.beginResultEdit(ctx, self.selectedResultInput());
+            try self.beginResultEdit(ctx, self.selectedResultInput());
+            self.editor_drag_origin = try self.editorCursorAt(mouse, size);
+            return;
         }
         if (inRange(col, geometry.inspector)) return self.focusInspector(ctx);
     }
@@ -1311,7 +1385,7 @@ fn draw(
                 .width = geometry.result.end - geometry.result.start -| 2,
                 .height = body.inspector_rows.end - editor_row,
             };
-            const child_surface = try result_text.draw(&self.editor, &self.editor_top, ctx.withConstraints(
+            const child_surface = try result_text.draw(&self.editor, &self.editor_top, self.editorSelection(), ctx.withConstraints(
                 editor_size,
                 vxfw.MaxSize.fromSize(editor_size),
             ));
@@ -1340,7 +1414,7 @@ fn submitCustom(
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata.?));
     const input = std.mem.trim(u8, value, "\r\n");
-    const started_empty = if (self.editor_start_resolution orelse if (self.selectedOperation()) |op| op.resolution else null) |resolution| switch (resolution) {
+    const started_empty = if (self.editor_start_resolution) |resolution| switch (resolution) {
         .custom => |start_value| start_value.len == 0,
         else => false,
     } else false;
@@ -1551,7 +1625,11 @@ fn handleEvent(
                 }
                 if (try self.handleEditorKey(ctx, key)) return;
             },
-            .mouse => |mouse| if (self.handleHierarchyWheel(ctx, mouse, size)) return,
+            .mouse => |mouse| {
+                // Queued input can target the previous surface before the editor is drawn.
+                if (ctx.phase == .at_target) return self.handleMouseWhileEditing(ctx, mouse, size);
+                if (self.handleHierarchyWheel(ctx, mouse, size)) return;
+            },
             else => {},
         }
         if (ctx.phase == .at_target) return self.editor.handleEvent(ctx, event);
@@ -1591,7 +1669,10 @@ fn handleEvent(
                 if (key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true })) {
                     try self.beginResultEdit(ctx, self.selectedResultInput());
                     _ = try self.handleEditorKey(ctx, key);
-                } else if (key.matches(vaxis.Key.backspace, .{}) or (key.text != null and key.text.?.len != 0)) {
+                } else if (key.matches(vaxis.Key.backspace, .{}) or key.matches(vaxis.Key.delete, .{})) {
+                    self.horizontal_offset = 0;
+                    try self.dispatch(ctx, .reopen_result, size);
+                } else if (key.text != null and key.text.?.len != 0) {
                     try self.beginTypedEdit(ctx, key);
                 }
             }
@@ -4574,7 +4655,9 @@ test "merge TUI: Enter asks before it applies an empty Result" {
     try pressKeyForTest(&view, &ctx, vaxis.Key.up);
     try focusResultForTest(&view, &ctx);
     try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
+    try testing.expect(!view.editing);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expect(view.dialog == null);
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
 
     // Empty YAML can be intentional, but one key press must not resolve it.
@@ -5071,7 +5154,7 @@ test "merge TUI: the first Backspace deletes one character from a prefilled Resu
     try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution != .unresolved);
 }
 
-test "merge TUI: Backspace starts editing and deletes one character" {
+test "merge TUI: Enter opens a cleared Result for a new value" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -5088,15 +5171,16 @@ test "merge TUI: Backspace starts editing and deletes one character" {
     try focusResultForTest(&view, &ctx);
     try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
 
-    // Deletion behaves the same whether editing started with the keyboard or the mouse.
-    const value = try view.editor.toOwnedSlice();
-    defer arena.free(value);
-    try testing.expectEqualStrings("1", value);
+    try testing.expect(!view.editing);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    // Enter opens the empty draft; only a subsequent submission can apply it.
     try testing.expect(view.editing);
-    try testing.expect(view.focus_area == .inspector);
-    try testing.expect(view.selected_value == .result);
-    try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
-    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution != .unresolved);
+    try testing.expect(view.dialog == null);
+    try testing.expectEqualStrings("", view.editor.buf.firstHalf());
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("4", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
 }
 
 test "merge TUI: Backspace edits typed Result text one character at a time" {
@@ -5393,4 +5477,264 @@ test "merge TUI: clicking inside the editor places the cursor on a Unicode line"
     try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = 'X', .text = "X" } });
     try testing.expectEqualStrings("  あいう\n  sXecond", try view.editor.buf.dupe());
     try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+}
+
+test "merge TUI: dragging Result highlights a range and typing replaces it" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    const geometry = Geometry.init(100);
+    const body = BodyGeometry.init(20);
+    // The initial click can enter editing and start the same drag gesture.
+    try view.widget().handleEvent(&ctx, .{ .mouse = .{
+        .col = @intCast(geometry.result.start + 2),
+        .row = @intCast(body.inspector_rows.start),
+        .button = .left,
+        .mods = .{},
+        .type = .press,
+    } });
+    var surface = try drawForTest(arena, view.widget(), 100, 20);
+    for ([_]vaxis.Mouse.Type{ .drag, .release }) |kind| {
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .mouse = .{
+            .col = @intCast(geometry.result.start + 3),
+            .row = @intCast(body.inspector_rows.start),
+            .button = .left,
+            .mods = .{},
+            .type = kind,
+        } });
+        surface = try drawForTest(arena, view.widget(), 100, 20);
+    }
+    try testing.expect(surface.children[0].surface.readCell(0, 0).style.reverse);
+    try testing.expect(!surface.children[0].surface.readCell(1, 0).style.reverse);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = '9', .text = "9" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("92", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+test "merge TUI: deletion before editing clears Result without entering the editor" {
+    for ([_]u21{ vaxis.Key.backspace, vaxis.Key.delete }) |key| {
+        for ([_]bool{ false, true }) |applied| {
+            var memory = std.heap.ArenaAllocator.init(testing.allocator);
+            defer memory.deinit();
+            const arena = memory.allocator();
+            var fixture = try screenPlan(arena);
+            var state = try merge_ui_state.State.init(arena, &fixture.plan);
+            try state.handle(.choose_ours);
+            if (applied) {
+                try state.handle(.apply_result);
+                try state.handle(.{ .select_conflict = 0 });
+            }
+            var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+            defer view.deinit();
+            _ = try drawForTest(arena, view.widget(), 100, 20);
+            var ctx = eventContext(arena);
+            try focusResultForTest(&view, &ctx);
+            try pressKeyForTest(&view, &ctx, key);
+            // Clearing a preview or accepted result reopens the choice without starting text input.
+            try testing.expect(!view.editing);
+            try testing.expect(view.focus_area == .inspector);
+            try testing.expect(view.selected_value == .result);
+            try testing.expectEqualStrings("", view.selectedResultInput());
+            try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+            try testing.expect(state.pending == null);
+        }
+    }
+}
+
+test "merge TUI: a retained component can be edited after applying Theirs" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try componentDeletePlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    try state.handle(.apply_result);
+    try state.handle(.{ .select_conflict = 0 });
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    const source_text = try view.editor.buf.dupe();
+    // The field value is part of the displayed component document, not a standalone scalar.
+    const digit = std.mem.indexOf(u8, source_text, "m_Mass: 2").? + "m_Mass: 2".len;
+    view.editor.buf.moveGapLeft(view.editor.buf.cursor - digit);
+    var surface = try drawForTest(arena, view.widget(), 100, 20);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.backspace } });
+    surface = try drawForTest(arena, view.widget(), 100, 20);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = '3', .text = "3" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    try testing.expect(!view.editing);
+    // Reopening the result must use the edited document, not the original side preview.
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try testing.expect(std.mem.indexOf(u8, try view.editor.buf.dupe(), "m_Mass: 3") != null);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    try testing.expect(!view.editing);
+    try testing.expectEqualStrings(try std.mem.replaceOwned(u8, arena, fixture.plan.theirs.bytes, "m_Mass: 2", "m_Mass: 3"), try core.merge.finish(arena, &fixture.plan));
+}
+
+test "merge TUI: a backward multiline drag supports paste deletion and indented newlines" {
+    const events = [_]vaxis.Key{
+        .{ .codepoint = vaxis.Key.backspace },
+        .{ .codepoint = vaxis.Key.delete },
+        .{ .codepoint = vaxis.Key.enter, .mods = .{ .shift = true } },
+    };
+    for (0..4) |case| {
+        var memory = std.heap.ArenaAllocator.init(testing.allocator);
+        defer memory.deinit();
+        const arena = memory.allocator();
+        var fixture = try screenPlan(arena);
+        var state = try merge_ui_state.State.init(arena, &fixture.plan);
+        var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+        defer view.deinit();
+        _ = try drawForTest(arena, view.widget(), 100, 20);
+        var ctx = eventContext(arena);
+        try focusResultForTest(&view, &ctx);
+        try view.beginResultEdit(&ctx, "  あいう\n  second");
+        var surface = try drawForTest(arena, view.widget(), 100, 20);
+        const geometry = Geometry.init(100);
+        const row = BodyGeometry.init(20).inspector_rows.start;
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .mouse = .{
+            .col = @intCast(geometry.result.start + 2 + 3),
+            .row = @intCast(row + 1),
+            .button = .left,
+            .mods = .{},
+            .type = .press,
+        } });
+        for ([_]vaxis.Mouse.Type{ .drag, .release }) |kind| {
+            try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .mouse = .{
+                .col = @intCast(geometry.result.start + 2 + 2),
+                .row = @intCast(row),
+                .button = .left,
+                .mods = .{},
+                .type = kind,
+            } });
+        }
+        surface = try drawForTest(arena, view.widget(), 100, 20);
+        // Unicode cells and the intervening newline belong to the same selection in either direction.
+        try testing.expect(surface.children[0].surface.readCell(2, 0).style.reverse);
+        try testing.expect(surface.children[0].surface.readCell(2, 1).style.reverse);
+        try testing.expect(!surface.children[0].surface.readCell(3, 1).style.reverse);
+        if (case == 3) {
+            try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "X") });
+        } else {
+            try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = events[case] });
+        }
+        const expected = switch (case) {
+            2 => "  \n  econd",
+            3 => "  Xecond",
+            else => "  econd",
+        };
+        try testing.expectEqualStrings(expected, try view.editor.buf.dupe());
+        try testing.expect(view.editorSelection() == null);
+        try testing.expect(view.editing);
+    }
+}
+
+test "merge TUI: replacing a full selection keeps the accepted resolution until apply" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_ours);
+    try state.handle(.apply_result);
+    try state.handle(.{ .select_conflict = 0 });
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try beginEditingForTest(&view, &ctx);
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    const geometry = Geometry.init(100);
+    const row = BodyGeometry.init(20).inspector_rows.start;
+    for ([_]vaxis.Mouse.Type{ .press, .drag, .release }) |kind| {
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .mouse = .{
+            .col = @intCast(geometry.result.start + 2 + @as(u16, if (kind == .press) 0 else 2)),
+            .row = @intCast(row),
+            .button = .left,
+            .mods = .{},
+            .type = kind,
+        } });
+    }
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "7") });
+    // Erasing the selection as part of replacement must not mark the accepted choice unresolved.
+    try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
+    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution == .take);
+    try testing.expectEqualStrings("7", view.editor.buf.firstHalf());
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter } });
+    try testing.expectEqualStrings("7", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+test "merge TUI: a CRLF component stays multiline while editing and keeps CRLF on apply" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const lf = try componentDeletePlan(arena);
+    var fixture = try core.merge.build(
+        arena,
+        try std.mem.replaceOwned(u8, arena, lf.plan.base.bytes, "\n", "\r\n"),
+        try std.mem.replaceOwned(u8, arena, lf.plan.ours.bytes, "\n", "\r\n"),
+        try std.mem.replaceOwned(u8, arena, lf.plan.theirs.bytes, "\n", "\r\n"),
+    );
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    // The editor uses logical LF lines; serialization restores the component's existing line ending.
+    try testing.expect(std.mem.indexOfScalar(u8, try view.editor.buf.dupe(), '\r') == null);
+    var surface = try drawForTest(arena, view.widget(), 100, 20);
+    try testing.expect(std.mem.startsWith(u8, try rowText(arena, surface.children[0].surface, 1), "Rigidbody:"));
+    for ([_]vaxis.Key{
+        .{ .codepoint = vaxis.Key.up },        .{ .codepoint = vaxis.Key.end },
+        .{ .codepoint = vaxis.Key.backspace }, .{ .codepoint = '3', .text = "3" },
+        .{ .codepoint = vaxis.Key.enter },
+    }) |key| {
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = key });
+        surface = try drawForTest(arena, view.widget(), 100, 20);
+    }
+    try testing.expectEqualStrings("", state.status);
+    try testing.expectEqualStrings(try std.mem.replaceOwned(u8, arena, fixture.plan.theirs.bytes, "m_Mass: 2", "m_Mass: 3"), try core.merge.finish(arena, &fixture.plan));
+}
+
+test "merge TUI: mouse dragging works before the editor has its first rendered surface" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    const geometry = Geometry.init(100);
+    const row = BodyGeometry.init(20).inspector_rows.start;
+    // Mouse hit testing can still target the root until the frame containing the editor is drawn.
+    for ([_]vaxis.Mouse.Type{ .press, .drag, .release }) |kind| {
+        try view.widget().handleEvent(&ctx, .{ .mouse = .{
+            .col = @intCast(geometry.result.start + 2 + @as(u16, if (kind == .press) 0 else 1)),
+            .row = @intCast(row),
+            .button = .left,
+            .mods = .{},
+            .type = kind,
+        } });
+    }
+    try testing.expect(view.editorSelection() != null);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '9', .text = "9" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("92", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
 }

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -191,7 +191,7 @@ pub const View = struct {
     editing: bool = false,
     editor_top: usize = 0,
     editor_anchor: ?usize = null,
-    editor_drag_origin: ?usize = null,
+    editor_drag_origin: ?result_text.Selection = null,
     pasting: bool = false,
     paste_into_result: bool = false,
     paste_buffer: std.ArrayList(u8) = .empty,
@@ -394,7 +394,21 @@ pub const View = struct {
     }
 
     fn handleEditorKey(self: *View, ctx: *vxfw.EventContext, key: vaxis.Key) !bool {
+        // Kitty keyboard reports can send a modifier before the copy key or terminal paste.
+        if (key.isModifier()) {
+            ctx.consumeEvent();
+            return true;
+        }
         self.editor_drag_origin = null;
+        if (key.matches('c', .{ .ctrl = true })) {
+            if (self.editorSelection()) |range| {
+                const text = try self.editor.buf.dupe();
+                defer self.editor.buf.allocator.free(text);
+                try ctx.copyToClipboard(text[range.start..range.end]);
+            }
+            ctx.consumeEvent();
+            return true;
+        }
         const newline = key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true });
         const deletion = key.matches(vaxis.Key.backspace, .{}) or key.matches(vaxis.Key.delete, .{}) or key.matches('d', .{ .ctrl = true });
         const text_input = key.text != null and key.text.?.len != 0 and !key.mods.ctrl and !key.mods.alt and !key.mods.super;
@@ -522,12 +536,12 @@ pub const View = struct {
         ctx.consumeAndRedraw();
     }
 
-    fn editorCursorAt(self: *View, mouse: vaxis.Mouse, size: vxfw.Size) !usize {
+    fn editorCellAt(self: *View, mouse: vaxis.Mouse, size: vxfw.Size) !result_text.Selection {
         const geometry = self.valueGeometry(size.width);
         const body = BodyGeometry.init(size.height);
         const col: usize = @intCast(@max(mouse.col, 0));
         const row: usize = @intCast(@max(mouse.row, 0));
-        return result_text.cursorAt(
+        return result_text.cellAt(
             &self.editor,
             geometry.result.end - geometry.result.start -| 2,
             self.editor_top + std.math.clamp(row, body.inspector_rows.start, body.inspector_rows.end - 1) - body.inspector_rows.start,
@@ -547,9 +561,15 @@ pub const View = struct {
                 if (mouse.type == .drag) {
                     if (mouse.row < body.inspector_rows.start) self.editor_top -|= 1;
                     if (mouse.row >= body.inspector_rows.end) self.editor_top += 1;
-                    self.editor_anchor = origin;
+                    self.editor_anchor = origin.start;
                 }
-                if (self.editor_anchor != null) result_text.setCursor(&self.editor, try self.editorCursorAt(mouse, size));
+                if (self.editor_anchor != null) {
+                    // Cell coordinates have no left/right half, so both endpoint glyphs belong to a drag.
+                    const cell = try self.editorCellAt(mouse, size);
+                    const backward = cell.start < origin.start;
+                    self.editor_anchor = if (backward) origin.end else origin.start;
+                    result_text.setCursor(&self.editor, if (backward) cell.start else cell.end);
+                }
                 if (mouse.type == .release) self.editor_drag_origin = null;
                 return ctx.consumeAndRedraw();
             }
@@ -563,10 +583,10 @@ pub const View = struct {
         if (self.canCombine() and row == body.inspector_heading_row and inRange(col, self.combineToggleRange(size.width)))
             return ctx.consumeEvent();
         if (row >= body.inspector_rows.start and row < body.inspector_rows.end and inRange(col, geometry.result)) {
-            const cursor = try self.editorCursorAt(mouse, size);
-            result_text.setCursor(&self.editor, cursor);
+            const cell = try self.editorCellAt(mouse, size);
+            result_text.setCursor(&self.editor, cell.start);
             self.editor_anchor = null;
-            self.editor_drag_origin = cursor;
+            self.editor_drag_origin = cell;
             return ctx.consumeAndRedraw();
         }
         if (!try self.finishEditorForNavigation(ctx)) return;
@@ -970,7 +990,7 @@ pub const View = struct {
             self.horizontal_offset = 0;
             try self.state.handle(.pane_right);
             try self.beginResultEdit(ctx, self.selectedResultInput());
-            self.editor_drag_origin = try self.editorCursorAt(mouse, size);
+            self.editor_drag_origin = try self.editorCellAt(mouse, size);
             return;
         }
         if (inRange(col, geometry.inspector)) return self.focusInspector(ctx);
@@ -1308,7 +1328,13 @@ fn draw(
     }
 
     if (self.selectedOperation() != null) {
-        writeClipped(surface, content_start, footer.row, footer.complete.start - content_start - 1, if (self.editing) "Shift+Enter Newline  Enter Apply  Esc Cancel" else "Ctrl+E Edit Result");
+        const hint = if (!self.editing)
+            "Ctrl+E Edit Result"
+        else if (self.editorSelection() != null)
+            "Ctrl+C Copy  Shift+Enter Newline  Enter Apply  Esc Cancel"
+        else
+            "Shift+Enter Newline  Enter Apply  Esc Cancel";
+        writeClipped(surface, content_start, footer.row, footer.complete.start - content_start - 1, hint);
     }
     if (self.state.outcome == .ready) {
         writeClipped(
@@ -1689,7 +1715,8 @@ pub fn run(
     path: []const u8,
     partial: []const u8,
 ) !void {
-    const tree = try merge_tree.build(allocator, partial, state.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(allocator, partial, state);
+    try state.handle(.{ .select_conflict = 0 });
     var tty_buffer: [4096]u8 = undefined;
     var app = try vxfw.App.init(io, allocator, env_map, &tty_buffer);
     defer app.deinit();
@@ -1921,7 +1948,7 @@ fn viewForTest(
     path: []const u8,
     partial: []const u8,
 ) !View {
-    const tree = try merge_tree.build(arena, partial, state.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, partial, state);
     return View.init(arena, state, path, tree);
 }
 
@@ -2064,7 +2091,7 @@ test "merge TUI: draws the full Unity tree and marks only conflict rows" {
     const arena = arena_state.allocator();
     var fixture = try hierarchyPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "Assets/Player.prefab", tree);
     defer view.deinit();
 
@@ -2116,7 +2143,7 @@ test "merge TUI: Escape opens a non-writing quit dialog" {
     const arena = arena_state.allocator();
     var fixture = try screenPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "A.prefab", tree);
     defer view.deinit();
     _ = try drawForTest(arena, view.widget(), 100, 20);
@@ -2199,7 +2226,7 @@ test "merge TUI: uses an empty pane gutter and no value dividers" {
     const arena = arena_state.allocator();
     var fixture = try screenPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "A.prefab", tree);
     defer view.deinit();
 
@@ -2230,7 +2257,7 @@ test "merge TUI: hides the Result editor while the tree owns focus" {
     const arena = arena_state.allocator();
     var fixture = try screenPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "A.prefab", tree);
     defer view.deinit();
 
@@ -2246,7 +2273,7 @@ test "merge TUI: keeps resolved conflicts in the tree" {
     const arena = arena_state.allocator();
     var fixture = try hierarchyPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "Assets/Player.prefab", tree);
     defer view.deinit();
     _ = try drawForTest(arena, view.widget(), 100, 20);
@@ -2269,7 +2296,7 @@ test "merge TUI: context clicks and hierarchy wheel preserve the selected confli
     const arena = arena_state.allocator();
     var fixture = try tallPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "A.prefab", tree);
     defer view.deinit();
     _ = try drawForTest(arena, view.widget(), 80, 10);
@@ -2309,7 +2336,7 @@ test "merge TUI: hierarchy wheel preserves the focused Result editor" {
     const arena = arena_state.allocator();
     var fixture = try tallPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var view = View.init(arena, &state, "A.prefab", tree);
     defer view.deinit();
     _ = try drawForTest(arena, view.widget(), 80, 10);
@@ -4354,7 +4381,7 @@ test "merge TUI: failed Result start keeps editor valid" {
     const arena = arena_state.allocator();
     var fixture = try screenPlan(arena);
     var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    const tree = try merge_tree.build(arena, fixture.partial, &fixture.plan, state.conflict_indices);
+    const tree = try merge_tree.buildForState(arena, fixture.partial, &state);
     var failing_allocator = testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 2 });
     var view = View.init(failing_allocator.allocator(), &state, "A.prefab", tree);
     defer view.deinit();
@@ -5512,10 +5539,11 @@ test "merge TUI: dragging Result highlights a range and typing replaces it" {
         surface = try drawForTest(arena, view.widget(), 100, 20);
     }
     try testing.expect(surface.children[0].surface.readCell(0, 0).style.reverse);
-    try testing.expect(!surface.children[0].surface.readCell(1, 0).style.reverse);
+    try testing.expect(surface.children[0].surface.readCell(1, 0).style.reverse);
+    try testing.expect(!surface.children[0].surface.readCell(2, 0).style.reverse);
     try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = '9', .text = "9" } });
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try testing.expectEqualStrings("92", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+    try testing.expectEqualStrings("9", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
 }
 
 test "merge TUI: deletion before editing clears Result without entering the editor" {
@@ -5623,16 +5651,17 @@ test "merge TUI: a backward multiline drag supports paste deletion and indented 
         // Unicode cells and the intervening newline belong to the same selection in either direction.
         try testing.expect(surface.children[0].surface.readCell(2, 0).style.reverse);
         try testing.expect(surface.children[0].surface.readCell(2, 1).style.reverse);
-        try testing.expect(!surface.children[0].surface.readCell(3, 1).style.reverse);
+        try testing.expect(surface.children[0].surface.readCell(3, 1).style.reverse);
+        try testing.expect(!surface.children[0].surface.readCell(4, 1).style.reverse);
         if (case == 3) {
             try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "X") });
         } else {
             try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = events[case] });
         }
         const expected = switch (case) {
-            2 => "  \n  econd",
-            3 => "  Xecond",
-            else => "  econd",
+            2 => "  \n  cond",
+            3 => "  Xcond",
+            else => "  cond",
         };
         try testing.expectEqualStrings(expected, try view.editor.buf.dupe());
         try testing.expect(view.editorSelection() == null);
@@ -5736,5 +5765,105 @@ test "merge TUI: mouse dragging works before the editor has its first rendered s
     try testing.expect(view.editorSelection() != null);
     try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '9', .text = "9" } });
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try testing.expectEqualStrings("92", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+    try testing.expectEqualStrings("9", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+fn dragEditorForTest(
+    arena: std.mem.Allocator,
+    view: *View,
+    ctx: *vxfw.EventContext,
+    start_col: u16,
+    start_row: u16,
+    end_col: u16,
+    end_row: u16,
+) !void {
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    const origin_col = Geometry.init(100).result.start + 2;
+    const origin_row = BodyGeometry.init(20).inspector_rows.start;
+    for ([_]vaxis.Mouse.Type{ .press, .drag, .release }) |kind| {
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), ctx, .{ .mouse = .{
+            .col = @intCast(origin_col + if (kind == .press) start_col else end_col),
+            .row = @intCast(origin_row + if (kind == .press) start_row else end_row),
+            .button = .left,
+            .mods = .{},
+            .type = kind,
+        } });
+    }
+}
+
+test "merge TUI: dragging through the last character replaces it on paste" {
+    const cases = [_]struct { text: []const u8, last_col: u16, last_row: u16 }{
+        .{ .text = "0.4", .last_col = 2, .last_row = 0 },
+        .{ .text = "あいう", .last_col = 5, .last_row = 0 },
+        .{ .text = "one\nlast", .last_col = 3, .last_row = 1 },
+    };
+    for (cases) |case| {
+        for ([_]bool{ false, true }) |backward| {
+            var memory = std.heap.ArenaAllocator.init(testing.allocator);
+            defer memory.deinit();
+            const arena = memory.allocator();
+            var fixture = try screenPlan(arena);
+            var state = try merge_ui_state.State.init(arena, &fixture.plan);
+            var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+            defer view.deinit();
+            _ = try drawForTest(arena, view.widget(), 100, 20);
+            var ctx = eventContext(arena);
+            try focusResultForTest(&view, &ctx);
+            try view.beginResultEdit(&ctx, case.text);
+            try dragEditorForTest(arena, &view, &ctx, if (backward) case.last_col else 0, if (backward) case.last_row else 0, if (backward) 0 else case.last_col, if (backward) 0 else case.last_row);
+            const surface = try drawForTest(arena, view.widget(), 100, 20);
+            // Terminal mouse reports identify cells, so stopping on the final glyph must include that glyph.
+            try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .paste_start);
+            try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = '7', .text = "7" } });
+            try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .paste_end);
+            try testing.expectEqualStrings("7", try view.editor.buf.dupe());
+        }
+    }
+}
+
+test "merge TUI: modifier key reports preserve selection for terminal paste" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try view.beginResultEdit(&ctx, "0.4");
+    try dragEditorForTest(arena, &view, &ctx, 0, 0, 3, 0);
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    // A terminal can report Command separately before sending its paste payload.
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.left_super, .mods = .{ .super = true } } });
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "0.6") });
+    try testing.expectEqualStrings("0.6", try view.editor.buf.dupe());
+}
+
+test "merge TUI: copying a selection preserves its text and selection" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    const original = "  あい\n  0.4";
+    try view.beginResultEdit(&ctx, original);
+    try dragEditorForTest(arena, &view, &ctx, 2, 0, 5, 1);
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    ctx.cmds.clearRetainingCapacity();
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = 'c', .mods = .{ .ctrl = true } } });
+    // The clipboard receives source text, including newlines, without the editor's padding or wrapping.
+    try testing.expectEqual(@as(usize, 1), ctx.cmds.items.len);
+    try testing.expectEqualStrings("あい\n  0.4", ctx.cmds.items[0].copy_to_clipboard);
+    try testing.expectEqualStrings(original, try view.editor.buf.dupe());
+    try testing.expect(view.editorSelection() != null);
+    try testing.expect(!view.editor_changed);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "7") });
+    try testing.expectEqualStrings("  7", try view.editor.buf.dupe());
 }

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -736,7 +736,7 @@ pub const View = struct {
                 }
                 ctx.consumeEvent();
             },
-            else => ctx.consumeEvent(),
+            else => {},
         }
     }
 
@@ -1382,6 +1382,31 @@ fn draw(
         for (dialog.top..dialog.bottom) |row| {
             styleRange(surface, @intCast(row), .{ .start = dialog.left, .end = dialog.right }, .{ .bg = Palette.focus_bg });
         }
+        const border_style: vaxis.Style = .{ .fg = Palette.muted, .bg = Palette.focus_bg };
+        for (dialog.top..dialog.bottom) |row| {
+            const top = row == dialog.top;
+            const bottom = row == dialog.bottom - 1;
+            surface.writeCell(dialog.left, @intCast(row), .{
+                .char = .{ .grapheme = if (top) "┌" else if (bottom) "└" else "│", .width = 1 },
+                .style = border_style,
+            });
+            surface.writeCell(dialog.right - 1, @intCast(row), .{
+                .char = .{ .grapheme = if (top) "┐" else if (bottom) "┘" else "│", .width = 1 },
+                .style = border_style,
+            });
+            if (top or bottom) {
+                for (dialog.left + 1..dialog.right - 1) |col| {
+                    surface.writeCell(@intCast(col), @intCast(row), .{
+                        .char = .{ .grapheme = "─", .width = 1 },
+                        .style = border_style,
+                    });
+                }
+            }
+        }
+        styleRange(surface, dialog.prompt_row, .{ .start = dialog.left + 3, .end = dialog.right - 3 }, .{
+            .bold = true,
+            .bg = Palette.focus_bg,
+        });
         var cancel_style: vaxis.Style = .{ .fg = Palette.muted, .bg = Palette.focus_bg };
         var confirm_style: vaxis.Style = .{ .fg = Palette.muted, .bg = Palette.focus_bg };
         if (self.dialog_choice == .cancel) {
@@ -2179,7 +2204,7 @@ test "merge TUI: dialogs cover the text and colors beneath them" {
         const surface = try drawForTest(arena, view.widget(), 100, 20);
         const dialog = DialogGeometry.init(100, 20, kind);
         // Component documents fill several rows beneath the modal, including its blank margins.
-        for (dialog.top..dialog.bottom) |row| {
+        for (dialog.top + 1..dialog.bottom - 1) |row| {
             const expected = if (row == dialog.prompt_row)
                 if (kind == .quit) "Quit before completion?" else "Use an empty value?"
             else if (row == dialog.detail_row)
@@ -2188,7 +2213,7 @@ test "merge TUI: dialogs cover the text and colors beneath them" {
                 if (kind == .quit) "[Cancel]    [Quit]" else "[Cancel]    [Use Empty]"
             else
                 "";
-            try testing.expectEqualStrings(expected, std.mem.trim(u8, try cellsText(arena, surface, @intCast(row), dialog.left, dialog.right - dialog.left), " "));
+            try testing.expectEqualStrings(expected, std.mem.trim(u8, try cellsText(arena, surface, @intCast(row), dialog.left + 1, dialog.right - dialog.left - 2), " "));
             for (dialog.left..dialog.right) |col| {
                 try testing.expect(vaxis.Color.eql(Palette.focus_bg, surface.readCell(@intCast(col), @intCast(row)).style.bg));
             }
@@ -4731,6 +4756,15 @@ test "merge TUI: the empty value dialog owns keyboard focus" {
         .request_focus => |widget| try testing.expect(widget.eql(view.widget())),
         else => return error.TestUnexpectedResult,
     }
+
+    // vxfw changes focus after resetting the last input event, so focus must not consume the next key.
+    ctx.consume_event = false;
+    ctx.phase = .at_target;
+    try view.widget().handleEvent(&ctx, .focus_in);
+    ctx.phase = .capturing;
+    try view.widget().captureEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.right } });
+    try testing.expect(view.dialog_choice == .confirm);
+    try testing.expect(view.dialog == .empty);
 }
 
 test "merge TUI: the empty value dialog handles captured keys" {

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -400,7 +400,7 @@ pub const View = struct {
             return true;
         }
         self.editor_drag_origin = null;
-        if (key.matches('c', .{ .ctrl = true })) {
+        if (key.matches('c', .{ .super = true }) or key.matches('c', .{ .ctrl = true })) {
             if (self.editorSelection()) |range| {
                 const text = try self.editor.buf.dupe();
                 defer self.editor.buf.allocator.free(text);
@@ -1327,15 +1327,6 @@ fn draw(
         }
     }
 
-    if (self.selectedOperation() != null) {
-        const hint = if (!self.editing)
-            "Ctrl+E Edit Result"
-        else if (self.editorSelection() != null)
-            "Ctrl+C Copy  Shift+Enter Newline  Enter Apply  Esc Cancel"
-        else
-            "Shift+Enter Newline  Enter Apply  Esc Cancel";
-        writeClipped(surface, content_start, footer.row, footer.complete.start - content_start - 1, hint);
-    }
     if (self.state.outcome == .ready) {
         writeClipped(
             surface,
@@ -1366,13 +1357,11 @@ fn draw(
 
     if (self.dialog) |kind| {
         const dialog = DialogGeometry.init(size.width, size.height, kind);
+        // Styling existing cells leaves the underlying diff visible between the modal's labels.
         for (dialog.top..dialog.bottom) |row| {
-            styleRange(
-                surface,
-                @intCast(row),
-                .{ .start = dialog.left, .end = dialog.right },
-                .{ .bg = Palette.focus_bg },
-            );
+            for (dialog.left..dialog.right) |col| {
+                surface.writeCell(@intCast(col), @intCast(row), .{ .char = .{ .grapheme = " ", .width = 1 } });
+            }
         }
         writeClipped(
             surface,
@@ -1390,6 +1379,9 @@ fn draw(
         );
         writeClipped(surface, dialog.cancel.start, dialog.buttons_row, 8, "[Cancel]");
         writeClipped(surface, dialog.confirm.start, dialog.buttons_row, @intCast(kind.confirmLabel().len), kind.confirmLabel());
+        for (dialog.top..dialog.bottom) |row| {
+            styleRange(surface, @intCast(row), .{ .start = dialog.left, .end = dialog.right }, .{ .bg = Palette.focus_bg });
+        }
         var cancel_style: vaxis.Style = .{ .fg = Palette.muted, .bg = Palette.focus_bg };
         var confirm_style: vaxis.Style = .{ .fg = Palette.muted, .bg = Palette.focus_bg };
         if (self.dialog_choice == .cancel) {
@@ -1683,7 +1675,7 @@ fn handleEvent(
             if (self.focus_area == .inspector and self.selected_value != .result and
                 self.canCombine() and key.matches('t', .{ .shift = true }))
                 return self.toggleCombine(ctx);
-            if (key.matches('e', .{ .ctrl = true }) or key.matches(vaxis.Key.f2, .{})) {
+            if (key.matches(vaxis.Key.f2, .{})) {
                 if (self.selectedOperation() == null) return;
                 self.focus_area = .inspector;
                 self.selected_value = .result;
@@ -1763,7 +1755,6 @@ test "merge TUI: collection toggle retains both orders until Enter applies the f
             try testing.expectEqualStrings("1 unresolved", try cellsText(arena, surface, BodyGeometry.init(20).header_row, width - horizontal_padding - 12, 12));
             try testing.expect(std.mem.indexOf(u8, labels, "Ours + Theirs") != null);
             try testing.expect(std.mem.indexOf(u8, labels, "Theirs + Ours") != null);
-            try testing.expectEqualStrings("Ctrl+E Edit Result", std.mem.trim(u8, try rowText(arena, surface, FooterGeometry.init(width, 20).row), " "));
             try testing.expectEqualStrings("", std.mem.trim(u8, try rowText(arena, surface, BodyGeometry.init(20).status_row), " "));
         }
         // Switching the available choices must not create or apply a Result preview.
@@ -2165,6 +2156,47 @@ test "merge TUI: Escape opens a non-writing quit dialog" {
     try testing.expect(!ctx.quit);
 }
 
+test "merge TUI: dialogs cover the text and colors beneath them" {
+    for ([_]Dialog{ .quit, .empty }) |kind| {
+        var memory = std.heap.ArenaAllocator.init(testing.allocator);
+        defer memory.deinit();
+        const arena = memory.allocator();
+        var fixture = try componentDeletePlan(arena);
+        var state = try merge_ui_state.State.init(arena, &fixture.plan);
+        try state.handle(.choose_theirs);
+        var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+        defer view.deinit();
+        _ = try drawForTest(arena, view.widget(), 100, 20);
+        var ctx = eventContext(arena);
+        if (kind == .quit) {
+            try pressKeyForTest(&view, &ctx, vaxis.Key.escape);
+        } else {
+            try focusResultForTest(&view, &ctx);
+            try view.beginResultEdit(&ctx, "");
+            try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+        }
+        try testing.expectEqual(kind, view.dialog.?);
+        const surface = try drawForTest(arena, view.widget(), 100, 20);
+        const dialog = DialogGeometry.init(100, 20, kind);
+        // Component documents fill several rows beneath the modal, including its blank margins.
+        for (dialog.top..dialog.bottom) |row| {
+            const expected = if (row == dialog.prompt_row)
+                if (kind == .quit) "Quit before completion?" else "Use an empty value?"
+            else if (row == dialog.detail_row)
+                if (kind == .quit) "PrefabLens will not write this result." else "This field will contain an empty YAML value."
+            else if (row == dialog.buttons_row)
+                if (kind == .quit) "[Cancel]    [Quit]" else "[Cancel]    [Use Empty]"
+            else
+                "";
+            try testing.expectEqualStrings(expected, std.mem.trim(u8, try cellsText(arena, surface, @intCast(row), dialog.left, dialog.right - dialog.left), " "));
+            for (dialog.left..dialog.right) |col| {
+                try testing.expect(vaxis.Color.eql(Palette.focus_bg, surface.readCell(@intCast(col), @intCast(row)).style.bg));
+            }
+        }
+        try testing.expectEqual(@as(usize, 0), surface.children.len);
+    }
+}
+
 test "merge TUI: y confirms and n cancels the quit dialog" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -2559,25 +2591,6 @@ test "merge TUI: draws two panes and sparse value columns" {
         " ",
         surface.readCell(geometry.hierarchy.end, body.inspector_labels_row).char.grapheme,
     );
-}
-
-test "merge TUI: the footer exposes Result editing without a status message" {
-    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
-    defer arena_state.deinit();
-    const arena = arena_state.allocator();
-    var fixture = try screenPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
-    defer view.deinit();
-
-    const surface = try drawForTest(arena, view.widget(), 100, 20);
-    const body = BodyGeometry.init(20);
-    const footer = FooterGeometry.init(100, 20);
-    const help = try rowText(arena, surface, body.status_row);
-    const actions = try rowText(arena, surface, footer.row);
-
-    try testing.expectEqual(@as(usize, 0), std.mem.trim(u8, help, " ").len);
-    try testing.expectEqualStrings("Ctrl+E Edit Result", std.mem.trim(u8, actions, " "));
 }
 
 test "merge TUI: side values and primary actions use distinct colors" {
@@ -4225,7 +4238,7 @@ test "merge TUI: the final choice focuses Complete before exit" {
     try testing.expect(ctx.quit);
 }
 
-test "merge TUI: the normal screen keeps only the Result editing hint" {
+test "merge TUI: the normal screen omits action hints" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -5423,7 +5436,7 @@ test "merge TUI: clicking the collection toggle and a side previews a replacemen
     try testing.expect(std.mem.indexOf(u8, try core.merge.finish(arena, &built.plan), "[A, Theirs, Ours]") != null);
 }
 
-test "merge TUI: Ctrl+E opens the displayed Result and retains inserted text" {
+test "merge TUI: Enter opens the focused Result and retains inserted text" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);
     defer memory.deinit();
     const arena = memory.allocator();
@@ -5434,7 +5447,11 @@ test "merge TUI: Ctrl+E opens the displayed Result and retains inserted text" {
     _ = try drawForTest(arena, view.widget(), 100, 20);
     var ctx = eventContext(arena);
     try state.handle(.choose_ours);
+    try focusResultForTest(&view, &ctx);
+    // Editing starts from the focused Result; Ctrl+E no longer changes the mode.
     try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try testing.expect(!view.editing);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
     try testing.expect(view.editing);
     var surface = try drawForTest(arena, view.widget(), 100, 20);
     // Starting an edit must show the current value before any key changes it.
@@ -5589,7 +5606,8 @@ test "merge TUI: a retained component can be edited after applying Theirs" {
     defer view.deinit();
     _ = try drawForTest(arena, view.widget(), 100, 20);
     var ctx = eventContext(arena);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.up);
+    try beginEditingForTest(&view, &ctx);
     const source_text = try view.editor.buf.dupe();
     // The field value is part of the displayed component document, not a standalone scalar.
     const digit = std.mem.indexOf(u8, source_text, "m_Mass: 2").? + "m_Mass: 2".len;
@@ -5602,7 +5620,8 @@ test "merge TUI: a retained component can be edited after applying Theirs" {
     try testing.expectEqualStrings("", state.status);
     try testing.expect(!view.editing);
     // Reopening the result must use the edited document, not the original side preview.
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.up);
+    try beginEditingForTest(&view, &ctx);
     try testing.expect(std.mem.indexOf(u8, try view.editor.buf.dupe(), "m_Mass: 3") != null);
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
     try testing.expectEqualStrings("", state.status);
@@ -5721,7 +5740,7 @@ test "merge TUI: a CRLF component stays multiline while editing and keeps CRLF o
     defer view.deinit();
     _ = try drawForTest(arena, view.widget(), 100, 20);
     var ctx = eventContext(arena);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try beginEditingForTest(&view, &ctx);
     // The editor uses logical LF lines; serialization restores the component's existing line ending.
     try testing.expect(std.mem.indexOfScalar(u8, try view.editor.buf.dupe(), '\r') == null);
     var surface = try drawForTest(arena, view.widget(), 100, 20);
@@ -5749,7 +5768,7 @@ test "merge TUI: mouse dragging works before the editor has its first rendered s
     _ = try drawForTest(arena, view.widget(), 100, 20);
     var ctx = eventContext(arena);
     try state.handle(.choose_ours);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try beginEditingForTest(&view, &ctx);
     const geometry = Geometry.init(100);
     const row = BodyGeometry.init(20).inspector_rows.start;
     // Mouse hit testing can still target the root until the frame containing the editor is drawn.
@@ -5842,28 +5861,33 @@ test "merge TUI: modifier key reports preserve selection for terminal paste" {
 }
 
 test "merge TUI: copying a selection preserves its text and selection" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    var fixture = try screenPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
-    defer view.deinit();
-    _ = try drawForTest(arena, view.widget(), 100, 20);
-    var ctx = eventContext(arena);
-    try focusResultForTest(&view, &ctx);
-    const original = "  あい\n  0.4";
-    try view.beginResultEdit(&ctx, original);
-    try dragEditorForTest(arena, &view, &ctx, 2, 0, 5, 1);
-    const surface = try drawForTest(arena, view.widget(), 100, 20);
-    ctx.cmds.clearRetainingCapacity();
-    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = 'c', .mods = .{ .ctrl = true } } });
-    // The clipboard receives source text, including newlines, without the editor's padding or wrapping.
-    try testing.expectEqual(@as(usize, 1), ctx.cmds.items.len);
-    try testing.expectEqualStrings("あい\n  0.4", ctx.cmds.items[0].copy_to_clipboard);
-    try testing.expectEqualStrings(original, try view.editor.buf.dupe());
-    try testing.expect(view.editorSelection() != null);
-    try testing.expect(!view.editor_changed);
-    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "7") });
-    try testing.expectEqualStrings("  7", try view.editor.buf.dupe());
+    for ([_][]const u8{ "\x1b[99;9u", "\x03" }) |input| {
+        var memory = std.heap.ArenaAllocator.init(testing.allocator);
+        defer memory.deinit();
+        const arena = memory.allocator();
+        var fixture = try screenPlan(arena);
+        var state = try merge_ui_state.State.init(arena, &fixture.plan);
+        var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+        defer view.deinit();
+        _ = try drawForTest(arena, view.widget(), 100, 20);
+        var ctx = eventContext(arena);
+        try focusResultForTest(&view, &ctx);
+        const original = "  あい\n  0.4";
+        try view.beginResultEdit(&ctx, original);
+        try dragEditorForTest(arena, &view, &ctx, 2, 0, 5, 1);
+        const surface = try drawForTest(arena, view.widget(), 100, 20);
+        ctx.cmds.clearRetainingCapacity();
+        // macOS sends Command as Super in Kitty reports; Control also works in legacy terminals.
+        var parser: vaxis.Parser = .{};
+        const key = (try parser.parse(input, arena)).event.?.key_press;
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = key });
+        // The clipboard receives source text, including newlines, without the editor's padding or wrapping.
+        try testing.expectEqual(@as(usize, 1), ctx.cmds.items.len);
+        try testing.expectEqualStrings("あい\n  0.4", ctx.cmds.items[0].copy_to_clipboard);
+        try testing.expectEqualStrings(original, try view.editor.buf.dupe());
+        try testing.expect(view.editorSelection() != null);
+        try testing.expect(!view.editor_changed);
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .paste = try arena.dupe(u8, "7") });
+        try testing.expectEqualStrings("  7", try view.editor.buf.dupe());
+    }
 }

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -183,40 +183,16 @@ fn valueStyle(column: ValueColumn) vaxis.Style {
     };
 }
 
-fn editsOrMovesTextFieldValue(key: vaxis.Key) bool {
-    return key.matches(vaxis.Key.left, .{}) or
-        key.matches(vaxis.Key.right, .{}) or
-        key.matches(vaxis.Key.home, .{}) or
-        key.matches(vaxis.Key.end, .{}) or
-        key.matches(vaxis.Key.delete, .{}) or
-        key.matches('a', .{ .ctrl = true }) or
-        key.matches('b', .{ .ctrl = true }) or
-        key.matches('d', .{ .ctrl = true }) or
-        key.matches('e', .{ .ctrl = true }) or
-        key.matches('f', .{ .ctrl = true }) or
-        key.matches('k', .{ .ctrl = true }) or
-        key.matches('u', .{ .ctrl = true }) or
-        key.matches('w', .{ .ctrl = true }) or
-        key.matches('b', .{ .alt = true }) or
-        key.matches('d', .{ .alt = true }) or
-        key.matches('f', .{ .alt = true }) or
-        key.matches(vaxis.Key.left, .{ .alt = true }) or
-        key.matches(vaxis.Key.right, .{ .alt = true }) or
-        key.matches(vaxis.Key.backspace, .{ .alt = true });
-}
-
 pub const View = struct {
     state: *merge_ui_state.State,
     path: []const u8,
     tree: merge_tree.Model,
     editor: vxfw.TextField,
     editing: bool = false,
-    editor_cursor_mode: bool = false,
     editor_top: usize = 0,
     pasting: bool = false,
     paste_into_result: bool = false,
     paste_buffer: std.ArrayList(u8) = .empty,
-    replace_on_input: bool = false,
     editor_start_resolution: ?core.merge.Resolution = null,
     editor_changed: bool = false,
     editor_reopened: bool = false,
@@ -365,7 +341,6 @@ pub const View = struct {
         self: *View,
         ctx: *vxfw.EventContext,
         initial: []const u8,
-        replace_on_input: bool,
     ) !void {
         self.editor.clearRetainingCapacity();
         try self.editor.insertSliceAtCursor(initial);
@@ -373,9 +348,7 @@ pub const View = struct {
         self.editor.buf.allocator.free(self.editor.previous_val);
         self.editor.previous_val = previous_val;
         self.editing = true;
-        self.editor_cursor_mode = false;
         self.editor_top = 0;
-        self.replace_on_input = replace_on_input;
         self.editor_start_resolution = self.state.pending;
         self.editor_changed = false;
         self.editor_reopened = false;
@@ -388,40 +361,13 @@ pub const View = struct {
         ctx: *vxfw.EventContext,
         key: vaxis.Key,
     ) !void {
-        try self.beginResultEdit(ctx, "", false);
+        try self.beginResultEdit(ctx, self.selectedResultInput());
         if (!self.editing) return;
         try self.editor.handleEvent(ctx, .{ .key_press = key });
     }
 
-    fn prepareEditorInput(
-        self: *View,
-        ctx: *vxfw.EventContext,
-        key: vaxis.Key,
-    ) !bool {
-        if (!self.editing or !self.replace_on_input) return false;
-        if (key.matches(vaxis.Key.backspace, .{})) {
-            try self.clearInitialResult(ctx);
-            return true;
-        }
-        if (editsOrMovesTextFieldValue(key)) {
-            self.replace_on_input = false;
-        } else if (key.text != null and key.text.?.len != 0) {
-            self.editor.clearRetainingCapacity();
-            self.replace_on_input = false;
-        }
-        return false;
-    }
-
     fn handleEditorKey(self: *View, ctx: *vxfw.EventContext, key: vaxis.Key) !bool {
-        if (key.matches(vaxis.Key.f2, .{})) {
-            self.replace_on_input = false;
-            self.editor_cursor_mode = true;
-            ctx.consumeAndRedraw();
-            return true;
-        }
         if (key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true })) {
-            self.replace_on_input = false;
-            self.editor_cursor_mode = true;
             const before = self.editor.buf.firstHalf();
             const start = if (std.mem.lastIndexOfScalar(u8, before, '\n')) |at| at + 1 else 0;
             const newline = try std.mem.concat(self.editor.buf.allocator, u8, &.{ "\n", before[start .. start + lineIndent(before[start..])] });
@@ -429,25 +375,22 @@ pub const View = struct {
             try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = newline } });
             return true;
         }
-        if (self.editor_cursor_mode and try result_text.moveLine(&self.editor, key)) {
+        if (try result_text.moveLine(&self.editor, key)) {
             ctx.consumeAndRedraw();
             return true;
         }
-        return self.prepareEditorInput(ctx, key);
+        return false;
     }
 
     fn insertPaste(self: *View, ctx: *vxfw.EventContext, text: []const u8) !void {
         if (text.len == 0) return;
-        if (!self.editing) try self.beginResultEdit(ctx, "", false);
+        if (!self.editing) try self.beginResultEdit(ctx, self.selectedResultInput());
         // A paste is one edit; newline key events must never submit a partial value.
         const normalized = try std.mem.replaceOwned(u8, self.editor.buf.allocator, text, "\r\n", "\n");
         defer self.editor.buf.allocator.free(normalized);
         for (normalized) |*byte| if (byte.* == '\r') {
             byte.* = '\n';
         };
-        if (self.replace_on_input) self.editor.clearRetainingCapacity();
-        self.replace_on_input = false;
-        self.editor_cursor_mode = true;
         try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = normalized } });
     }
 
@@ -491,15 +434,6 @@ pub const View = struct {
         }
         ctx.consumeAndRedraw();
         return true;
-    }
-
-    fn clearInitialResult(self: *View, ctx: *vxfw.EventContext) !void {
-        self.editor.clearRetainingCapacity();
-        self.replace_on_input = false;
-        self.editor_changed = true;
-        try self.state.handle(.reopen_result);
-        self.editor_reopened = true;
-        ctx.consumeAndRedraw();
     }
 
     fn applyPendingResult(
@@ -556,7 +490,15 @@ pub const View = struct {
         const body = BodyGeometry.init(size.height);
         if (self.canCombine() and row == body.inspector_heading_row and inRange(col, self.combineToggleRange(size.width)))
             return ctx.consumeEvent();
-        if (row >= body.inspector_rows.start and row < body.inspector_rows.end and inRange(col, geometry.result)) return;
+        if (row >= body.inspector_rows.start and row < body.inspector_rows.end and inRange(col, geometry.result)) {
+            try result_text.placeCursor(
+                &self.editor,
+                geometry.result.end - geometry.result.start -| 2,
+                self.editor_top + row - body.inspector_rows.start,
+                col -| (geometry.result.start + 2),
+            );
+            return ctx.consumeAndRedraw();
+        }
         if (!try self.finishEditorForNavigation(ctx)) return;
         try self.handleMouse(ctx, mouse, size);
     }
@@ -564,9 +506,7 @@ pub const View = struct {
     fn resetEditor(self: *View) void {
         self.editor.clearRetainingCapacity();
         self.editing = false;
-        self.editor_cursor_mode = false;
         self.editor_top = 0;
-        self.replace_on_input = false;
         self.editor_start_resolution = null;
         self.editor_changed = false;
         self.editor_reopened = false;
@@ -616,19 +556,6 @@ pub const View = struct {
         }
         try submitCustom(self, ctx, input);
         return !self.editing;
-    }
-
-    fn applyEditorAndMove(
-        self: *View,
-        ctx: *vxfw.EventContext,
-        key: vaxis.Key,
-        size: vxfw.Size,
-    ) !void {
-        if (!try self.finishEditorForNavigation(ctx)) return;
-        if (key.matches(vaxis.Key.left, .{})) return self.moveLeft(ctx);
-        if (key.matches(vaxis.Key.right, .{})) return self.moveRight(ctx);
-        if (key.matches(vaxis.Key.up, .{})) return self.moveUp(ctx, size);
-        if (key.matches(vaxis.Key.down, .{})) return self.moveDown(ctx, size);
     }
 
     fn focusComplete(self: *View, ctx: *vxfw.EventContext) void {
@@ -753,13 +680,21 @@ pub const View = struct {
         const resolution = self.state.pending orelse operation.resolution;
         return switch (resolution) {
             .unresolved => "",
-            .take => |side| switch (side) {
-                .base => rawSideText(operation.values.base),
-                .ours => rawSideText(operation.values.ours),
-                .theirs => rawSideText(operation.values.theirs),
-            },
-            .remove => "<removed>",
+            .take => |side| if (operation.values.get(side)) |value|
+                documentPreview(self.state.plan, operation, side) orelse value.bytes
+            else
+                "",
+            .remove => "",
             .custom => |value| value,
+        };
+    }
+
+    fn resultIsRemoval(self: *const View) bool {
+        const operation = self.selectedOperation() orelse return false;
+        return switch (self.state.pending orelse operation.resolution) {
+            .remove => true,
+            .take => |side| operation.values.get(side) == null,
+            else => false,
         };
     }
 
@@ -860,20 +795,6 @@ pub const View = struct {
         }
     }
 
-    fn activateResult(self: *View, ctx: *vxfw.EventContext, size: vxfw.Size) !void {
-        const operation = self.selectedOperation() orelse return;
-        const confirmed_empty = switch (operation.resolution) {
-            .custom => |value| value.len == 0,
-            else => false,
-        };
-        const input = self.selectedResultInput();
-        if (input.len == 0 and !confirmed_empty) {
-            try self.beginResultEdit(ctx, input, true);
-            return self.openDialog(ctx, .empty);
-        }
-        try self.applyPendingResult(ctx, size);
-    }
-
     fn activate(self: *View, ctx: *vxfw.EventContext, size: vxfw.Size) !void {
         switch (self.focus_area) {
             .hierarchy => try self.focusInspector(ctx),
@@ -886,7 +807,7 @@ pub const View = struct {
                     try self.state.handle(self.choiceAction(.theirs));
                     try self.applyPendingResult(ctx, size);
                 },
-                .result => try self.activateResult(ctx, size),
+                .result => try self.beginResultEdit(ctx, self.selectedResultInput()),
             },
             .complete => {
                 if (self.state.outcome == .ready) ctx.quit = true;
@@ -976,8 +897,7 @@ pub const View = struct {
             self.selected_value = .result;
             self.horizontal_offset = 0;
             try self.state.handle(.pane_right);
-            ctx.consumeAndRedraw();
-            return;
+            return self.beginResultEdit(ctx, self.selectedResultInput());
         }
         if (inRange(col, geometry.inspector)) return self.focusInspector(ctx);
     }
@@ -1313,8 +1233,8 @@ fn draw(
         }
     }
 
-    if (self.focus_area == .inspector and self.selected_value == .result) {
-        writeClipped(surface, content_start, footer.row, footer.complete.start - content_start - 1, if (self.editing) "F2 Edit  Ctrl+J Newline  Enter Apply  Esc Cancel" else "F2 Edit value  Enter Apply");
+    if (self.selectedOperation() != null) {
+        writeClipped(surface, content_start, footer.row, footer.complete.start - content_start - 1, if (self.editing) "Shift+Enter Newline  Enter Apply  Esc Cancel" else "Ctrl+E Edit Result");
     }
     if (self.state.outcome == .ready) {
         writeClipped(
@@ -1395,6 +1315,10 @@ fn draw(
                 editor_size,
                 vxfw.MaxSize.fromSize(editor_size),
             ));
+            if (!self.editor_changed and self.resultIsRemoval()) {
+                writeClipped(child_surface, 0, 0, editor_size.width, "<removed>");
+                styleRange(child_surface, 0, .{ .start = 0, .end = editor_size.width }, self.editor.style);
+            }
             const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
             children[0] = .{
                 .origin = .{
@@ -1416,10 +1340,11 @@ fn submitCustom(
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata.?));
     const input = std.mem.trim(u8, value, "\r\n");
-    const started_empty = if (self.editor_start_resolution) |resolution| switch (resolution) {
+    const started_empty = if (self.editor_start_resolution orelse if (self.selectedOperation()) |op| op.resolution else null) |resolution| switch (resolution) {
         .custom => |start_value| start_value.len == 0,
         else => false,
     } else false;
+    if (!self.editor_changed and self.resultIsRemoval()) return self.applyPendingResult(ctx, self.eventSize());
     if (input.len == 0 and !started_empty) return self.openDialog(ctx, .empty);
     if (self.editor_changed or input.len == 0) {
         try self.state.handle(.{ .edit_result = input });
@@ -1500,12 +1425,13 @@ fn paintColumnValue(
         const visible = if (isPlaceholderValue(text)) line else skipLineIndent(line, indent);
         var rest = visible;
         while (row < end_row) {
-            styleRange(surface, row, range, style);
             if (rest.len == 0) {
+                styleRange(surface, row, range, style);
                 row += 1;
                 break;
             }
             const consumed = writeClippedCount(surface, inner_start, row, inner_width, rest);
+            styleRange(surface, row, range, style);
             if (consumed == 0) break;
             rest = rest[consumed..];
             row += 1;
@@ -1586,15 +1512,8 @@ fn captureEvent(
         else => {},
     };
     switch (event) {
-        .key_press => |key| if (self.editing and !self.editor_cursor_mode and
-            (key.matches(vaxis.Key.left, .{}) or
-                key.matches(vaxis.Key.right, .{}) or
-                key.matches(vaxis.Key.up, .{}) or
-                key.matches(vaxis.Key.down, .{})))
-        {
-            try self.applyEditorAndMove(ctx, key, self.eventSize());
-        } else {
-            if (self.editing and try self.handleEditorKey(ctx, key)) return;
+        .key_press => |key| if (self.editing) {
+            _ = try self.handleEditorKey(ctx, key);
         },
         .mouse => |mouse| if (self.editing) {
             try self.handleMouseWhileEditing(ctx, mouse, self.eventSize());
@@ -1660,21 +1579,22 @@ fn handleEvent(
             if (self.focus_area == .inspector and self.selected_value != .result and
                 self.canCombine() and key.matches('t', .{ .shift = true }))
                 return self.toggleCombine(ctx);
-            if (self.focus_area == .inspector and self.selected_value == .result and key.matches(vaxis.Key.f2, .{})) {
-                try self.beginResultEdit(ctx, self.selectedResultInput(), false);
-                self.editor_cursor_mode = true;
-                return;
+            if (key.matches('e', .{ .ctrl = true }) or key.matches(vaxis.Key.f2, .{})) {
+                if (self.selectedOperation() == null) return;
+                self.focus_area = .inspector;
+                self.selected_value = .result;
+                self.horizontal_offset = 0;
+                try self.state.handle(.pane_right);
+                return self.beginResultEdit(ctx, self.selectedResultInput());
             }
-            if (self.focus_area == .inspector and self.selected_value == .result and
-                key.matches(vaxis.Key.backspace, .{}))
-            {
-                try self.beginResultEdit(ctx, self.selectedResultInput(), true);
-                if (!self.editing) return;
-                return self.clearInitialResult(ctx);
+            if (self.focus_area == .inspector and self.selected_value == .result) {
+                if (key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true })) {
+                    try self.beginResultEdit(ctx, self.selectedResultInput());
+                    _ = try self.handleEditorKey(ctx, key);
+                } else if (key.matches(vaxis.Key.backspace, .{}) or (key.text != null and key.text.?.len != 0)) {
+                    try self.beginTypedEdit(ctx, key);
+                }
             }
-            if (self.focus_area == .inspector and self.selected_value == .result and
-                key.text != null and key.text.?.len != 0)
-                return self.beginTypedEdit(ctx, key);
         },
         else => {},
     }
@@ -1735,7 +1655,7 @@ test "merge TUI: collection toggle retains both orders until Enter applies the f
             try testing.expectEqualStrings("1 unresolved", try cellsText(arena, surface, BodyGeometry.init(20).header_row, width - horizontal_padding - 12, 12));
             try testing.expect(std.mem.indexOf(u8, labels, "Ours + Theirs") != null);
             try testing.expect(std.mem.indexOf(u8, labels, "Theirs + Ours") != null);
-            try testing.expectEqualStrings("", std.mem.trim(u8, try rowText(arena, surface, FooterGeometry.init(width, 20).row), " "));
+            try testing.expectEqualStrings("Ctrl+E Edit Result", std.mem.trim(u8, try rowText(arena, surface, FooterGeometry.init(width, 20).row), " "));
             try testing.expectEqualStrings("", std.mem.trim(u8, try rowText(arena, surface, BodyGeometry.init(20).status_row), " "));
         }
         // Switching the available choices must not create or apply a Result preview.
@@ -2011,7 +1931,7 @@ fn focusResultForTest(view: *View, ctx: *vxfw.EventContext) !void {
 fn beginEditingForTest(view: *View, ctx: *vxfw.EventContext) !void {
     try focusResultForTest(view, ctx);
     // Editor tests need a stable setup that does not assign an input event to the behavior under test.
-    try view.beginResultEdit(ctx, view.selectedResultInput(), true);
+    try view.beginResultEdit(ctx, view.selectedResultInput());
 }
 
 fn findFocusedPath(
@@ -2533,7 +2453,7 @@ test "merge TUI: draws two panes and sparse value columns" {
     );
 }
 
-test "merge TUI: the normal status and footer rows are empty" {
+test "merge TUI: the footer exposes Result editing without a status message" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -2549,7 +2469,7 @@ test "merge TUI: the normal status and footer rows are empty" {
     const actions = try rowText(arena, surface, footer.row);
 
     try testing.expectEqual(@as(usize, 0), std.mem.trim(u8, help, " ").len);
-    try testing.expectEqual(@as(usize, 0), std.mem.trim(u8, actions, " ").len);
+    try testing.expectEqualStrings("Ctrl+E Edit Result", std.mem.trim(u8, actions, " "));
 }
 
 test "merge TUI: side values and primary actions use distinct colors" {
@@ -2563,8 +2483,8 @@ test "merge TUI: side values and primary actions use distinct colors" {
     const surface = try drawForTest(arena, view.widget(), 100, 20);
     const geometry = Geometry.init(100);
     const body = BodyGeometry.init(20);
-    const ours = surface.readCell(geometry.ours.start, body.inspector_rows.start).style.fg;
-    const theirs = surface.readCell(geometry.theirs.start, body.inspector_rows.start).style.fg;
+    const ours = surface.readCell(geometry.ours.start + 2, body.inspector_rows.start).style.fg;
+    const theirs = surface.readCell(geometry.theirs.start + 2, body.inspector_rows.start).style.fg;
 
     // Distinct colors prevent both sides from becoming one undifferentiated value table.
     try testing.expect(ours != .default);
@@ -2801,7 +2721,7 @@ test "merge TUI: selected value style follows Ours Theirs and Result" {
     } });
     surface = try drawForTest(arena, view.widget(), 80, 10);
     // Result focus must stay visible before keyboard input starts the editor.
-    try testing.expectEqual(@as(usize, 0), surface.children.len);
+    try testing.expectEqual(@as(usize, 1), surface.children.len);
     try testing.expectEqualStrings("▌", surface.readCell(geometry.result.start, body.inspector_rows.start).char.grapheme);
     try testing.expect(vaxis.Color.eql(surface.readCell(geometry.result.start, body.inspector_rows.start).style.bg, Palette.focus_bg));
 }
@@ -3058,7 +2978,7 @@ test "merge TUI: TextField applies an arbitrary YAML value" {
     try testing.expect(!ctx.quit);
 }
 
-test "merge TUI: typing in Result replaces the current value" {
+test "merge TUI: typing in an empty Result starts editing" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -3075,7 +2995,7 @@ test "merge TUI: typing in Result replaces the current value" {
         .text = "100",
     } });
 
-    // Direct input must replace the displayed Result without a separate editor action.
+    // An unresolved value can be entered directly after keyboard navigation.
     try testing.expect(view.editing);
     const value = try view.editor.toOwnedSlice();
     defer arena.free(value);
@@ -3293,7 +3213,7 @@ test "merge TUI: multiline editor keeps its cursor visible and moves by Unicode 
     try testing.expect(surface.children[0].surface.cursor.?.row < surface.children[0].surface.size.height);
 }
 
-test "merge TUI: Enter in Result applies the pending value" {
+test "merge TUI: Enter in Result opens the pending value before applying it" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -3309,6 +3229,10 @@ test "merge TUI: Enter in Result applies the pending value" {
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
 
     // Result Enter must apply the choice instead of opening an editor.
+    try testing.expect(view.editing);
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    try testing.expectEqualStrings("12", view.editor.buf.firstHalf());
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
     try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
     try testing.expect(view.focus_area == .hierarchy);
 }
@@ -3378,6 +3302,8 @@ test "merge TUI: Escape keeps the pending value that existed before editing" {
 
     try state.handle(.choose_theirs);
     try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.home);
     try view.widget().handleEvent(&ctx, .{ .key_press = .{
         .codepoint = '{',
         .text = "{bad",
@@ -3394,7 +3320,7 @@ test "merge TUI: Escape keeps the pending value that existed before editing" {
     try testing.expect(view.selected_value == .result);
 }
 
-test "merge TUI: Enter can replace a resolved choice" {
+test "merge TUI: Enter applies edits to a resolved choice" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -3421,7 +3347,7 @@ test "merge TUI: Enter can replace a resolved choice" {
     try testing.expect(!view.editing);
     try testing.expect(view.focus_area == .hierarchy);
     switch (fixture.plan.operations[operation_index].resolution) {
-        .custom => |value| try testing.expectEqualStrings("100", value),
+        .custom => |value| try testing.expectEqualStrings("12100", value),
         else => return error.TestUnexpectedResult,
     }
 }
@@ -4191,7 +4117,7 @@ test "merge TUI: the final choice focuses Complete before exit" {
     try testing.expect(ctx.quit);
 }
 
-test "merge TUI: the normal screen has no action footer or key help" {
+test "merge TUI: the normal screen keeps only the Result editing hint" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -4310,7 +4236,7 @@ test "merge TUI: mouse clicks Complete to exit" {
     try testing.expect(ctx.quit);
 }
 
-test "merge TUI: clicking Result focuses it without editing" {
+test "merge TUI: clicking Result starts editing with a text cursor" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -4322,7 +4248,7 @@ test "merge TUI: clicking Result focuses it without editing" {
     var ctx = eventContext(arena);
     const body = BodyGeometry.init(20);
 
-    // A mouse click must move focus without showing the text cursor.
+    // The visible Result cell is also the entry point for mouse editing.
     try view.widget().handleEvent(&ctx, .{ .mouse = .{
         .col = @intCast(Geometry.init(100).result.start),
         .row = @intCast(body.inspector_rows.start),
@@ -4335,8 +4261,8 @@ test "merge TUI: clicking Result focuses it without editing" {
     try testing.expectEqual(merge_ui_state.Pane.inspector, state.pane);
     try testing.expect(view.focus_area == .inspector);
     try testing.expect(view.selected_value == .result);
-    try testing.expect(!view.editing);
-    try testing.expectEqual(@as(usize, 0), surface.children.len);
+    try testing.expect(view.editing);
+    try testing.expectEqual(@as(usize, 1), surface.children.len);
     try testing.expect(ctx.consume_event);
     try testing.expect(ctx.redraw);
 }
@@ -4357,7 +4283,7 @@ test "merge TUI: failed Result start keeps editor valid" {
     var ctx = eventContext(arena);
 
     // The old value must keep its allocation until the replacement allocation succeeds.
-    try testing.expectError(error.OutOfMemory, view.beginResultEdit(&ctx, "new", true));
+    try testing.expectError(error.OutOfMemory, view.beginResultEdit(&ctx, "new"));
     try testing.expect(failing_allocator.has_induced_failure);
     try testing.expectEqualStrings("old", view.editor.previous_val);
     try testing.expect(!view.editing);
@@ -4447,7 +4373,7 @@ test "merge TUI: input replaces removed Result" {
     );
 }
 
-test "merge TUI: typing after a Result click replaces the displayed value" {
+test "merge TUI: typing after a Result click retains the displayed value" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -4468,20 +4394,20 @@ test "merge TUI: typing after a Result click replaces the displayed value" {
         .mods = .{},
         .type = .press,
     } });
-    try testing.expect(!view.editing);
+    try testing.expect(view.editing);
     try view.widget().handleEvent(&ctx, .{ .key_press = .{
         .codepoint = '1',
         .text = "100",
     } });
 
-    // Keyboard input must start editing and replace the value that the mouse focused.
+    // A click retains the chosen value, so typing adds text at its cursor.
     try testing.expect(view.editing);
     const value = try view.editor.toOwnedSlice();
     defer arena.free(value);
-    try testing.expectEqualStrings("100", value);
+    try testing.expectEqualStrings("12100", value);
 }
 
-test "merge TUI: focused Result input replaces the displayed value" {
+test "merge TUI: focused Result input inserts into the displayed value" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -4503,13 +4429,13 @@ test "merge TUI: focused Result input replaces the displayed value" {
         .{ .key_press = .{ .codepoint = '1', .text = "100" } },
     );
 
-    // This test prevents the focused TextField from appending input before the parent can replace its value.
+    // Parent event capture must preserve the same insertion behavior as direct input.
     const value = try view.editor.toOwnedSlice();
     defer arena.free(value);
-    try testing.expectEqualStrings("100", value);
+    try testing.expectEqualStrings("12100", value);
 }
 
-test "merge TUI: an arrow applies Result input before navigation" {
+test "merge TUI: an arrow moves the Result cursor without applying input" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -4538,18 +4464,15 @@ test "merge TUI: an arrow applies Result input before navigation" {
         .{ .key_press = .{ .codepoint = vaxis.Key.right } },
     );
 
-    // One arrow applies the current value and then performs normal navigation.
-    try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
-    switch (fixture.plan.operations[state.conflict_indices[0]].resolution) {
-        .custom => |value| try testing.expectEqualStrings("100", value),
-        else => return error.TestUnexpectedResult,
-    }
-    try testing.expect(!view.editing);
-    try testing.expect(view.focus_area == .inspector);
-    try testing.expect(view.selected_value == .ours);
+    // Editing must not resolve a conflict just because the user moves the caret.
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution == .unresolved);
+    try testing.expect(view.editing);
+    try testing.expect(view.selected_value == .result);
+    try testing.expectEqualStrings("100", view.editor.buf.firstHalf());
 }
 
-test "merge TUI: clearing Result and moving reopens the conflict" {
+test "merge TUI: clearing Result leaves an editable unresolved draft" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -4586,11 +4509,12 @@ test "merge TUI: clearing Result and moving reopens the conflict" {
         .{ .key_press = .{ .codepoint = vaxis.Key.left } },
     );
 
-    // A cleared draft means that the user wants to decide this conflict later.
+    // Cursor movement must keep even an empty draft editable.
     try testing.expect(fixture.plan.operations[operation_index].resolution == .unresolved);
     try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
     try testing.expectEqual(@as(usize, 0), state.selected_conflict);
-    try testing.expect(view.focus_area == .hierarchy);
+    try testing.expect(view.focus_area == .inspector);
+    try testing.expect(view.editing);
 }
 
 test "merge TUI: clearing Result and pressing Escape reopens the conflict" {
@@ -4649,6 +4573,7 @@ test "merge TUI: Enter asks before it applies an empty Result" {
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
     try pressKeyForTest(&view, &ctx, vaxis.Key.up);
     try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
     try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
 
@@ -4986,6 +4911,9 @@ test "merge TUI: Enter asks when the focused Result is empty" {
     try focusResultForTest(&view, &ctx);
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
 
+    try testing.expect(view.dialog == null);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+
     // Result focus must not bypass the empty value confirmation.
     try testing.expect(fixture.plan.operations[operation_index].resolution == .unresolved);
     try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
@@ -5013,6 +4941,8 @@ test "merge TUI: Enter does not ask again for a confirmed empty Result" {
     try focusResultForTest(&view, &ctx);
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
 
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+
     // A confirmed empty value does not need a second confirmation.
     switch (fixture.plan.operations[operation_index].resolution) {
         .custom => |value| try testing.expectEqualStrings("", value),
@@ -5026,7 +4956,7 @@ test "merge TUI: Enter does not ask again for a confirmed empty Result" {
     try testing.expect(std.mem.indexOf(u8, screen, "Use an empty value?") == null);
 }
 
-test "merge TUI: invalid Result input blocks arrow navigation" {
+test "merge TUI: invalid Result input remains editable during cursor movement" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -5057,7 +4987,7 @@ test "merge TUI: invalid Result input blocks arrow navigation" {
 
     // Invalid YAML keeps Result active so the user can correct the value.
     try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
-    try testing.expectEqualStrings("The result is not valid Unity YAML.", state.status);
+    try testing.expectEqualStrings("", state.status);
     try testing.expect(view.editing);
     try testing.expect(view.focus_area == .inspector);
     try testing.expect(view.selected_value == .result);
@@ -5110,7 +5040,7 @@ test "merge TUI: Enter on Theirs resolves the conflict and selects the next row"
     try testing.expect(!ctx.quit);
 }
 
-test "merge TUI: the first Backspace clears a prefilled Result" {
+test "merge TUI: the first Backspace deletes one character from a prefilled Result" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -5134,14 +5064,14 @@ test "merge TUI: the first Backspace clears a prefilled Result" {
         .{ .key_press = .{ .codepoint = vaxis.Key.backspace } },
     );
 
-    // Result starts as one selected value, so one Backspace must clear all of it.
+    // Editing a resolved choice must retain the other characters and its resolution until apply.
     const value = try view.editor.toOwnedSlice();
     defer arena.free(value);
-    try testing.expectEqualStrings("", value);
-    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution == .unresolved);
+    try testing.expectEqualStrings("1", value);
+    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution != .unresolved);
 }
 
-test "merge TUI: Backspace clears a focused Result before editing" {
+test "merge TUI: Backspace starts editing and deletes one character" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const arena = arena_state.allocator();
@@ -5158,15 +5088,15 @@ test "merge TUI: Backspace clears a focused Result before editing" {
     try focusResultForTest(&view, &ctx);
     try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
 
-    // Keyboard focus must let Backspace clear the value without a mouse edit transition.
+    // Deletion behaves the same whether editing started with the keyboard or the mouse.
     const value = try view.editor.toOwnedSlice();
     defer arena.free(value);
-    try testing.expectEqualStrings("", value);
+    try testing.expectEqualStrings("1", value);
     try testing.expect(view.editing);
     try testing.expect(view.focus_area == .inspector);
     try testing.expect(view.selected_value == .result);
-    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
-    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution == .unresolved);
+    try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
+    try testing.expect(fixture.plan.operations[state.conflict_indices[0]].resolution != .unresolved);
 }
 
 test "merge TUI: Backspace edits typed Result text one character at a time" {
@@ -5204,7 +5134,7 @@ test "merge TUI: Backspace edits typed Result text one character at a time" {
     try testing.expectEqualStrings("10", value);
 }
 
-test "merge TUI: TextField navigation makes Backspace delete normally" {
+test "merge TUI: TextField navigation retains normal Backspace behavior" {
     const navigation_keys = [_]vaxis.Key{
         .{ .codepoint = 'a', .mods = .{ .ctrl = true } },
         .{ .codepoint = 'e', .mods = .{ .ctrl = true } },
@@ -5246,7 +5176,7 @@ test "merge TUI: TextField navigation makes Backspace delete normally" {
             .{ .key_press = .{ .codepoint = vaxis.Key.backspace } },
         );
 
-        // Navigation cancels whole-value replacement before TextField handles Backspace.
+        // Text navigation must preserve the characters outside the deleted grapheme.
         const value = try view.editor.toOwnedSlice();
         defer arena.free(value);
         try testing.expect(value.len != 0);
@@ -5375,6 +5305,92 @@ test "merge TUI: clicking the collection toggle and a side previews a replacemen
     try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 't', .mods = .{ .shift = true } } });
     try pressKeyForTest(&view, &ctx, vaxis.Key.right);
     try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expect(view.editing);
+    try testing.expectEqualStrings("[Theirs, Ours]", view.editor.buf.firstHalf());
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
     try testing.expectEqual(merge_ui_state.Outcome.ready, state.outcome);
     try testing.expect(std.mem.indexOf(u8, try core.merge.finish(arena, &built.plan), "[A, Theirs, Ours]") != null);
+}
+
+test "merge TUI: Ctrl+E opens the displayed Result and retains inserted text" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .mods = .{ .ctrl = true } } });
+    try testing.expect(view.editing);
+    var surface = try drawForTest(arena, view.widget(), 100, 20);
+    // Starting an edit must show the current value before any key changes it.
+    try testing.expect(std.mem.startsWith(u8, try rowText(arena, surface.children[0].surface, 0), "12"));
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = '3', .text = "3" } });
+    surface = try drawForTest(arena, view.widget(), 100, 20);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.left } });
+    try testing.expectEqualStrings("123", try view.editor.buf.dupe());
+    try testing.expectEqual(@as(usize, 2), view.editor.buf.cursor);
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+}
+
+test "merge TUI: Shift+Enter starts a retained multiline Result edit" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    try focusResultForTest(&view, &ctx);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter, .mods = .{ .shift = true } } });
+    try testing.expect(view.editing);
+    try testing.expectEqualStrings("12\n", try view.editor.buf.dupe());
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    // The editor still owns Shift+Enter after the TextField receives focus.
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter, .mods = .{ .shift = true } } });
+    try testing.expectEqualStrings("12\n\n", try view.editor.buf.dupe());
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+}
+
+test "merge TUI: clicking inside the editor places the cursor on a Unicode line" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try view.beginResultEdit(&ctx, "  あいう\n  second");
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    const geometry = Geometry.init(100);
+    const body = BodyGeometry.init(20);
+    // Clicking within a wide grapheme must place the caret at a valid UTF-8 boundary.
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .mouse = .{
+        .col = @intCast(geometry.result.start + 2 + 3),
+        .row = @intCast(body.inspector_rows.start),
+        .button = .left,
+        .mods = .{},
+        .type = .press,
+    } });
+    try testing.expectEqual(@as(usize, 2), view.editor.buf.cursor);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .mouse = .{
+        .col = @intCast(geometry.result.start + 2 + 3),
+        .row = @intCast(body.inspector_rows.start + 1),
+        .button = .left,
+        .mods = .{},
+        .type = .press,
+    } });
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = 'X', .text = "X" } });
+    try testing.expectEqualStrings("  あいう\n  sXecond", try view.editor.buf.dupe());
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
 }

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -4,6 +4,7 @@ const vaxis = @import("vaxis");
 
 const merge_tree = @import("merge_tree.zig");
 const merge_ui_state = @import("merge_ui_state.zig");
+const result_text = @import("merge_result_text.zig");
 const testing = std.testing;
 const vxfw = vaxis.vxfw;
 
@@ -210,6 +211,11 @@ pub const View = struct {
     tree: merge_tree.Model,
     editor: vxfw.TextField,
     editing: bool = false,
+    editor_cursor_mode: bool = false,
+    editor_top: usize = 0,
+    pasting: bool = false,
+    paste_into_result: bool = false,
+    paste_buffer: std.ArrayList(u8) = .empty,
     replace_on_input: bool = false,
     editor_start_resolution: ?core.merge.Resolution = null,
     editor_changed: bool = false,
@@ -241,6 +247,7 @@ pub const View = struct {
     }
 
     pub fn deinit(self: *View) void {
+        self.paste_buffer.deinit(self.editor.buf.allocator);
         self.editor.deinit();
     }
 
@@ -366,6 +373,8 @@ pub const View = struct {
         self.editor.buf.allocator.free(self.editor.previous_val);
         self.editor.previous_val = previous_val;
         self.editing = true;
+        self.editor_cursor_mode = false;
+        self.editor_top = 0;
         self.replace_on_input = replace_on_input;
         self.editor_start_resolution = self.state.pending;
         self.editor_changed = false;
@@ -401,6 +410,87 @@ pub const View = struct {
             self.replace_on_input = false;
         }
         return false;
+    }
+
+    fn handleEditorKey(self: *View, ctx: *vxfw.EventContext, key: vaxis.Key) !bool {
+        if (key.matches(vaxis.Key.f2, .{})) {
+            self.replace_on_input = false;
+            self.editor_cursor_mode = true;
+            ctx.consumeAndRedraw();
+            return true;
+        }
+        if (key.matches('j', .{ .ctrl = true }) or key.matches(vaxis.Key.enter, .{ .shift = true })) {
+            self.replace_on_input = false;
+            self.editor_cursor_mode = true;
+            const before = self.editor.buf.firstHalf();
+            const start = if (std.mem.lastIndexOfScalar(u8, before, '\n')) |at| at + 1 else 0;
+            const newline = try std.mem.concat(self.editor.buf.allocator, u8, &.{ "\n", before[start .. start + lineIndent(before[start..])] });
+            defer self.editor.buf.allocator.free(newline);
+            try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = newline } });
+            return true;
+        }
+        if (self.editor_cursor_mode and try result_text.moveLine(&self.editor, key)) {
+            ctx.consumeAndRedraw();
+            return true;
+        }
+        return self.prepareEditorInput(ctx, key);
+    }
+
+    fn insertPaste(self: *View, ctx: *vxfw.EventContext, text: []const u8) !void {
+        if (text.len == 0) return;
+        if (!self.editing) try self.beginResultEdit(ctx, "", false);
+        // A paste is one edit; newline key events must never submit a partial value.
+        const normalized = try std.mem.replaceOwned(u8, self.editor.buf.allocator, text, "\r\n", "\n");
+        defer self.editor.buf.allocator.free(normalized);
+        for (normalized) |*byte| if (byte.* == '\r') {
+            byte.* = '\n';
+        };
+        if (self.replace_on_input) self.editor.clearRetainingCapacity();
+        self.replace_on_input = false;
+        self.editor_cursor_mode = true;
+        try self.editor.handleEvent(ctx, .{ .key_press = .{ .codepoint = 0, .text = normalized } });
+    }
+
+    fn handlePaste(self: *View, ctx: *vxfw.EventContext, event: vxfw.Event) !bool {
+        switch (event) {
+            .paste_start => {
+                self.pasting = true;
+                self.paste_into_result = isUsableSize(self.eventSize()) and self.dialog == null and
+                    self.focus_area == .inspector and self.selected_value == .result;
+                self.paste_buffer.clearRetainingCapacity();
+            },
+            .paste_end => {
+                self.pasting = false;
+                if (self.paste_into_result and isUsableSize(self.eventSize())) try self.insertPaste(ctx, self.paste_buffer.items);
+                self.paste_into_result = false;
+                self.paste_buffer.clearRetainingCapacity();
+            },
+            .key_press => |key| {
+                if (!self.pasting) return false;
+                if (!isUsableSize(self.eventSize())) self.paste_into_result = false;
+                if (self.paste_into_result) {
+                    const allocator = self.editor.buf.allocator;
+                    if (key.matches(vaxis.Key.enter, .{})) {
+                        try self.paste_buffer.append(allocator, '\r');
+                    } else if (key.matches(vaxis.Key.tab, .{})) {
+                        try self.paste_buffer.append(allocator, '\t');
+                    } else if (key.mods.ctrl and key.codepoint >= 'a' and key.codepoint <= 'z') {
+                        try self.paste_buffer.append(allocator, @intCast(key.codepoint - 'a' + 1));
+                    } else if (key.text) |text| {
+                        try self.paste_buffer.appendSlice(allocator, text);
+                    }
+                }
+            },
+            .mouse => if (!self.pasting) return false,
+            .paste => |text| {
+                defer ctx.alloc.free(text);
+                if (isUsableSize(self.eventSize()) and self.dialog == null and self.focus_area == .inspector and self.selected_value == .result)
+                    try self.insertPaste(ctx, text);
+            },
+            else => return false,
+        }
+        ctx.consumeAndRedraw();
+        return true;
     }
 
     fn clearInitialResult(self: *View, ctx: *vxfw.EventContext) !void {
@@ -474,6 +564,8 @@ pub const View = struct {
     fn resetEditor(self: *View) void {
         self.editor.clearRetainingCapacity();
         self.editing = false;
+        self.editor_cursor_mode = false;
+        self.editor_top = 0;
         self.replace_on_input = false;
         self.editor_start_resolution = null;
         self.editor_changed = false;
@@ -502,7 +594,7 @@ pub const View = struct {
         if (self.editor_changed) {
             const input = try self.editor.toOwnedSlice();
             defer self.editor.buf.allocator.free(input);
-            if (input.len == 0) return self.reopenResult(ctx, self.eventSize());
+            if (std.mem.trim(u8, input, "\r\n").len == 0) return self.reopenResult(ctx, self.eventSize());
         }
         try self.leaveEditorWithoutApply(ctx);
         try self.focusHierarchy(ctx);
@@ -518,7 +610,7 @@ pub const View = struct {
         }
         const input = try self.editor.toOwnedSlice();
         defer self.editor.buf.allocator.free(input);
-        if (input.len == 0) {
+        if (std.mem.trim(u8, input, "\r\n").len == 0) {
             try self.reopenResult(ctx, self.eventSize());
             return true;
         }
@@ -1221,6 +1313,9 @@ fn draw(
         }
     }
 
+    if (self.focus_area == .inspector and self.selected_value == .result) {
+        writeClipped(surface, content_start, footer.row, footer.complete.start - content_start - 1, if (self.editing) "F2 Edit  Ctrl+J Newline  Enter Apply  Esc Cancel" else "F2 Edit value  Enter Apply");
+    }
     if (self.state.outcome == .ready) {
         writeClipped(
             surface,
@@ -1294,9 +1389,9 @@ fn draw(
             self.editor.style = .{ .bg = Palette.focus_bg };
             const editor_size: vxfw.Size = .{
                 .width = geometry.result.end - geometry.result.start -| 2,
-                .height = 1,
+                .height = body.inspector_rows.end - editor_row,
             };
-            const child_surface = try self.editor.widget().draw(ctx.withConstraints(
+            const child_surface = try result_text.draw(&self.editor, &self.editor_top, ctx.withConstraints(
                 editor_size,
                 vxfw.MaxSize.fromSize(editor_size),
             ));
@@ -1320,13 +1415,14 @@ fn submitCustom(
     value: []const u8,
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata.?));
+    const input = std.mem.trim(u8, value, "\r\n");
     const started_empty = if (self.editor_start_resolution) |resolution| switch (resolution) {
         .custom => |start_value| start_value.len == 0,
         else => false,
     } else false;
-    if (value.len == 0 and !started_empty) return self.openDialog(ctx, .empty);
-    if (self.editor_changed or value.len == 0) {
-        try self.state.handle(.{ .edit_result = value });
+    if (input.len == 0 and !started_empty) return self.openDialog(ctx, .empty);
+    if (self.editor_changed or input.len == 0) {
+        try self.state.handle(.{ .edit_result = input });
     } else {
         self.state.pending = self.editor_start_resolution;
     }
@@ -1479,6 +1575,7 @@ fn captureEvent(
     event: vxfw.Event,
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata));
+    if (try self.handlePaste(ctx, event)) return;
     if (!isUsableSize(self.eventSize())) switch (event) {
         .key_press, .mouse => ctx.consumeEvent(),
         else => {},
@@ -1489,7 +1586,7 @@ fn captureEvent(
         else => {},
     };
     switch (event) {
-        .key_press => |key| if (self.editing and
+        .key_press => |key| if (self.editing and !self.editor_cursor_mode and
             (key.matches(vaxis.Key.left, .{}) or
                 key.matches(vaxis.Key.right, .{}) or
                 key.matches(vaxis.Key.up, .{}) or
@@ -1497,7 +1594,7 @@ fn captureEvent(
         {
             try self.applyEditorAndMove(ctx, key, self.eventSize());
         } else {
-            if (try self.prepareEditorInput(ctx, key)) return;
+            if (self.editing and try self.handleEditorKey(ctx, key)) return;
         },
         .mouse => |mouse| if (self.editing) {
             try self.handleMouseWhileEditing(ctx, mouse, self.eventSize());
@@ -1512,6 +1609,7 @@ fn handleEvent(
     event: vxfw.Event,
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata));
+    if (ctx.phase == .at_target and try self.handlePaste(ctx, event)) return;
     const size = self.eventSize();
     switch (event) {
         .winsize => return ctx.consumeAndRedraw(),
@@ -1532,7 +1630,7 @@ fn handleEvent(
                 if (key.matches(vaxis.Key.escape, .{})) {
                     return self.leaveResultForHierarchy(ctx);
                 }
-                if (try self.prepareEditorInput(ctx, key)) return;
+                if (try self.handleEditorKey(ctx, key)) return;
             },
             .mouse => |mouse| if (self.handleHierarchyWheel(ctx, mouse, size)) return,
             else => {},
@@ -1562,6 +1660,11 @@ fn handleEvent(
             if (self.focus_area == .inspector and self.selected_value != .result and
                 self.canCombine() and key.matches('t', .{ .shift = true }))
                 return self.toggleCombine(ctx);
+            if (self.focus_area == .inspector and self.selected_value == .result and key.matches(vaxis.Key.f2, .{})) {
+                try self.beginResultEdit(ctx, self.selectedResultInput(), false);
+                self.editor_cursor_mode = true;
+                return;
+            }
             if (self.focus_area == .inspector and self.selected_value == .result and
                 key.matches(vaxis.Key.backspace, .{}))
             {
@@ -2977,6 +3080,217 @@ test "merge TUI: typing in Result replaces the current value" {
     const value = try view.editor.toOwnedSlice();
     defer arena.free(value);
     try testing.expectEqualStrings("100", value);
+}
+
+test "merge TUI: F2 edits an existing Result without replacing it" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.f2);
+    try testing.expect(view.editing);
+
+    // Cursor movement must edit the chosen value without applying it or replacing the other digit.
+    for ([_]vxfw.Event{
+        .{ .key_press = .{ .codepoint = vaxis.Key.left } },
+        .{ .key_press = .{ .codepoint = vaxis.Key.backspace } },
+        .{ .key_press = .{ .codepoint = '9', .text = "9" } },
+    }) |event| {
+        const surface = try drawForTest(arena, view.widget(), 100, 20);
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, event);
+    }
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("92", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+test "merge TUI: bracketed YAML paste preserves lines until explicit apply" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  items: ";
+    var fixture = try core.merge.build(arena, prefix ++ "[A]\n", prefix ++ "[A, Ours]\n", prefix ++ "[A, Theirs]\n");
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "Array.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 140, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+
+    // Terminal paste sends ordinary key events between markers, including Enter for CR.
+    for ([_]vxfw.Event{
+        .paste_start,
+        .{ .key_press = .{ .codepoint = ' ', .text = "  - One" } },
+        .{ .key_press = .{ .codepoint = vaxis.Key.enter } },
+        .{ .key_press = .{ .codepoint = 'j', .mods = .{ .ctrl = true } } },
+        .{ .key_press = .{ .codepoint = ' ', .text = "  - Two" } },
+        .paste_end,
+    }) |event| {
+        ctx.consume_event = false;
+        try view.widget().handleEvent(&ctx, event);
+    }
+    try testing.expect(view.editing);
+    try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
+    try testing.expectEqualStrings("", state.status);
+    try testing.expectEqualStrings("  - One\n  - Two", try view.editor.buf.dupe());
+    const surface = try drawForTest(arena, view.widget(), 140, 20);
+    try testing.expect(std.mem.startsWith(u8, try rowText(arena, surface.children[0].surface, 1), "  - Two"));
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings(prefix ++ "[A, One, Two]\n", try core.merge.finish(arena, &fixture.plan));
+}
+
+test "merge TUI: a copied scalar line applies without its terminal newline" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    // Copying a value line commonly includes its final line ending, which is outside the YAML value span.
+    try view.widget().handleEvent(&ctx, .{ .paste = try arena.dupe(u8, "42\r\n") });
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    try testing.expectEqualStrings("42", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+test "merge TUI: paste inserts at the F2 cursor and cannot submit through child focus" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.f2);
+    // Paste must pass through the parent before the focused TextField can interpret its keys.
+    for ([_]vxfw.Event{
+        .{ .key_press = .{ .codepoint = vaxis.Key.left } },
+        .paste_start,
+        .{ .key_press = .{ .codepoint = '0', .text = "0" } },
+        .paste_end,
+    }) |event| {
+        const surface = try drawForTest(arena, view.widget(), 100, 20);
+        try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, event);
+    }
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter } });
+    try testing.expectEqualStrings("", state.status);
+    try testing.expectEqual(@as(usize, 1), state.unresolvedCount());
+    try testing.expectEqualStrings("102", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+test "merge TUI: a pasted blank line still requires empty-value confirmation" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try view.widget().handleEvent(&ctx, .{ .paste = try arena.dupe(u8, "\n") });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    // Removing a copied line ending must not bypass the existing empty-value dialog.
+    try testing.expectEqual(Dialog.empty, view.dialog.?);
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+}
+
+test "merge TUI: a paste cannot move to another conflict before it finishes" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try view.widget().handleEvent(&ctx, .paste_start);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '9', .text = "99" } });
+    // A mouse event can arrive between paste chunks, but must not redirect the value to another field.
+    try view.widget().handleEvent(&ctx, .{ .mouse = .{
+        .col = 5,
+        .row = @intCast(BodyGeometry.init(20).hierarchy_rows.start + 3),
+        .button = .left,
+        .mods = .{},
+        .type = .press,
+    } });
+    try view.widget().handleEvent(&ctx, .paste_end);
+    try testing.expectEqual(@as(usize, 0), state.selected_conflict);
+    try testing.expectEqual(ValueColumn.result, view.selected_value);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("99", fixture.plan.operations[state.conflict_indices[0]].resolution.custom);
+}
+
+test "merge TUI: a paste interrupted by a small viewport preserves the existing value" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+    try state.handle(.choose_ours);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.f2);
+    try view.widget().handleEvent(&ctx, .paste_start);
+    _ = try drawForTest(arena, view.widget(), 70, 9);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '9', .text = "99" } });
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    try view.widget().handleEvent(&ctx, .paste_end);
+    // Recovering the viewport must not insert input that arrived while Result was hidden.
+    try testing.expectEqualStrings("12", try view.editor.buf.dupe());
+    try testing.expectEqual(@as(usize, 2), state.unresolvedCount());
+}
+
+test "merge TUI: multiline editor keeps its cursor visible and moves by Unicode columns" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try screenPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 80, 10);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.f2);
+    try view.widget().handleEvent(&ctx, .{ .paste = try arena.dupe(u8, "first\nsecond\nthird\n日本語\ne\u{301}x") });
+    var surface = try drawForTest(arena, view.widget(), 80, 10);
+    const child = surface.children[0].surface;
+    // The three-row viewport follows the caret, rather than clipping off later editable lines.
+    try testing.expectEqual(@as(u16, 2), child.cursor.?.row);
+    try testing.expectEqual(@as(u16, 2), child.cursor.?.col);
+    try testing.expect(std.mem.startsWith(u8, try rowText(arena, child, 2), "e\u{301}x"));
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.up } });
+    const text = try view.editor.buf.dupe();
+    try testing.expectEqualStrings("本語\ne\u{301}x", text[view.editor.buf.cursor..]);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.home } });
+    surface = try drawForTest(arena, view.widget(), 140, 20);
+    try testing.expectEqual(@as(u16, 0), surface.children[0].surface.cursor.?.col);
+    try testing.expect(surface.children[0].surface.cursor.?.row < surface.children[0].surface.size.height);
 }
 
 test "merge TUI: Enter in Result applies the pending value" {

--- a/cli/src/merge_ui_state.zig
+++ b/cli/src/merge_ui_state.zig
@@ -122,6 +122,39 @@ pub const State = struct {
         self.pending = if (resolution == .unresolved) null else resolution;
     }
 
+    pub fn reorderConflicts(self: *State, visual_order: []const usize) !void {
+        std.debug.assert(visual_order.len == self.conflict_indices.len);
+        if (visual_order.len == 0) {
+            self.selected_conflict = 0;
+            return;
+        }
+
+        // A tree is built after the plan is known, but it may be rebuilt after a
+        // selection or preview exists. Preserve that operation while changing only
+        // the navigation order to match the rendered rows.
+        const selected_operation_index = if (self.selected_conflict < self.conflict_indices.len)
+            self.conflict_indices[self.selected_conflict]
+        else
+            null;
+        const old_conflict_indices = try self.allocator.dupe(usize, self.conflict_indices);
+        defer self.allocator.free(old_conflict_indices);
+        for (visual_order, 0..) |old_index, visual_index| {
+            std.debug.assert(old_index < old_conflict_indices.len);
+            self.conflict_indices[visual_index] = old_conflict_indices[old_index];
+        }
+        if (selected_operation_index) |operation_index| {
+            for (self.conflict_indices, 0..) |candidate, index| {
+                if (candidate == operation_index) {
+                    self.selected_conflict = index;
+                    return;
+                }
+            }
+            std.debug.assert(false);
+        } else {
+            self.selected_conflict = 0;
+        }
+    }
+
     fn advance(self: *State) void {
         if (self.conflict_indices.len == 0) {
             self.outcome = .ready;
@@ -349,6 +382,24 @@ fn groupConflicts(arena: std.mem.Allocator, plan: *core.merge.MergePlan) !void {
         &.{ plan.operations[0].id, plan.operations[1].id },
     );
     plan.atomic_operations = plan.atomic_operations[0..1];
+}
+
+test "merge UI state: visual reordering keeps a preview attached to its operation" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try conflictPlan(arena, 2);
+    var state = try State.init(arena, &fixture.plan);
+    try state.handle(.choose_ours);
+    try state.reorderConflicts(&.{ 1, 0 });
+    // Rebuilding a tree must not apply the pending Mass preview to Drag after their indices change.
+    try state.handle(.apply_result);
+    try state.handle(.choose_theirs);
+    try state.handle(.apply_result);
+    try testing.expectEqualStrings(
+        "--- !u!54 &54\nRigidbody:\n  m_Mass: 12\n  m_Drag: 3\n",
+        try core.merge.finish(arena, &fixture.plan),
+    );
 }
 
 test "merge UI state: choose and apply advances to the next conflict" {

--- a/cli/src/merge_ui_state.zig
+++ b/cli/src/merge_ui_state.zig
@@ -77,6 +77,18 @@ pub const State = struct {
         }
         var conflict_index: usize = 0;
         for (plan.atomic_operations) |atomic| {
+            // A component Result shows its document; the membership only tracks its GameObject reference.
+            if (atomic.kind == .component) {
+                const document_index = for (plan.operations, 0..) |operation_item, index| {
+                    if (operation_item.atomic_id == atomic.id and operation_item.kind == .component and
+                        operation_item.resolution == .unresolved) break index;
+                } else null;
+                if (document_index) |index| {
+                    conflicts[conflict_index] = index;
+                    conflict_index += 1;
+                    continue;
+                }
+            }
             for (atomic.operation_ids) |id| {
                 for (plan.operations, 0..) |operation_item, operation_index| {
                     if (operation_item.id == id and operation_item.resolution == .unresolved) {

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -143,6 +143,11 @@ fn testResultEditing(io: std.Io, arena: std.mem.Allocator, scratch: []const u8, 
     const cases = [_]struct { name: []const u8, base: []const u8, ours: []const u8, theirs: []const u8, keys: []const u8, expected: []const u8 }{
         // Ctrl+E retains the side preview; editing one digit must not replace the rest of the value.
         .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
+        // SGR drag reports must select text in the focused editor before replacement.
+        .{ .name = "result-drag", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[<0;85;5M\x1b[<32;86;5M\x1b[<0;86;5m9\r\r", .expected = scalar_prefix ++ "92\n" },
+        // Both deletion keys clear the entire preview before Ctrl+E opens a fresh editor.
+        .{ .name = "result-clear-backspace", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x7f\x054\r\r", .expected = scalar_prefix ++ "4\n" },
+        .{ .name = "result-clear-delete", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x1b[3~\x054\r\r", .expected = scalar_prefix ++ "4\n" },
         // CRLF inside bracketed paste must not accept a partial interval or trigger Complete.
         .{ .name = "result-paste", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M\x1b[200~  - One\r\n  - Two\r\n\x1b[201~\r\r", .expected = try collectionFile(arena, "[A, One, Two]", 2, 3) },
         // A newline retains indentation, and Up edits the preceding line without applying it.
@@ -337,8 +342,8 @@ fn testBackspaceBeforeEditing(
     _ = try integration.expectMarkers(io, arena, repo, "Assets/Conflict.prefab");
 
     // A raw DEL byte is the macOS Delete key and must work before a Result click.
-    // Enter opens the dialog. Right and Enter apply the empty value. The final Enter confirms Complete.
-    const keys = "\x1b[C\r\x1b[A\x1b[C\x1b[C\x1b[C\x7f\r\x1b[C\r\r";
+    // The first Enter starts editing; the second asks before applying the cleared value.
+    const keys = "\x1b[C\r\x1b[A\x1b[C\x1b[C\x1b[C\x7f\r\r\x1b[C\r\r";
     const result = try runMergetoolInPty(io, arena, repo, keys, 30);
     try integration.expectCode(result, 0, "clear focused Result in PTY");
     try integration.expectFile(io, arena, repo, "Assets/Conflict.prefab", conflict_empty);

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -140,11 +140,19 @@ fn collectionFile(arena: std.mem.Allocator, items: []const u8, left: u8, right: 
 
 fn testResultEditing(io: std.Io, arena: std.mem.Allocator, scratch: []const u8, prefablens: []const u8) !void {
     const scalar_prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Value: ";
-    const cases = [_]struct { name: []const u8, base: []const u8, ours: []const u8, theirs: []const u8, keys: []const u8, expected: []const u8 }{
+    const object = "--- !u!1 &1\nGameObject:\n  m_Name: Arm\n  m_Component:\n  - component: {fileID: 4}\n";
+    const sphere_reference = "  - component: {fileID: 135}\n";
+    const transform = "--- !u!4 &4\nTransform:\n  m_GameObject: {fileID: 1}\n  m_Children: []\n  m_Father: {fileID: 0}\n  m_LocalPosition: ";
+    const sphere = "--- !u!135 &135\nSphereCollider:\n  m_GameObject: {fileID: 1}\n  m_Radius: ";
+    const cases = [_]struct { name: []const u8, base: []const u8, ours: []const u8, theirs: []const u8, keys: []const u8, expected: []const u8, clipboard_sequence: ?[]const u8 = null }{
         // Ctrl+E retains the side preview; editing one digit must not replace the rest of the value.
         .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
         // SGR drag reports must select text in the focused editor before replacement.
-        .{ .name = "result-drag", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[<0;85;5M\x1b[<32;86;5M\x1b[<0;86;5m9\r\r", .expected = scalar_prefix ++ "92\n" },
+        .{ .name = "result-drag", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[<0;85;5M\x1b[<32;86;5M\x1b[<0;86;5m9\r\r", .expected = scalar_prefix ++ "9\n" },
+        // Copy must emit the entire selection and keep it selected for the following bracketed paste.
+        .{ .name = "result-copy-paste", .base = scalar_prefix ++ "0.1\n", .ours = scalar_prefix ++ "0.4\n", .theirs = scalar_prefix ++ "0.2\n", .keys = "\x1b[<0;52;5M\x05\x1b[<0;85;5M\x1b[<32;87;5M\x1b[<0;87;5m\x03\x1b[200~0.6\x1b[201~\r\r", .expected = scalar_prefix ++ "0.6\n", .clipboard_sequence = "\x1b]52;c;MC40\x1b\\" },
+        // Startup must focus Position.x before SphereCollider, then advance in that same visual order.
+        .{ .name = "result-visual-order", .base = object ++ sphere_reference ++ transform ++ "{x: 0, y: 0, z: 0}\n" ++ sphere ++ "0.25\n", .ours = object ++ transform ++ "{x: 1, y: 0, z: 0}\n", .theirs = object ++ sphere_reference ++ transform ++ "{x: 2, y: 0, z: 0}\n" ++ sphere ++ "0.4\n", .keys = "\x1b[C\x1b[C\r\x1b[C\r\r", .expected = object ++ transform ++ "{x: 2, y: 0, z: 0}\n" },
         // Both deletion keys clear the entire preview before Ctrl+E opens a fresh editor.
         .{ .name = "result-clear-backspace", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x7f\x054\r\r", .expected = scalar_prefix ++ "4\n" },
         .{ .name = "result-clear-delete", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x1b[3~\x054\r\r", .expected = scalar_prefix ++ "4\n" },
@@ -165,6 +173,8 @@ fn testResultEditing(io: std.Io, arena: std.mem.Allocator, scratch: []const u8, 
         try integration.expectNonzero(try integration.gitRun(io, arena, repo, &.{ "merge", "--no-edit", "remote" }), "prepare Result editing conflict");
         const result = try runMergetoolInPty(io, arena, repo, case.keys, 30);
         try integration.expectCode(result, 0, case.name);
+        if (case.clipboard_sequence) |sequence|
+            try integration.require(std.mem.indexOf(u8, result.stdout, sequence) != null, "Result copy did not emit the selected text to the terminal clipboard");
         try integration.expectFile(io, arena, repo, "Assets/Conflict.prefab", case.expected);
         const unmerged = try integration.gitRun(io, arena, repo, &.{ "ls-files", "-u" });
         try integration.expectCode(unmerged, 0, "list index after Result editing");

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -141,12 +141,14 @@ fn collectionFile(arena: std.mem.Allocator, items: []const u8, left: u8, right: 
 fn testResultEditing(io: std.Io, arena: std.mem.Allocator, scratch: []const u8, prefablens: []const u8) !void {
     const scalar_prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Value: ";
     const cases = [_]struct { name: []const u8, base: []const u8, ours: []const u8, theirs: []const u8, keys: []const u8, expected: []const u8 }{
-        // F2 retains the side preview; editing one digit must not replace the rest of the value.
-        .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[<0;83;5M\x1bOQ\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
+        // Ctrl+E retains the side preview; editing one digit must not replace the rest of the value.
+        .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
         // CRLF inside bracketed paste must not accept a partial interval or trigger Complete.
         .{ .name = "result-paste", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M\x1b[200~  - One\r\n  - Two\r\n\x1b[201~\r\r", .expected = try collectionFile(arena, "[A, One, Two]", 2, 3) },
         // A newline retains indentation, and Up edits the preceding line without applying it.
         .{ .name = "result-multiline", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M  - One\x0a- Two\x1b[A\x1b[F\x7fX\r\r", .expected = try collectionFile(arena, "[A, OnX, Two]", 2, 3) },
+        // Modified Enter reports must insert a newline without submitting through TextField focus.
+        .{ .name = "result-shift-enter", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M  - One\x1b[13;2u- Two\x1b[A\x1b[F\x7fX\r\r", .expected = try collectionFile(arena, "[A, OnX, Two]", 2, 3) },
     };
     for (cases) |case| {
         const repo = try prepareMergetoolRepositoryWithSides(io, arena, scratch, prefablens, case.name, .{
@@ -278,7 +280,7 @@ fn testCompletion(
     try integration.expectNonzero(merge, "prepare mergetool completion conflict");
     const markers = try integration.expectMarkers(io, arena, repo, "Assets/Conflict.prefab");
 
-    // The mouse click focuses Result. The first key starts editing and replaces the value.
+    // Clicking the empty Result opens the editor so typing inserts a custom value.
     // The first Enter applies Result. The second Enter confirms Complete.
     const result = runMergetoolInPty(io, arena, repo, "\x1b[<0;83;5M4\r\r", 30) catch |err| {
         if (err == error.Timeout) {

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -145,17 +145,18 @@ fn testResultEditing(io: std.Io, arena: std.mem.Allocator, scratch: []const u8, 
     const transform = "--- !u!4 &4\nTransform:\n  m_GameObject: {fileID: 1}\n  m_Children: []\n  m_Father: {fileID: 0}\n  m_LocalPosition: ";
     const sphere = "--- !u!135 &135\nSphereCollider:\n  m_GameObject: {fileID: 1}\n  m_Radius: ";
     const cases = [_]struct { name: []const u8, base: []const u8, ours: []const u8, theirs: []const u8, keys: []const u8, expected: []const u8, clipboard_sequence: ?[]const u8 = null }{
-        // Ctrl+E retains the side preview; editing one digit must not replace the rest of the value.
-        .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
+        // Enter on Result retains the side preview; editing one digit must not replace the rest of the value.
+        .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\r\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
         // SGR drag reports must select text in the focused editor before replacement.
-        .{ .name = "result-drag", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x05\x1b[<0;85;5M\x1b[<32;86;5M\x1b[<0;86;5m9\r\r", .expected = scalar_prefix ++ "9\n" },
+        .{ .name = "result-drag", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[<0;85;5M\x1b[<32;86;5M\x1b[<0;86;5m9\r\r", .expected = scalar_prefix ++ "9\n" },
         // Copy must emit the entire selection and keep it selected for the following bracketed paste.
-        .{ .name = "result-copy-paste", .base = scalar_prefix ++ "0.1\n", .ours = scalar_prefix ++ "0.4\n", .theirs = scalar_prefix ++ "0.2\n", .keys = "\x1b[<0;52;5M\x05\x1b[<0;85;5M\x1b[<32;87;5M\x1b[<0;87;5m\x03\x1b[200~0.6\x1b[201~\r\r", .expected = scalar_prefix ++ "0.6\n", .clipboard_sequence = "\x1b]52;c;MC40\x1b\\" },
+        .{ .name = "result-copy-paste", .base = scalar_prefix ++ "0.1\n", .ours = scalar_prefix ++ "0.4\n", .theirs = scalar_prefix ++ "0.2\n", .keys = "\x1b[<0;52;5M\x1b[<0;85;5M\x1b[<32;87;5M\x1b[<0;87;5m\x03\x1b[200~0.6\x1b[201~\r\r", .expected = scalar_prefix ++ "0.6\n", .clipboard_sequence = "\x1b]52;c;MC40\x1b\\" },
+        .{ .name = "result-cmd-copy-paste", .base = scalar_prefix ++ "0.1\n", .ours = scalar_prefix ++ "0.4\n", .theirs = scalar_prefix ++ "0.2\n", .keys = "\x1b[<0;52;5M\x1b[<0;85;5M\x1b[<32;87;5M\x1b[<0;87;5m\x1b[57444;9u\x1b[99;9u\x1b[200~0.6\x1b[201~\r\r", .expected = scalar_prefix ++ "0.6\n", .clipboard_sequence = "\x1b]52;c;MC40\x1b\\" },
         // Startup must focus Position.x before SphereCollider, then advance in that same visual order.
         .{ .name = "result-visual-order", .base = object ++ sphere_reference ++ transform ++ "{x: 0, y: 0, z: 0}\n" ++ sphere ++ "0.25\n", .ours = object ++ transform ++ "{x: 1, y: 0, z: 0}\n", .theirs = object ++ sphere_reference ++ transform ++ "{x: 2, y: 0, z: 0}\n" ++ sphere ++ "0.4\n", .keys = "\x1b[C\x1b[C\r\x1b[C\r\r", .expected = object ++ transform ++ "{x: 2, y: 0, z: 0}\n" },
-        // Both deletion keys clear the entire preview before Ctrl+E opens a fresh editor.
-        .{ .name = "result-clear-backspace", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x7f\x054\r\r", .expected = scalar_prefix ++ "4\n" },
-        .{ .name = "result-clear-delete", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x1b[3~\x054\r\r", .expected = scalar_prefix ++ "4\n" },
+        // Both deletion keys clear the entire preview before Enter opens a fresh editor.
+        .{ .name = "result-clear-backspace", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x7f\r4\r\r", .expected = scalar_prefix ++ "4\n" },
+        .{ .name = "result-clear-delete", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[C\x1b[C\x1b[3~\r4\r\r", .expected = scalar_prefix ++ "4\n" },
         // CRLF inside bracketed paste must not accept a partial interval or trigger Complete.
         .{ .name = "result-paste", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M\x1b[200~  - One\r\n  - Two\r\n\x1b[201~\r\r", .expected = try collectionFile(arena, "[A, One, Two]", 2, 3) },
         // A newline retains indentation, and Up edits the preceding line without applying it.

--- a/cli/src/pty_smoke_test_main.zig
+++ b/cli/src/pty_smoke_test_main.zig
@@ -73,6 +73,7 @@ pub fn main(init: std.process.Init) !u8 {
     if (args.len == 3) return 0;
     try testCompletion(io, arena, scratch, prefablens);
     try testBackspaceBeforeEditing(io, arena, scratch, prefablens);
+    try testResultEditing(io, arena, scratch, prefablens);
     try testDeletionChoices(io, arena, scratch, prefablens);
     try testCollectionChoices(io, arena, scratch, prefablens);
     try testQuit(io, arena, scratch, prefablens);
@@ -135,6 +136,33 @@ fn testCollectionChoices(
 
 fn collectionFile(arena: std.mem.Allocator, items: []const u8, left: u8, right: u8) ![]const u8 {
     return std.fmt.allocPrint(arena, "--- !u!114 &1\nMonoBehaviour:\n  m_Items: {s}\n  m_Left: {d}\n  m_Right: {d}\n", .{ items, left, right });
+}
+
+fn testResultEditing(io: std.Io, arena: std.mem.Allocator, scratch: []const u8, prefablens: []const u8) !void {
+    const scalar_prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Value: ";
+    const cases = [_]struct { name: []const u8, base: []const u8, ours: []const u8, theirs: []const u8, keys: []const u8, expected: []const u8 }{
+        // F2 retains the side preview; editing one digit must not replace the rest of the value.
+        .{ .name = "result-cursor", .base = scalar_prefix ++ "5\n", .ours = scalar_prefix ++ "12\n", .theirs = scalar_prefix ++ "8\n", .keys = "\x1b[<0;52;5M\x1b[<0;83;5M\x1bOQ\x1b[D\x7f9\r\r", .expected = scalar_prefix ++ "92\n" },
+        // CRLF inside bracketed paste must not accept a partial interval or trigger Complete.
+        .{ .name = "result-paste", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M\x1b[200~  - One\r\n  - Two\r\n\x1b[201~\r\r", .expected = try collectionFile(arena, "[A, One, Two]", 2, 3) },
+        // A newline retains indentation, and Up edits the preceding line without applying it.
+        .{ .name = "result-multiline", .base = try collectionFile(arena, "[A]", 1, 1), .ours = try collectionFile(arena, "[A, Ours]", 2, 1), .theirs = try collectionFile(arena, "[A, Theirs]", 1, 3), .keys = "\x1b[<0;83;5M  - One\x0a- Two\x1b[A\x1b[F\x7fX\r\r", .expected = try collectionFile(arena, "[A, OnX, Two]", 2, 3) },
+    };
+    for (cases) |case| {
+        const repo = try prepareMergetoolRepositoryWithSides(io, arena, scratch, prefablens, case.name, .{
+            .path = "Assets/Conflict.prefab",
+            .base = case.base,
+            .ours = case.ours,
+            .theirs = case.theirs,
+        });
+        try integration.expectNonzero(try integration.gitRun(io, arena, repo, &.{ "merge", "--no-edit", "remote" }), "prepare Result editing conflict");
+        const result = try runMergetoolInPty(io, arena, repo, case.keys, 30);
+        try integration.expectCode(result, 0, case.name);
+        try integration.expectFile(io, arena, repo, "Assets/Conflict.prefab", case.expected);
+        const unmerged = try integration.gitRun(io, arena, repo, &.{ "ls-files", "-u" });
+        try integration.expectCode(unmerged, 0, "list index after Result editing");
+        try integration.require(unmerged.stdout.len == 0, "Result editing left unmerged entries");
+    }
 }
 
 fn testDeletionChoices(

--- a/core/src/merge.zig
+++ b/core/src/merge.zig
@@ -96,12 +96,17 @@ pub fn resolve(
     const atomic = merge_model.atomicById(plan, operation.atomic_id) orelse
         return error.InvalidResolution;
     var stored_resolution = resolution;
+    var component_custom: ?ComponentCustom = null;
     switch (resolution) {
         .unresolved => return error.InvalidResolution,
         .take => |side| if (side == .base or operation.values.get(side) == null)
             return error.InvalidResolution,
         .custom => |value| {
-            if (operation.collection) |binding_ref| {
+            if (atomic.kind == .component and
+                (operation.kind == .sequence_membership or operation.kind == .component))
+            {
+                component_custom = try validateComponentCustom(arena, plan, operation, atomic, value);
+            } else if (operation.collection) |binding_ref| {
                 const parsed = @import("merge_yaml.zig").parseValue(arena, value) catch |err| switch (err) {
                     error.OutOfMemory => return error.OutOfMemory,
                     else => return error.InvalidResolution,
@@ -128,7 +133,17 @@ pub fn resolve(
     for (atomic.operation_ids, previous) |id, *old_resolution| {
         const member = merge_model.operationById(plan, id).?;
         old_resolution.* = member.resolution;
-        member.resolution = stored_resolution;
+        if (component_custom) |custom| {
+            if (member.id == custom.membership_id) {
+                member.resolution = .{ .take = custom.membership_side };
+            } else if (member.id == custom.document_id) {
+                member.resolution = stored_resolution;
+            } else {
+                return error.InvalidResolution;
+            }
+        } else {
+            member.resolution = stored_resolution;
+        }
     }
     errdefer {
         for (atomic.operation_ids, previous) |id, old_resolution| {
@@ -143,6 +158,94 @@ pub fn resolve(
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidResolution,
     };
+}
+
+const ComponentCustom = struct {
+    membership_id: OperationId,
+    document_id: OperationId,
+    membership_side: Side,
+};
+
+fn validateComponentCustom(
+    arena: std.mem.Allocator,
+    plan: *const MergePlan,
+    operation: *const Operation,
+    atomic: *const merge_model.AtomicOperation,
+    value: []const u8,
+) Error!ComponentCustom {
+    var membership: ?*const Operation = null;
+    var document: ?*const Operation = null;
+    for (atomic.operation_ids) |member_id| {
+        const member = merge_model.operationByIdConst(plan, member_id) orelse
+            return error.InvalidResolution;
+        switch (member.kind) {
+            .sequence_membership => {
+                if (membership != null) return error.InvalidResolution;
+                membership = member;
+            },
+            .component => {
+                if (document != null) return error.InvalidResolution;
+                document = member;
+            },
+            else => return error.InvalidResolution,
+        }
+    }
+    const membership_operation = membership orelse return error.InvalidResolution;
+    const document_operation = document orelse return error.InvalidResolution;
+    if (atomic.operation_ids.len != 2) return error.InvalidResolution;
+    if (operation.id != membership_operation.id and operation.id != document_operation.id)
+        return error.InvalidResolution;
+    const membership_side = componentMembershipSide(membership_operation);
+    if (membership_operation.values.get(membership_side) == null or
+        document_operation.values.get(membership_side) == null)
+        return error.InvalidResolution;
+    const selected_document = componentDocument(plan, document_operation, membership_side) orelse
+        return error.InvalidResolution;
+
+    const parsed = merge_planner.parseMergeSide(arena, value) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.InvalidResolution,
+    };
+    if (parsed.documents.len != 1) return error.InvalidResolution;
+    const custom_document = parsed.documents[0];
+    if (custom_document.class_id != document_operation.identity.document.class_id or
+        custom_document.file_id != document_operation.identity.document.file_id or
+        !std.mem.eql(u8, custom_document.type_name, selected_document.type_name) or
+        custom_document.stripped != selected_document.stripped)
+        return error.InvalidResolution;
+    const owner = custom_document.body.get("m_GameObject") orelse
+        return error.InvalidResolution;
+    if (owner.* != .ref or owner.ref.guid != null or
+        owner.ref.file_id != membership_operation.identity.document.file_id)
+        return error.InvalidResolution;
+
+    return .{
+        .membership_id = membership_operation.id,
+        .document_id = document_operation.id,
+        .membership_side = membership_side,
+    };
+}
+
+fn componentDocument(
+    plan: *const MergePlan,
+    operation: *const Operation,
+    side: Side,
+) ?*const model.Document {
+    const id = operation.identity.document;
+    for (plan.file(side).documents) |*document| {
+        if (document.class_id == id.class_id and document.file_id == id.file_id) return document;
+    }
+    return null;
+}
+
+fn componentMembershipSide(operation: *const Operation) Side {
+    switch (operation.resolution) {
+        .take => |side| if (operation.values.get(side) != null) return side,
+        else => {},
+    }
+    if (operation.values.ours != null) return .ours;
+    if (operation.values.theirs != null) return .theirs;
+    return .base;
 }
 
 pub const CollectionConflict = struct { reason: @import("merge_value.zig").Reason, both_orders: bool };
@@ -167,6 +270,12 @@ pub fn combinedCollectionValue(arena: std.mem.Allocator, plan: *const MergePlan,
 pub fn supportsCustomResolution(plan: *const MergePlan, operation_id: OperationId) bool {
     const operation = merge_model.operationByIdConst(plan, operation_id) orelse return false;
     if (operation.collection != null) return true;
+    const atomic = for (plan.atomic_operations) |*candidate| {
+        if (candidate.id == operation.atomic_id) break candidate;
+    } else return false;
+    if (atomic.kind == .component and
+        (operation.kind == .sequence_membership or operation.kind == .component))
+        return true;
     return (operation.kind == .field or (operation.kind == .prefab_override and operation.item_path != null)) and supportsCustomValue(operation) and wasConflict(operation);
 }
 
@@ -360,6 +469,230 @@ test "map container delete and edit resolves symmetrically" {
         try resolve(arena, &take_edited.plan, edited_operation.id, edited_resolution);
         try std.testing.expectEqualStrings(edited, try finish(arena, &take_edited.plan));
     }
+}
+
+test "component document custom resolution keeps its owner membership" {
+    const support = @import("merge_test_support.zig");
+    const fixture = support.load("component-delete-edit", true);
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var built = try build(arena, fixture.base, fixture.ours, fixture.theirs);
+    const atomic = support.findAtomicByKind(&built.plan, .component).?;
+    const membership = merge_model.operationById(&built.plan, atomic.operation_ids[0]).?;
+    const component = for (atomic.operation_ids) |operation_id| {
+        const candidate = merge_model.operationById(&built.plan, operation_id).?;
+        if (candidate.kind == .component) break candidate;
+    } else return error.TestUnexpectedResult;
+    const corrected = "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 3";
+    const expected = try std.mem.replaceOwned(u8, arena, fixture.expected, "m_Mass: 2\n", "m_Mass: 3\n");
+
+    try testing.expectEqual(merge_model.OperationKind.sequence_membership, membership.kind);
+    try testing.expect(supportsCustomResolution(&built.plan, membership.id));
+    try testing.expect(supportsCustomResolution(&built.plan, component.id));
+    try resolve(arena, &built.plan, component.id, .{ .custom = corrected });
+    try testing.expectEqualStrings(expected, try finish(arena, &built.plan));
+}
+
+test "component document custom resolution can be edited again and reversed" {
+    const support = @import("merge_test_support.zig");
+    const fixture = support.load("component-delete-edit", true);
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var built = try build(arena, fixture.base, fixture.ours, fixture.theirs);
+    const atomic = support.findAtomicByKind(&built.plan, .component).?;
+    const membership = merge_model.operationById(&built.plan, atomic.operation_ids[0]).?;
+    const corrected_three =
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 3\n";
+    const corrected_four =
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 4\n";
+
+    try resolve(arena, &built.plan, membership.id, .{ .custom = corrected_three });
+    try testing.expect(std.mem.indexOf(u8, try finish(arena, &built.plan), "m_Mass: 3") != null);
+    try resolve(arena, &built.plan, membership.id, .{ .custom = corrected_four });
+    try testing.expect(std.mem.indexOf(u8, try finish(arena, &built.plan), "m_Mass: 4") != null);
+    try resolve(arena, &built.plan, membership.id, .{ .take = .theirs });
+    try testing.expectEqualStrings(fixture.theirs, try finish(arena, &built.plan));
+    try resolve(arena, &built.plan, membership.id, .remove);
+    try testing.expectEqualStrings(fixture.ours, try finish(arena, &built.plan));
+}
+
+test "component document custom resolution rejects invalid identity and owner" {
+    const support = @import("merge_test_support.zig");
+    const fixture = support.load("component-delete-edit", true);
+    const invalid_documents = [_][]const u8{
+        "--- !u!54 &99\nRigidbody:\n  m_GameObject: {fileID: 1}\n  m_Mass: 3\n",
+        "--- !u!65 &54\nBoxCollider:\n  m_GameObject: {fileID: 1}\n  m_Mass: 3\n",
+        "--- !u!54 &54\nBoxCollider:\n  m_GameObject: {fileID: 1}\n  m_Mass: 3\n",
+        "--- !u!54 &54\nRigidbody:\n  m_GameObject: {fileID: 2}\n  m_Mass: 3\n",
+        "--- !u!54 &54\nRigidbody:\n  m_GameObject: {fileID: 1, guid: bad}\n  m_Mass: 3\n",
+        "",
+    };
+
+    for (invalid_documents) |invalid| {
+        var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+        defer arena_state.deinit();
+        const arena = arena_state.allocator();
+        var built = try build(arena, fixture.base, fixture.ours, fixture.theirs);
+        const atomic = support.findAtomicByKind(&built.plan, .component).?;
+        const membership = merge_model.operationById(&built.plan, atomic.operation_ids[0]).?;
+        try testing.expectError(
+            error.InvalidResolution,
+            resolve(arena, &built.plan, membership.id, .{ .custom = invalid }),
+        );
+        try testing.expectEqualStrings(
+            fixture.partial.?,
+            try merge_apply.applyResolved(arena, &built.plan, false),
+        );
+    }
+}
+
+test "component document custom resolution preserves a previous edit after rejection" {
+    const support = @import("merge_test_support.zig");
+    const fixture = support.load("component-delete-edit", true);
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var built = try build(arena, fixture.base, fixture.ours, fixture.theirs);
+    const atomic = support.findAtomicByKind(&built.plan, .component).?;
+    const membership = merge_model.operationById(&built.plan, atomic.operation_ids[0]).?;
+    const corrected =
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 3\n";
+    const invalid =
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 2}\n" ++
+        "  m_Mass: 9\n";
+
+    try resolve(arena, &built.plan, membership.id, .{ .custom = corrected });
+    try testing.expectError(
+        error.InvalidResolution,
+        resolve(arena, &built.plan, membership.id, .{ .custom = invalid }),
+    );
+    try testing.expect(std.mem.indexOf(u8, try finish(arena, &built.plan), "m_Mass: 3") != null);
+}
+
+test "component document custom resolution keeps CRLF before a following document" {
+    const support = @import("merge_test_support.zig");
+    const base_lf =
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  - component: {fileID: 54}\n" ++
+        "  - component: {fileID: 65}\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Children: []\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 1\n" ++
+        "--- !u!65 &65\n" ++
+        "BoxCollider:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_IsTrigger: 0\n";
+    const ours_lf =
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  - component: {fileID: 54}\n" ++
+        "  - component: {fileID: 65}\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Children: []\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 3\n" ++
+        "--- !u!65 &65\n" ++
+        "BoxCollider:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_IsTrigger: 0\n";
+    const theirs_lf =
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  - component: {fileID: 65}\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Children: []\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "--- !u!65 &65\n" ++
+        "BoxCollider:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_IsTrigger: 0\n";
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const base = try std.mem.replaceOwned(u8, arena, base_lf, "\n", "\r\n");
+    const ours = try std.mem.replaceOwned(u8, arena, ours_lf, "\n", "\r\n");
+    const theirs = try std.mem.replaceOwned(u8, arena, theirs_lf, "\n", "\r\n");
+    var built = try build(arena, base, ours, theirs);
+    const atomic = support.findAtomicByKind(&built.plan, .component).?;
+    const membership = merge_model.operationById(&built.plan, atomic.operation_ids[0]).?;
+    const corrected =
+        "--- !u!54 &54\n" ++
+        "Rigidbody:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Mass: 4";
+    const expected = try std.mem.replaceOwned(u8, arena, ours, "m_Mass: 3\r\n", "m_Mass: 4\r\n");
+
+    try resolve(arena, &built.plan, membership.id, .{ .custom = corrected });
+    try testing.expectEqualStrings(expected, try finish(arena, &built.plan));
+}
+
+test "component document custom insertion follows selected document order" {
+    const support = @import("merge_test_support.zig");
+    const base =
+        "--- !u!1 &1\nGameObject:\n  m_Component:\n  - component: {fileID: 4}\n  - component: {fileID: 54}\n" ++
+        "--- !u!4 &4\nTransform:\n  m_GameObject: {fileID: 1}\n  m_Children: []\n  m_Father: {fileID: 0}\n" ++
+        "--- !u!54 &54\nRigidbody:\n  m_GameObject: {fileID: 1}\n  m_Mass: 1\n";
+    const ours =
+        "--- !u!1 &1\nGameObject:\n  m_Component:\n  - component: {fileID: 4}\n" ++
+        "--- !u!4 &4\nTransform:\n  m_GameObject: {fileID: 1}\n  m_Children: []\n  m_Father: {fileID: 0}\n";
+    const theirs =
+        "--- !u!1 &1\nGameObject:\n  m_Component:\n  - component: {fileID: 4}\n  - component: {fileID: 54}\n  - component: {fileID: 65}\n" ++
+        "--- !u!4 &4\nTransform:\n  m_GameObject: {fileID: 1}\n  m_Children: []\n  m_Father: {fileID: 0}\n" ++
+        "--- !u!54 &54\nRigidbody:\n  m_GameObject: {fileID: 1}\n  m_Mass: 2\n" ++
+        "--- !u!65 &65\nBoxCollider:\n  m_GameObject: {fileID: 1}\n  m_IsTrigger: 0\n";
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    var built = try build(arena, base, ours, theirs);
+    const component_atomic = support.findAtomicByKind(&built.plan, .component).?;
+    const component = for (component_atomic.operation_ids) |operation_id| {
+        const candidate = merge_model.operationById(&built.plan, operation_id).?;
+        if (candidate.kind == .component) break candidate;
+    } else return error.TestUnexpectedResult;
+    const corrected =
+        "--- !u!54 &54\nRigidbody:\n  m_GameObject: {fileID: 1}\n  m_Mass: 3\n";
+
+    try resolve(arena, &built.plan, component.id, .{ .custom = corrected });
+    const finished = try finish(arena, &built.plan);
+    const component_54 = std.mem.indexOf(u8, finished, "--- !u!54 &54").?;
+    const component_65 = std.mem.indexOf(u8, finished, "--- !u!65 &65").?;
+    try testing.expect(component_54 < component_65);
 }
 
 test "merge build rejects a malformed flow entry" {

--- a/core/src/merge.zig
+++ b/core/src/merge.zig
@@ -476,6 +476,56 @@ test "collection public resolves local insertion orders and abort restores ours"
     try testing.expectEqualStrings(prefix ++ "[y, x, a, b, z]\n", try finish(arena, &built.plan));
 }
 
+test "collection public accepts pasted block YAML without changing surrounding source" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix = "--- !u!114 &1\r\nMonoBehaviour:\r\n  values:\r\n  - A\r\n";
+    const suffix = "  after: keep # comment\r\n";
+    var built = try build(arena, prefix ++ suffix, prefix ++ "  - Ours\r\n" ++ suffix, prefix ++ "  - Theirs\r\n" ++ suffix);
+
+    // A pasted block replaces only the conflicting interval and retains the file's CRLF layout.
+    try resolve(arena, &built.plan, built.plan.operations[0].id, .{ .custom = "  - One\n  - Two\n" });
+    try testing.expectEqualStrings(prefix ++ "  - One\r\n  - Two\r\n" ++ suffix, try finish(arena, &built.plan));
+}
+
+test "collection public accepts line breaks while editing a flow value" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  values: ";
+    var built = try build(arena, prefix ++ "[A]\n", prefix ++ "[A, Ours]\n", prefix ++ "[A, Theirs]\n");
+    // Existing previews use flow YAML, so adding a line break must keep the same collection shape.
+    try resolve(arena, &built.plan, built.plan.operations[0].id, .{ .custom = "[\n  One,\n  {name: \"two words\", count: 2}\n]\n" });
+    try testing.expectEqualStrings(prefix ++ "[A, One, {name: two words, count: 2}]\n", try finish(arena, &built.plan));
+    // Apostrophes inside a plain scalar do not open a quoted YAML token.
+    try resolve(arena, &built.plan, built.plan.operations[0].id, .{ .custom = "[O'Reilly,\n 'Two',\n \"#Three\"]" });
+    try testing.expectEqualStrings(prefix ++ "[A, O'Reilly, Two, \"#Three\"]\n", try finish(arena, &built.plan));
+}
+
+test "collection public rejects malformed multiline values without changing the result" {
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  values: ";
+    for ([_][]const u8{
+        "  - One\ninvalid: sibling",
+        "- One\n\t- Two",
+        "[One,\n {bad: shape]\n]",
+        "[\"first\nsecond\"]",
+        "[first\n  second]",
+        "[first\n\n  second]",
+        "- One\n--- !u!114 &2\nMonoBehaviour:\n  field: value",
+        "- One\n%ignored\n- Two",
+    }) |input| {
+        var memory = std.heap.ArenaAllocator.init(testing.allocator);
+        defer memory.deinit();
+        const arena = memory.allocator();
+        var built = try build(arena, prefix ++ "[A]\n", prefix ++ "[A, Ours]\n", prefix ++ "[A, Theirs]\n");
+        try resolve(arena, &built.plan, built.plan.operations[0].id, .{ .custom = "[Keep]" });
+        // Rejection must leave the previous valid resolution available for completion.
+        try testing.expectError(error.InvalidResolution, resolve(arena, &built.plan, built.plan.operations[0].id, .{ .custom = input }));
+        try testing.expectEqualStrings(prefix ++ "[A, Keep]\n", try finish(arena, &built.plan));
+    }
+}
+
 test "collection public item field conflict retains independent changes" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);
     defer memory.deinit();

--- a/core/src/merge_apply.zig
+++ b/core/src/merge_apply.zig
@@ -1242,21 +1242,39 @@ fn appendDocumentPatch(
     plan: *const merge_model.MergePlan,
     operation: *const merge_model.Operation,
 ) merge_model.Error!void {
+    const custom = switch (operation.resolution) {
+        .custom => |value| if (operation.kind == .component) value else return error.InvalidResolution,
+        else => null,
+    };
+    const custom_bytes = if (custom) |value|
+        try completeCustomDocument(arena, plan, operation, value)
+    else
+        null;
     const selected = switch (operation.resolution) {
         .unresolved => return error.InvalidResolution,
         .remove => null,
         .take => |side| operation.values.get(side),
-        .custom => return error.InvalidResolution,
+        .custom => null,
     };
     if (operation.values.ours) |ours| {
         const span = ours.span orelse return error.UnsupportedStructure;
-        const replacement = if (selected) |value| value.bytes else "";
+        const replacement = if (custom_bytes) |value| value else if (selected) |value| value.bytes else "";
         if (std.mem.eql(u8, span.bytes(plan.ours.bytes), replacement)) return;
         return patches.append(arena, .{
             .span = span,
             .replacement = replacement,
             .atomic_id = operation.atomic_id,
             .order = operation.id,
+        });
+    }
+    if (custom_bytes) |value| {
+        const insertion_side = customComponentInsertionSide(plan, operation) orelse
+            return error.InvalidMerge;
+        return patches.append(arena, .{
+            .span = .{ .start = plan.ours.bytes.len, .end = plan.ours.bytes.len },
+            .replacement = value,
+            .atomic_id = operation.atomic_id,
+            .order = documentInsertionOrder(plan, operation, insertion_side),
         });
     }
     const inserted = selected orelse return;
@@ -1282,6 +1300,76 @@ fn appendDocumentPatch(
     });
 }
 
+fn completeCustomDocument(
+    arena: std.mem.Allocator,
+    plan: *const merge_model.MergePlan,
+    operation: *const merge_model.Operation,
+    value: []const u8,
+) merge_model.Error![]const u8 {
+    const destination_ending = documentLineEnding(plan, operation);
+    const normalized = try normalizeCustomDocument(arena, value, destination_ending);
+    const ours_ending = trailingLineEnding(plan.ours.bytes);
+    const needs_prefix = operation.values.ours == null and plan.ours.bytes.len != 0 and ours_ending == null;
+    const needs_suffix = trailingLineEnding(normalized) == null and destination_ending.len != 0 and
+        customDocumentHasBoundary(plan, operation);
+    if (!needs_prefix and !needs_suffix) return normalized;
+    const prefix = if (needs_prefix) destination_ending else "";
+    const suffix = if (needs_suffix) destination_ending else "";
+    return std.mem.concat(arena, u8, &.{ prefix, normalized, suffix });
+}
+
+fn normalizeCustomDocument(
+    arena: std.mem.Allocator,
+    value: []const u8,
+    destination_ending: []const u8,
+) merge_model.Error![]const u8 {
+    if (std.mem.eql(u8, destination_ending, "\r\n")) {
+        const lf = try std.mem.replaceOwned(u8, arena, value, "\r\n", "\n");
+        return std.mem.replaceOwned(u8, arena, lf, "\n", "\r\n");
+    }
+    if (std.mem.eql(u8, destination_ending, "\n"))
+        return std.mem.replaceOwned(u8, arena, value, "\r\n", "\n");
+    return value;
+}
+
+fn customDocumentHasBoundary(
+    plan: *const merge_model.MergePlan,
+    operation: *const merge_model.Operation,
+) bool {
+    if (operation.values.ours) |ours| {
+        if (ours.span) |span| return trailingLineEnding(span.bytes(plan.ours.bytes)) != null;
+    }
+    if (trailingLineEnding(plan.ours.bytes) != null) return true;
+    inline for (.{ operation.values.theirs, operation.values.base }) |value| {
+        if (value) |present| if (trailingLineEnding(present.bytes) != null) return true;
+    }
+    return false;
+}
+
+fn documentLineEnding(
+    plan: *const merge_model.MergePlan,
+    operation: *const merge_model.Operation,
+) []const u8 {
+    if (operation.values.ours) |ours| {
+        if (ours.span) |span| {
+            if (trailingLineEnding(span.bytes(plan.ours.bytes))) |ending| return ending;
+        }
+    }
+    if (trailingLineEnding(plan.ours.bytes)) |ending| return ending;
+    inline for (.{ operation.values.theirs, operation.values.base }) |value| {
+        if (value) |present| {
+            if (trailingLineEnding(present.bytes)) |ending| return ending;
+        }
+    }
+    return plan.ours.lineEndingAt(plan.ours.bytes.len);
+}
+
+fn trailingLineEnding(bytes: []const u8) ?[]const u8 {
+    if (std.mem.endsWith(u8, bytes, "\r\n")) return "\r\n";
+    if (std.mem.endsWith(u8, bytes, "\n")) return "\n";
+    return null;
+}
+
 fn documentInsertionOrder(
     plan: *const merge_model.MergePlan,
     operation: *const merge_model.Operation,
@@ -1292,6 +1380,22 @@ fn documentInsertionOrder(
         if (document.class_id == operation.identity.document.class_id and
             document.file_id == operation.identity.document.file_id) break index;
     } else selected_file.documents.len;
+}
+
+fn customComponentInsertionSide(
+    plan: *const merge_model.MergePlan,
+    operation: *const merge_model.Operation,
+) ?merge_model.Side {
+    const atomic = atomicByIdConst(plan, operation.atomic_id) orelse return null;
+    for (atomic.operation_ids) |member_id| {
+        const member = merge_model.operationByIdConst(plan, member_id) orelse return null;
+        if (member.kind != .sequence_membership) continue;
+        return switch (member.resolution) {
+            .take => |side| if (member.values.get(side) != null) side else null,
+            else => null,
+        };
+    }
+    return null;
 }
 
 fn documentInsertionOffset(

--- a/core/src/merge_yaml.zig
+++ b/core/src/merge_yaml.zig
@@ -8,6 +8,8 @@ pub const Error = parser.Error || error{InvalidValue};
 pub const Replacement = struct { span: source.Span, bytes: []const u8 };
 
 pub fn parseValue(arena: std.mem.Allocator, input: []const u8) Error!*const model.Node {
+    if (std.mem.indexOfAny(u8, input, "\r\n") != null or std.mem.startsWith(u8, std.mem.trimStart(u8, input, " "), "- "))
+        return parseBlockValue(arena, input);
     if (std.mem.indexOfAny(u8, input, "\r\n\x00") != null) return error.InvalidValue;
     try validateRawText(input);
     if (!std.mem.eql(u8, input, std.mem.trim(u8, input, " \t"))) return error.InvalidValue;
@@ -19,6 +21,68 @@ pub fn parseValue(arena: std.mem.Allocator, input: []const u8) Error!*const mode
     const value = body.get("value") orelse return error.InvalidValue;
     const raw = parsed.nodeBytes(value) orelse return error.InvalidValue;
     if (!std.mem.eql(u8, raw, input)) return error.InvalidValue;
+    try validateFlowNode(arena, parsed, value);
+    return value;
+}
+
+fn parseBlockValue(arena: std.mem.Allocator, input: []const u8) Error!*const model.Node {
+    const trimmed = std.mem.trim(u8, input, " \r\n");
+    if (std.mem.startsWith(u8, trimmed, "[") or std.mem.startsWith(u8, trimmed, "{")) {
+        const compact = try arena.dupe(u8, trimmed);
+        var quote: ?u8 = null;
+        var escaped = false;
+        var scalar_start = true;
+        for (compact, 0..) |*byte, index| {
+            if (byte.* == '\r' or byte.* == '\n') {
+                // Only separators may span lines; folding scalar text could change its whitespace.
+                if (quote != null) return error.InvalidValue;
+                const before = std.mem.trimEnd(u8, compact[0..index], " ");
+                const after = std.mem.trimStart(u8, compact[index + 1 ..], " \r\n");
+                const follows_separator = before.len > 0 and std.mem.indexOfScalar(u8, "[{,:", before[before.len - 1]) != null;
+                const precedes_separator = after.len > 0 and std.mem.indexOfScalar(u8, ",:]}", after[0]) != null;
+                if (!follows_separator and !precedes_separator) return error.InvalidValue;
+                byte.* = ' ';
+            }
+            if (escaped) {
+                escaped = false;
+            } else if (quote) |delimiter| {
+                if (delimiter == '"' and byte.* == '\\') escaped = true else if (byte.* == delimiter) quote = null;
+            } else if (scalar_start and (byte.* == '\'' or byte.* == '"')) {
+                quote = byte.*;
+                scalar_start = false;
+            } else if (std.mem.indexOfScalar(u8, "[{,", byte.*) != null or
+                (byte.* == ':' and index + 1 < compact.len and std.ascii.isWhitespace(compact[index + 1])))
+            {
+                scalar_start = true;
+            } else if (!std.ascii.isWhitespace(byte.*)) scalar_start = false;
+        }
+        return parseValue(arena, compact);
+    }
+    if (std.mem.indexOfAny(u8, trimmed, "\r\n") == null and !std.mem.startsWith(u8, trimmed, "- "))
+        return parseValue(arena, trimmed);
+    var lines = std.mem.splitScalar(u8, input, '\n');
+    var indent: ?usize = null;
+    var wrapper: std.ArrayList(u8) = .empty;
+    try wrapper.appendSlice(arena, "--- !u!114 &1\nMonoBehaviour:\n  value:\n");
+    while (lines.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        try validateRawText(line);
+        const content = std.mem.trimStart(u8, line, " ");
+        if (content.len == 0) continue;
+        // The document parser skips directives; a value must not silently discard one.
+        if (content[0] == '%') return error.InvalidValue;
+        if (indent == null) indent = leadingSpaces(line);
+        if (leadingSpaces(line) < indent.?) return error.InvalidValue;
+        try wrapper.appendSlice(arena, "    ");
+        try wrapper.appendSlice(arena, line[indent.?..]);
+        try wrapper.append(arena, '\n');
+    }
+    const parsed = try parser.parseSpanned(arena, try wrapper.toOwnedSlice(arena));
+    if (parsed.diagnostics.len != 0 or parsed.documents.len != 1) return error.InvalidValue;
+    const body = parsed.documents[0].body;
+    if (body.* != .map or body.map.len != 1) return error.InvalidValue;
+    const value = body.get("value") orelse return error.InvalidValue;
+    if (value.* != .seq and value.* != .map) return error.InvalidValue;
     try validateFlowNode(arena, parsed, value);
     return value;
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,6 +193,7 @@ The user can edit it with another tool and complete the normal Git workflow.
 
 #### Edit Result
 
+Navigation and automatic selection of the next conflict follow the hierarchy's order from top to bottom.
 Click **Ours** or **Theirs** to preview a value.
 Click **Result**, or focus it and press **Enter**, to edit the existing value.
 **Ctrl+E** opens the Result editor directly from the selected conflict; **F2** also works.
@@ -202,6 +203,8 @@ While editing, typing and pasting insert at the cursor; **Backspace** and **Dele
 Arrow keys move the cursor within the value.
 Click inside the editor to place the cursor, or drag to select text across lines.
 Selected text is highlighted; typing or pasting replaces it.
+**Ctrl+C** copies the selected text and keeps it selected.
+Copy requires a terminal that supports clipboard writes through OSC 52, such as Ghostty.
 **Home** / **Ctrl+A** and **End** / **Ctrl+E** move to the start and end of the current line.
 **Shift+Enter** inserts a newline with the current indentation.
 If your terminal sends the same key code for Enter and Shift+Enter, use **Ctrl+J** or configure Shift+Enter to send a newline (`\n`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -196,15 +196,16 @@ The user can edit it with another tool and complete the normal Git workflow.
 Navigation and automatic selection of the next conflict follow the hierarchy's order from top to bottom.
 Click **Ours** or **Theirs** to preview a value.
 Click **Result**, or focus it and press **Enter**, to edit the existing value.
-**Ctrl+E** opens the Result editor directly from the selected conflict; **F2** also works.
+**F2** also opens the Result editor directly from the selected conflict.
 Before editing, **Backspace** or **Delete** clears the focused Result and reopens the conflict without starting the editor.
 While editing, typing and pasting insert at the cursor; **Backspace** and **Delete** remove a character or the selected range.
 
 Arrow keys move the cursor within the value.
 Click inside the editor to place the cursor, or drag to select text across lines.
 Selected text is highlighted; typing or pasting replaces it.
-**Ctrl+C** copies the selected text and keeps it selected.
+**Cmd+C** on macOS or **Ctrl+C** on Windows and Linux copies the selected text and keeps it selected.
 Copy requires a terminal that supports clipboard writes through OSC 52, such as Ghostty.
+If your terminal intercepts **Cmd+C**, configure it to forward the shortcut or use **Ctrl+C**.
 **Home** / **Ctrl+A** and **End** / **Ctrl+E** move to the start and end of the current line.
 **Shift+Enter** inserts a newline with the current indentation.
 If your terminal sends the same key code for Enter and Shift+Enter, use **Ctrl+J** or configure Shift+Enter to send a newline (`\n`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,28 @@ It does not parse the markers.
 If the user quits, startup fails, or the UI is interrupted, the working conflict representation stays in place.
 The user can edit it with another tool and complete the normal Git workflow.
 
+#### Edit Result
+
+Click **Ours** or **Theirs** to preview that value, then focus **Result**.
+Typing replaces the current value, and **Backspace** clears it, as before.
+Press **F2** to keep the current value and edit part of it.
+
+In **F2** editing, arrow keys move the cursor within the value.
+**Home** and **End** move to the start and end of the current line.
+**Ctrl+J** or **Shift+Enter** inserts a newline with the current indentation.
+Adding a newline or pasting also enables cursor movement within the value.
+**Enter** applies the value; **Escape** cancels editing and returns to the hierarchy.
+Clearing the value and leaving **Result** reopens the conflict.
+Applying an empty value still requires confirmation.
+
+Paste the YAML value from a diff, without diff markers, headers, or the enclosing property name.
+Bracketed paste keeps indentation and line breaks and waits for **Enter** before applying the value.
+Collection values accept block YAML and flow YAML split across lines.
+Keep each scalar token on one line; folded scalar input remains unsupported.
+PrefabLens keeps the existing collection shape checks and output formatting rules.
+
+#### Completion checks
+
 Before PrefabLens writes a completed semantic resolution, it verifies these conditions:
 
 1. Every atomic operation has a result.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -193,14 +193,16 @@ The user can edit it with another tool and complete the normal Git workflow.
 
 #### Edit Result
 
-Click **Ours** or **Theirs** to preview that value, then focus **Result**.
-Typing replaces the current value, and **Backspace** clears it, as before.
-Press **F2** to keep the current value and edit part of it.
+Click **Ours** or **Theirs** to preview a value.
+Click **Result**, or focus it and press **Enter**, to edit the existing value.
+**Ctrl+E** opens the Result editor directly from the selected conflict; **F2** also works.
+Typing and pasting insert at the cursor, and **Backspace** deletes one character.
 
-In **F2** editing, arrow keys move the cursor within the value.
-**Home** and **End** move to the start and end of the current line.
-**Ctrl+J** or **Shift+Enter** inserts a newline with the current indentation.
-Adding a newline or pasting also enables cursor movement within the value.
+Arrow keys move the cursor within the value.
+Click inside the editor to place the cursor.
+**Home** / **Ctrl+A** and **End** / **Ctrl+E** move to the start and end of the current line.
+**Shift+Enter** inserts a newline with the current indentation.
+If your terminal sends the same key code for Enter and Shift+Enter, use **Ctrl+J** or configure Shift+Enter to send a newline (`\n`).
 **Enter** applies the value; **Escape** cancels editing and returns to the hierarchy.
 Clearing the value and leaving **Result** reopens the conflict.
 Applying an empty value still requires confirmation.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -196,10 +196,12 @@ The user can edit it with another tool and complete the normal Git workflow.
 Click **Ours** or **Theirs** to preview a value.
 Click **Result**, or focus it and press **Enter**, to edit the existing value.
 **Ctrl+E** opens the Result editor directly from the selected conflict; **F2** also works.
-Typing and pasting insert at the cursor, and **Backspace** deletes one character.
+Before editing, **Backspace** or **Delete** clears the focused Result and reopens the conflict without starting the editor.
+While editing, typing and pasting insert at the cursor; **Backspace** and **Delete** remove a character or the selected range.
 
 Arrow keys move the cursor within the value.
-Click inside the editor to place the cursor.
+Click inside the editor to place the cursor, or drag to select text across lines.
+Selected text is highlighted; typing or pasting replaces it.
 **Home** / **Ctrl+A** and **End** / **Ctrl+E** move to the start and end of the current line.
 **Shift+Enter** inserts a newline with the current indentation.
 If your terminal sends the same key code for Enter and Shift+Enter, use **Ctrl+J** or configure Shift+Enter to send a newline (`\n`).
@@ -212,6 +214,8 @@ Bracketed paste keeps indentation and line breaks and waits for **Enter** before
 Collection values accept block YAML and flow YAML split across lines.
 Keep each scalar token on one line; folded scalar input remains unsupported.
 PrefabLens keeps the existing collection shape checks and output formatting rules.
+For a component delete/edit conflict, Result contains the whole component document.
+You can edit its properties while keeping its document header, type, and `m_GameObject` reference unchanged.
 
 #### Completion checks
 

--- a/docs/collection-merge.md
+++ b/docs/collection-merge.md
@@ -35,6 +35,8 @@ Letters enter text when **Result** has focus.
 
 To preview a choice before applying it, click its value.
 Then focus **Result** to inspect, edit, or apply the preview.
+Press **F2** to edit the preview without replacing it.
+See [Edit Result](cli.md#edit-result) for multiline editing and paste controls.
 When all conflicts have a resolution, select **Complete**.
 A local choice retains independent accepted changes elsewhere in the collection.
 

--- a/docs/collection-merge.md
+++ b/docs/collection-merge.md
@@ -34,7 +34,7 @@ Scalar fields and array delete/edit conflicts do not show the control.
 Letters enter text when **Result** has focus.
 
 To preview a choice before applying it, click its value.
-Click **Result** or press **Ctrl+E** to edit the preview.
+Click **Result**, or focus it and press **Enter**, to edit the preview.
 The existing text stays in place; press **Enter** to apply it.
 See [Edit Result](cli.md#edit-result) for multiline editing and paste controls.
 When all conflicts have a resolution, select **Complete**.

--- a/docs/collection-merge.md
+++ b/docs/collection-merge.md
@@ -34,8 +34,8 @@ Scalar fields and array delete/edit conflicts do not show the control.
 Letters enter text when **Result** has focus.
 
 To preview a choice before applying it, click its value.
-Then focus **Result** to inspect, edit, or apply the preview.
-Press **F2** to edit the preview without replacing it.
+Click **Result** or press **Ctrl+E** to edit the preview.
+The existing text stays in place; press **Enter** to apply it.
 See [Edit Result](cli.md#edit-result) for multiline editing and paste controls.
 When all conflicts have a resolution, select **Complete**.
 A local choice retains independent accepted changes elsewhere in the collection.


### PR DESCRIPTION
## Summary

Make merge Result editing retain the current value and support cursor edits, copying selections, multiline YAML, and paste. Keep Ours red and Theirs green before and after focus changes, and navigate conflicts in hierarchy order.

## Motivation

Manual edits replaced existing values, pasted newlines could apply incomplete YAML, and source colors appeared only after focus. Editing a retained component document also failed validation, mouse dragging did not select text, deletion before editing unexpectedly opened the editor, and automatic focus could jump over a higher conflict row.

## Changes

- Open Result editing with a click or Enter on Result. Retain F2 as an alternative and remove Ctrl+E as an entry shortcut.
- Remove the editing hints from the footer before and during editing.
- Move the cursor with arrow keys or a click, and drag to select text across lines. Include both endpoint characters, including Unicode graphemes. Typing and paste replace the whole highlighted range; Backspace and Delete remove a character or selection.
- Copy selected Result text with Cmd+C on macOS or Ctrl+C on Windows and Linux through the terminal clipboard. Preserve selection after copying and when modifier keys arrive before a terminal paste. Keep Ctrl+C available when a terminal intercepts Cmd+C.
- Select the top conflict when opening the UI, and follow displayed row order for navigation and automatic focus. Preserve existing previews when reordering.
- Before editing, Backspace or Delete clears the focused Result and reopens the conflict without starting the editor.
- Add indented newlines with Shift+Enter or Ctrl+J. Keep Enter to apply, Escape to cancel, empty-value confirmation, and deletion choices.
- Treat bracketed paste as one edit. Preserve indentation and output line endings, and support block and multiline flow collection values with the existing shape checks.
- Allow edits to component documents in delete/edit conflicts, including after applying Theirs. Preserve component identity, owner membership, document order, and prior edits when validation fails.
- Give Quit and Use Empty dialogs a single-line outline, opaque background, and bold prompt using the existing palette and geometry.
- Keep the first key available after Use Empty gains focus. Focus events no longer consume the next input event.
- Keep source colors visible without focus and document the editor controls.

## Testing

- `mise exec -- zig build test lint --summary all`: 32/32 steps succeeded; 639/639 tests passed, including all Git and PTY integration executables.
- `mise exec -- zig build lint`: passed.
- `mise exec -- zig build -Doptimize=ReleaseSafe --summary all`: 8/8 steps succeeded.
- Real PTY showcase with the ReleaseSafe binary: launched with `git merge remote`, resolved all 11 conflicts, and matched the expected Prefab byte for byte. Verified unfocused source colors, retained scalar edits, clearing before editing, combined arrays, multiline paste, Shift+Enter, and Position.x → SphereCollider focus order. After applying Theirs, dragged through Radius's last character, copied `0.4`, and pasted `0.6` without leaving a trailing character. Verified the Cmd+C OSC 52 clipboard payload and retained selection. PTY integration tests also cover Ctrl+C. Reopening the component retained the edit. Verified click and Enter edit entry and absent editing hints. Checked both confirmation dialogs at 80×10, 100×20, 120×24, and 160×34, with Cancel and Confirm selected. Their outlines, opaque backgrounds, bold prompts, and button highlights remained intact after resize. The first Right key selected Use Empty after opening the dialog.
- Regression check: the first-key focus test failed before the lifecycle fix and passed after it.
- `git diff --check`: passed.
