### PR TITLE
fix: clear file list on failed refresh

### DIFF
--- a/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
+++ b/editor/DotNetTests~/Package/Stubs/UIElementsStubs.cs
@@ -109,12 +109,20 @@ namespace UnityEngine.UIElements
 
     public class VisualElement
     {
+        readonly List<VisualElement> children = new();
+
         public IStyle style { get; } = new Style();
         public string tooltip { get; set; }
 
-        public void Add(VisualElement child) { }
+        public int childCount => children.Count;
 
-        public void Clear() { }
+        public VisualElement this[int key] => children[key];
+
+        public void Add(VisualElement child) => children.Add(child);
+
+        public void Clear() => children.Clear();
+
+        public IEnumerable<VisualElement> Children() => children;
     }
 
     public delegate void EventCallback<in TEventType>(TEventType evt);
@@ -214,6 +222,8 @@ namespace UnityEngine.UIElements
         public event Action<IEnumerable<object>> selectionChanged;
 
         public void SetSelection(int index) { }
+
+        public void ClearSelectionWithoutNotify() { }
 
         public void RefreshItems() { }
     }

--- a/editor/Editor/PrefabLensWindow.cs
+++ b/editor/Editor/PrefabLensWindow.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
+
+[assembly: InternalsVisibleTo("PrefabLens.Editor.Tests")]
 
 namespace PrefabLens
 {
@@ -27,6 +30,15 @@ namespace PrefabLens
         public static void Open() => GetWindow<PrefabLensWindow>("PrefabLens");
 
         public void CreateGUI()
+        {
+            CreateLayout();
+            // Window-lifetime token for CLI runs; domain reload re-enters CreateGUI with a fresh one.
+            runCts = new CancellationTokenSource();
+            Refresh();
+        }
+
+        /// Toolbar and split view only. Tests feed fixtures through ShowBulkResult without a CLI run.
+        internal void CreateLayout()
         {
             var toolbar = new VisualElement
             {
@@ -68,10 +80,11 @@ namespace PrefabLens
             content = new VisualElement { style = { flexGrow = 1 } };
             split.Add(content);
             rootVisualElement.Add(split);
-            // Window-lifetime token for CLI runs; domain reload re-enters CreateGUI with a fresh one.
-            runCts = new CancellationTokenSource();
-            Refresh();
         }
+
+        internal ListView FileList => list;
+        internal VisualElement DetailPane => content;
+        internal string StatusText => status.text;
 
         /// Unity calls this whenever the window gains focus; before CreateGUI on first open.
         void OnFocus()
@@ -124,7 +137,7 @@ namespace PrefabLens
                 Refresh(); // the base ref changed mid-run: run again with the current field
         }
 
-        void ShowBulkResult(Cli.Result res, string runRef)
+        internal void ShowBulkResult(Cli.Result res, string runRef)
         {
             // Unchanged output — the common focus-triggered refresh. Leave the whole UI
             // alone so the user's tree fold state survives; only restore the status line.
@@ -133,12 +146,11 @@ namespace PrefabLens
                 status.text = CountText(runRef);
                 return;
             }
-            content.Clear();
             if (res.ExitCode != 0)
             {
                 // The CLI's stderr is the primary source (non-git repository, timeout, etc.)
-                lastStdout = null;
-                status.text = "";
+                ResetList();
+                content.Clear();
                 Note(string.IsNullOrEmpty(res.Stderr) ? $"prefablens exited with {res.ExitCode}" : res.Stderr.Trim());
                 return;
             }
@@ -151,8 +163,8 @@ namespace PrefabLens
                 // The generic UI note stays short; the console carries the real reason
                 // (exception type + message) so a version mismatch is diagnosable.
                 Debug.LogException(e);
-                lastStdout = null;
-                status.text = "";
+                ResetList();
+                content.Clear();
                 Note("Could not parse CLI output (CLI version mismatch?):");
                 Note(res.Stdout.Length > 200 ? res.Stdout.Substring(0, 200) + "…" : res.Stdout);
                 return;
@@ -163,7 +175,10 @@ namespace PrefabLens
             status.text = CountText(runRef);
 
             if (bulk.Entries.Count == 0)
+            {
+                content.Clear();
                 return;
+            }
             var idx = bulk.Entries.FindIndex(entry => entry.Path == selectedPath);
             if (idx < 0)
                 idx = 0;
@@ -207,11 +222,12 @@ namespace PrefabLens
                 content.Add(DiffTreeView.BuildTree(entry.Diff));
         }
 
