### PR TITLE
test: keep high-value editor tests only

### DIFF
--- a/editor/Tests/Editor/BulkModelTests.cs
+++ b/editor/Tests/Editor/BulkModelTests.cs
@@ -22,12 +22,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void EmptyArrayYieldsNoEntries()
-        {
-            Assert.AreEqual(0, BulkModel.Parse("[]").Entries.Count);
-        }
-
-        [Test]
         public void ThrowsOnMalformedOrNonArrayJson()
         {
             // Same contract as DiffModel.Parse: the window converts the throw into
@@ -51,16 +45,6 @@ namespace PrefabLens.Tests
         public void AcceptsTrailingWhitespaceAfterArray()
         {
             Assert.AreEqual(0, BulkModel.Parse("[]  \n\t").Entries.Count);
-        }
-
-        [Test]
-        public void SkipsEntriesMissingPathOrDiff()
-        {
-            var m = BulkModel.Parse(
-                "[{\"path\":\"Assets/A.prefab\"},{\"diff\":{\"roots\":[],\"loose\":[]}},{\"path\":\"Assets/B.prefab\",\"diff\":{\"roots\":[],\"loose\":[]}}]"
-            );
-            Assert.AreEqual(1, m.Entries.Count);
-            Assert.AreEqual("Assets/B.prefab", m.Entries[0].Path);
         }
 
         [Test]

--- a/editor/Tests/Editor/CliTests.Download.cs
+++ b/editor/Tests/Editor/CliTests.Download.cs
@@ -44,15 +44,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void DownloadUrlPointsAtTheVersionedRelease()
-        {
-            Assert.AreEqual(
-                "https://github.com/hashiiiii/PrefabLens/releases/download/v0.1.0/prefablens-macos-arm64.zip",
-                Cli.DownloadUrl("0.1.0", "prefablens-macos-arm64.zip")
-            );
-        }
-
-        [Test]
         public void ExtractToWritesOnlyTheExactNativeCliEntry()
         {
             var archive = CreateNativeArchive(
@@ -98,28 +89,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void MarkExecutableMakesTheRealNativeCliRunnable()
-        {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                Assert.Ignore("chmod is a Unix concern");
-            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Directory.CreateDirectory(dir);
-            try
-            {
-                var archive = CreateNativeCliArchive(NativeCliDirectory());
-                Cli.ExtractTo(archive, dir);
-                var cliPath = Path.Combine(dir, Cli.BinaryName);
-                Cli.MarkExecutable(cliPath);
-
-                Assert.AreEqual(0, Cli.RunProcess(cliPath, "--version", dir, 10_000).ExitCode);
-            }
-            finally
-            {
-                Directory.Delete(dir, recursive: true);
-            }
-        }
-
-        [Test]
         public void DeleteStaleVersionsKeepsOnlyThePinnedVersion()
         {
             // Simulates Library/PrefabLens after a package upgrade: the old cache dir
@@ -138,15 +107,6 @@ namespace PrefabLens.Tests
             {
                 Directory.Delete(root, recursive: true);
             }
-        }
-
-        [Test]
-        public void DeleteStaleVersionsToleratesAMissingRoot()
-        {
-            // First-ever download: Library/PrefabLens does not exist yet.
-            // Cleanup must be a silent no-op, not a DirectoryNotFoundException.
-            var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            Assert.DoesNotThrow(() => Cli.DeleteStaleVersions(root, keep: "0.6.1"));
         }
 
         /// One-shot HTTP server on a loopback socket: real HttpClient traffic, no mocks.
@@ -234,25 +194,6 @@ namespace PrefabLens.Tests
                 release.Set();
                 listener.Stop();
             }
-        }
-
-        [Test]
-        public void ExpectedSha256FindsTheAssetLine()
-        {
-            // shasum -a 256 text-mode output: "<hex>  <name>" (two spaces), one line per asset.
-            var sums = "aaaa  prefablens-linux-x64.zip\nbbbb  prefablens-macos-arm64.zip\n";
-            Assert.AreEqual("bbbb", Cli.ExpectedSha256(sums, "prefablens-macos-arm64.zip"));
-            Assert.IsNull(Cli.ExpectedSha256(sums, "prefablens-windows-x64.zip"));
-        }
-
-        [Test]
-        public void Sha256HexMatchesAKnownVector()
-        {
-            // FIPS 180-2 test vector for "abc".
-            Assert.AreEqual(
-                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
-                Cli.Sha256Hex(Encoding.ASCII.GetBytes("abc"))
-            );
         }
 
         [Test]
@@ -351,18 +292,6 @@ namespace PrefabLens.Tests
             {
                 Directory.Delete(root, recursive: true);
             }
-        }
-
-        [Test]
-        public void MarkExecutableFailsTheDownloadStepNamingTheBinaryPath()
-        {
-            // A swallowed chmod failure used to resurface later as an unrelated
-            // Process.Start error on first run; it must fail here, naming the path.
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                Assert.Ignore("chmod is a unix concern");
-            var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "prefablens");
-            var e = Assert.Throws<InvalidOperationException>(() => Cli.MarkExecutable(missing));
-            StringAssert.Contains(missing, e.Message);
         }
     }
 }

