### PR TITLE
build: remove undici override from site workspace

### DIFF
--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -105,9 +105,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  undici: ^8.0.0
-
 importers:
 
   .:
@@ -1047,9 +1044,9 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  undici@8.10.0:
-    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
-    engines: {node: '>=22.19.0'}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -1759,7 +1756,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 8.10.0
+      undici: 7.29.0
       workerd: 1.20260828.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -1937,7 +1934,7 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  undici@8.10.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -2,7 +2,3 @@ allowBuilds:
   esbuild: false
   workerd: false
 minimumReleaseAge: 4320
-# miniflare pins undici to a version with known vulnerabilities.
-# Remove this override when miniflare requires undici >= 7.29.0.
-overrides:
-  undici: ^8.0.0


### PR DESCRIPTION
## Summary

Remove the site pnpm override for undici now that miniflare requires 7.29.0.

## Motivation

pnpm applies overrides silently. A leftover override can pin an older major version after miniflare moves on. miniflare 5.20260828.0-alpha requires undici 7.29.0, so the override is no longer needed.

Closes #278

## Changes

- Remove the `overrides` entry from `site/pnpm-workspace.yaml`
- Refresh `site/pnpm-lock.yaml` so miniflare resolves undici 7.29.0

## Testing

```
$ npm view miniflare@5.20260828.0-alpha dependencies.undici
7.29.0

$ pnpm install
Done in 2.8s using pnpm v12.2.1

$ pnpm run build
[11ty] Copied 36 Wrote 6 files in 0.04 seconds (v3.1.6)

$ pnpm test
✔ Raw diffs retain fixture changes when Git forces color (725.865584ms)
ℹ tests 1
ℹ pass 1
ℹ fail 0
```