-        /// Clears the list pane and status; the missing-CLI screen and the download
-        /// start share this exact reset.
+        /// Clears the list pane, selection, and status. Missing-CLI, download start,
+        /// and a failed refresh share this reset.
         void ResetList()
         {
             bulk = new BulkModel();
+            list.ClearSelectionWithoutNotify();
             list.itemsSource = bulk.Entries;
             list.RefreshItems();
             lastStdout = null;

--- a/editor/Tests/Editor/PrefabLensWindowTests.cs
+++ b/editor/Tests/Editor/PrefabLensWindowTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+#if UNITY_EDITOR
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+#endif
+
+namespace PrefabLens.Tests
+{
+    public sealed class PrefabLensWindowTests
+    {
+        // One bulk entry in the v2 shape the window parses. A later failed refresh must
+        // not leave this path selectable.
+        const string OneFile =
+            "[{\"path\":\"Assets/Smoke.prefab\",\"diff\":{\"schema\":\"prefablens.diff.v2\",\"unresolvedGuids\":[],\"roots\":[{\"kind\":\"gameObject\",\"fileId\":\"1\",\"name\":\"Smoke\",\"status\":\"unchanged\",\"components\":[{\"kind\":\"component\",\"fileId\":\"4\",\"classId\":4,\"typeName\":\"Transform\",\"scriptGuid\":null,\"className\":null,\"status\":\"modified\",\"fields\":[{\"path\":\"Position.x\",\"status\":\"modified\",\"before\":\"0\",\"after\":\"1\"}]}],\"children\":[]}],\"loose\":[]}}]";
+
+        const string CliError = "fatal: Needed a single revision";
+
+        [Test]
+        public void FailedCliResultClearsThePreviousFileListAndKeepsTheError()
+        {
+            var window = OpenRenderedWindow();
+            try
+            {
+                window.ShowBulkResult(Ok(OneFile), "HEAD");
+                Assert.AreEqual(1, FileCount(window));
+
+                window.ShowBulkResult(
+                    new Cli.Result
+                    {
+                        ExitCode = 128,
+                        Stdout = "",
+                        Stderr = CliError + "\n",
+                    },
+                    "missing-ref"
+                );
+
+                Assert.AreEqual(0, FileCount(window));
+                Assert.AreEqual("", window.StatusText);
+                Assert.That(Labels(window.DetailPane), Does.Contain(CliError));
+            }
+            finally
+            {
+                CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void JsonParseFailureClearsThePreviousFileListAndKeepsTheDiagnostic()
+        {
+#if UNITY_EDITOR
+            LogAssert.Expect(LogType.Exception, new Regex("bulk json root is not an array"));
+#endif
+            var window = OpenRenderedWindow();
+            try
+            {
+                window.ShowBulkResult(Ok(OneFile), "HEAD");
+                Assert.AreEqual(1, FileCount(window));
+
+                window.ShowBulkResult(Ok("not json"), "HEAD");
+
+                Assert.AreEqual(0, FileCount(window));
+                Assert.AreEqual("", window.StatusText);
+                var labels = Labels(window.DetailPane);
+                Assert.That(labels, Does.Contain("Could not parse CLI output (CLI version mismatch?):"));
+                Assert.That(labels, Does.Contain("not json"));
+            }
+            finally
+            {
+                CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void SuccessfulRefreshAfterFailureShowsTheNewFileListAndDiff()
+        {
+            var window = OpenRenderedWindow();
+            try
+            {
+                window.ShowBulkResult(Ok(OneFile), "HEAD");
+                window.ShowBulkResult(
+                    new Cli.Result
+                    {
+                        ExitCode = 128,
+                        Stdout = "",
+                        Stderr = CliError,
+                    },
+                    "missing-ref"
+                );
+
+                window.ShowBulkResult(Ok(OneFile), "HEAD");
+
+                Assert.AreEqual(1, FileCount(window));
+                Assert.AreEqual("1 changed vs HEAD", window.StatusText);
+                var labels = Labels(window.DetailPane);
+                Assert.That(labels, Does.Contain("Assets/Smoke.prefab"));
+                Assert.That(labels, Does.Not.Contain(CliError));
+            }
+            finally
+            {
+                CloseWindow(window);
+            }
+        }
+
+        static Cli.Result Ok(string stdout) =>
+            new Cli.Result
+            {
+                ExitCode = 0,
+                Stdout = stdout,
+                Stderr = "",
+            };
+
+        static PrefabLensWindow OpenRenderedWindow()
+        {
+#if UNITY_EDITOR
+            var window = ScriptableObject.CreateInstance<PrefabLensWindow>();
+#else
+            var window = new PrefabLensWindow();
+#endif
+            window.CreateLayout();
+            return window;
+        }
+
+        static void CloseWindow(PrefabLensWindow window)
+        {
+#if UNITY_EDITOR
+            window.Close();
+#endif
+        }
+
+        static int FileCount(PrefabLensWindow window) => window.FileList.itemsSource?.Count ?? 0;
+
+        static List<string> Labels(VisualElement root)
+        {
+            var texts = new List<string>();
+            Collect(root, texts);
+            return texts;
+        }
+
+        static void Collect(VisualElement element, List<string> texts)
+        {
+            if (element is Label label)
+                texts.Add(label.text);
+            foreach (var child in element.Children())
+                Collect(child, texts);
+        }
+    }
+}

--- a/editor/Tests/Editor/PrefabLensWindowTests.cs.meta
+++ b/editor/Tests/Editor/PrefabLensWindowTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 875dd4fcb0a44f7d8c2e989cafd6b687
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Clear the Editor file list when a bulk comparison fails, so a previous diff cannot replace the current error.

## Motivation

A failed refresh left the previous file list selectable. Choosing an old entry replaced the CLI or parse diagnostic with a stale diff.

Closes #356

## Changes

- Reset the list, selection, and cached stdout before showing a CLI error or a JSON parse failure.
- Keep a later successful refresh on the existing path that fills the list and selected diff.
- Add `PrefabLensWindowTests` that pass success and failure fixtures to the window renderer.
- Record `VisualElement` children in the headless UI stubs so those tests can assert the diagnostic text.

## Testing

```
cd editor
dotnet csharpier check . --no-msbuild-check
```

```
Checked 29 files in 250ms.
```

RED (before the `ResetList` calls on the failure paths):

```
dotnet test DotNetTests~/Tests --filter PrefabLensWindowTests --nologo
```

```
Failed FailedCliResultClearsThePreviousFileListAndKeepsTheError
  Expected: 0
  But was:  1

Failed JsonParseFailureClearsThePreviousFileListAndKeepsTheDiagnostic
  Expected: 0
  But was:  1

Failed!  - Failed:     2, Passed:     1, Skipped:     0, Total:     3
```

GREEN:

```
dotnet test DotNetTests~/Tests --filter PrefabLensWindowTests --nologo
```

```
Passed!  - Failed:     0, Passed:     3, Skipped:     0, Total:     3
```

Full Editor suite after `zig build test-installation-binaries -Doptimize=ReleaseSafe`:

```
PREFABLENS_TEST_BIN_DIR="$PWD/../zig-out/bin" \
PREFABLENS_TEST_ALT_BIN_DIR="$PWD/../zig-out/test-alternate-bin" \
  dotnet test DotNetTests~/Tests --nologo
```

```
Passed!  - Failed:     0, Passed:    85, Skipped:     0, Total:    85, Duration: 4 s
```

These tests drive UI Toolkit widgets. CI does not run the EditMode suite inside the Unity Editor.