--- a/editor/Tests/Editor/CliTests.Run.cs
+++ b/editor/Tests/Editor/CliTests.Run.cs
@@ -35,18 +35,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void RunProcessReturnsOutputWhenTheProcessExitsInTime()
-        {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            var file = isWindows ? "cmd.exe" : "/bin/sh";
-            var args = isWindows ? "/c echo hello" : "-c \"echo hello\"";
-            var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs);
-            Assert.IsFalse(res.TimedOut);
-            Assert.AreEqual(0, res.ExitCode);
-            StringAssert.Contains("hello", res.Stdout);
-        }
-
-        [Test]
         public void RunProcessCapturesStderrAndExitCode()
         {
             // When ExitCode != 0 the Window shows stderr as the primary source. Verifies that wiring.
@@ -80,31 +68,17 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void BuildBulkArgsRequestsAllChangedFilesAsJson()
+        public void BuildBulkArgsOmitsABlankBaseRefAndPassesATrimmedRef()
         {
-            // Bare `prefablens --json` is bulk mode: HEAD vs working tree, all changed Unity files.
+            // Bare `prefablens --json` is bulk mode. A non-blank operand is a git ref.
+            // The window feeds a free-form text field: null, empty, and whitespace-only
+            // must keep the default invocation, and surrounding whitespace must not leak.
             Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs());
-        }
-
-        [Test]
-        public void BuildBulkArgsWithABaseRefComparesRefVsWorkingTree()
-        {
-            // CLI grammar (cli/src/main.zig parseArgs): one operand without a Unity YAML
-            // extension is a git ref, so `prefablens <ref> --json` is ref vs working tree,
-            // still bulk mode because no path operand is given.
-            Assert.AreEqual(new[] { "main", "--json" }, Cli.BuildBulkArgs("main"));
-            Assert.AreEqual(new[] { "HEAD~1", "--json" }, Cli.BuildBulkArgs("HEAD~1"));
-        }
-
-        [Test]
-        public void BuildBulkArgsTreatsABlankBaseRefAsTheDefault()
-        {
-            // The window feeds a free-form text field straight in: null, empty, and
-            // whitespace-only must all keep the default invocation byte-for-byte, and
-            // surrounding whitespace must not leak into the git ref.
             Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs(null));
             Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs(""));
             Assert.AreEqual(new[] { "--json" }, Cli.BuildBulkArgs("   "));
+            Assert.AreEqual(new[] { "main", "--json" }, Cli.BuildBulkArgs("main"));
+            Assert.AreEqual(new[] { "HEAD~1", "--json" }, Cli.BuildBulkArgs("HEAD~1"));
             Assert.AreEqual(new[] { "main", "--json" }, Cli.BuildBulkArgs(" main "));
         }
 
