### PR TITLE
fix: reject trailing content in CLI JSON

### DIFF
--- a/editor/Editor/MiniJson.cs
+++ b/editor/Editor/MiniJson.cs
@@ -27,7 +27,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 // Bundled into PrefabLens from: https://gist.github.com/darktable/1411710 (rev 513f1c0, MIT)
-// Changes: namespace MiniJSON -> PrefabLens.MiniJson; removed unused serialization and its example.
+// Changes: namespace MiniJSON -> PrefabLens.MiniJson; removed unused serialization and its example;
+// reject non-whitespace after the root value so CLI output must be one JSON document.
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -89,8 +90,29 @@ namespace PrefabLens.MiniJson
             {
                 using (var instance = new Parser(jsonString))
                 {
-                    return instance.ParseValue();
+                    var value = instance.ParseValue();
+                    if (!instance.IsAtEnd())
+                    {
+                        return null;
+                    }
+
+                    return value;
                 }
+            }
+
+            bool IsAtEnd()
+            {
+                while (json.Peek() != -1)
+                {
+                    if (!Char.IsWhiteSpace(PeekChar))
+                    {
+                        return false;
+                    }
+
+                    json.Read();
+                }
+
+                return true;
             }
 
             public void Dispose()

--- a/editor/Tests/Editor/BulkModelTests.cs
+++ b/editor/Tests/Editor/BulkModelTests.cs
@@ -38,6 +38,22 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void ThrowsOnTrailingContentAfterArray()
+        {
+            Assert.That(
+                () => BulkModel.Parse("[{\"path\":\"Assets/Robot.prefab\",\"diff\":{}}]trailing-garbage"),
+                Throws.Exception
+            );
+            Assert.That(() => BulkModel.Parse("[]{}"), Throws.Exception);
+        }
+
+        [Test]
+        public void AcceptsTrailingWhitespaceAfterArray()
+        {
+            Assert.AreEqual(0, BulkModel.Parse("[]  \n\t").Entries.Count);
+        }
+
+        [Test]
         public void SkipsEntriesMissingPathOrDiff()
         {
             var m = BulkModel.Parse(

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -142,6 +142,20 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void ThrowsOnTrailingContentAfterObject()
+        {
+            Assert.That(() => DiffModel.Parse("{\"roots\":[],\"loose\":[]}trailing-garbage"), Throws.Exception);
+            Assert.That(() => DiffModel.Parse("{\"roots\":[],\"loose\":[]}{}"), Throws.Exception);
+        }
+
+        [Test]
+        public void AcceptsTrailingWhitespaceAfterObject()
+        {
+            var m = DiffModel.Parse("{\"roots\":[],\"loose\":[]}  \n\t");
+            Assert.IsTrue(m.IsEmpty);
+        }
+
+        [Test]
         public void ResolveWithFillsOnlyUnresolvedGuids()
         {
             var m = DiffModel.Parse(Golden);


### PR DESCRIPTION
## Summary

The bundled MiniJSON parser now requires a single JSON document. Bulk and diff parsing fail when non-whitespace text follows the root value.

## Motivation

The parser returned after the first JSON value and ignored the rest of the input. `BulkModel.Parse` and `DiffModel.Parse` therefore accepted malformed CLI output such as a valid array followed by `trailing-garbage`. The window depends on parse failures to show a CLI output error.

Closes #357

## Changes

- After the root value, `Parser.Parse` skips remaining whitespace and returns null when any other input remains.
- `BulkModel.Parse` and `DiffModel.Parse` still throw when deserialize returns null, so trailing garbage and a second JSON value become parse failures.
- Trailing spaces and newlines stay valid. Unknown schema fields stay tolerated.
- EditMode tests cover both bulk arrays and individual diff objects.

## Testing

```
$ cd editor && dotnet csharpier check . --no-msbuild-check
Checked 28 files in 123ms.
```

RED (before the parser change):

```
$ cd editor && dotnet test DotNetTests~/Tests --filter "FullyQualifiedName~ThrowsOnTrailingContentAfterArray|FullyQualifiedName~ThrowsOnTrailingContentAfterObject|FullyQualifiedName~AcceptsTrailingWhitespaceAfterArray|FullyQualifiedName~AcceptsTrailingWhitespaceAfterObject"
Failed!  - Failed:     2, Passed:     2, Skipped:     0, Total:     4
  Failed ThrowsOnTrailingContentAfterArray
     Expected: an exception to be thrown
     But was:  no exception thrown
  Failed ThrowsOnTrailingContentAfterObject
     Expected: an exception to be thrown
     But was:  no exception thrown
```

GREEN (after the parser change):

```
$ cd editor && dotnet test DotNetTests~/Tests --filter "FullyQualifiedName~DiffModelTests|FullyQualifiedName~BulkModelTests"
Passed!  - Failed:     0, Passed:    17, Skipped:     0, Total:    17
```

```
$ cd editor && dotnet test DotNetTests~/Tests --filter "FullyQualifiedName!~CliTests"
Passed!  - Failed:     0, Passed:    47, Skipped:     0, Total:    47
```

`CliTests` were not run here. They need `PREFABLENS_TEST_BIN_DIR` and a native CLI binary.