### PR TITLE
fix: restore Playwright CI and Result Enter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,12 @@ jobs:
           pnpm run typecheck
           pnpm test
           pnpm run build
+      - name: Disable hosted browser apt sources
+        # GitHub-hosted Ubuntu images register Google Chrome and Microsoft Edge
+        # apt sources. playwright install-deps runs apt-get update against every
+        # source, so a Hash Sum mismatch from dl.google.com fails the job even
+        # though E2E launches Playwright's Chromium channel, not those browsers.
+        run: sudo rm -f /etc/apt/sources.list.d/google-chrome* /etc/apt/sources.list.d/microsoft-edge*
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: extension

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -1456,6 +1456,11 @@ fn submitCustom(
     value: []const u8,
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata.?));
+    if (!self.editing) {
+        // A queued Enter can still target the TextField after apply closed it.
+        if (self.focus_area == .complete) return self.activate(ctx, self.eventSize());
+        return;
+    }
     const input = std.mem.trim(u8, value, "\r\n");
     const started_empty = if (self.editor_start_resolution) |resolution| switch (resolution) {
         .custom => |start_value| start_value.len == 0,
@@ -5078,6 +5083,36 @@ test "merge TUI: Enter asks when the focused Result is empty" {
     try testing.expect(view.focus_area == .inspector);
     const screen = try surfaceText(arena, try drawForTest(arena, view.widget(), 100, 20));
     try testing.expect(std.mem.indexOf(u8, screen, "Use an empty value?") != null);
+}
+
+test "merge TUI: a queued Enter after apply completes instead of asking for empty" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try core.merge.build(
+        arena,
+        "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 1\n",
+        "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 2\n",
+        "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 3\n",
+    );
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "A.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 100, 20);
+    var ctx = eventContext(arena);
+
+    try focusResultForTest(&view, &ctx);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
+    const surface = try drawForTest(arena, view.widget(), 100, 20);
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter } });
+    try testing.expectEqual(merge_ui_state.Outcome.ready, state.outcome);
+    try testing.expect(!view.editing);
+    try testing.expect(view.focus_area == .complete);
+
+    // The TextField can still be focused for a queued Enter after apply cleared it.
+    try routeFocusedEventForTest(arena, surface, view.editor.widget(), &ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter } });
+    try testing.expect(view.dialog == null);
+    try testing.expect(ctx.quit);
 }
 
 test "merge TUI: Enter does not ask again for a confirmed empty Result" {


### PR DESCRIPTION
## Summary

Stop main CI from failing on Playwright apt sources and on a queued Result Enter after apply.

## Motivation

The last two completed CI runs on `main` failed. Both `extension` jobs died on `playwright install-deps chromium` because `apt-get update` hit a Hash Sum mismatch from Google Chrome's apt source on the GitHub-hosted Ubuntu image. Extension E2E uses Playwright's Chromium channel, not Google Chrome.

The v0.10.1 run also failed `core (macos-latest)` in `pty-smoke-tests`: after a custom Result apply, a second queued Enter targeted the cleared TextField and opened "Use an empty value?" instead of Complete.

Closes #390

## Changes

- Remove Google Chrome and Microsoft Edge apt sources before Playwright installs OS dependencies.
- Ignore a Result submit after the editor is closed, and treat that Enter as Complete when the merge is ready.
- Add a merge TUI test that routes a queued Enter to the stale editor after apply.

## Testing

```
$ zig build test-merge-tui --summary all
Build Summary: 8/8 steps succeeded; 130/130 tests passed
test-merge-tui success
+- run test merge-tui-test 130 pass (130 total) 459ms MaxRSS:14M
```

The new test failed before the `submitCustom` change (`view.dialog == null`) and passed after it.

```
$ zig build lint
```

Exit code 0.

```
$ zig build test-merge-pty --summary all
Build Summary: 8/8 steps succeeded
test-merge-pty success
+- run exe pty-smoke-tests success 32s
```