@@ -171,20 +145,6 @@ namespace PrefabLens.Tests
             Assert.IsTrue(res.Canceled, "expected the killed run to be reported as canceled");
             Assert.AreNotEqual(0, res.ExitCode);
             Assert.Less(sw.ElapsedMilliseconds, 30_000, "cancellation must not degrade into waiting out the timeout");
-        }
-
-        [Test]
-        public void RunProcessWithAnUncanceledTokenBehavesAsBefore()
-        {
-            // The token is additive: a live token must not disturb the normal exit path.
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            var file = isWindows ? "cmd.exe" : "/bin/sh";
-            var args = isWindows ? "/c echo hello" : "-c \"echo hello\"";
-            using var cts = new CancellationTokenSource();
-            var res = Cli.RunProcess(file, args, ".", timeoutMs: Cli.RunTimeoutMs, ct: cts.Token);
-            Assert.IsFalse(res.Canceled);
-            Assert.AreEqual(0, res.ExitCode);
-            StringAssert.Contains("hello", res.Stdout);
         }
 
         [Test]

--- a/editor/Tests/Editor/CliTests.cs
+++ b/editor/Tests/Editor/CliTests.cs
@@ -63,23 +63,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void LocateUsesAStandaloneDefaultCli()
-        {
-            var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            CopyNativeCli(NativeCliDirectory(), dir);
-            var cliPath = Path.Combine(dir, Cli.BinaryName);
-            try
-            {
-                var loc = Cli.Locate("", cliPath);
-                Assert.AreEqual(cliPath, loc.Path);
-            }
-            finally
-            {
-                Directory.Delete(dir, recursive: true);
-            }
-        }
-
-        [Test]
         public void LocateRejectsADefaultCliFromAnotherRelease()
         {
             // The automatic cache belongs to Cli.Version and cannot silently use another release.

--- a/editor/Tests/Editor/DiffModelTests.cs
+++ b/editor/Tests/Editor/DiffModelTests.cs
@@ -100,16 +100,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void EmptyDiffIsEmpty()
-        {
-            // On no changes the Window checks IsEmpty and shows "No semantic changes". The basis for that branch.
-            var m = DiffModel.Parse(
-                @"{""schema"":""prefablens.diff.v2"",""unresolvedGuids"":[],""roots"":[],""loose"":[]}"
-            );
-            Assert.IsTrue(m.IsEmpty);
-        }
-
-        [Test]
         public void ParsesResolvedMapAndRemovedStatus()
         {
             // resolved is the guid -> path already resolved by the CLI (that ResolveWith doesn't overwrite it is verified in another test).

--- a/editor/Tests/Editor/DiffTreeTests.cs
+++ b/editor/Tests/Editor/DiffTreeTests.cs
@@ -18,14 +18,6 @@ namespace PrefabLens.Tests
         }
 
         [Test]
-        public void RowSuppressesNullAndEmptySpans()
-        {
-            // A node with no name must not emit an empty Label after the badge.
-            var row = new Row().Add(null).Add("");
-            Assert.AreEqual(0, row.Spans.Count);
-        }
-
-        [Test]
         public void NodesComeBeforeTheLooseComponentsGroup()
         {
             // The group keeps loose components separate from the GameObject hierarchy.
@@ -41,26 +33,6 @@ namespace PrefabLens.Tests
             AssertSpan(items[1].Row.Spans[0], "Components (1)", Palette.Muted);
             Assert.AreEqual(DiffStatus.Added, items[1].Children[0].Row.Status);
             AssertSpan(items[1].Children[0].Row.Spans[0], "SphereCollider", null);
-        }
-
-        [Test]
-        public void ComponentsGroupShowsItsCardCount()
-        {
-            // The count helps readers scan the tree before they expand the group.
-            const string json =
-                @"{
-                ""unresolvedGuids"":[],
-                ""roots"":[{""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""modified"",
-                    ""components"":[{""kind"":""component"",""fileId"":""4"",""classId"":4,""typeName"":""Transform"",""scriptGuid"":null,""className"":null,""status"":""modified"",""fields"":[]}],
-                    ""children"":[]}],
-                ""loose"":[]
-            }";
-            var items = Build(json);
-            Assert.AreEqual(DiffStatus.Modified, items[0].Row.Status);
-            var group = items[0].Children[0];
-            Assert.AreEqual(RowKind.Group, group.Row.Kind);
-            AssertSpan(group.Row.Spans[0], "Components (1)", Palette.Muted);
-            AssertSpan(group.Children[0].Row.Spans[0], "Transform", null);
         }
 
         [Test]
