### PR TITLE
fix: preserve quotes in chmod path

### DIFF
--- a/editor/Editor/Cli.Download.cs
+++ b/editor/Editor/Cli.Download.cs
@@ -252,7 +252,7 @@ namespace PrefabLens
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return;
-            var res = RunProcess("chmod", "+x \"" + cliPath + "\"", ".", RunTimeoutMs);
+            var res = RunProcess("chmod", QuoteArgs(new[] { "+x", cliPath }), ".", RunTimeoutMs);
             if (res.ExitCode != 0)
                 throw new InvalidOperationException(
                     $"chmod +x failed for {cliPath}: "

--- a/editor/Tests/Editor/CliTests.Download.cs
+++ b/editor/Tests/Editor/CliTests.Download.cs
@@ -307,6 +307,29 @@ namespace PrefabLens.Tests
         }
 
         [Test]
+        public void InstallArchiveSucceedsInsideADirectoryWithSpacesAndQuotes()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Ignore("Windows filesystem naming rules are out of scope");
+            var root = Path.Combine(Path.GetTempPath(), "Project \"quoted\" " + Path.GetRandomFileName());
+            var finalDirectory = Path.Combine(root, Cli.Version);
+            var archive = CreateNativeCliArchive(NativeCliDirectory());
+            try
+            {
+                var installed = Cli.InstallArchive(archive, finalDirectory, Cli.Version);
+                Assert.AreEqual(Path.Combine(finalDirectory, Cli.BinaryName), installed);
+                var version = Cli.RunProcess(installed, "--version", finalDirectory, 10_000);
+                Assert.AreEqual(0, version.ExitCode);
+                StringAssert.Contains("prefablens " + Cli.Version, version.Stdout.Trim());
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                    Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Test]
         public void InstallArchiveKeepsAUsableCacheWhenTheArchiveHasAnotherVersion()
         {
             // Validation must finish in staging before the installer replaces a usable cache.


### PR DESCRIPTION
## Summary

`MarkExecutable` now passes `chmod` arguments through `QuoteArgs`, so installation keeps filesystem paths that contain double quotes.

## Motivation

Closes #355

`MarkExecutable` inserted the CLI path into `ProcessStartInfo.Arguments` as `+x "path"`. A parent directory named `Project "quoted"` made `chmod` receive `Project quoted` instead, and installation threw `InvalidOperationException`.

## Changes

- Build `chmod` arguments with `QuoteArgs` so embedded quotes stay part of the path.
- Add `InstallArchiveSucceedsInsideADirectoryWithSpacesAndQuotes`, which installs the real native CLI under a directory with spaces and quotes, then checks `--version`.

## Testing

Before the `QuoteArgs` change, the new test failed with the reported `chmod` path split:

```
Failed InstallArchiveSucceedsInsideADirectoryWithSpacesAndQuotes
System.InvalidOperationException : chmod +x failed for .../Project "quoted" .../prefablens:
chmod: .../Project quoted .../prefablens: No such file or directory
```

After the change:

```
cd editor
dotnet csharpier check . --no-msbuild-check
```

```
Checked 28 files in 142ms.
```

```
PREFABLENS_TEST_BIN_DIR="$PWD/../zig-out/bin" \
PREFABLENS_TEST_ALT_BIN_DIR="$PWD/../zig-out/test-alternate-bin" \
  dotnet test DotNetTests~/Tests
```

```
Passed!  - Failed:     0, Passed:    83, Skipped:     0, Total:    83, Duration: 4 s - PrefabLens.Editor.Tests.dll (net10.0)
```

The quoted-path install test, `InstallArchiveInstallsAndRunsTheNativeCli`, and `MarkExecutableFailsTheDownloadStepNamingTheBinaryPath` also passed together (3/3).