@@ -234,27 +206,6 @@ namespace PrefabLens.Tests
             AssertSpan(items[2].Row.Spans[0], "MonoBehaviour", null);
             // Built-in components always read as the type name.
             AssertSpan(items[3].Row.Spans[0], "Transform", null);
-        }
-
-        [Test]
-        public void GameObjectOverrideRendersInsideAComponentCard()
-        {
-            const string json =
-                @"{
-                ""unresolvedGuids"":[],
-                ""roots"":[{""kind"":""gameObject"",""fileId"":""1"",""name"":""Plane"",""status"":""modified"",
-                    ""overrides"":[{""group"":"""",""label"":""Name"",""status"":""modified"",""before"":""Old"",""after"":""New""}],
-                    ""components"":[],""children"":[]}],
-                ""loose"":[]
-            }";
-            var components = Build(json)[0].Children[0];
-            AssertSpan(components.Row.Spans[0], "Components (1)", Palette.Muted);
-            var card = components.Children[0];
-            AssertSpan(card.Row.Spans[0], "Overrides", null);
-            AssertSpan(card.Children[0].Row.Spans[0], "Name ", Palette.Muted);
-            AssertSpan(card.Children[0].Row.Spans[1], "Old", Palette.Removed);
-            AssertSpan(card.Children[0].Row.Spans[2], " → ", Palette.Muted);
-            AssertSpan(card.Children[0].Row.Spans[3], "New", Palette.Added);
         }
 
         [Test]

--- a/editor/Tests/Editor/DiffTreeViewTests.cs
+++ b/editor/Tests/Editor/DiffTreeViewTests.cs
@@ -1,17 +1,11 @@
-#if UNITY_EDITOR
-using System.Collections;
+using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEditor;
-using UnityEngine;
 using UnityEngine.UIElements;
-using UnityEngine.TestTools;
 
 namespace PrefabLens.Tests
 {
     public sealed class DiffTreeViewTests
     {
-        sealed class TreeHostWindow : EditorWindow { }
-
         [TestCase(DiffStatus.Added, "+")]
         [TestCase(DiffStatus.Removed, "−")]
         [TestCase(DiffStatus.Modified, "~")]
@@ -25,8 +19,7 @@ namespace PrefabLens.Tests
 
             DiffTreeView.BindRow(element, DiffTree.Build(model)[0].Row);
 
-            var labels = element.Query<Label>().ToList().ConvertAll(label => label.text);
-            CollectionAssert.AreEqual(badge == null ? new[] { "Robot" } : new[] { "Robot", badge }, labels);
+            CollectionAssert.AreEqual(badge == null ? new[] { "Robot" } : new[] { "Robot", badge }, Labels(element));
         }
 
         [Test]
@@ -49,66 +42,22 @@ namespace PrefabLens.Tests
 
             DiffTreeView.BindRow(element, DiffTree.Build(model)[0].Children[0].Children[0].Row);
 
-            CollectionAssert.AreEqual(
-                new[] { "Position.x ", "0", " → ", "1" },
-                element.Query<Label>().ToList().ConvertAll(label => label.text)
-            );
+            CollectionAssert.AreEqual(new[] { "Position.x ", "0", " → ", "1" }, Labels(element));
         }
 
-        [Test]
-        public void GroupLabelUsesRegularFontWeight()
+        static List<string> Labels(VisualElement root)
         {
-            var element = new VisualElement();
-            var row = new Row(kind: RowKind.Group).Add("Components (1)", Palette.Muted);
-
-            DiffTreeView.BindRow(element, row);
-
-            Assert.AreEqual(FontStyle.Normal, element.Q<Label>().resolvedStyle.unityFontStyleAndWeight);
+            var texts = new List<string>();
+            Collect(root, texts);
+            return texts;
         }
 
-        [UnityTest]
-        public IEnumerator TreeToggleAlignsWithGroupLabel()
+        static void Collect(VisualElement element, List<string> texts)
         {
-            var model = new DiffModel();
-            var root = new GameObjectDiff { Name = "Robot", Status = DiffStatus.Modified };
-            root.Components.Add(new ComponentDiff { TypeName = "Transform", Status = DiffStatus.Modified });
-            model.Roots.Add(root);
-
-            // The panel resolves the geometry of the TreeView items.
-            var window = ScriptableObject.CreateInstance<TreeHostWindow>();
-            try
-            {
-                window.position = new Rect(0, 0, 600, 400);
-                var tree = DiffTreeView.BuildTree(model);
-                window.rootVisualElement.Add(tree);
-                window.Show();
-
-                yield return null;
-
-                var label = tree.Query<Label>().ToList().Find(element => element.text == "Components (1)");
-                Assert.NotNull(label);
-                var item = label.parent;
-                while (item != null && !item.ClassListContains(BaseTreeView.itemUssClassName))
-                    item = item.parent;
-                Assert.NotNull(item);
-                var toggle = item.Q<Toggle>(className: BaseTreeView.itemToggleUssClassName);
-                Assert.NotNull(toggle);
-                var checkmark = toggle.Q<VisualElement>(className: Toggle.checkmarkUssClassName);
-                Assert.NotNull(checkmark);
-                Assert.AreEqual(
-                    label.worldBound.center.y,
-                    checkmark.worldBound.center.y,
-                    0.5f,
-                    $"item={item.worldBound}, label={label.worldBound}, toggle={toggle.worldBound}, "
-                        + $"checkmark={checkmark.worldBound}, itemAlign={item.resolvedStyle.alignItems}, "
-                        + $"toggleAlign={toggle.resolvedStyle.alignSelf}, checkmarkMarginTop={checkmark.resolvedStyle.marginTop}"
-                );
-            }
-            finally
-            {
-                window.Close();
-            }
+            if (element is Label label)
+                texts.Add(label.text);
+            foreach (var child in element.Children())
+                Collect(child, texts);
         }
     }
 }
-#endif

--- a/editor/Tests/Editor/PrefabLensWindowTests.cs
+++ b/editor/Tests/Editor/PrefabLensWindowTests.cs
@@ -104,6 +104,68 @@ namespace PrefabLens.Tests
             }
         }
 
+        [Test]
+        public void UnchangedStdoutKeepsTheFileListAndOnlyRestoresTheStatus()
+        {
+            // Focus-triggered refresh reuses the last stdout. The list and tree must stay
+            // put; only the status line follows the current base ref.
+            var window = OpenRenderedWindow();
+            try
+            {
+                window.ShowBulkResult(Ok(OneFile), "HEAD");
+                Assert.AreEqual(1, FileCount(window));
+
+                window.ShowBulkResult(Ok(OneFile), "main");
+
+                Assert.AreEqual(1, FileCount(window));
+                Assert.AreEqual("1 changed vs main", window.StatusText);
+                Assert.That(Labels(window.DetailPane), Does.Contain("Assets/Smoke.prefab"));
+            }
+            finally
+            {
+                CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void EmptyBulkResultShowsNoFilesAndTheNoChangesStatus()
+        {
+            var window = OpenRenderedWindow();
+            try
+            {
+                window.ShowBulkResult(Ok("[]"), "HEAD");
+
+                Assert.AreEqual(0, FileCount(window));
+                Assert.AreEqual("No changes vs HEAD", window.StatusText);
+            }
+            finally
+            {
+                CloseWindow(window);
+            }
+        }
+
+        [Test]
+        public void EmptySemanticDiffShowsTheFileAndTheNoSemanticChangesNote()
+        {
+            const string emptyDiff =
+                "[{\"path\":\"Assets/Smoke.prefab\",\"diff\":{\"schema\":\"prefablens.diff.v2\",\"unresolvedGuids\":[],\"roots\":[],\"loose\":[]}}]";
+            var window = OpenRenderedWindow();
+            try
+            {
+                window.ShowBulkResult(Ok(emptyDiff), "HEAD");
+
+                Assert.AreEqual(1, FileCount(window));
+                Assert.AreEqual("1 changed vs HEAD", window.StatusText);
+                var labels = Labels(window.DetailPane);
+                Assert.That(labels, Does.Contain("Assets/Smoke.prefab"));
+                Assert.That(labels, Does.Contain("No semantic changes"));
+            }
+            finally
+            {
+                CloseWindow(window);
+            }
+        }
+
         static Cli.Result Ok(string stdout) =>
             new Cli.Result
             {

--- a/editor/Tests/Editor/SettingsTests.cs
+++ b/editor/Tests/Editor/SettingsTests.cs
@@ -5,39 +5,21 @@ namespace PrefabLens.Tests
     public class SettingsTests
     {
         [Test]
-        public void ResolvedLabelTagsTheDownloadedBinary()
+        public void ResolvedLabelAndOverrideNoteNameTheBinaryTheWindowWillRun()
         {
-            var loc = new Cli.Location(Cli.DefaultPath, null);
             Assert.AreEqual(
                 $"Resolved CLI (downloaded): {Cli.DefaultPath}",
-                PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
+                PrefabLensSettings.ResolvedLabel(new Cli.Location(Cli.DefaultPath, null), "0.7.1")
             );
-        }
-
-        [Test]
-        public void ResolvedLabelTagsAnOverrideBinary()
-        {
-            var loc = new Cli.Location("/custom/prefablens", null);
             Assert.AreEqual(
                 "Resolved CLI (override): /custom/prefablens",
-                PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
+                PrefabLensSettings.ResolvedLabel(new Cli.Location("/custom/prefablens", null), "0.7.1")
             );
-        }
-
-        [Test]
-        public void ResolvedLabelExplainsTheDownloadWhenNothingExists()
-        {
-            // The page must not show a blank/None path: say what will happen instead.
-            var loc = new Cli.Location(null, null);
             Assert.AreEqual(
                 "Resolved CLI: not found — the PrefabLens window downloads v0.7.1 on its next refresh",
-                PrefabLensSettings.ResolvedLabel(loc, "0.7.1")
+                PrefabLensSettings.ResolvedLabel(new Cli.Location(null, null), "0.7.1")
             );
-        }
 
-        [Test]
-        public void OverrideErrorNoteSurfacesTheValidationError()
-        {
             var broken = new Cli.Location(
                 "Library/PrefabLens/0.7.1/prefablens",
                 "prefablens was not found at '/gone/prefablens'."


### PR DESCRIPTION
## Summary

Trim the Unity Editor test suite to cases with high necessity, drop duplicates, and cover three untested window refresh paths.

## Motivation

Low-value and overlapping tests add noise without catching extra regressions. The window still lacked coverage for an unchanged stdout refresh, an empty bulk result, and a file with no semantic diff.

No tracking issue for this change.

## Changes

- Remove editor tests below the necessity bar, including SHA-256 helper checks, duplicate locate/run/install paths, visual alignment, and defensive parse skips.
- Merge `BuildBulkArgs` and Preferences label cases into one test each.
- Move status-badge row checks off `UNITY_EDITOR` so they run in `DotNetTests~`.
- Add window tests for unchanged stdout, an empty bulk list, and the "No semantic changes" note.

## Testing

```
cd editor
dotnet csharpier check .
PREFABLENS_TEST_BIN_DIR="$PWD/../zig-out/bin" \
PREFABLENS_TEST_ALT_BIN_DIR="$PWD/../zig-out/test-alternate-bin" \
  dotnet test DotNetTests~/Tests
```

```
Checked 29 files in 135ms.
Passed!  - Failed:     0, Passed:    78, Skipped:     0, Total:    78, Duration: 3 s - PrefabLens.Editor.Tests.dll (net10.0)
```