### PR TITLE
feat: merge keyed dictionaries and variant arrays

### DIFF
--- a/cli/src/git_merge_strategy.zig
+++ b/cli/src/git_merge_strategy.zig
@@ -122,28 +122,33 @@ pub fn run(io: std.Io, arena: std.mem.Allocator, args: []const []const u8, env: 
 fn resolveSession(git: Git, candidate: *candidate_module.Candidate, env: *std.process.Environ.Map, stderr: *std.Io.Writer) !u8 {
     // Git owns MERGE_HEAD, merge commits, squash and abort after this command returns.
     const tty = (std.Io.File.stdin().isTty(git.io) catch false) and (std.Io.File.stdout().isTty(git.io) catch false);
-    if (tty) while (true) {
-        const index = for (candidate.items.items, 0..) |_, i| {
-            if (candidate.ready(i)) break i;
-        } else break;
-        candidate.items.items[index].attempted = true;
-        const item = candidate.items.items[index];
-        var captured = try session_context.readIndex(&candidate.store);
-        captured.snapshot = session_context.maskUnresolved(captured.snapshot, try candidate.pendingPaths());
-        if (item.conflict != null and isStructural(item.conflict.?.kind)) {
-            switch (try file_conflict.resolveWithContext(git, candidate.result, item.conflict.?, env, captured)) {
-                .unresolved => {},
-                .aborted => break,
-                .resolved => |paths| try candidate.refresh(paths),
-            }
-        } else {
-            switch (try resolveContent(git, candidate, index, captured, env)) {
-                .resolved => try candidate.refresh(item.paths),
-                .aborted => break,
-                .unresolved => {},
+    if (tty) {
+        var tty_buffer: [4096]u8 = undefined;
+        var session: ?merge_tui.Session = null;
+        defer if (session) |*open| open.deinit();
+        while (true) {
+            const index = for (candidate.items.items, 0..) |_, i| {
+                if (candidate.ready(i)) break i;
+            } else break;
+            candidate.items.items[index].attempted = true;
+            const item = candidate.items.items[index];
+            var captured = try session_context.readIndex(&candidate.store);
+            captured.snapshot = session_context.maskUnresolved(captured.snapshot, try candidate.pendingPaths());
+            if (item.conflict != null and isStructural(item.conflict.?.kind)) {
+                switch (try file_conflict.resolveWithContext(git, candidate.result, item.conflict.?, env, captured)) {
+                    .unresolved => {},
+                    .aborted => break,
+                    .resolved => |paths| try candidate.refresh(paths),
+                }
+            } else {
+                switch (try resolveContent(git, candidate, index, captured, env, &tty_buffer, &session)) {
+                    .resolved => try candidate.refresh(item.paths),
+                    .aborted => break,
+                    .unresolved => {},
+                }
             }
         }
-    };
+    }
     for (candidate.result.conflicts) |conflict| try stderr.writeAll(conflict.message);
     const remaining = try git.output(&.{ "ls-files", "--unmerged", "-z" });
     return if (candidate.result.conflicts.len != 0 or remaining.len != 0) 1 else 0;
@@ -230,7 +235,15 @@ pub fn blob(git: Git, stage: ?Stage) ![]const u8 {
 
 const ContentOutcome = enum { resolved, unresolved, aborted };
 
-fn resolveContent(git: Git, candidate: *candidate_module.Candidate, index: usize, captured: session_context.Index, env: *std.process.Environ.Map) !ContentOutcome {
+fn resolveContent(
+    git: Git,
+    candidate: *candidate_module.Candidate,
+    index: usize,
+    captured: session_context.Index,
+    env: *std.process.Environ.Map,
+    tty_buffer: []u8,
+    session: *?merge_tui.Session,
+) !ContentOutcome {
     const path = candidate.items.items[index].paths[0];
     if (candidate.result.sources.?.known == null) {
         if (candidate.items.items[index].paths.len != 1) return .unresolved;
@@ -246,7 +259,12 @@ fn resolveContent(git: Git, candidate: *candidate_module.Candidate, index: usize
     const prepared = try file_conflict.prepareContent(git, candidate.result, path) orelse return .unresolved;
     if (!std.mem.eql(u8, captured.before, prepared.index_before)) return error.SourceChanged;
     var state = try merge_ui_state.State.init(git.arena, &built.plan);
-    if (state.outcome != .ready) try merge_tui.run(git.io, git.arena, env, &state, path, built.partial);
+    if (state.outcome != .ready) {
+        if (session.* == null) session.* = try merge_tui.Session.init(git.io, git.arena, env, tty_buffer);
+        if (session.*) |*open| {
+            try open.present(git.arena, &state, path, built.partial);
+        } else unreachable;
+    }
     if (state.outcome == .aborted) return .aborted;
     if (state.outcome != .ready) return .unresolved;
     const bytes = core.merge.finish(git.arena, &built.plan) catch return .unresolved;

--- a/cli/src/merge_csharp.zig
+++ b/cli/src/merge_csharp.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const testing = std.testing;
 
-pub const Kind = enum { ordered_array, int32_array };
+pub const Kind = enum { ordered_array, int32_array, dictionary };
 pub const Field = struct { name: []const u8, kind: Kind };
 
 // A revision reader must inspect all available source declarations before read().
@@ -275,10 +275,50 @@ fn fieldDeclaration(declaration: []const Token, imports: Imports, names: Names) 
     if (end < at + 2 or declaration[end - 1].kind != .identifier) return null;
     const field_name = declaration[end - 1].text;
     const type_tokens = declaration[at .. end - 1];
+    if (dictionaryType(type_tokens)) return .{ .name = field_name, .kind = .dictionary };
     if (type_tokens.len < 3 or !type_tokens[type_tokens.len - 2].is("[") or !type_tokens[type_tokens.len - 1].is("]")) return null;
     const element = type_tokens[0 .. type_tokens.len - 2];
     for (element) |token| if (token.kind != .identifier and !token.is(".") and !token.is(":")) return null;
     return .{ .name = field_name, .kind = if (pathIs(element, "int")) .int32_array else .ordered_array };
+}
+
+fn dictionaryType(type_tokens: []const Token) bool {
+    var lt: ?usize = null;
+    for (type_tokens, 0..) |token, i| {
+        if (token.is("<")) {
+            lt = i;
+            break;
+        }
+    }
+    const open = lt orelse return false;
+    if (open == 0) return false;
+    const name = type_tokens[0..open];
+    for (name) |token| if (token.kind != .identifier and !token.is(".") and !token.is(":")) return false;
+    return pathIs(name, "Dictionary") or
+        pathIs(name, "SerializedDictionary") or
+        pathIs(name, "System.Collections.Generic.Dictionary") or
+        pathIs(name, "UnityEngine.SerializedDictionary") or
+        pathIs(name, "UnityEngine.UIElements.Experimental.SerializedDictionary");
+}
+
+test "C# collection schema recognizes serialized dictionaries" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const source =
+        \\using System.Collections.Generic;
+        \\using UnityEngine;
+        \\public class Inventory : MonoBehaviour {
+        \\  public Dictionary<string, int> stats;
+        \\  public SerializedDictionary<string, float> named;
+        \\  public int[] numbers;
+        \\}
+    ;
+    const fields = try read(arena, source, "Inventory", .{});
+    try testing.expectEqual(@as(usize, 3), fields.len);
+    try testing.expectEqual(Kind.dictionary, find(fields, "stats").?);
+    try testing.expectEqual(Kind.dictionary, find(fields, "named").?);
+    try testing.expectEqual(Kind.int32_array, find(fields, "numbers").?);
 }
 
 test "C# collection schema recognizes direct serialized arrays" {

--- a/cli/src/merge_driver.zig
+++ b/cli/src/merge_driver.zig
@@ -328,7 +328,7 @@ test "merge driver: preserves a commented document" {
     try runDriverCase(base, ours, theirs_commented_document, expected_commented_document, 0);
 }
 
-test "merge driver: merges ordered arrays and falls back for keyed shapes" {
+test "merge driver: merges ordered arrays and keyed dictionaries" {
     const valid = "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 1\n";
     // A misleading extension must not let non-Unity content reach the merge engine.
     try runDriverCase("not Unity YAML\n", valid, valid, valid, 0);
@@ -338,11 +338,11 @@ test "merge driver: merges ordered arrays and falls back for keyed shapes" {
     const ours = "--- !u!114 &1\nMonoBehaviour:\n  m_Unknown:\n  - 1\n  - 3\n";
     try runDriverCase(base, ours, base, ours, 0);
 
-    // A keyed shape remains a whole-field choice because its identity is
-    // outside the supported ordered-array schema.
+    // Independent keyed insertions merge without field type metadata.
     const keyed_base = "--- !u!114 &1\nMonoBehaviour:\n  m_Unknown:\n  - key: A\n    value: 1\n";
-    const keyed_ours = "--- !u!114 &1\nMonoBehaviour:\n  m_Unknown:\n  - key: A\n    value: 2\n";
-    try runDriverCase(keyed_base, keyed_ours, keyed_base, "<<<<<<< ours\n" ++ keyed_ours ++ "=======\n" ++ keyed_base ++ ">>>>>>> theirs\n", 1);
+    const keyed_ours = "--- !u!114 &1\nMonoBehaviour:\n  m_Unknown:\n  - key: A\n    value: 1\n  - key: B\n    value: 2\n";
+    const keyed_theirs = "--- !u!114 &1\nMonoBehaviour:\n  m_Unknown:\n  - key: A\n    value: 1\n  - key: C\n    value: 3\n";
+    try runDriverCase(keyed_base, keyed_ours, keyed_theirs, "--- !u!114 &1\nMonoBehaviour:\n  m_Unknown:\n  - key: A\n    value: 1\n  - key: B\n    value: 2\n  - key: C\n    value: 3\n", 0);
 }
 
 test "merge driver: keeps ours unchanged when an input cannot be read" {

--- a/cli/src/merge_inspector.zig
+++ b/cli/src/merge_inspector.zig
@@ -33,6 +33,63 @@ test "merge TUI: property comparisons expose changed children when value shapes 
     try std.testing.expectEqualStrings("2", try valueText(arena, model.rows[1].values[3]));
 }
 
+test "merge TUI: dictionary field conflicts expose key and value rows" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix = "--- !u!114 &2\nMonoBehaviour:\n  m_Stats:\n";
+    var fixture = try core.merge.build(
+        arena,
+        prefix ++ "  - key: Goblin\n    value: 1\n",
+        prefix ++ "  - key: Goblin\n    value: 2\n",
+        prefix ++ "  - key: Goblin\n    value: 3\n",
+    );
+    const operation = &fixture.plan.operations[0];
+    try std.testing.expect(supports(operation));
+    const model = try build(arena, operation, .unresolved);
+    // SphereCollider already walks maps into named rows. A pair conflict must do the same
+    // so Key stays visible next to the disagreed Value.
+    try std.testing.expectEqual(@as(usize, 2), model.rows.len);
+    try std.testing.expectEqualStrings("Key", model.rows[0].label);
+    try std.testing.expectEqualStrings("Value", model.rows[1].label);
+    try std.testing.expectEqualStrings("Goblin", try valueText(arena, model.rows[0].values[1]));
+    try std.testing.expectEqualStrings("2", try valueText(arena, model.rows[1].values[1]));
+    try std.testing.expectEqualStrings("3", try valueText(arena, model.rows[1].values[2]));
+}
+
+test "merge TUI: prefab override conflicts expose path and value rows" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix =
+        "--- !u!1001 &1\n" ++
+        "PrefabInstance:\n" ++
+        "  m_Modification:\n" ++
+        "    m_Modifications:\n" ++
+        "    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: items.Array.data[0].speed\n" ++
+        "      value: ";
+    const suffix = "\n      objectReference: {fileID: 0}\n";
+    const fixture = try core.merge.build(
+        arena,
+        prefix ++ "1" ++ suffix,
+        prefix ++ "2" ++ suffix,
+        prefix ++ "3" ++ suffix,
+    );
+    const operation = for (fixture.plan.operations) |*op| {
+        if (op.resolution == .unresolved) break op;
+    } else return error.TestUnexpectedResult;
+    try std.testing.expect(supports(operation));
+    const model = try build(arena, operation, .unresolved);
+    // Variant overrides are a path plus a scalar. The tree label is not enough once ⇧R is available.
+    try std.testing.expectEqual(@as(usize, 2), model.rows.len);
+    try std.testing.expectEqualStrings("Path", model.rows[0].label);
+    try std.testing.expectEqualStrings("Value", model.rows[1].label);
+    try std.testing.expectEqualStrings("Items[0].Speed", try valueText(arena, model.rows[0].values[1]));
+    try std.testing.expectEqualStrings("2", try valueText(arena, model.rows[1].values[1]));
+    try std.testing.expectEqualStrings("3", try valueText(arena, model.rows[1].values[2]));
+}
+
 test "merge TUI: literal property keys remain distinct from nested paths and array indices" {
     var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer memory.deinit();
@@ -61,8 +118,21 @@ pub const Model = struct {
 
     pub fn editable(self: Model, index: usize) bool {
         if (index >= self.rows.len) return false;
-        const result = self.documents[3] orelse return false;
-        return result.editable(self.rows[index].path);
+        const row = self.rows[index];
+        if (self.documents[3]) |result| {
+            return result.editable(row.path);
+        }
+        // A missing Result document is not editable. Synthetic Path/Value tables have no documents.
+        for (self.documents) |document| {
+            if (document != null) return false;
+        }
+        if (std.mem.eql(u8, row.label, "Path") or std.mem.eql(u8, row.label, "Key")) return false;
+        for (row.values) |node| {
+            if (node) |value| {
+                if (value.* != .scalar and value.* != .ref) return false;
+            }
+        }
+        return true;
     }
 
     pub fn text(self: Model, arena: std.mem.Allocator, index: usize, column: usize) ![]const u8 {
@@ -74,6 +144,17 @@ pub const Model = struct {
 };
 
 pub fn supports(operation: *const core.merge.Operation) bool {
+    if (operation.kind == .prefab_override) return true;
+    if (operation.kind == .field) {
+        var saw_map = false;
+        for ([_]?core.merge.SideValue{ operation.values.base, operation.values.ours, operation.values.theirs }) |value| {
+            const present = value orelse continue;
+            const node = present.node orelse return false;
+            if (node.* != .map) return false;
+            saw_map = true;
+        }
+        return saw_map;
+    }
     if (operation.kind != .component and operation.kind != .document) return false;
     for ([_]?core.merge.SideValue{ operation.values.base, operation.values.ours, operation.values.theirs }) |value| if (value) |present| {
         const node = present.node orelse return false;
@@ -83,6 +164,22 @@ pub fn supports(operation: *const core.merge.Operation) bool {
 }
 
 pub fn build(arena: std.mem.Allocator, operation: *const core.merge.Operation, resolution: core.merge.Resolution) !Model {
+    if (operation.kind == .prefab_override) return buildPrefabOverride(arena, operation, resolution);
+    if (operation.kind == .field) {
+        const roots: [4]?*const Node = .{
+            if (operation.values.base) |value| value.node else null,
+            if (operation.values.ours) |value| value.node else null,
+            if (operation.values.theirs) |value| value.node else null,
+            switch (resolution) {
+                .take => |side| if (operation.values.get(side)) |value| value.node else null,
+                .custom => |text| try customFieldRoot(arena, operation, text),
+                else => null,
+            },
+        };
+        var builder: Builder = .{ .arena = arena, .documents = @splat(null) };
+        try builder.walk(&.{}, "", roots);
+        return .{ .documents = @splat(null), .rows = try builder.rows.toOwnedSlice(arena) };
+    }
     const result_bytes: ?[]const u8 = switch (resolution) {
         .take => |side| if (operation.values.get(side)) |value| value.bytes else null,
         .custom => |value| value,
@@ -107,6 +204,81 @@ pub fn build(arena: std.mem.Allocator, operation: *const core.merge.Operation, r
     };
     try builder.walk(&.{}, "", roots);
     return .{ .documents = documents, .rows = try builder.rows.toOwnedSlice(arena) };
+}
+
+fn buildPrefabOverride(
+    arena: std.mem.Allocator,
+    operation: *const core.merge.Operation,
+    resolution: core.merge.Resolution,
+) !Model {
+    const path_text = try core.displayPropertyPath(arena, operation.identity.property_path);
+    const path_node = try scalarNode(arena, path_text);
+    const rows = try arena.alloc(Row, 2);
+    rows[0] = .{
+        .path = try arena.dupe(properties.Segment, &.{.{ .key = "propertyPath" }}),
+        .label = "Path",
+        .values = .{ path_node, path_node, path_node, path_node },
+        .changed = false,
+    };
+    rows[1] = .{
+        .path = try arena.dupe(properties.Segment, &.{.{ .key = "value" }}),
+        .label = "Value",
+        .values = .{
+            if (operation.values.base) |value| value.node else null,
+            if (operation.values.ours) |value| value.node else null,
+            if (operation.values.theirs) |value| value.node else null,
+            switch (resolution) {
+                .take => |side| if (operation.values.get(side)) |value| value.node else null,
+                .custom => |text| if (std.mem.indexOfAny(u8, text, "\r\n") == null) try scalarNode(arena, text) else null,
+                else => null,
+            },
+        },
+        .changed = true,
+    };
+    return .{ .documents = @splat(null), .rows = rows };
+}
+
+fn customFieldRoot(
+    arena: std.mem.Allocator,
+    operation: *const core.merge.Operation,
+    text: []const u8,
+) !?*const Node {
+    const template = operation.values.theirs orelse operation.values.ours orelse operation.values.base orelse return null;
+    const node = template.node orelse return null;
+    if (node.* != .map) return null;
+    const scalar = customFieldScalar(text) orelse return null;
+    const entries = try arena.dupe(core.model.Entry, node.map);
+    for (entries) |*entry| {
+        if (std.mem.eql(u8, entry.key, "value") or std.mem.eql(u8, entry.key, "second")) {
+            const value_node = try arena.create(Node);
+            value_node.* = .{ .scalar = scalar };
+            entry.value = value_node;
+        }
+    }
+    const copy = try arena.create(Node);
+    copy.* = .{ .map = entries };
+    return copy;
+}
+
+fn customFieldScalar(text: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, text, " \r\n");
+    if (trimmed.len == 0) return null;
+    if (std.mem.indexOfAny(u8, trimmed, "\r\n") == null) return trimmed;
+    var lines = std.mem.splitScalar(u8, trimmed, '\n');
+    var found: ?[]const u8 = null;
+    while (lines.next()) |raw| {
+        const content = std.mem.trimStart(u8, std.mem.trimEnd(u8, raw, "\r"), " ");
+        if (std.mem.startsWith(u8, content, "value:")) {
+            found = std.mem.trim(u8, content["value:".len..], " ");
+        }
+    }
+    return found;
+}
+
+fn scalarNode(arena: std.mem.Allocator, text: []const u8) !*const Node {
+    const node = try arena.create(Node);
+    node.* = .{ .scalar = text };
+    return node;
 }
 
 const Builder = struct {
@@ -171,15 +343,30 @@ const Builder = struct {
         if (path.len == 0) return;
         var compared = false;
         var first: ?*const Node = null;
-        var changed = self.documents[0] == null;
-        for (nodes, self.documents) |node, document| {
-            // A removed component is one existence change, not a change to every unchanged property.
-            if (document == null) continue;
-            if (compared) {
-                changed = changed or !equal(first, node);
-            } else {
-                first = node;
-                compared = true;
+        var any_document = false;
+        for (self.documents) |document| if (document != null) {
+            any_document = true;
+        };
+        var changed = if (any_document) self.documents[0] == null else false;
+        if (any_document) {
+            for (nodes, self.documents) |node, document| {
+                // A removed component is one existence change, not a change to every unchanged property.
+                if (document == null) continue;
+                if (compared) {
+                    changed = changed or !equal(first, node);
+                } else {
+                    first = node;
+                    compared = true;
+                }
+            }
+        } else {
+            for (nodes) |node| {
+                if (compared) {
+                    changed = changed or !equal(first, node);
+                } else {
+                    first = node;
+                    compared = true;
+                }
             }
         }
         try self.rows.append(self.arena, .{ .path = path, .label = label, .values = nodes, .changed = changed });

--- a/cli/src/merge_revision.zig
+++ b/cli/src/merge_revision.zig
@@ -106,6 +106,7 @@ pub const Store = struct {
                     try fields.append(arena, .{ .path = field.name, .kind = switch (field.kind) {
                         .ordered_array => .ordered,
                         .int32_array => .int32_array,
+                        .dictionary => .dictionary,
                     } });
                 }
             }

--- a/cli/src/merge_tree.zig
+++ b/cli/src/merge_tree.zig
@@ -65,10 +65,14 @@ const Builder = struct {
     ) !void {
         const key: NodeKey = .{ .object = object.file_id };
         if (!self.nodes.contains(key)) {
+            const name = display.objectName(object, null);
             try self.nodes.put(self.arena, key, .{
                 .key = key,
                 .parent = parent,
-                .name = display.objectName(object, null),
+                .name = if (object.kind == .prefab_instance)
+                    try std.fmt.allocPrint(self.arena, "{s} ‹Prefab›", .{name})
+                else
+                    name,
                 .kind = .game_object,
             });
             if (parent) |parent_key| {
@@ -158,9 +162,16 @@ const Builder = struct {
                         operation.identity.property_path
                     else
                         operation.property_path;
+                    const labeled_path = blk: {
+                        if (operation.kind == .prefab_override) break :blk property_path;
+                        const item = operation.item_path orelse break :blk property_path;
+                        if (item.len != 0 and item[0] == '[')
+                            break :blk try std.fmt.allocPrint(self.arena, "{s}{s}", .{ property_path, item });
+                        break :blk try std.fmt.allocPrint(self.arena, "{s}.{s}", .{ property_path, item });
+                    };
                     try entry.value_ptr.append(self.arena, .{
                         .ordinal = ordinal,
-                        .label = try core.displayPropertyPath(self.arena, property_path),
+                        .label = try core.displayPropertyPath(self.arena, labeled_path),
                     });
                 },
             }
@@ -571,4 +582,69 @@ test "merge TUI: conflict focus follows visual order across an edited component"
     try state.handle(.choose_theirs);
     try state.handle(.apply_result);
     try testing.expectEqual(merge_ui_state.Outcome.ready, state.outcome);
+}
+
+test "merge TUI: dictionary conflict label includes the key" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const prefix =
+        "--- !u!1 &1\n" ++
+        "GameObject:\n" ++
+        "  m_Name: Player\n" ++
+        "  m_Component:\n" ++
+        "  - component: {fileID: 4}\n" ++
+        "  - component: {fileID: 114}\n" ++
+        "--- !u!4 &4\n" ++
+        "Transform:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Father: {fileID: 0}\n" ++
+        "  m_Children: []\n" ++
+        "--- !u!114 &114\n" ++
+        "MonoBehaviour:\n" ++
+        "  m_GameObject: {fileID: 1}\n" ++
+        "  m_Stats:\n";
+    var built = try core.merge.build(
+        arena,
+        prefix ++ "  - key: Goblin\n    value: 1\n",
+        prefix ++ "  - key: Goblin\n    value: 2\n",
+        prefix ++ "  - key: Goblin\n    value: 3\n",
+    );
+    const state = try merge_ui_state.State.init(arena, &built.plan);
+    const tree = try build(arena, built.partial, &built.plan, state.conflict_indices);
+    const row = tree.rowForConflict(0).?;
+    // The tree only showed Stats, so Goblin vs Dragon conflicts were indistinguishable.
+    try testing.expectEqualStrings("Stats[Goblin]", tree.rows[row].label);
+}
+
+test "merge TUI: prefab override label collapses Array.data and marks Prefab" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const prefix =
+        "--- !u!1001 &1\n" ++
+        "PrefabInstance:\n" ++
+        "  m_Modification:\n" ++
+        "    m_Modifications:\n" ++
+        "    - target: {fileID: 10, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: m_Name\n" ++
+        "      value: Enemy\n" ++
+        "    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: items.Array.data[0].speed\n" ++
+        "      value: ";
+    const suffix =
+        "\n      objectReference: {fileID: 0}\n" ++
+        "  m_SourcePrefab: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n";
+    var built = try core.merge.build(
+        arena,
+        prefix ++ "1" ++ suffix,
+        prefix ++ "2" ++ suffix,
+        prefix ++ "3" ++ suffix,
+    );
+    const state = try merge_ui_state.State.init(arena, &built.plan);
+    const tree = try build(arena, built.partial, &built.plan, state.conflict_indices);
+    const row = tree.rowForConflict(0).?;
+    // Concatenating the modification's value key produced speedvalue, and Array.data hid the item.
+    try testing.expectEqualStrings("Items[0].Speed", tree.rows[row].label);
+    try testing.expectEqualStrings("Enemy ‹Prefab›", tree.rows[0].label);
 }

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -137,6 +137,298 @@ test "merge TUI: property and raw views preserve the selected result across togg
     try testing.expectEqual(core.merge.Side.theirs, state.pending.?.take);
 }
 
+test "merge TUI: prefab override shows Prefab mark semantic path and raw YAML" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix =
+        "--- !u!1001 &1\n" ++
+        "PrefabInstance:\n" ++
+        "  m_Modification:\n" ++
+        "    m_Modifications:\n" ++
+        "    - target: {fileID: 10, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: m_Name\n" ++
+        "      value: Enemy\n" ++
+        "    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: items.Array.data[0].speed\n" ++
+        "      value: ";
+    const suffix =
+        "\n      objectReference: {fileID: 0}\n" ++
+        "  m_SourcePrefab: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n";
+    var fixture = try core.merge.build(
+        arena,
+        prefix ++ "1" ++ suffix,
+        prefix ++ "2" ++ suffix,
+        prefix ++ "3" ++ suffix,
+    );
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    var view = try viewForTest(arena, &state, "Enemy Variant.prefab", fixture.partial);
+    defer view.deinit();
+    const semantic = try surfaceText(arena, try drawForTest(arena, view.widget(), 120, 24));
+    // Hierarchy otherwise looks like a named GameObject, so the Prefab mark has to be on screen.
+    try testing.expect(std.mem.indexOf(u8, semantic, "‹Prefab›") != null);
+    try testing.expect(std.mem.indexOf(u8, semantic, "Items[0].Speed") != null);
+    try testing.expect(std.mem.indexOf(u8, semantic, "⇧R Raw") != null);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
+    const raw = try surfaceText(arena, try drawForTest(arena, view.widget(), 180, 24));
+    try testing.expect(std.mem.indexOf(u8, raw, "propertyPath:") != null);
+    try testing.expect(std.mem.indexOf(u8, raw, "⇧R Semantic") != null);
+}
+
+test "merge TUI: prefab override raw edit keeps the displayed modification YAML" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try prefabOverrideSpeedPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Enemy Variant.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 180, 24);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    // Raw Result already shows the modification item. The editor must open on that YAML,
+    // not the scalar conflict bytes that apply uses.
+    const text = try view.editor.buf.dupe();
+    try testing.expect(view.editing);
+    try testing.expect(std.mem.indexOf(u8, text, "propertyPath:") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "value: 3") != null);
+    try testing.expect(!std.mem.eql(u8, text, "3"));
+}
+
+test "merge TUI: prefab override semantic value can be edited to a custom result" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try prefabOverrideSpeedPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Enemy Variant.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 160, 24);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.down);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("3", try view.editor.buf.dupe());
+    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    try testing.expectEqualStrings(
+        try std.mem.replaceOwned(u8, arena, fixture.plan.theirs.bytes, "value: 3", "value: 4"),
+        try core.merge.finish(arena, &fixture.plan),
+    );
+}
+
+test "merge TUI: dictionary raw edit keeps the displayed pair YAML" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try dictionaryGoblinPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Stats.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 160, 24);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    // Pair conflicts display the sequence item. Opening the editor must not drop the key.
+    const text = try view.editor.buf.dupe();
+    try testing.expect(view.editing);
+    try testing.expect(std.mem.indexOf(u8, text, "key: Goblin") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "value: 3") != null);
+    try testing.expect(!std.mem.eql(u8, text, "3"));
+}
+
+test "merge TUI: dictionary custom result keeps pair indent on every side" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try dictionaryUnionPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Dictionary.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 180, 24);
+    view.raw_view = true;
+    const operation = view.selectedOperation().?;
+    const ours_before = try view.columnText(arena, operation, .ours);
+    const theirs_before = try view.columnText(arena, operation, .theirs);
+    try state.handle(.{ .edit_result = "key: Goblin\nvalue: 4" });
+    // Result must keep the sequence-item indent. Otherwise common indent drops to 0
+    // and Ours/Theirs appear to shift by two spaces of invalid YAML.
+    try testing.expectEqualStrings(ours_before, try view.columnText(arena, operation, .ours));
+    try testing.expectEqualStrings(theirs_before, try view.columnText(arena, operation, .theirs));
+    const result = try view.columnText(arena, operation, .result);
+    try testing.expect(std.mem.indexOf(u8, result, "key: Goblin") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "value: 4") != null);
+    try testing.expectEqual(lineIndent(ours_before), lineIndent(result));
+}
+
+test "merge TUI: prefab override custom result keeps the modification item" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try prefabOverrideOnlySpeedPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Variant.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 180, 24);
+    view.raw_view = true;
+    const operation = view.selectedOperation().?;
+    try state.handle(.{ .edit_result = "4" });
+    const result = try view.columnText(arena, operation, .result);
+    // Custom is the scalar. The Result column still has to show the modification YAML
+    // so Enter does not look like it deleted target, propertyPath, and objectReference.
+    try testing.expect(std.mem.indexOf(u8, result, "propertyPath:") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "value: 4") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "objectReference:") != null);
+    try testing.expect(!std.mem.eql(u8, result, "4"));
+}
+
+test "merge TUI: dictionary semantic value can be edited to a custom result" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try dictionaryGoblinPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Stats.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 160, 24);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.down);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("3", try view.editor.buf.dupe());
+    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    // A Value-cell edit is still the original pair. Reconstructing a flow map would
+    // change YAML Unity did not ask to restyle.
+    try testing.expectEqualStrings(
+        try std.mem.replaceOwned(u8, arena, fixture.plan.theirs.bytes, "value: 3", "value: 4"),
+        try core.merge.finish(arena, &fixture.plan),
+    );
+}
+
+test "merge TUI: dictionary raw pair edit keeps sibling keys and side YAML" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try dictionaryUnionPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Dictionary.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 180, 24);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    const before = try view.editor.buf.dupe();
+    try testing.expect(std.mem.indexOf(u8, before, "value: 3") != null);
+    const updated = try std.mem.replaceOwned(u8, arena, before, "value: 3", "value: 4");
+    view.editor.clearRetainingCapacity();
+    try view.editor.insertSliceAtCursor(updated);
+    view.editor_changed = true;
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    try testing.expectEqualStrings(
+        "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n  - key: Goblin\n    value: 4\n  - key: Dragon\n    value: 9\n  - key: Slime\n    value: 2\n",
+        try core.merge.finish(arena, &fixture.plan),
+    );
+}
+
+test "merge TUI: dictionary value edit keeps sibling keys and side YAML" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try dictionaryUnionPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Dictionary.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 160, 24);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.down);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    try testing.expect(!view.editing);
+    // Independent keys keep their source pair layout. A reconstructed Goblin pair
+    // must use the same block indent as Dragon and Slime or Unity YAML is invalid.
+    try testing.expectEqualStrings(
+        "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n  - key: Goblin\n    value: 4\n  - key: Dragon\n    value: 9\n  - key: Slime\n    value: 2\n",
+        try core.merge.finish(arena, &fixture.plan),
+    );
+}
+
+test "merge TUI: prefab override value edit keeps the modification item" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try prefabOverrideOnlySpeedPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Variant.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 160, 24);
+    var ctx = eventContext(arena);
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.down);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    const finished = try core.merge.finish(arena, &fixture.plan);
+    // Custom is the scalar. The modification's target, path, and objectReference must stay.
+    try testing.expect(std.mem.indexOf(u8, finished, "propertyPath: items.Array.data[0].speed") != null);
+    try testing.expect(std.mem.indexOf(u8, finished, "value: 4") != null);
+    try testing.expect(std.mem.indexOf(u8, finished, "objectReference: {fileID: 0}") != null);
+    try testing.expect(std.mem.indexOf(u8, finished, "m_SourcePrefab:") != null);
+}
+
+test "merge TUI: prefab override raw value edit keeps the modification item" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    var fixture = try prefabOverrideOnlySpeedPlan(arena);
+    var state = try merge_ui_state.State.init(arena, &fixture.plan);
+    try state.handle(.choose_theirs);
+    var view = try viewForTest(arena, &state, "Variant.prefab", fixture.partial);
+    defer view.deinit();
+    _ = try drawForTest(arena, view.widget(), 180, 24);
+    var ctx = eventContext(arena);
+    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
+    try focusResultForTest(&view, &ctx);
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    const before = try view.editor.buf.dupe();
+    try testing.expect(std.mem.indexOf(u8, before, "value: 3") != null);
+    const updated = try std.mem.replaceOwned(u8, arena, before, "value: 3", "value: 4");
+    view.editor.clearRetainingCapacity();
+    try view.editor.insertSliceAtCursor(updated);
+    view.editor_changed = true;
+    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
+    try testing.expectEqualStrings("", state.status);
+    const finished = try core.merge.finish(arena, &fixture.plan);
+    try testing.expect(std.mem.indexOf(u8, finished, "propertyPath: items.Array.data[0].speed") != null);
+    try testing.expect(std.mem.indexOf(u8, finished, "value: 4") != null);
+    try testing.expect(std.mem.indexOf(u8, finished, "objectReference: {fileID: 0}") != null);
+}
+
 test "merge TUI: Raw shortcut preserves typed letters in the Result editor" {
     // Terminals can report Shift as a modifier or as an uppercase character.
     for ([_]bool{ false, true }) |explicit_shift| {
@@ -395,6 +687,7 @@ pub const View = struct {
     property_memory: std.heap.ArenaAllocator,
     editor_document: ?core.merge.properties.Document = null,
     editor_property: ?[]const core.merge.properties.Segment = null,
+    editor_semantic_value: bool = false,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -489,9 +782,13 @@ pub const View = struct {
         ctx.consumeAndRedraw();
     }
 
+    fn editsPropertyCell(self: *const View) bool {
+        return self.editor_property != null or self.editor_semantic_value;
+    }
+
     fn editorRow(self: *const View, size: vxfw.Size) u16 {
         const start = BodyGeometry.init(size.height).inspector_rows.start;
-        return start + if (self.editor_property != null) @as(u16, @intCast(self.property_row -| self.property_top)) else @as(u16, 0);
+        return start + if (self.editsPropertyCell()) @as(u16, @intCast(self.property_row -| self.property_top)) else @as(u16, 0);
     }
 
     fn inspectorHeadingGeometry(self: *const View, width: u16) InspectorHeadingGeometry {
@@ -583,19 +880,30 @@ pub const View = struct {
             }
             _ = self.property_memory.reset(.retain_capacity);
             const model = try self.propertyModel(self.property_memory.allocator());
-            const document = model.documents[3] orelse {
+            if (model.documents[3]) |document| {
+                if (!model.editable(self.property_row)) {
+                    self.state.status = "This property cannot be edited.";
+                    return ctx.consumeAndRedraw();
+                }
+                self.editor_document = document;
+                self.editor_property = model.rows[self.property_row].path;
+                input = document.input(model.rows[self.property_row].path).?;
+            } else if (hasParsedDocuments(model)) {
                 self.state.status = "Choose a component to keep before editing its properties.";
                 return ctx.consumeAndRedraw();
-            };
-            const index = self.property_row;
-            if (!model.editable(index)) {
-                self.state.status = "This property cannot be edited.";
-                return ctx.consumeAndRedraw();
+            } else {
+                if (!selectEditableProperty(&self.property_row, model)) {
+                    self.state.status = "This property cannot be edited.";
+                    return ctx.consumeAndRedraw();
+                }
+                // Dictionary and Variant tables are not Unity documents. Edit the Value cell.
+                self.editor_document = null;
+                self.editor_property = null;
+                self.editor_semantic_value = true;
+                const cell = try model.text(self.property_memory.allocator(), self.property_row, 3);
+                input = if (isPlaceholderValue(cell) or std.mem.eql(u8, cell, "—")) "" else cell;
             }
-            self.editor_document = document;
-            self.editor_property = model.rows[index].path;
             self.ensurePropertyVisible(self.eventSize(), model.rows.len);
-            input = document.input(model.rows[index].path).?;
             self.state.status = "";
         }
         const normalized = try result_text.normalizeNewlines(self.editor.buf.allocator, input);
@@ -803,7 +1111,7 @@ pub const View = struct {
         return result_text.cellAt(
             &self.editor,
             geometry.result.end - geometry.result.start -| 2,
-            self.editor_top + std.math.clamp(row, self.editorRow(size), if (self.editor_property != null) self.editorRow(size) else body.inspector_rows.end - 1) - self.editorRow(size),
+            self.editor_top + std.math.clamp(row, self.editorRow(size), if (self.editsPropertyCell()) self.editorRow(size) else body.inspector_rows.end - 1) - self.editorRow(size),
             col -| (geometry.result.start + 2),
         );
     }
@@ -840,7 +1148,7 @@ pub const View = struct {
         const geometry = self.valueGeometry(size.width);
         const body = BodyGeometry.init(size.height);
         if (row >= body.inspector_rows.start and row < body.inspector_rows.end and inRange(col, geometry.result) and
-            (self.editor_property == null or row == self.editorRow(size)))
+            (self.editsPropertyCell() == false or row == self.editorRow(size)))
         {
             const cell = try self.editorCellAt(mouse, size);
             result_text.setCursor(&self.editor, cell.start);
@@ -863,6 +1171,7 @@ pub const View = struct {
         self.editor_reopened = false;
         self.editor_document = null;
         self.editor_property = null;
+        self.editor_semantic_value = false;
         _ = self.property_memory.reset(.retain_capacity);
     }
 
@@ -885,7 +1194,7 @@ pub const View = struct {
     }
 
     fn leaveResultForHierarchy(self: *View, ctx: *vxfw.EventContext) !void {
-        if (self.editor_changed and self.editor_property == null) {
+        if (self.editor_changed and !self.editsPropertyCell()) {
             const input = try self.editor.toOwnedSlice();
             defer self.editor.buf.allocator.free(input);
             if (std.mem.trim(u8, input, "\r\n").len == 0) return self.reopenResult(ctx, self.eventSize());
@@ -905,7 +1214,7 @@ pub const View = struct {
         const input = try self.editor.toOwnedSlice();
         defer self.editor.buf.allocator.free(input);
         if (std.mem.trim(u8, input, "\r\n").len == 0) {
-            if (self.editor_property != null) {
+            if (self.editsPropertyCell()) {
                 try self.openDialog(ctx, .empty);
                 return false;
             }
@@ -946,7 +1255,8 @@ pub const View = struct {
             .quit => try self.dispatch(ctx, .abort, size),
             .empty => {
                 if (self.editor_property != null) return self.submitProperty(ctx, "");
-                try self.state.handle(.{ .edit_result = "" });
+                const payload = try self.customResultInput("");
+                try self.state.handle(.{ .edit_result = payload });
                 try self.applyPendingResult(ctx, size);
                 if (self.editing) try ctx.requestFocus(self.editor.widget());
             },
@@ -1025,7 +1335,7 @@ pub const View = struct {
             .base => displaySide(self.state.plan, operation, .base, operation.values.base),
             .ours => displaySide(self.state.plan, operation, .ours, operation.values.ours),
             .theirs => displaySide(self.state.plan, operation, .theirs, operation.values.theirs),
-            .result => displayResolution(self.state.plan, operation, pending),
+            .result => try displayResolution(arena, self.state.plan, operation, pending),
         };
     }
 
@@ -1057,13 +1367,22 @@ pub const View = struct {
         const resolution = self.state.pending orelse operation.resolution;
         return switch (resolution) {
             .unresolved => "",
-            .take => |side| if (operation.values.get(side)) |value|
-                documentPreview(self.state.plan, operation, side) orelse value.bytes
-            else
-                "",
+            .take => |side| displaySide(self.state.plan, operation, side, operation.values.get(side)),
             .remove => "",
-            .custom => |value| value,
+            .custom => |value| displayResolution(self.editor.buf.allocator, self.state.plan, operation, .{ .custom = value }) catch value,
         };
+    }
+
+    fn customResultInput(self: *View, input: []const u8) ![]const u8 {
+        const operation = self.selectedOperation() orelse return input;
+        if (operation.kind == .prefab_override) {
+            if (self.editor_semantic_value) return input;
+            return extractOverrideValue(input);
+        }
+        if (operation.kind == .field) {
+            return dictionaryCustom(self.property_memory.allocator(), self.state.plan, operation, input);
+        }
+        return input;
     }
 
     fn resultIsRemoval(self: *const View) bool {
@@ -1317,20 +1636,155 @@ fn displaySide(
     value: ?core.merge.SideValue,
 ) []const u8 {
     if (documentPreview(plan, operation, side)) |bytes| return bytes;
+    if (operation.kind == .prefab_override) {
+        if (prefabOverrideRaw(plan, operation, side)) |bytes| return bytes;
+    }
     return sideText(value);
 }
 
+fn prefabOverrideRaw(
+    plan: *const core.merge.MergePlan,
+    operation: *const core.merge.Operation,
+    side: core.merge.Side,
+) ?[]const u8 {
+    const file = plan.file(side);
+    const target_id = if (operation.identity.item_ref) |reference| reference.file_id else 0;
+    for (file.documents) |*document| {
+        if (document.file_id != operation.identity.document.file_id) continue;
+        const modification = document.body.get("m_Modification") orelse continue;
+        if (modification.* != .map) continue;
+        const list = modification.get("m_Modifications") orelse continue;
+        if (list.* != .seq) continue;
+        for (list.seq) |item| {
+            const path = core.model.Node.asScalar(item.get("propertyPath")) orelse continue;
+            if (!std.mem.eql(u8, path, operation.identity.property_path)) continue;
+            if (core.model.Node.asRef(item.get("target"))) |target| {
+                if (target.file_id != target_id) continue;
+            }
+            const raw = file.sequenceItemBytes(item) orelse continue;
+            return std.mem.trim(u8, raw, "\r\n");
+        }
+    }
+    return null;
+}
+
 fn displayResolution(
+    arena: std.mem.Allocator,
     plan: *const core.merge.MergePlan,
     operation: *const core.merge.Operation,
     resolution: core.merge.Resolution,
-) []const u8 {
+) std.mem.Allocator.Error![]const u8 {
     return switch (resolution) {
         .unresolved => "",
         .take => |side| displaySide(plan, operation, side, operation.values.get(side)),
         .remove => "<removed>",
-        .custom => |value| if (value.len == 0) "<empty>" else value,
+        .custom => |value| if (value.len == 0) "<empty>" else try customResultDisplay(arena, plan, operation, value),
     };
+}
+
+fn customResultDisplay(
+    arena: std.mem.Allocator,
+    plan: *const core.merge.MergePlan,
+    operation: *const core.merge.Operation,
+    value: []const u8,
+) std.mem.Allocator.Error![]const u8 {
+    const scalar = customScalarText(value) orelse return value;
+    if (operation.kind == .prefab_override) {
+        if (try patchedPrefabOverrideDisplay(arena, plan, operation, scalar)) |bytes| return bytes;
+    }
+    if (operation.kind == .field) {
+        if (try patchedDictionaryItemDisplay(arena, plan, operation, scalar)) |bytes| return bytes;
+    }
+    return value;
+}
+
+fn customScalarText(value: []const u8) ?[]const u8 {
+    const trimmed = std.mem.trim(u8, value, " \r\n");
+    if (trimmed.len == 0) return null;
+    if (std.mem.indexOfAny(u8, trimmed, "\r\n") == null and
+        !std.mem.startsWith(u8, std.mem.trimStart(u8, trimmed, " "), "- ") and
+        !std.mem.startsWith(u8, trimmed, "{"))
+    {
+        return trimmed;
+    }
+    var lines = std.mem.splitScalar(u8, trimmed, '\n');
+    var found: ?[]const u8 = null;
+    while (lines.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        const content = std.mem.trimStart(u8, line, " ");
+        if (std.mem.startsWith(u8, content, "value:")) {
+            found = std.mem.trim(u8, content["value:".len..], " ");
+        }
+    }
+    return found;
+}
+
+fn templateSide(operation: *const core.merge.Operation) ?core.merge.Side {
+    if (operation.values.theirs != null) return .theirs;
+    if (operation.values.ours != null) return .ours;
+    if (operation.values.base != null) return .base;
+    return null;
+}
+
+fn patchedDictionaryItemDisplay(
+    arena: std.mem.Allocator,
+    plan: *const core.merge.MergePlan,
+    operation: *const core.merge.Operation,
+    scalar: []const u8,
+) std.mem.Allocator.Error!?[]const u8 {
+    const side = templateSide(operation) orelse return null;
+    const pair = operation.values.get(side) orelse return null;
+    const node = pair.node orelse return null;
+    if (node.* != .map) return null;
+    const value_node = node.get("value") orelse node.get("second") orelse return null;
+    return patchedSequenceItemDisplay(arena, plan.file(side), node, value_node, scalar);
+}
+
+fn patchedPrefabOverrideDisplay(
+    arena: std.mem.Allocator,
+    plan: *const core.merge.MergePlan,
+    operation: *const core.merge.Operation,
+    scalar: []const u8,
+) std.mem.Allocator.Error!?[]const u8 {
+    const side = templateSide(operation) orelse return null;
+    const value = operation.values.get(side) orelse return null;
+    const value_node = value.node orelse return null;
+    const file = plan.file(side);
+    const target_id = if (operation.identity.item_ref) |reference| reference.file_id else 0;
+    for (file.documents) |*document| {
+        if (document.file_id != operation.identity.document.file_id) continue;
+        const modification = document.body.get("m_Modification") orelse continue;
+        if (modification.* != .map) continue;
+        const list = modification.get("m_Modifications") orelse continue;
+        if (list.* != .seq) continue;
+        for (list.seq) |item| {
+            const path = core.model.Node.asScalar(item.get("propertyPath")) orelse continue;
+            if (!std.mem.eql(u8, path, operation.identity.property_path)) continue;
+            if (core.model.Node.asRef(item.get("target"))) |target| {
+                if (target.file_id != target_id) continue;
+            }
+            return patchedSequenceItemDisplay(arena, file, item, value_node, scalar);
+        }
+    }
+    return null;
+}
+
+fn patchedSequenceItemDisplay(
+    arena: std.mem.Allocator,
+    file: core.source.ParsedFile,
+    item: *const core.model.Node,
+    value_node: *const core.model.Node,
+    scalar: []const u8,
+) std.mem.Allocator.Error!?[]const u8 {
+    const item_span = file.sequence_item_spans.get(item) orelse return null;
+    const value_span = file.node_spans.get(value_node) orelse return null;
+    if (value_span.start < item_span.start or value_span.end > item_span.end) return null;
+    const patched = try std.mem.concat(arena, u8, &.{
+        file.bytes[item_span.start..value_span.start],
+        scalar,
+        file.bytes[value_span.end..item_span.end],
+    });
+    return std.mem.trim(u8, patched, "\r\n");
 }
 
 fn documentPreview(
@@ -1596,7 +2050,7 @@ fn draw(
             .{ geometry.theirs, try self.columnText(ctx.arena, operation, .theirs), ValueColumn.theirs },
             .{ geometry.result, try self.columnText(ctx.arena, operation, .result), ValueColumn.result },
         };
-        const indent = commonIndent(&.{ columns[0][1], columns[1][1], columns[2][1], columns[3][1] });
+        const indent = commonIndent(&.{ columns[0][1], columns[1][1], columns[2][1] });
         var painted_end = [_]u16{body.inspector_rows.start} ** 4;
         inline for (columns, 0..) |column, index| {
             const text = if (column[2] == self.selected_value)
@@ -1729,7 +2183,7 @@ fn draw(
             self.editor.style = .{ .bg = Palette.focus_bg };
             const editor_size: vxfw.Size = .{
                 .width = geometry.result.end - geometry.result.start -| 2,
-                .height = if (self.editor_property != null) 1 else body.inspector_rows.end - editor_row,
+                .height = if (self.editsPropertyCell()) 1 else body.inspector_rows.end - editor_row,
             };
             const child_surface = try result_text.draw(&self.editor, &self.editor_top, self.editorSelection(), ctx.withConstraints(
                 editor_size,
@@ -1798,8 +2252,9 @@ fn submitCustom(
     if (!self.editor_changed and self.resultIsRemoval()) return self.applyPendingResult(ctx, self.eventSize());
     if (input.len == 0 and !started_empty) return self.openDialog(ctx, .empty);
     if (self.editor_property != null) return self.submitProperty(ctx, input);
-    if (self.editor_changed or input.len == 0) {
-        try self.state.handle(.{ .edit_result = input });
+    const payload = try self.customResultInput(input);
+    if (self.editor_changed or payload.len == 0) {
+        try self.state.handle(.{ .edit_result = payload });
     } else {
         self.state.pending = self.editor_start_resolution;
     }
@@ -1817,10 +2272,130 @@ fn markEditorChanged(
 ) !void {
     const self: *View = @ptrCast(@alignCast(userdata.?));
     self.editor_changed = true;
-    if (value.len == 0 and self.editor_property == null) {
+    if (value.len == 0 and !self.editsPropertyCell()) {
         try self.state.handle(.reopen_result);
         self.editor_reopened = true;
     }
+}
+
+fn hasParsedDocuments(model: inspector.Model) bool {
+    for (model.documents) |document| {
+        if (document != null) return true;
+    }
+    return false;
+}
+
+fn selectEditableProperty(property_row: *usize, model: inspector.Model) bool {
+    if (model.editable(property_row.*)) return true;
+    for (model.rows, 0..) |_, i| {
+        if (model.editable(i)) {
+            property_row.* = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+fn dictionaryCustom(
+    arena: std.mem.Allocator,
+    plan: *const core.merge.MergePlan,
+    operation: *const core.merge.Operation,
+    input: []const u8,
+) ![]const u8 {
+    const template = operation.values.ours orelse operation.values.theirs orelse operation.values.base orelse return input;
+    const node = template.node orelse return input;
+    if (node.* != .map) return input;
+    // Keep the sequence-item indent. Trimming it leaves `value:` nested under `key:`.
+    const trimmed = std.mem.trim(u8, input, "\r\n");
+    const content = std.mem.trimStart(u8, trimmed, " ");
+    if (std.mem.startsWith(u8, content, "- ")) {
+        return stripSequenceItemDash(arena, trimmed);
+    }
+    if (std.mem.indexOfAny(u8, trimmed, "\r\n") != null or std.mem.startsWith(u8, trimmed, "{")) {
+        return trimmed;
+    }
+    return dictionaryValueCustom(arena, plan, node, trimmed);
+}
+
+fn dictionaryValueCustom(
+    arena: std.mem.Allocator,
+    plan: *const core.merge.MergePlan,
+    node: *const core.model.Node,
+    input: []const u8,
+) ![]const u8 {
+    var output: std.ArrayList(u8) = .empty;
+    for (node.map, 0..) |entry, i| {
+        if (i != 0) try output.append(arena, '\n');
+        try output.appendSlice(arena, entry.key);
+        try output.appendSlice(arena, ": ");
+        const field = if (std.mem.eql(u8, entry.key, "value") or std.mem.eql(u8, entry.key, "second"))
+            input
+        else
+            fieldSourceBytes(plan, entry.value) orelse return input;
+        try output.appendSlice(arena, field);
+    }
+    return output.toOwnedSlice(arena);
+}
+
+fn fieldSourceBytes(plan: *const core.merge.MergePlan, node: *const core.model.Node) ?[]const u8 {
+    inline for (.{ core.merge.Side.ours, .theirs, .base }) |side| {
+        if (plan.file(side).nodeBytes(node)) |bytes| return bytes;
+    }
+    return switch (node.*) {
+        .scalar => |text| text,
+        else => null,
+    };
+}
+
+fn stripSequenceItemDash(arena: std.mem.Allocator, input: []const u8) ![]const u8 {
+    var lines = std.mem.splitScalar(u8, input, '\n');
+    const first_raw = lines.next() orelse return input;
+    const first_line = std.mem.trimEnd(u8, first_raw, "\r");
+    const first_indent = lineIndent(first_line);
+    const rest = first_line[first_indent..];
+    if (!std.mem.startsWith(u8, rest, "- ")) return input;
+    var body_indent: ?usize = null;
+    var preview = lines;
+    while (preview.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        if (std.mem.trim(u8, line, " ").len == 0) continue;
+        const indent = lineIndent(line);
+        body_indent = if (body_indent) |current| @min(current, indent) else indent;
+    }
+    const strip = body_indent orelse first_indent + 2;
+    var output: std.ArrayList(u8) = .empty;
+    try output.appendSlice(arena, rest[2..]);
+    lines = std.mem.splitScalar(u8, input, '\n');
+    _ = lines.next();
+    while (lines.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        if (std.mem.trim(u8, line, " ").len == 0) continue;
+        try output.append(arena, '\n');
+        const indent = lineIndent(line);
+        if (indent >= strip) {
+            try output.appendSlice(arena, line[strip..]);
+        } else {
+            try output.appendSlice(arena, std.mem.trimStart(u8, line, " "));
+        }
+    }
+    return output.toOwnedSlice(arena);
+}
+
+fn extractOverrideValue(input: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, input, " \r\n");
+    if (std.mem.indexOfAny(u8, trimmed, "\r\n") == null and !std.mem.startsWith(u8, std.mem.trimStart(u8, trimmed, " "), "- ")) {
+        return trimmed;
+    }
+    var lines = std.mem.splitScalar(u8, trimmed, '\n');
+    var found: ?[]const u8 = null;
+    while (lines.next()) |raw| {
+        const line = std.mem.trimEnd(u8, raw, "\r");
+        const content = std.mem.trimStart(u8, line, " ");
+        if (std.mem.startsWith(u8, content, "value:")) {
+            found = std.mem.trim(u8, content["value:".len..], " ");
+        }
+    }
+    return found orelse trimmed;
 }
 
 fn isPlaceholderValue(text: []const u8) bool {
@@ -2076,16 +2651,44 @@ pub fn run(
     path: []const u8,
     partial: []const u8,
 ) !void {
-    const tree = try merge_tree.buildForState(allocator, partial, state);
-    try state.handle(.{ .select_conflict = 0 });
     var tty_buffer: [4096]u8 = undefined;
-    var app = try vxfw.App.init(io, allocator, env_map, &tty_buffer);
-    defer app.deinit();
-    var view = View.init(allocator, state, path, tree);
-    defer view.deinit();
-    view.live_screen = &app.vx.screen;
-    try app.run(view.widget(), .{});
+    var session = try Session.init(io, allocator, env_map, &tty_buffer);
+    defer session.deinit();
+    try session.present(allocator, state, path, partial);
 }
+
+/// One terminal session covers every remaining content conflict in a merge.
+pub const Session = struct {
+    app: vxfw.App,
+
+    pub fn init(
+        io: std.Io,
+        allocator: std.mem.Allocator,
+        env_map: *std.process.Environ.Map,
+        buffer: []u8,
+    ) !Session {
+        return .{ .app = try vxfw.App.init(io, allocator, env_map, buffer) };
+    }
+
+    pub fn deinit(self: *Session) void {
+        self.app.deinit();
+    }
+
+    pub fn present(
+        self: *Session,
+        allocator: std.mem.Allocator,
+        state: *merge_ui_state.State,
+        path: []const u8,
+        partial: []const u8,
+    ) !void {
+        const tree = try merge_tree.buildForState(allocator, partial, state);
+        try state.handle(.{ .select_conflict = 0 });
+        var view = View.init(allocator, state, path, tree);
+        defer view.deinit();
+        view.live_screen = &self.app.vx.screen;
+        try self.app.run(view.widget(), .{});
+    }
+};
 
 fn screenPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
     return core.merge.build(
@@ -2172,6 +2775,59 @@ fn deleteEditPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
         "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 1\n  m_After: keep\n",
         "--- !u!114 &1\nMonoBehaviour:\n  m_After: keep\n",
         "--- !u!114 &1\nMonoBehaviour:\n  m_Value: 2\n  m_After: keep\n",
+    );
+}
+
+fn prefabOverrideSpeedPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
+    const prefix =
+        "--- !u!1001 &1\n" ++
+        "PrefabInstance:\n" ++
+        "  m_Modification:\n" ++
+        "    m_Modifications:\n" ++
+        "    - target: {fileID: 10, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: m_Name\n" ++
+        "      value: Enemy\n" ++
+        "    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "      propertyPath: items.Array.data[0].speed\n" ++
+        "      value: ";
+    const suffix =
+        "\n      objectReference: {fileID: 0}\n" ++
+        "  m_SourcePrefab: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n";
+    return core.merge.build(arena, prefix ++ "1" ++ suffix, prefix ++ "2" ++ suffix, prefix ++ "3" ++ suffix);
+}
+
+fn prefabOverrideOnlySpeedPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
+    const prefix =
+        "--- !u!1001 &1\n" ++
+        "PrefabInstance:\n" ++
+        "  m_Modification:\n" ++
+        "    m_Modifications:\n" ++
+        "    - target: {fileID: 50, guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, type: 3}\n" ++
+        "      propertyPath: items.Array.data[0].speed\n" ++
+        "      value: ";
+    const suffix =
+        "\n      objectReference: {fileID: 0}\n" ++
+        "  m_SourcePrefab: {fileID: 100100000, guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, type: 3}\n";
+    return core.merge.build(arena, prefix ++ "1" ++ suffix, prefix ++ "2" ++ suffix, prefix ++ "3" ++ suffix);
+}
+
+fn dictionaryGoblinPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
+    const prefix = "--- !u!114 &2\nMonoBehaviour:\n  m_Stats:\n";
+    return core.merge.build(
+        arena,
+        prefix ++ "  - key: Goblin\n    value: 1\n",
+        prefix ++ "  - key: Goblin\n    value: 2\n",
+        prefix ++ "  - key: Goblin\n    value: 3\n",
+    );
+}
+
+fn dictionaryUnionPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n";
+    return core.merge.build(
+        arena,
+        prefix ++ "  - key: Goblin\n    value: 1\n",
+        prefix ++ "  - key: Goblin\n    value: 2\n  - key: Dragon\n    value: 9\n",
+        prefix ++ "  - key: Goblin\n    value: 3\n  - key: Slime\n    value: 2\n",
     );
 }
 

--- a/cli/src/merge_tui.zig
+++ b/cli/src/merge_tui.zig
@@ -137,45 +137,6 @@ test "merge TUI: property and raw views preserve the selected result across togg
     try testing.expectEqual(core.merge.Side.theirs, state.pending.?.take);
 }
 
-test "merge TUI: prefab override shows Prefab mark semantic path and raw YAML" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    const prefix =
-        "--- !u!1001 &1\n" ++
-        "PrefabInstance:\n" ++
-        "  m_Modification:\n" ++
-        "    m_Modifications:\n" ++
-        "    - target: {fileID: 10, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
-        "      propertyPath: m_Name\n" ++
-        "      value: Enemy\n" ++
-        "    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
-        "      propertyPath: items.Array.data[0].speed\n" ++
-        "      value: ";
-    const suffix =
-        "\n      objectReference: {fileID: 0}\n" ++
-        "  m_SourcePrefab: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n";
-    var fixture = try core.merge.build(
-        arena,
-        prefix ++ "1" ++ suffix,
-        prefix ++ "2" ++ suffix,
-        prefix ++ "3" ++ suffix,
-    );
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    var view = try viewForTest(arena, &state, "Enemy Variant.prefab", fixture.partial);
-    defer view.deinit();
-    const semantic = try surfaceText(arena, try drawForTest(arena, view.widget(), 120, 24));
-    // Hierarchy otherwise looks like a named GameObject, so the Prefab mark has to be on screen.
-    try testing.expect(std.mem.indexOf(u8, semantic, "‹Prefab›") != null);
-    try testing.expect(std.mem.indexOf(u8, semantic, "Items[0].Speed") != null);
-    try testing.expect(std.mem.indexOf(u8, semantic, "⇧R Raw") != null);
-    var ctx = eventContext(arena);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
-    const raw = try surfaceText(arena, try drawForTest(arena, view.widget(), 180, 24));
-    try testing.expect(std.mem.indexOf(u8, raw, "propertyPath:") != null);
-    try testing.expect(std.mem.indexOf(u8, raw, "⇧R Semantic") != null);
-}
-
 test "merge TUI: prefab override raw edit keeps the displayed modification YAML" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);
     defer memory.deinit();
@@ -271,28 +232,6 @@ test "merge TUI: dictionary custom result keeps pair indent on every side" {
     try testing.expectEqual(lineIndent(ours_before), lineIndent(result));
 }
 
-test "merge TUI: prefab override custom result keeps the modification item" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    var fixture = try prefabOverrideOnlySpeedPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    try state.handle(.choose_theirs);
-    var view = try viewForTest(arena, &state, "Variant.prefab", fixture.partial);
-    defer view.deinit();
-    _ = try drawForTest(arena, view.widget(), 180, 24);
-    view.raw_view = true;
-    const operation = view.selectedOperation().?;
-    try state.handle(.{ .edit_result = "4" });
-    const result = try view.columnText(arena, operation, .result);
-    // Custom is the scalar. The Result column still has to show the modification YAML
-    // so Enter does not look like it deleted target, propertyPath, and objectReference.
-    try testing.expect(std.mem.indexOf(u8, result, "propertyPath:") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "value: 4") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "objectReference:") != null);
-    try testing.expect(!std.mem.eql(u8, result, "4"));
-}
-
 test "merge TUI: dictionary semantic value can be edited to a custom result" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);
     defer memory.deinit();
@@ -318,115 +257,6 @@ test "merge TUI: dictionary semantic value can be edited to a custom result" {
         try std.mem.replaceOwned(u8, arena, fixture.plan.theirs.bytes, "value: 3", "value: 4"),
         try core.merge.finish(arena, &fixture.plan),
     );
-}
-
-test "merge TUI: dictionary raw pair edit keeps sibling keys and side YAML" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    var fixture = try dictionaryUnionPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    try state.handle(.choose_theirs);
-    var view = try viewForTest(arena, &state, "Dictionary.prefab", fixture.partial);
-    defer view.deinit();
-    _ = try drawForTest(arena, view.widget(), 180, 24);
-    var ctx = eventContext(arena);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
-    try focusResultForTest(&view, &ctx);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    const before = try view.editor.buf.dupe();
-    try testing.expect(std.mem.indexOf(u8, before, "value: 3") != null);
-    const updated = try std.mem.replaceOwned(u8, arena, before, "value: 3", "value: 4");
-    view.editor.clearRetainingCapacity();
-    try view.editor.insertSliceAtCursor(updated);
-    view.editor_changed = true;
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try testing.expectEqualStrings("", state.status);
-    try testing.expectEqualStrings(
-        "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n  - key: Goblin\n    value: 4\n  - key: Dragon\n    value: 9\n  - key: Slime\n    value: 2\n",
-        try core.merge.finish(arena, &fixture.plan),
-    );
-}
-
-test "merge TUI: dictionary value edit keeps sibling keys and side YAML" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    var fixture = try dictionaryUnionPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    try state.handle(.choose_theirs);
-    var view = try viewForTest(arena, &state, "Dictionary.prefab", fixture.partial);
-    defer view.deinit();
-    _ = try drawForTest(arena, view.widget(), 160, 24);
-    var ctx = eventContext(arena);
-    try focusResultForTest(&view, &ctx);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.down);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try testing.expectEqualStrings("", state.status);
-    try testing.expect(!view.editing);
-    // Independent keys keep their source pair layout. A reconstructed Goblin pair
-    // must use the same block indent as Dragon and Slime or Unity YAML is invalid.
-    try testing.expectEqualStrings(
-        "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n  - key: Goblin\n    value: 4\n  - key: Dragon\n    value: 9\n  - key: Slime\n    value: 2\n",
-        try core.merge.finish(arena, &fixture.plan),
-    );
-}
-
-test "merge TUI: prefab override value edit keeps the modification item" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    var fixture = try prefabOverrideOnlySpeedPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    try state.handle(.choose_theirs);
-    var view = try viewForTest(arena, &state, "Variant.prefab", fixture.partial);
-    defer view.deinit();
-    _ = try drawForTest(arena, view.widget(), 160, 24);
-    var ctx = eventContext(arena);
-    try focusResultForTest(&view, &ctx);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.down);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.backspace);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = '4', .text = "4" } });
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try testing.expectEqualStrings("", state.status);
-    const finished = try core.merge.finish(arena, &fixture.plan);
-    // Custom is the scalar. The modification's target, path, and objectReference must stay.
-    try testing.expect(std.mem.indexOf(u8, finished, "propertyPath: items.Array.data[0].speed") != null);
-    try testing.expect(std.mem.indexOf(u8, finished, "value: 4") != null);
-    try testing.expect(std.mem.indexOf(u8, finished, "objectReference: {fileID: 0}") != null);
-    try testing.expect(std.mem.indexOf(u8, finished, "m_SourcePrefab:") != null);
-}
-
-test "merge TUI: prefab override raw value edit keeps the modification item" {
-    var memory = std.heap.ArenaAllocator.init(testing.allocator);
-    defer memory.deinit();
-    const arena = memory.allocator();
-    var fixture = try prefabOverrideOnlySpeedPlan(arena);
-    var state = try merge_ui_state.State.init(arena, &fixture.plan);
-    try state.handle(.choose_theirs);
-    var view = try viewForTest(arena, &state, "Variant.prefab", fixture.partial);
-    defer view.deinit();
-    _ = try drawForTest(arena, view.widget(), 180, 24);
-    var ctx = eventContext(arena);
-    try view.widget().handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'r', .mods = .{ .shift = true }, .text = "R" } });
-    try focusResultForTest(&view, &ctx);
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    const before = try view.editor.buf.dupe();
-    try testing.expect(std.mem.indexOf(u8, before, "value: 3") != null);
-    const updated = try std.mem.replaceOwned(u8, arena, before, "value: 3", "value: 4");
-    view.editor.clearRetainingCapacity();
-    try view.editor.insertSliceAtCursor(updated);
-    view.editor_changed = true;
-    try pressKeyForTest(&view, &ctx, vaxis.Key.enter);
-    try testing.expectEqualStrings("", state.status);
-    const finished = try core.merge.finish(arena, &fixture.plan);
-    try testing.expect(std.mem.indexOf(u8, finished, "propertyPath: items.Array.data[0].speed") != null);
-    try testing.expect(std.mem.indexOf(u8, finished, "value: 4") != null);
-    try testing.expect(std.mem.indexOf(u8, finished, "objectReference: {fileID: 0}") != null);
 }
 
 test "merge TUI: Raw shortcut preserves typed letters in the Result editor" {
@@ -2793,21 +2623,6 @@ fn prefabOverrideSpeedPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
     const suffix =
         "\n      objectReference: {fileID: 0}\n" ++
         "  m_SourcePrefab: {fileID: 100100000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n";
-    return core.merge.build(arena, prefix ++ "1" ++ suffix, prefix ++ "2" ++ suffix, prefix ++ "3" ++ suffix);
-}
-
-fn prefabOverrideOnlySpeedPlan(arena: std.mem.Allocator) !core.merge.BuildResult {
-    const prefix =
-        "--- !u!1001 &1\n" ++
-        "PrefabInstance:\n" ++
-        "  m_Modification:\n" ++
-        "    m_Modifications:\n" ++
-        "    - target: {fileID: 50, guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, type: 3}\n" ++
-        "      propertyPath: items.Array.data[0].speed\n" ++
-        "      value: ";
-    const suffix =
-        "\n      objectReference: {fileID: 0}\n" ++
-        "  m_SourcePrefab: {fileID: 100100000, guid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, type: 3}\n";
     return core.merge.build(arena, prefix ++ "1" ++ suffix, prefix ++ "2" ++ suffix, prefix ++ "3" ++ suffix);
 }
 

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -288,6 +288,36 @@ test "diff: dictionary pairs and parallel keys match by key not index" {
     try testing.expect(!saw_index);
 }
 
+test "diff: dictionary reorder without value change is hidden" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  stats:
+        \\  - key: Goblin
+        \\    value: 10
+        \\  - key: Slime
+        \\    value: 3
+    ;
+    const after =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  stats:
+        \\  - key: Slime
+        \\    value: 3
+        \\  - key: Goblin
+        \\    value: 10
+    ;
+    const fd = try compute(arena, before, after);
+    const d = findDoc(fd, 5).?;
+    // Index matching would mark every moved pair modified. A pure key shuffle
+    // is not a content change.
+    try testing.expectEqual(model.Status.unchanged, d.component.status);
+    try testing.expectEqual(@as(usize, 0), d.component.fields.len);
+}
+
 test "diff: unresolved guids are deduplicated in first-reference order" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();

--- a/core/src/diff.zig
+++ b/core/src/diff.zig
@@ -223,6 +223,71 @@ test "diff: hidden-only changes leave the document unchanged" {
     try testing.expectEqual(model.Status.unchanged, findDoc(fd, 4).?.component.status);
 }
 
+test "diff: dictionary pairs and parallel keys match by key not index" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const before =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  stats:
+        \\  - key: Goblin
+        \\    value: 10
+        \\  - key: Slime
+        \\    value: 3
+        \\  named:
+        \\    m_Keys:
+        \\    - Fire
+        \\    m_Values:
+        \\    - 1
+    ;
+    const after =
+        \\--- !u!114 &5
+        \\MonoBehaviour:
+        \\  stats:
+        \\  - key: Dragon
+        \\    value: 50
+        \\  - key: Goblin
+        \\    value: 12
+        \\  - key: Slime
+        \\    value: 3
+        \\  named:
+        \\    m_Keys:
+        \\    - Ice
+        \\    - Fire
+        \\    m_Values:
+        \\    - 2
+        \\    - 1
+    ;
+    const fd = try compute(arena, before, after);
+    const d = findDoc(fd, 5).?;
+    var saw_dragon = false;
+    var saw_goblin = false;
+    var saw_ice = false;
+    var saw_index = false;
+    for (d.component.fields) |f| {
+        if (std.mem.indexOf(u8, f.path, "[0]") != null or std.mem.indexOf(u8, f.path, "[1]") != null) saw_index = true;
+        if (std.mem.eql(u8, f.path, "Stats[Dragon]")) {
+            saw_dragon = true;
+            try testing.expectEqual(model.Status.added, f.status);
+        }
+        if (std.mem.eql(u8, f.path, "Stats[Goblin]")) {
+            saw_goblin = true;
+            try testing.expectEqual(model.Status.modified, f.status);
+            try testing.expectEqualStrings("10", f.before.?.scalar);
+            try testing.expectEqualStrings("12", f.after.?.scalar);
+        }
+        if (std.mem.eql(u8, f.path, "Named[Ice]")) {
+            saw_ice = true;
+            try testing.expectEqual(model.Status.added, f.status);
+        }
+    }
+    try testing.expect(saw_dragon);
+    try testing.expect(saw_goblin);
+    try testing.expect(saw_ice);
+    try testing.expect(!saw_index);
+}
+
 test "diff: unresolved guids are deduplicated in first-reference order" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -273,6 +338,7 @@ test "diff: removed document enumerates fields with vector collapse" {
 const parser = @import("parser.zig");
 const classid = @import("classid.zig");
 const inspector = @import("inspector.zig");
+const dictionary = @import("merge_dictionary.zig");
 const diff_overrides = @import("diff_overrides.zig");
 const Node = model.Node;
 const Status = model.Status;
@@ -413,6 +479,7 @@ fn diffNode(
     a: *const Node,
     b: *const Node,
 ) std.mem.Allocator.Error!void {
+    if (try diffDictionary(arena, out, prefix, a, b)) return;
     // Recurse if the same kind.
     if (a.* == .map and b.* == .map) {
         try diffMap(arena, out, prefix, a.map, b.map);
@@ -475,6 +542,35 @@ fn diffSeq(
     }
 }
 
+fn diffDictionary(
+    arena: std.mem.Allocator,
+    out: *std.ArrayList(FieldDiff),
+    prefix: []const u8,
+    a: *const Node,
+    b: *const Node,
+) std.mem.Allocator.Error!bool {
+    switch (dictionary.detect(a, b, a)) {
+        .none, .malformed => return false,
+        .shape => |shape| {
+            const before = (try dictionary.entries(arena, a, shape)) orelse return false;
+            const after = (try dictionary.entries(arena, b, shape)) orelse return false;
+            for (before) |entry| {
+                const path = try dictionary.keyPath(arena, prefix, entry.key);
+                if (dictionary.find(after, entry.key)) |matched| {
+                    try diffNode(arena, out, path, entry.value, matched.value);
+                } else {
+                    try flattenSubtree(arena, out, path, entry.value, .removed);
+                }
+            }
+            for (after) |entry| {
+                if (dictionary.contains(before, entry.key)) continue;
+                try flattenSubtree(arena, out, try dictionary.keyPath(arena, prefix, entry.key), entry.value, .added);
+            }
+            return true;
+        },
+    }
+}
+
 fn joinKey(arena: std.mem.Allocator, prefix: []const u8, key: []const u8) ![]const u8 {
     if (prefix.len == 0) return key;
     return std.fmt.allocPrint(arena, "{s}.{s}", .{ prefix, key });
@@ -512,6 +608,17 @@ fn flattenSubtree(
     node: *const Node,
     status: Status,
 ) std.mem.Allocator.Error!void {
+    switch (dictionary.detect(node, node, node)) {
+        .shape => |shape| {
+            if ((try dictionary.entries(arena, node, shape))) |list| {
+                for (list) |entry| {
+                    try flattenSubtree(arena, out, try dictionary.keyPath(arena, prefix, entry.key), entry.value, status);
+                }
+                return;
+            }
+        },
+        else => {},
+    }
     switch (node.*) {
         .map => |entries| {
             if (isVectorMap(entries)) {

--- a/core/src/inspector.zig
+++ b/core/src/inspector.zig
@@ -23,6 +23,10 @@ test "inspector: displayPath maps table entries and nicifies the rest" {
     try testing.expectEqualStrings("Max Hp", try displayPath(arena, "maxHp"));
     try testing.expectEqualStrings("Constrain Proportions Scale", try displayPath(arena, "m_ConstrainProportionsScale"));
     try testing.expectEqualStrings("Materials[0]", try displayPath(arena, "m_Materials[0]"));
+    // Unity YAML stores list elements as Array.data[i]; the Inspector path is Items[0].Speed.
+    try testing.expectEqualStrings("Items[0].Speed", try displayPath(arena, "items.Array.data[0].speed"));
+    try testing.expectEqualStrings("Items.Size", try displayPath(arena, "items.Array.size"));
+    try testing.expectEqualStrings("Materials[0]", try displayPath(arena, "m_Materials.Array.data[0]"));
 }
 
 // Fields not shown in the Inspector (matched by the path's first segment).
@@ -69,13 +73,36 @@ pub fn isHidden(path: []const u8) bool {
 }
 
 pub fn displayPath(arena: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const collapsed = try collapseSerializedArrayPath(arena, path);
     var out: std.ArrayList(u8) = .empty;
-    var it = std.mem.splitScalar(u8, path, '.');
+    var it = std.mem.splitScalar(u8, collapsed, '.');
     var first = true;
     while (it.next()) |seg| {
         if (!first) try out.append(arena, '.');
         first = false;
         try appendSegment(arena, &out, seg);
+    }
+    return out.toOwnedSlice(arena);
+}
+
+fn collapseSerializedArrayPath(arena: std.mem.Allocator, path: []const u8) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    var rest = path;
+    while (rest.len != 0) {
+        if (std.mem.indexOf(u8, rest, ".Array.data[")) |index| {
+            try out.appendSlice(arena, rest[0..index]);
+            try out.append(arena, '[');
+            rest = rest[index + ".Array.data[".len ..];
+            continue;
+        }
+        if (std.mem.indexOf(u8, rest, ".Array.size")) |index| {
+            try out.appendSlice(arena, rest[0..index]);
+            try out.appendSlice(arena, ".size");
+            rest = rest[index + ".Array.size".len ..];
+            continue;
+        }
+        try out.appendSlice(arena, rest);
+        break;
     }
     return out.toOwnedSlice(arena);
 }

--- a/core/src/instantiate.zig
+++ b/core/src/instantiate.zig
@@ -21,10 +21,11 @@ const Ctx = struct {
     guids: std.StringArrayHashMapUnmanaged(void) = .empty,
     // guids of the ancestor chain (cycle guard). Reusing the same source among siblings is allowed.
     chain: std.ArrayList([]const u8) = .empty,
+    fd: diffmod.FlatDiff = undefined,
 };
 
 pub fn expand(arena: std.mem.Allocator, res: *model.DiffResult, fd: diffmod.FlatDiff, assets: *const Assets) !void {
-    var ctx = Ctx{ .arena = arena, .assets = assets };
+    var ctx = Ctx{ .arena = arena, .assets = assets, .fd = fd };
     // Merge source-derived external references (scripts/materials etc.) into the
     // top-level unresolvedGuids so they too become subject to host resolution.
     for (res.unresolved_guids) |g| try ctx.guids.put(arena, g, {});
@@ -51,6 +52,10 @@ fn neededSlice(ctx: *Ctx) ![]model.NeededSource {
 fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *model.Document), depth: usize) !void {
     for (node.children) |*child| try expandNode(ctx, child, docs, depth);
     if (node.kind != .prefab_instance) return;
+    if (node.status == .modified) {
+        try expandModified(ctx, node, depth);
+        return;
+    }
     if (node.status != .added and node.status != .removed) return;
     const guid = node.source_guid orelse return;
     if (depth >= model.max_prefab_nesting or inChain(ctx, guid)) return;
@@ -102,6 +107,57 @@ fn expandNode(ctx: *Ctx, node: *model.ObjectDiff, docs: *std.AutoHashMap(i64, *m
     // Keep unapplied mods as rows (don't drop them silently).
     const leftover = try diff_overrides.soleInstanceOverridesSkipping(ctx.arena, inst_doc, node.status, &applied);
     node.overrides = try concatOverrides(ctx.arena, leftover, inner_overrides);
+}
+
+fn expandModified(ctx: *Ctx, node: *model.ObjectDiff, depth: usize) !void {
+    const guid = node.source_guid orelse return;
+    if (depth >= model.max_prefab_nesting or inChain(ctx, guid)) return;
+    const bytes = ctx.assets.get(guid) orelse {
+        try ctx.needed.put(ctx.arena, guid, .after);
+        return;
+    };
+    const before_inst = documentById(ctx.fd.before, node.file_id) orelse return;
+    const after_inst = documentById(ctx.fd.after, node.file_id) orelse return;
+    const src_before = parser.parse(ctx.arena, bytes) catch |err| switch (err) {
+        error.NestingTooDeep => return,
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    const src_after = parser.parse(ctx.arena, bytes) catch |err| switch (err) {
+        error.NestingTooDeep => return,
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    applyRemovedComponents(before_inst, src_before);
+    applyRemovedComponents(after_inst, src_after);
+    var applied = try applyModifications(ctx.arena, after_inst, src_after, guid);
+    _ = try applyModifications(ctx.arena, before_inst, src_before, guid);
+    const sub_fd = try diffmod.computeParsed(ctx.arena, src_before, src_after);
+    for (sub_fd.unresolved_guids) |g| try ctx.guids.put(ctx.arena, g, {});
+    node.overrides = try overridesFromResolved(ctx.arena, sub_fd);
+    const leftover = try diff_overrides.soleInstanceOverridesSkipping(ctx.arena, after_inst, .added, &applied);
+    node.overrides = try concatOverrides(ctx.arena, node.overrides, leftover);
+}
+
+fn documentById(documents: []model.Document, file_id: i64) ?*model.Document {
+    for (documents) |*document| {
+        if (document.file_id == file_id) return document;
+    }
+    return null;
+}
+
+fn overridesFromResolved(arena: std.mem.Allocator, fd: diffmod.FlatDiff) ![]model.OverrideDiff {
+    var out: std.ArrayList(model.OverrideDiff) = .empty;
+    for (fd.docs) |doc| {
+        for (doc.component.fields) |field| {
+            try out.append(arena, .{
+                .group = doc.component.type_name,
+                .label = field.path,
+                .status = field.status,
+                .before = field.before,
+                .after = field.after,
+            });
+        }
+    }
+    return out.toOwnedSlice(arena);
 }
 
 fn concatOverrides(arena: std.mem.Allocator, a: []model.OverrideDiff, b: []model.OverrideDiff) ![]model.OverrideDiff {
@@ -156,30 +212,37 @@ const AppliedSet = std.StringHashMapUnmanaged(void);
 // Returns the key set of mods that were applied or pushed down (for the leftover degraded view).
 fn applyModifications(arena: std.mem.Allocator, inst_doc: *const model.Document, src_docs: []model.Document, source_guid: []const u8) !AppliedSet {
     var applied: AppliedSet = .empty;
+    var mods: std.ArrayList(prefab.Modification) = .empty;
     var iterator = prefab.modifications(inst_doc);
-    while (iterator.next()) |modification| {
-        const target = modification.target orelse continue;
-        const target_guid = target.guid orelse continue;
-        if (!std.mem.eql(u8, target_guid, source_guid)) continue;
-        const effective_value = modification.effectiveValue() orelse continue;
-        var handled = false;
-        for (src_docs) |*doc| {
-            if (doc.file_id != target.file_id) continue;
-            setByPropertyPath(doc.body, modification.property_path, effective_value);
-            handled = true;
-            break;
+    while (iterator.next()) |modification| try mods.append(arena, modification);
+    // Array.size must run before Array.data[i] so later indices exist.
+    for ([_]bool{ true, false }) |sizes_only| {
+        for (mods.items) |modification| {
+            const is_size = std.mem.endsWith(u8, modification.property_path, ".Array.size");
+            if (is_size != sizes_only) continue;
+            const target = modification.target orelse continue;
+            const target_guid = target.guid orelse continue;
+            if (!std.mem.eql(u8, target_guid, source_guid)) continue;
+            const effective_value = modification.effectiveValue() orelse continue;
+            var handled = false;
+            for (src_docs) |*doc| {
+                if (doc.file_id != target.file_id) continue;
+                try setByPropertyPath(arena, doc.body, modification.property_path, effective_value);
+                handled = true;
+                break;
+            }
+            if (!handled) {
+                handled = try pushDown(
+                    arena,
+                    src_docs,
+                    target.file_id,
+                    modification.property_path,
+                    modification.value,
+                    modification.object_reference,
+                );
+            }
+            if (handled) try applied.put(arena, try modification.key(arena), {});
         }
-        if (!handled) {
-            handled = try pushDown(
-                arena,
-                src_docs,
-                target.file_id,
-                modification.property_path,
-                modification.value,
-                modification.object_reference,
-            );
-        }
-        if (handled) try applied.put(arena, try modification.key(arena), {});
     }
     return applied;
 }
@@ -222,7 +285,7 @@ fn appendMod(arena: std.mem.Allocator, pi_doc: *model.Document, inner_id: i64, p
 
 // Replace a leaf via a path like "m_LocalScale.y" / "m_Materials.Array.data[0]".
 // Paths with a missing intermediate or a type mismatch are silently dropped (safe side, since this is display merging).
-fn setByPropertyPath(body: *model.Node, path: []const u8, value: *model.Node) void {
+fn setByPropertyPath(arena: std.mem.Allocator, body: *model.Node, path: []const u8, value: *model.Node) !void {
     var cur: *model.Node = body;
     var it = std.mem.splitScalar(u8, path, '.');
     var pending: ?[]const u8 = it.next();
@@ -231,6 +294,12 @@ fn setByPropertyPath(body: *model.Node, path: []const u8, value: *model.Node) vo
         if (std.mem.eql(u8, seg, "Array")) {
             pending = next;
             continue; // Unity's virtual segment
+        }
+        if (std.mem.eql(u8, seg, "size") and next == null) {
+            if (cur.* != .seq or value.* != .scalar) return;
+            const count = std.fmt.parseInt(usize, value.scalar, 10) catch return;
+            try resizeSequence(arena, cur, count);
+            return;
         }
         if (std.mem.startsWith(u8, seg, "data[")) {
             const close = std.mem.indexOfScalar(u8, seg, ']') orelse return;
@@ -245,20 +314,45 @@ fn setByPropertyPath(body: *model.Node, path: []const u8, value: *model.Node) vo
             continue;
         }
         if (cur.* != .map) return;
-        var advanced = false;
+        var found: ?*model.Node = null;
         for (cur.map) |*e| {
             if (!std.mem.eql(u8, e.key, seg)) continue;
-            if (next == null) {
-                e.value = value;
-                return;
-            }
-            cur = e.value;
-            advanced = true;
+            found = e.value;
             break;
         }
-        if (!advanced) return;
+        if (found == null) {
+            const created = try arena.create(model.Node);
+            created.* = if (next == null) value.* else .{ .map = &.{} };
+            const grown = try arena.alloc(model.Entry, cur.map.len + 1);
+            @memcpy(grown[0..cur.map.len], cur.map);
+            grown[cur.map.len] = .{ .key = seg, .value = created };
+            cur.map = grown;
+            if (next == null) return;
+            found = created;
+        } else if (next == null) {
+            found.?.* = value.*;
+            return;
+        }
+        cur = found.?;
         pending = next;
     }
+}
+
+fn resizeSequence(arena: std.mem.Allocator, sequence: *model.Node, count: usize) !void {
+    if (sequence.* != .seq) return;
+    if (count == sequence.seq.len) return;
+    if (count < sequence.seq.len) {
+        sequence.seq = sequence.seq[0..count];
+        return;
+    }
+    const grown = try arena.alloc(*model.Node, count);
+    @memcpy(grown[0..sequence.seq.len], sequence.seq);
+    for (grown[sequence.seq.len..]) |*item| {
+        const empty = try arena.create(model.Node);
+        empty.* = .{ .map = &.{} };
+        item.* = empty;
+    }
+    sequence.seq = grown;
 }
 
 const testing = std.testing;
@@ -558,16 +652,75 @@ test "instantiate: setByPropertyPath handles nested and array paths" {
     var value = model.Node{ .scalar = "9" };
 
     // Nested path.
-    setByPropertyPath(docs[0].body, "m_LocalScale.y", &value);
+    try setByPropertyPath(arena, docs[0].body, "m_LocalScale.y", &value);
     const scale = model.findValue(docs[0].body.map, "m_LocalScale").?;
     try testing.expectEqualStrings("9", scale.get("y").?.scalar);
 
     // Array.data[i] path (leaf replacement).
-    setByPropertyPath(docs[0].body, "m_Materials.Array.data[1]", &value);
+    try setByPropertyPath(arena, docs[0].body, "m_Materials.Array.data[1]", &value);
     const mats = model.findValue(docs[0].body.map, "m_Materials").?;
     try testing.expectEqualStrings("9", mats.seq[1].scalar);
 
     // A missing path and an out-of-range index are no-ops (no panic).
-    setByPropertyPath(docs[0].body, "m_Missing.x", &value);
-    setByPropertyPath(docs[0].body, "m_Materials.Array.data[99]", &value);
+    try setByPropertyPath(arena, docs[0].body, "m_Missing.x", &value);
+    try setByPropertyPath(arena, docs[0].body, "m_Materials.Array.data[99]", &value);
+
+    var size = model.Node{ .scalar = "3" };
+    try setByPropertyPath(arena, docs[0].body, "m_Materials.Array.size", &size);
+    try testing.expectEqual(@as(usize, 3), model.findValue(docs[0].body.map, "m_Materials").?.seq.len);
+
+    var speed = model.Node{ .scalar = "9" };
+    try setByPropertyPath(arena, docs[0].body, "m_Materials.Array.data[2].speed", &speed);
+    try testing.expectEqualStrings("9", model.findValue(docs[0].body.map, "m_Materials").?.seq[2].get("speed").?.scalar);
+}
+
+test "instantiate: modified variant collection overrides show resolved item paths" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+    const source =
+        \\--- !u!1 &10
+        \\GameObject:
+        \\  m_Name: Enemy
+        \\  m_Component:
+        \\  - component: {fileID: 50}
+        \\--- !u!114 &50
+        \\MonoBehaviour:
+        \\  m_GameObject: {fileID: 10}
+        \\  m_Script: {fileID: 11500000, guid: scriptguid, type: 3}
+        \\  items:
+        \\  - speed: 1
+        \\  - speed: 2
+    ;
+    const before =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications: []
+        \\  m_SourcePrefab: {fileID: 100100000, guid: srcguid, type: 3}
+    ;
+    const after =
+        \\--- !u!1001 &1001
+        \\PrefabInstance:
+        \\  m_Modification:
+        \\    m_Modifications:
+        \\    - target: {fileID: 50, guid: srcguid, type: 3}
+        \\      propertyPath: items.Array.size
+        \\      value: 3
+        \\    - target: {fileID: 50, guid: srcguid, type: 3}
+        \\      propertyPath: items.Array.data[2].speed
+        \\      value: 9
+        \\  m_SourcePrefab: {fileID: 100100000, guid: srcguid, type: 3}
+    ;
+    var assets: Assets = .empty;
+    try assets.put(arena, "srcguid", source);
+    const res = try root.diffBytesWithAssets(arena, before, after, &assets);
+    var saw = false;
+    for (res.roots[0].overrides) |row| {
+        if (!std.mem.eql(u8, row.label, "Items[2].Speed")) continue;
+        saw = true;
+        try testing.expectEqual(model.Status.added, row.status);
+        try testing.expectEqualStrings("9", row.after.?.scalar);
+    }
+    try testing.expect(saw);
 }

--- a/core/src/merge.zig
+++ b/core/src/merge.zig
@@ -657,7 +657,66 @@ fn collectionTestContext(field: @import("merge_context.zig").Field, arena: std.m
     return .{ .base = snapshot, .ours = snapshot, .theirs = snapshot, .output = snapshot };
 }
 
-test "collection public key value arrays require declared ordered types" {
+test "collection public key value arrays keep block YAML after taking one side" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix =
+        "--- !u!114 &1\n" ++
+        "MonoBehaviour:\n" ++
+        "  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n" ++
+        "  m_Stats:\n";
+    const base = prefix ++
+        "  - key: Goblin\n" ++
+        "    value: 1\n";
+    const ours = prefix ++
+        "  - key: Goblin\n" ++
+        "    value: 2\n" ++
+        "  - key: Dragon\n" ++
+        "    value: 9\n";
+    const theirs = prefix ++
+        "  - key: Goblin\n" ++
+        "    value: 3\n" ++
+        "  - key: Slime\n" ++
+        "    value: 2\n";
+    var merged = try build(arena, base, ours, theirs);
+    try testing.expectEqual(@as(usize, 1), merged.plan.unresolvedCount());
+    try resolve(arena, &merged.plan, merged.plan.operations[0].id, .{ .take = .theirs });
+    // Independent keys must keep their source pair layout. A reconstructed flow map
+    // is not the same YAML Unity wrote for the chosen side.
+    try testing.expectEqualStrings(
+        prefix ++
+            "  - key: Goblin\n" ++
+            "    value: 3\n" ++
+            "  - key: Dragon\n" ++
+            "    value: 9\n" ++
+            "  - key: Slime\n" ++
+            "    value: 2\n",
+        try finish(arena, &merged.plan),
+    );
+}
+
+test "collection public key value arrays accept a custom scalar pair value" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n";
+    var merged = try build(
+        arena,
+        prefix ++ "  - key: Goblin\n    value: 1\n",
+        prefix ++ "  - key: Goblin\n    value: 2\n  - key: Dragon\n    value: 9\n",
+        prefix ++ "  - key: Goblin\n    value: 3\n  - key: Slime\n    value: 2\n",
+    );
+    // Semantic Result edits send the Value cell, not a reconstructed pair. That
+    // scalar must still keep Goblin's key and the independent Dragon / Slime items.
+    try resolve(arena, &merged.plan, merged.plan.operations[0].id, .{ .custom = "4" });
+    try testing.expectEqualStrings(
+        prefix ++ "  - key: Goblin\n    value: 4\n  - key: Dragon\n    value: 9\n  - key: Slime\n    value: 2\n",
+        try finish(arena, &merged.plan),
+    );
+}
+
+test "collection public key value arrays merge by key without a schema" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);
     defer memory.deinit();
     const arena = memory.allocator();
@@ -666,8 +725,8 @@ test "collection public key value arrays require declared ordered types" {
     const ours = prefix ++ "[{key: a, value: 1}]\n";
     const theirs = prefix ++ "[{key: b, value: 2}]\n";
     var unknown = try build(arena, base, ours, theirs);
-    try testing.expectEqualStrings(ours, unknown.partial);
-    try testing.expectEqual(@import("merge_value.zig").Reason.context_required, collectionConflict(&unknown.plan, unknown.plan.operations[0].id).?.reason);
+    try testing.expectEqual(@as(usize, 0), unknown.plan.unresolvedCount());
+    try testing.expectEqualStrings(prefix ++ "[{key: a, value: 1}, {key: b, value: 2}]\n", unknown.partial);
     const ordered_context = try collectionTestContext(.{ .path = "values", .kind = .ordered }, arena);
     var ordered = try buildWithContext(arena, base, ours, theirs, ordered_context);
     try testing.expect(collectionConflict(&ordered.plan, ordered.plan.operations[0].id).?.both_orders);

--- a/core/src/merge.zig
+++ b/core/src/merge.zig
@@ -253,8 +253,17 @@ pub const CollectionConflict = struct { reason: @import("merge_value.zig").Reaso
 pub fn collectionConflict(plan: *const MergePlan, operation_id: OperationId) ?CollectionConflict {
     const operation = merge_model.operationByIdConst(plan, operation_id) orelse return null;
     const ref = operation.collection orelse return null;
-    const conflict = plan.collections[ref.binding].plan.conflicts[ref.conflict];
-    return .{ .reason = conflict.reason, .both_orders = conflict.reason == .insertion_order };
+    const collection = plan.collections[ref.binding];
+    const conflict = collection.plan.conflicts[ref.conflict];
+    return .{ .reason = conflict.reason, .both_orders = offersBothOrders(collection.plan, conflict) };
+}
+fn offersBothOrders(plan: @import("merge_value.zig").Plan, conflict: @import("merge_value.zig").Conflict) bool {
+    if (conflict.reason != .insertion_order) return false;
+    if (plan.input.schema) |schema| return schema.kind != .dictionary;
+    return switch (@import("merge_dictionary.zig").detect(conflict.nodes.base, conflict.nodes.ours, conflict.nodes.theirs)) {
+        .shape => false,
+        else => true,
+    };
 }
 pub fn combinedCollectionValue(arena: std.mem.Allocator, plan: *const MergePlan, operation_id: OperationId, order: @import("merge_value.zig").Order) Error![]const u8 {
     const operation = merge_model.operationByIdConst(plan, operation_id) orelse return error.InvalidResolution;
@@ -730,6 +739,36 @@ test "collection public key value arrays merge by key without a schema" {
     const ordered_context = try collectionTestContext(.{ .path = "values", .kind = .ordered }, arena);
     var ordered = try buildWithContext(arena, base, ours, theirs, ordered_context);
     try testing.expect(collectionConflict(&ordered.plan, ordered.plan.operations[0].id).?.both_orders);
+}
+
+test "collection public dictionary reorder conflict does not offer both orders" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n";
+    var merged = try build(
+        arena,
+        prefix ++ "  - key: a\n    value: 1\n  - key: b\n    value: 2\n  - key: c\n    value: 3\n",
+        prefix ++ "  - key: c\n    value: 3\n  - key: b\n    value: 2\n  - key: a\n    value: 1\n",
+        prefix ++ "  - key: b\n    value: 2\n  - key: a\n    value: 1\n  - key: c\n    value: 3\n",
+    );
+    try testing.expectEqual(@as(usize, 1), merged.plan.unresolvedCount());
+    const conflict = collectionConflict(&merged.plan, merged.plan.operations[0].id).?;
+    // Concatenating pair sequences would duplicate keys. Dictionaries only
+    // accept one side's order, unlike ordered arrays.
+    try testing.expectEqual(@import("merge_value.zig").Reason.insertion_order, conflict.reason);
+    try testing.expect(!conflict.both_orders);
+}
+
+test "collection public packed integer insertion order still offers both orders" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const context = try collectionTestContext(.{ .path = "values", .kind = .int32_array }, arena);
+    const prefix = "--- !u!114 &1\nMonoBehaviour:\n  m_Script: {fileID: 11500000, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n  values: ";
+    var built = try buildWithContext(arena, prefix ++ "01000000\n", prefix ++ "0100000002000000\n", prefix ++ "0100000003000000\n", context);
+    // Packed int[] uses the same Both sides insertion-order choice as ordered arrays.
+    try testing.expect(collectionConflict(&built.plan, built.plan.operations[0].id).?.both_orders);
 }
 
 test "collection public missing array type evidence stays editable" {

--- a/core/src/merge_binding.zig
+++ b/core/src/merge_binding.zig
@@ -35,19 +35,25 @@ pub fn collect(arena: std.mem.Allocator, state: *State, operations: *std.ArrayLi
     for (plan.conflicts, 0..) |c, i| {
         const id: mm.OperationId = @intCast(operations.items.len);
         const atomic_id: mm.AtomicId = @intCast(atomics.items.len);
-        try operations.append(arena, .{ .id = id, .atomic_id = atomic_id, .kind = .field, .identity = .{ .document = document, .property_path = path }, .hierarchy_path = hierarchy, .property_path = path, .item_path = if (c.path.len > 0) c.path else null, .values = .{ .base = try side(arena, c.nodes.base), .ours = try side(arena, c.nodes.ours), .theirs = try side(arena, c.nodes.theirs) }, .resolution = .unresolved, .collection = .{ .binding = binding_id, .conflict = i } });
+        try operations.append(arena, .{ .id = id, .atomic_id = atomic_id, .kind = .field, .identity = .{ .document = document, .property_path = path }, .hierarchy_path = hierarchy, .property_path = path, .item_path = if (c.path.len > 0) c.path else null, .values = .{ .base = try side(arena, c.nodes.base, files), .ours = try side(arena, c.nodes.ours, files), .theirs = try side(arena, c.nodes.theirs, files) }, .resolution = .unresolved, .collection = .{ .binding = binding_id, .conflict = i } });
         const members = try arena.dupe(mm.OperationId, &.{id});
         try atomics.append(arena, .{ .id = atomic_id, .kind = .field, .operation_ids = members });
         try ids.append(arena, id);
     }
     try state.bindings.append(arena, .{ .plan = plan, .source_nodes = nodes, .original = original, .identity = .{ .document = document, .property_path = path }, .operation_ids = try ids.toOwnedSlice(arena) });
 }
-fn side(arena: std.mem.Allocator, n: ?*const model.Node) mm.Error!?mm.SideValue {
+fn side(arena: std.mem.Allocator, n: ?*const model.Node, files: [3]source.ParsedFile) mm.Error!?mm.SideValue {
     const v = n orelse return null;
-    return .{ .node = v, .span = null, .bytes = yaml.flow(arena, v) catch |err| switch (err) {
-        error.OutOfMemory => return error.OutOfMemory,
-        else => return error.InvalidResolution,
-    } };
+    const bytes = blk: {
+        for (files) |file| {
+            if (file.sequenceItemBytes(v)) |raw| break :blk std.mem.trim(u8, raw, "\r\n");
+        }
+        break :blk yaml.flow(arena, v) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.InvalidResolution,
+        };
+    };
+    return .{ .node = v, .span = null, .bytes = bytes };
 }
 pub fn choices(arena: std.mem.Allocator, plan: *const mm.MergePlan, binding: Binding) mm.Error![]value.Choice {
     const result = try arena.alloc(value.Choice, binding.operation_ids.len);
@@ -57,10 +63,14 @@ pub fn choices(arena: std.mem.Allocator, plan: *const mm.MergePlan, binding: Bin
             .unresolved => .unresolved,
             .remove => .remove,
             .take => |s| .{ .take = @enumFromInt(@intFromEnum(s)) },
-            .custom => |text| .{ .custom = yaml.parseValue(arena, text) catch |err| switch (err) {
-                error.OutOfMemory => return error.OutOfMemory,
-                else => return error.InvalidResolution,
-            } },
+            .custom => |text| blk: {
+                const parsed = yaml.parseValue(arena, text) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    else => return error.InvalidResolution,
+                };
+                const reference = op.collection orelse break :blk .{ .custom = parsed };
+                break :blk .{ .custom = try pairCustom(arena, binding.plan.conflicts[reference.conflict], parsed) };
+            },
         };
     }
     return result;
@@ -148,6 +158,30 @@ pub fn validateSelection(arena: std.mem.Allocator, plan: *const mm.MergePlan, re
     };
 }
 
+fn pairCustom(arena: std.mem.Allocator, conflict: value.Conflict, parsed: *const model.Node) mm.Error!*const model.Node {
+    if (conflict.sequence) {
+        if (parsed.* != .seq) return error.InvalidResolution;
+        return parsed;
+    }
+    if (parsed.* == .map or parsed.* == .seq) return parsed;
+    const template = conflict.nodes.ours orelse conflict.nodes.theirs orelse conflict.nodes.base orelse
+        return error.InvalidResolution;
+    if (template.* != .map) return parsed;
+    var value_key: ?[]const u8 = null;
+    for (template.map) |entry| {
+        if (std.mem.eql(u8, entry.key, "value") or std.mem.eql(u8, entry.key, "second")) {
+            value_key = entry.key;
+            break;
+        }
+    }
+    const value_field = value_key orelse return parsed;
+    const entries = try arena.dupe(model.Entry, template.map);
+    for (entries) |*entry| {
+        if (std.mem.eql(u8, entry.key, value_field)) entry.value = @constCast(parsed);
+    }
+    return value.node(arena, .{ .map = entries });
+}
+
 fn uniqueItem(sequence: *const model.Node, target: *const model.Node) ?*const model.Node {
     var found: ?*const model.Node = null;
     for (sequence.seq) |item| {
@@ -219,6 +253,17 @@ fn preserveItems(arena: std.mem.Allocator, result: *const model.Node, n: value.N
             changed = true;
         }
     }
+    for (items) |*item| {
+        const has_bytes = for (files) |file| {
+            if (itemBytes(file, item.*) != null) break true;
+        } else false;
+        if (has_bytes) continue;
+        const selected = uniqueItem(n.theirs.?, item.*) orelse uniqueItem(n.ours.?, item.*) orelse uniqueItem(n.base.?, item.*) orelse continue;
+        if (item.* != selected) {
+            item.* = @constCast(selected);
+            changed = true;
+        }
+    }
     return if (changed) try value.node(arena, .{ .seq = items }) else result;
 }
 
@@ -230,7 +275,7 @@ fn insertReplacement(arena: std.mem.Allocator, plan: *const mm.MergePlan, bindin
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.InvalidResolution,
     };
-    const operation: mm.Operation = .{ .id = 0, .atomic_id = 0, .kind = .field, .identity = binding.identity, .hierarchy_path = "", .property_path = binding.identity.property_path, .values = .{ .base = try side(arena, binding.source_nodes.base), .ours = null, .theirs = try side(arena, binding.source_nodes.theirs) }, .resolution = .{ .take = template_side } };
+    const operation: mm.Operation = .{ .id = 0, .atomic_id = 0, .kind = .field, .identity = binding.identity, .hierarchy_path = "", .property_path = binding.identity.property_path, .values = .{ .base = try side(arena, binding.source_nodes.base, .{ plan.base, plan.ours, plan.theirs }), .ours = null, .theirs = try side(arena, binding.source_nodes.theirs, .{ plan.base, plan.ours, plan.theirs }) }, .resolution = .{ .take = template_side } };
     const offset = try @import("merge_apply.zig").insertionOffset(plan, &operation);
     return .{ .span = .{ .start = offset, .end = offset }, .bytes = rendered.bytes };
 }

--- a/core/src/merge_context.zig
+++ b/core/src/merge_context.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub const Kind = enum { ordered, int32_array };
+pub const Kind = enum { ordered, int32_array, dictionary };
 pub const Field = struct {
     path: []const u8,
     kind: Kind,

--- a/core/src/merge_dictionary.zig
+++ b/core/src/merge_dictionary.zig
@@ -1,0 +1,175 @@
+const std = @import("std");
+const model = @import("model.zig");
+
+pub const Shape = enum { pair_key_value, pair_first_second, parallel };
+pub const Detected = union(enum) { none, malformed, shape: Shape };
+pub const Entry = struct {
+    key: *const model.Node,
+    value: *const model.Node,
+    item: *const model.Node,
+};
+
+pub const PairFields = struct { key: []const u8, value: []const u8 };
+
+pub fn pairFields(shape: Shape) ?PairFields {
+    return switch (shape) {
+        .pair_key_value => .{ .key = "key", .value = "value" },
+        .pair_first_second => .{ .key = "first", .value = "second" },
+        .parallel => null,
+    };
+}
+
+pub fn detect(base: ?*const model.Node, ours: ?*const model.Node, theirs: ?*const model.Node) Detected {
+    var found: ?Shape = null;
+    for ([_]?*const model.Node{ base, ours, theirs }) |optional| {
+        const node = optional orelse continue;
+        switch (nodeShape(node)) {
+            .none => {
+                if (node.* == .seq or node.* == .map) continue;
+                if (found != null) return .malformed;
+            },
+            .malformed => return .malformed,
+            .shape => |shape| {
+                if (found) |previous| {
+                    if (previous != shape) return .malformed;
+                } else found = shape;
+            },
+        }
+    }
+    return if (found) |shape| .{ .shape = shape } else .none;
+}
+
+fn nodeShape(node: *const model.Node) Detected {
+    if (node.* == .seq) return sequenceShape(node.seq);
+    if (node.* == .map) {
+        if (parallelShape(node)) return .{ .shape = .parallel };
+        return .none;
+    }
+    return .none;
+}
+
+fn sequenceShape(items: []const *model.Node) Detected {
+    if (items.len == 0) return .none;
+    var found: ?Shape = null;
+    var non_pair = false;
+    for (items, 0..) |item, index| {
+        const shape = pairShape(item) orelse {
+            non_pair = true;
+            continue;
+        };
+        if (found) |previous| {
+            if (previous != shape) return .malformed;
+        } else found = shape;
+        const key = pairKey(item, shape) orelse return .malformed;
+        for (items[0..index]) |previous| {
+            const previous_shape = pairShape(previous) orelse continue;
+            const previous_key = pairKey(previous, previous_shape) orelse return .malformed;
+            if (model.Node.eql(previous_key, key)) return .malformed;
+        }
+    }
+    if (found == null) return .none;
+    if (non_pair) return .malformed;
+    return .{ .shape = found.? };
+}
+
+fn pairShape(item: *const model.Node) ?Shape {
+    if (item.* != .map) return null;
+    const has_key = model.findValue(item.map, "key") != null;
+    const has_value = model.findValue(item.map, "value") != null;
+    const has_first = model.findValue(item.map, "first") != null;
+    const has_second = model.findValue(item.map, "second") != null;
+    if (has_key and has_value and !has_first and !has_second) return .pair_key_value;
+    if (has_first and has_second and !has_key and !has_value) return .pair_first_second;
+    return null;
+}
+
+fn pairKey(item: *const model.Node, shape: Shape) ?*const model.Node {
+    const fields = pairFields(shape) orelse return null;
+    return model.findValue(item.map, fields.key);
+}
+
+pub fn pairValue(item: *const model.Node, shape: Shape) ?*const model.Node {
+    const fields = pairFields(shape) orelse return null;
+    return model.findValue(item.map, fields.value);
+}
+
+fn parallelShape(node: *const model.Node) bool {
+    const keys = node.get("m_Keys") orelse return false;
+    const values = node.get("m_Values") orelse return false;
+    return keys.* == .seq and values.* == .seq and keys.seq.len == values.seq.len;
+}
+
+pub fn entries(arena: std.mem.Allocator, node: ?*const model.Node, shape: Shape) std.mem.Allocator.Error!?[]Entry {
+    const value = node orelse return &.{};
+    return switch (shape) {
+        .pair_key_value, .pair_first_second => pairEntries(arena, value, shape),
+        .parallel => parallelEntries(arena, value),
+    };
+}
+
+fn pairEntries(arena: std.mem.Allocator, node: *const model.Node, shape: Shape) std.mem.Allocator.Error!?[]Entry {
+    if (node.* != .seq) return null;
+    const fields = pairFields(shape).?;
+    const result = try arena.alloc(Entry, node.seq.len);
+    for (node.seq, result) |item, *entry| {
+        if (item.* != .map) return null;
+        entry.* = .{
+            .key = model.findValue(item.map, fields.key) orelse return null,
+            .value = model.findValue(item.map, fields.value) orelse return null,
+            .item = item,
+        };
+    }
+    return result;
+}
+
+fn parallelEntries(arena: std.mem.Allocator, node: *const model.Node) std.mem.Allocator.Error!?[]Entry {
+    if (node.* != .map) return null;
+    const keys = node.get("m_Keys") orelse return null;
+    const values = node.get("m_Values") orelse return null;
+    if (keys.* != .seq or values.* != .seq or keys.seq.len != values.seq.len) return null;
+    const result = try arena.alloc(Entry, keys.seq.len);
+    for (keys.seq, values.seq, result) |key, value, *entry| {
+        entry.* = .{ .key = key, .value = value, .item = value };
+    }
+    return result;
+}
+
+pub fn find(list: []const Entry, key: *const model.Node) ?Entry {
+    for (list) |entry| {
+        if (model.Node.eql(entry.key, key)) return entry;
+    }
+    return null;
+}
+
+pub fn contains(list: []const Entry, key: *const model.Node) bool {
+    return find(list, key) != null;
+}
+
+pub fn keyPath(arena: std.mem.Allocator, prefix: []const u8, key: *const model.Node) std.mem.Allocator.Error![]const u8 {
+    const bracket = try keyBracket(arena, key);
+    if (prefix.len == 0) return bracket;
+    return std.fmt.allocPrint(arena, "{s}{s}", .{ prefix, bracket });
+}
+
+pub fn keyBracket(arena: std.mem.Allocator, key: *const model.Node) std.mem.Allocator.Error![]const u8 {
+    if (key.* == .scalar) {
+        if (std.mem.indexOfAny(u8, key.scalar, "[]\"") == null)
+            return std.fmt.allocPrint(arena, "[{s}]", .{key.scalar});
+        return std.fmt.allocPrint(arena, "[\"{s}\"]", .{key.scalar});
+    }
+    return "[key]";
+}
+
+pub fn sharedOrderChanged(side: []const Entry, base: []const Entry) bool {
+    var side_i: usize = 0;
+    var base_i: usize = 0;
+    while (true) {
+        while (side_i < side.len and find(base, side[side_i].key) == null) side_i += 1;
+        while (base_i < base.len and find(side, base[base_i].key) == null) base_i += 1;
+        if (side_i == side.len or base_i == base.len) return side_i != side.len or base_i != base.len;
+        if (!model.Node.eql(side[side_i].key, base[base_i].key)) return true;
+        side_i += 1;
+        base_i += 1;
+    }
+}
+

--- a/core/src/merge_dictionary.zig
+++ b/core/src/merge_dictionary.zig
@@ -41,10 +41,7 @@ pub fn detect(base: ?*const model.Node, ours: ?*const model.Node, theirs: ?*cons
 
 fn nodeShape(node: *const model.Node) Detected {
     if (node.* == .seq) return sequenceShape(node.seq);
-    if (node.* == .map) {
-        if (parallelShape(node)) return .{ .shape = .parallel };
-        return .none;
-    }
+    if (node.* == .map) return parallelShape(node);
     return .none;
 }
 
@@ -93,10 +90,12 @@ pub fn pairValue(item: *const model.Node, shape: Shape) ?*const model.Node {
     return model.findValue(item.map, fields.value);
 }
 
-fn parallelShape(node: *const model.Node) bool {
-    const keys = node.get("m_Keys") orelse return false;
-    const values = node.get("m_Values") orelse return false;
-    return keys.* == .seq and values.* == .seq and keys.seq.len == values.seq.len;
+fn parallelShape(node: *const model.Node) Detected {
+    const keys = node.get("m_Keys") orelse return .none;
+    const values = node.get("m_Values") orelse return .none;
+    if (keys.* != .seq or values.* != .seq) return .none;
+    if (keys.seq.len != values.seq.len) return .malformed;
+    return .{ .shape = .parallel };
 }
 
 pub fn entries(arena: std.mem.Allocator, node: ?*const model.Node, shape: Shape) std.mem.Allocator.Error!?[]Entry {
@@ -172,4 +171,3 @@ pub fn sharedOrderChanged(side: []const Entry, base: []const Entry) bool {
         base_i += 1;
     }
 }
-

--- a/core/src/merge_planner.zig
+++ b/core/src/merge_planner.zig
@@ -1419,9 +1419,9 @@ fn collectSequence(
         if (kind == .prefab_properties) {
             const item = base_item orelse ours_item orelse theirs_item.?;
             const path = item.identity.property_path.?;
-            if (std.mem.endsWith(u8, path, ".Array.size") or std.mem.indexOf(u8, path, ".Array.data[") != null) {
-                // The ordinary override merge cannot prove that array indices
-                // still refer to the same inherited items.
+            if (std.mem.endsWith(u8, path, ".Array.size")) {
+                // A size change reshuffles inherited item identity. Value-only
+                // Array.data[i] edits keep their propertyPath key and can merge.
                 const base_node = if (base_item) |v| v.node else null;
                 const ours_node = if (ours_item) |v| v.node else null;
                 const theirs_node = if (theirs_item) |v| v.node else null;
@@ -2796,22 +2796,33 @@ test "merge planner: deletes the final child from a block sequence" {
     try testing.expectEqualStrings(inline_empty, built.partial);
 }
 
-test "merge planner: changed collection overrides require unsupported fallback" {
+test "merge planner: changed collection size overrides require unsupported fallback" {
     var memory = std.heap.ArenaAllocator.init(testing.allocator);
     defer memory.deinit();
     const arena = memory.allocator();
     const merge = @import("merge.zig");
     const prefix = "--- !u!1001 &1\nPrefabInstance:\n  m_Modification:\n    m_Modifications:\n    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n      propertyPath: ";
-    // Serialized indices do not prove the identity of inherited array items.
-    // Keep these edits out of the ordinary keyed override merge.
-    for ([_][]const u8{ "items.Array.size", "items.Array.data[0].speed" }) |path| {
-        const base = try std.fmt.allocPrint(arena, "{s}{s}\n      value: 1\n      objectReference: {{fileID: 0}}\n", .{ prefix, path });
-        const changed = try std.mem.replaceOwned(u8, arena, base, "value: 1", "value: 2");
-        try testing.expectError(error.UnsupportedStructure, merge.build(arena, base, base, changed));
-        try testing.expectError(error.UnsupportedStructure, merge.build(arena, base, changed, base));
-        const unchanged = try merge.build(arena, base, base, base);
-        try testing.expectEqualStrings(base, unchanged.partial);
-    }
+    // A size change cannot prove that later Array.data[i] rows still name the
+    // same inherited items, so keep it out of the ordinary keyed override merge.
+    const base = try std.fmt.allocPrint(arena, "{s}items.Array.size\n      value: 1\n      objectReference: {{fileID: 0}}\n", .{prefix});
+    const changed = try std.mem.replaceOwned(u8, arena, base, "value: 1", "value: 2");
+    try testing.expectError(error.UnsupportedStructure, merge.build(arena, base, base, changed));
+    try testing.expectError(error.UnsupportedStructure, merge.build(arena, base, changed, base));
+    const unchanged = try merge.build(arena, base, base, base);
+    try testing.expectEqualStrings(base, unchanged.partial);
+}
+
+test "merge planner: value-only collection data overrides merge by property path" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const merge = @import("merge.zig");
+    const prefix = "--- !u!1001 &1\nPrefabInstance:\n  m_Modification:\n    m_Modifications:\n    - target: {fileID: 40, guid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, type: 3}\n      propertyPath: items.Array.data[0].speed\n      value: ";
+    const base = prefix ++ "1\n      objectReference: {fileID: 0}\n";
+    const changed = prefix ++ "2\n      objectReference: {fileID: 0}\n";
+    const built = try merge.build(arena, base, base, changed);
+    try testing.expectEqual(@as(usize, 0), built.plan.unresolvedCount());
+    try testing.expectEqualStrings(changed, built.partial);
 }
 
 test "merge planner: rejects a structural override without its object change" {

--- a/core/src/merge_value.zig
+++ b/core/src/merge_value.zig
@@ -3,6 +3,7 @@ const model = @import("model.zig");
 const ordered = @import("merge_collection.zig");
 const context = @import("merge_context.zig");
 const packed_int = @import("merge_packed.zig");
+const dictionary = @import("merge_dictionary.zig");
 const A = std.mem.Allocator;
 pub const Side = enum { base, ours, theirs };
 pub const Nodes = struct { base: ?*const model.Node, ours: ?*const model.Node, theirs: ?*const model.Node };
@@ -47,9 +48,11 @@ pub fn build(arena: A, input: Input) Error!Plan {
                 root = try planValue(arena, &conflicts, logical, false);
             },
             .ordered => root = try planValue(arena, &conflicts, input.nodes, true),
+            .dictionary => root = try planDictionary(arena, &conflicts, input.nodes) orelse
+                try conflict(arena, &conflicts, input.nodes, .context_required, anySequence(input.nodes)),
         }
-    } else if (keyValueShape(input.nodes) and !(eql(input.nodes.base, input.nodes.ours) and eql(input.nodes.base, input.nodes.theirs))) {
-        root = try conflict(arena, &conflicts, input.nodes, .context_required, true);
+    } else if (try planDictionary(arena, &conflicts, input.nodes)) |planned| {
+        root = planned;
     } else root = try planValue(arena, &conflicts, logical, false);
     return .{ .root = root, .conflicts = try conflicts.toOwnedSlice(arena), .input = input, .packed_layout = layout, .logical_nodes = if (layout != null) logical else null };
 }
@@ -95,11 +98,283 @@ fn conflict(arena: A, list: *std.ArrayList(Conflict), n: Nodes, reason: Reason, 
     try list.append(arena, .{ .nodes = n, .reason = reason, .sequence = sequence });
     return alloc(arena, .{ .conflict = id });
 }
+
+fn planDictionary(arena: A, list: *std.ArrayList(Conflict), n: Nodes) Error!?*const Value {
+    if (n.ours == null or n.theirs == null) return null;
+    switch (dictionary.detect(n.base, n.ours, n.theirs)) {
+        .none => return null,
+        .malformed => return try conflict(arena, list, n, .context_required, anySequence(n)),
+        .shape => |shape| {
+            if (eql(n.ours, n.theirs) or eql(n.base, n.theirs)) return alloc(arena, .{ .accepted = n.ours });
+            if (eql(n.base, n.ours)) return alloc(arena, .{ .accepted = n.theirs });
+            const base_entries = (try dictionary.entries(arena, n.base, shape)) orelse
+                return try conflict(arena, list, n, .context_required, anySequence(n));
+            const ours_entries = (try dictionary.entries(arena, n.ours, shape)) orelse
+                return try conflict(arena, list, n, .context_required, anySequence(n));
+            const theirs_entries = (try dictionary.entries(arena, n.theirs, shape)) orelse
+                return try conflict(arena, list, n, .context_required, anySequence(n));
+            if (dictionary.sharedOrderChanged(ours_entries, base_entries) and
+                dictionary.sharedOrderChanged(theirs_entries, base_entries) and
+                sharedKeyOrderDiffers(ours_entries, theirs_entries))
+            {
+                return try conflict(arena, list, n, .insertion_order, true);
+            }
+            const use_theirs_order = dictionary.sharedOrderChanged(theirs_entries, base_entries) and
+                !dictionary.sharedOrderChanged(ours_entries, base_entries);
+            const primary = if (use_theirs_order) theirs_entries else ours_entries;
+            const secondary = if (use_theirs_order) ours_entries else theirs_entries;
+            const keys = try mergeKeyOrder(arena, primary, secondary);
+            return switch (shape) {
+                .pair_key_value, .pair_first_second => try planPairEntries(
+                    arena,
+                    list,
+                    shape,
+                    keys,
+                    base_entries,
+                    ours_entries,
+                    theirs_entries,
+                ),
+                .parallel => try planParallelEntries(
+                    arena,
+                    list,
+                    n,
+                    keys,
+                    base_entries,
+                    ours_entries,
+                    theirs_entries,
+                ),
+            };
+        },
+    }
+}
+
+fn sharedKeyOrderDiffers(ours: []const dictionary.Entry, theirs: []const dictionary.Entry) bool {
+    var ours_i: usize = 0;
+    var theirs_i: usize = 0;
+    while (true) {
+        while (ours_i < ours.len and dictionary.find(theirs, ours[ours_i].key) == null) ours_i += 1;
+        while (theirs_i < theirs.len and dictionary.find(ours, theirs[theirs_i].key) == null) theirs_i += 1;
+        if (ours_i == ours.len or theirs_i == theirs.len) return ours_i != ours.len or theirs_i != theirs.len;
+        if (!model.Node.eql(ours[ours_i].key, theirs[theirs_i].key)) return true;
+        ours_i += 1;
+        theirs_i += 1;
+    }
+}
+
+fn mergeKeyOrder(
+    arena: A,
+    primary: []const dictionary.Entry,
+    secondary: []const dictionary.Entry,
+) A.Error![]const *const model.Node {
+    var keys: std.ArrayList(*const model.Node) = .empty;
+    for (primary) |entry| try keys.append(arena, entry.key);
+    for (secondary) |entry| {
+        if (dictionary.contains(primary, entry.key)) continue;
+        var insert_at = keys.items.len;
+        if (indexOfEntry(secondary, entry.key)) |here| {
+            var previous = here;
+            while (previous > 0) {
+                previous -= 1;
+                if (indexOfKey(keys.items, secondary[previous].key)) |idx| {
+                    insert_at = idx + 1;
+                    while (insert_at < keys.items.len and dictionary.find(secondary, keys.items[insert_at]) == null)
+                        insert_at += 1;
+                    break;
+                }
+            }
+        }
+        try keys.insert(arena, insert_at, entry.key);
+    }
+    return keys.items;
+}
+
+fn indexOfEntry(list: []const dictionary.Entry, key: *const model.Node) ?usize {
+    for (list, 0..) |entry, i| {
+        if (model.Node.eql(entry.key, key)) return i;
+    }
+    return null;
+}
+
+fn indexOfKey(list: []const *const model.Node, key: *const model.Node) ?usize {
+    for (list, 0..) |item, i| {
+        if (model.Node.eql(item, key)) return i;
+    }
+    return null;
+}
+
+fn planPairEntries(
+    arena: A,
+    list: *std.ArrayList(Conflict),
+    shape: dictionary.Shape,
+    keys: []const *const model.Node,
+    base_entries: []const dictionary.Entry,
+    ours_entries: []const dictionary.Entry,
+    theirs_entries: []const dictionary.Entry,
+) Error!*const Value {
+    var pieces: std.ArrayList(Piece) = .empty;
+    for (keys) |key| {
+        const first_conflict = list.items.len;
+        const planned = try planDictionaryEntry(
+            arena,
+            list,
+            dictionary.find(base_entries, key),
+            dictionary.find(ours_entries, key),
+            dictionary.find(theirs_entries, key),
+            shape,
+        );
+        if (planned) |value| try pieces.append(arena, .{ .spread = false, .value = value });
+        try prefixConflicts(arena, list, first_conflict, try dictionaryKeyPath(arena, key));
+    }
+    return alloc(arena, .{ .sequence = try pieces.toOwnedSlice(arena) });
+}
+
+fn planParallelEntries(
+    arena: A,
+    list: *std.ArrayList(Conflict),
+    n: Nodes,
+    keys: []const *const model.Node,
+    base_entries: []const dictionary.Entry,
+    ours_entries: []const dictionary.Entry,
+    theirs_entries: []const dictionary.Entry,
+) Error!*const Value {
+    var key_nodes: std.ArrayList(*model.Node) = .empty;
+    var value_pieces: std.ArrayList(Piece) = .empty;
+    for (keys) |key| {
+        const first_conflict = list.items.len;
+        const base_entry = dictionary.find(base_entries, key);
+        const ours_entry = dictionary.find(ours_entries, key);
+        const theirs_entry = dictionary.find(theirs_entries, key);
+        const planned = try planDictionaryValue(
+            arena,
+            list,
+            if (base_entry) |e| e.value else null,
+            if (ours_entry) |e| e.value else null,
+            if (theirs_entry) |e| e.value else null,
+        );
+        if (planned) |value| {
+            try key_nodes.append(arena, @constCast(if (ours_entry) |e| e.key else if (theirs_entry) |e| e.key else key));
+            try value_pieces.append(arena, .{ .spread = false, .value = value });
+        }
+        try prefixConflicts(arena, list, first_conflict, try dictionaryKeyPath(arena, key));
+    }
+    var fields: std.ArrayList(Field) = .empty;
+    const template = n.ours.?;
+    if (template.* == .map) {
+        for (template.map) |entry| {
+            if (std.mem.eql(u8, entry.key, "m_Keys") or std.mem.eql(u8, entry.key, "m_Values")) continue;
+            try fields.append(arena, .{
+                .key = entry.key,
+                .value = try planValue(arena, list, .{
+                    .base = if (n.base) |base| base.get(entry.key) else null,
+                    .ours = n.ours.?.get(entry.key),
+                    .theirs = if (n.theirs) |theirs| theirs.get(entry.key) else null,
+                }, false),
+            });
+        }
+    }
+    const key_seq = try alloc(arena, .{ .accepted = try node(arena, .{ .seq = try key_nodes.toOwnedSlice(arena) }) });
+    const value_seq = try alloc(arena, .{ .sequence = try value_pieces.toOwnedSlice(arena) });
+    try fields.append(arena, .{ .key = "m_Keys", .value = key_seq });
+    try fields.append(arena, .{ .key = "m_Values", .value = value_seq });
+    return alloc(arena, .{ .map = try fields.toOwnedSlice(arena) });
+}
+
+fn planDictionaryEntry(
+    arena: A,
+    list: *std.ArrayList(Conflict),
+    base_entry: ?dictionary.Entry,
+    ours_entry: ?dictionary.Entry,
+    theirs_entry: ?dictionary.Entry,
+    shape: dictionary.Shape,
+) Error!?*const Value {
+    _ = shape;
+    if (base_entry == null) {
+        if (ours_entry == null) return alloc(arena, .{ .accepted = theirs_entry.?.item });
+        if (theirs_entry == null) return alloc(arena, .{ .accepted = ours_entry.?.item });
+        if (model.Node.eql(ours_entry.?.item, theirs_entry.?.item)) return alloc(arena, .{ .accepted = ours_entry.?.item });
+        return try conflict(arena, list, .{
+            .base = null,
+            .ours = ours_entry.?.item,
+            .theirs = theirs_entry.?.item,
+        }, .edit_edit, false);
+    }
+    if (ours_entry == null and theirs_entry == null) return null;
+    if (ours_entry == null) {
+        if (model.Node.eql(theirs_entry.?.item, base_entry.?.item)) return null;
+        return try conflict(arena, list, .{
+            .base = base_entry.?.item,
+            .ours = null,
+            .theirs = theirs_entry.?.item,
+        }, .delete_edit, false);
+    }
+    if (theirs_entry == null) {
+        if (model.Node.eql(ours_entry.?.item, base_entry.?.item)) return null;
+        return try conflict(arena, list, .{
+            .base = base_entry.?.item,
+            .ours = ours_entry.?.item,
+            .theirs = null,
+        }, .delete_edit, false);
+    }
+    if (leafDictionaryValue(ours_entry.?.value) and leafDictionaryValue(theirs_entry.?.value) and
+        leafDictionaryValue(base_entry.?.value))
+    {
+        if (eql(ours_entry.?.item, theirs_entry.?.item) or eql(base_entry.?.item, theirs_entry.?.item))
+            return alloc(arena, .{ .accepted = ours_entry.?.item });
+        if (eql(base_entry.?.item, ours_entry.?.item))
+            return alloc(arena, .{ .accepted = theirs_entry.?.item });
+        return try conflict(arena, list, .{
+            .base = base_entry.?.item,
+            .ours = ours_entry.?.item,
+            .theirs = theirs_entry.?.item,
+        }, .edit_edit, false);
+    }
+    return planValue(arena, list, .{
+        .base = base_entry.?.item,
+        .ours = ours_entry.?.item,
+        .theirs = theirs_entry.?.item,
+    }, false);
+}
+
+fn leafDictionaryValue(n: *const model.Node) bool {
+    return n.* != .map and n.* != .seq;
+}
+
+fn planDictionaryValue(
+    arena: A,
+    list: *std.ArrayList(Conflict),
+    base_value: ?*const model.Node,
+    ours_value: ?*const model.Node,
+    theirs_value: ?*const model.Node,
+) Error!?*const Value {
+    if (base_value == null) {
+        if (ours_value == null) return alloc(arena, .{ .accepted = theirs_value });
+        if (theirs_value == null) return alloc(arena, .{ .accepted = ours_value });
+        if (eql(ours_value, theirs_value)) return alloc(arena, .{ .accepted = ours_value });
+        return try conflict(arena, list, .{ .base = null, .ours = ours_value, .theirs = theirs_value }, .edit_edit, false);
+    }
+    if (ours_value == null and theirs_value == null) return null;
+    if (ours_value == null) {
+        if (eql(theirs_value, base_value)) return null;
+        return try conflict(arena, list, .{ .base = base_value, .ours = null, .theirs = theirs_value }, .delete_edit, false);
+    }
+    if (theirs_value == null) {
+        if (eql(ours_value, base_value)) return null;
+        return try conflict(arena, list, .{ .base = base_value, .ours = ours_value, .theirs = null }, .delete_edit, false);
+    }
+    return planValue(arena, list, .{ .base = base_value, .ours = ours_value, .theirs = theirs_value }, false);
+}
+
+fn dictionaryKeyPath(arena: A, key: *const model.Node) A.Error![]const u8 {
+    return dictionary.keyBracket(arena, key);
+}
+
 fn planValue(arena: A, list: *std.ArrayList(Conflict), n: Nodes, ordered_schema: bool) Error!*const Value {
     if (n.base == null and n.ours != null and n.theirs != null and n.ours.?.* == .seq and n.theirs.?.* == .seq) {
         return planValue(arena, list, .{ .base = try node(arena, .{ .seq = &.{} }), .ours = n.ours, .theirs = n.theirs }, ordered_schema);
     }
-    if (!ordered_schema and keyValueShape(n) and !(eql(n.base, n.ours) and eql(n.base, n.theirs))) return conflict(arena, list, n, .context_required, true);
+    if (!ordered_schema) {
+        if (try planDictionary(arena, list, n)) |planned| return planned;
+    }
     if (eql(n.ours, n.theirs) or eql(n.base, n.theirs)) return alloc(arena, .{ .accepted = n.ours });
     if (eql(n.base, n.ours)) return alloc(arena, .{ .accepted = n.theirs });
     if (n.base != null and n.ours != null and n.theirs != null and n.base.?.* == .map and n.ours.?.* == .map and n.theirs.?.* == .map) {
@@ -312,17 +587,6 @@ fn decodePackedNode(arena: A, n: ?*const model.Node) Error!?*const model.Node {
 fn decodePackedNodes(arena: A, n: Nodes) Error!Nodes {
     return .{ .base = try decodePackedNode(arena, n.base), .ours = try decodePackedNode(arena, n.ours), .theirs = try decodePackedNode(arena, n.theirs) };
 }
-fn keyValueShape(n: Nodes) bool {
-    for ([_]?*const model.Node{ n.base, n.ours, n.theirs }) |optional| {
-        if (optional) |v| {
-            if (v.* != .seq) continue;
-            for (v.seq) |item| {
-                if (item.* == .map and model.findValue(item.map, "key") != null and model.findValue(item.map, "value") != null) return true;
-            }
-        }
-    }
-    return false;
-}
 
 test "value materialization preserves leaf pointer provenance" {
     var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -359,4 +623,68 @@ test "value packed byte-only choices retain their source or expose a conflict" {
     try std.testing.expectEqual(Reason.source_bytes, plan.conflicts[0].reason);
     const selected = (try materialize(arena, plan, &.{.{ .take = .theirs }})).?;
     try std.testing.expect(selected == t);
+}
+
+test "value keyed pairs merge independent key insertions" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const yaml = @import("merge_yaml.zig");
+    const b = try yaml.parseValue(arena, "[{key: a, value: 1}]");
+    const o = try yaml.parseValue(arena, "[{key: a, value: 1}, {key: b, value: 2}]");
+    const t = try yaml.parseValue(arena, "[{key: a, value: 1}, {key: c, value: 3}]");
+    const plan = try build(arena, .{ .nodes = .{ .base = b, .ours = o, .theirs = t } });
+    try std.testing.expectEqual(@as(usize, 0), plan.conflicts.len);
+    const result = (try materialize(arena, plan, &.{})).?;
+    try std.testing.expectEqual(@as(usize, 3), result.seq.len);
+    try std.testing.expectEqualStrings("a", model.findValue(result.seq[0].map, "key").?.scalar);
+    try std.testing.expectEqualStrings("b", model.findValue(result.seq[1].map, "key").?.scalar);
+    try std.testing.expectEqualStrings("c", model.findValue(result.seq[2].map, "key").?.scalar);
+    try std.testing.expectEqualStrings("2", model.findValue(result.seq[1].map, "value").?.scalar);
+    try std.testing.expectEqualStrings("3", model.findValue(result.seq[2].map, "value").?.scalar);
+}
+
+test "value keyed pairs conflict when both sides edit the same key" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const yaml = @import("merge_yaml.zig");
+    const b = try yaml.parseValue(arena, "[{key: a, value: 1}]");
+    const o = try yaml.parseValue(arena, "[{key: a, value: 2}]");
+    const t = try yaml.parseValue(arena, "[{key: a, value: 3}]");
+    const plan = try build(arena, .{ .nodes = .{ .base = b, .ours = o, .theirs = t } });
+    try std.testing.expectEqual(@as(usize, 1), plan.conflicts.len);
+    try std.testing.expectEqual(Reason.edit_edit, plan.conflicts[0].reason);
+    try std.testing.expectEqualStrings("[a]", plan.conflicts[0].path);
+}
+
+test "value keyed first-second pairs and parallel keys merge by key" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const yaml = @import("merge_yaml.zig");
+    const pair_b = try yaml.parseValue(arena, "[{first: a, second: 1}]");
+    const pair_o = try yaml.parseValue(arena, "[{first: a, second: 1}, {first: b, second: 2}]");
+    const pair_t = try yaml.parseValue(arena, "[{first: a, second: 1}, {first: c, second: 3}]");
+    const pair_plan = try build(arena, .{ .nodes = .{ .base = pair_b, .ours = pair_o, .theirs = pair_t } });
+    try std.testing.expectEqual(@as(usize, 0), pair_plan.conflicts.len);
+    const pair = (try materialize(arena, pair_plan, &.{})).?;
+    try std.testing.expectEqual(@as(usize, 3), pair.seq.len);
+    try std.testing.expectEqualStrings("b", model.findValue(pair.seq[1].map, "first").?.scalar);
+    try std.testing.expectEqualStrings("c", model.findValue(pair.seq[2].map, "first").?.scalar);
+
+    const par_b = try yaml.parseValue(arena, "{m_Keys: [a], m_Values: [1]}");
+    try std.testing.expect(par_b.* == .map);
+    try std.testing.expect(par_b.get("m_Keys").?.* == .seq);
+    const par_o = try yaml.parseValue(arena, "{m_Keys: [a, b], m_Values: [1, 2]}");
+    const par_t = try yaml.parseValue(arena, "{m_Keys: [a, c], m_Values: [1, 3]}");
+    const par_plan = try build(arena, .{ .nodes = .{ .base = par_b, .ours = par_o, .theirs = par_t } });
+    try std.testing.expectEqual(@as(usize, 0), par_plan.conflicts.len);
+    const par = (try materialize(arena, par_plan, &.{})).?;
+    try std.testing.expectEqual(@as(usize, 3), par.get("m_Keys").?.seq.len);
+    try std.testing.expectEqualStrings("a", par.get("m_Keys").?.seq[0].scalar);
+    try std.testing.expectEqualStrings("b", par.get("m_Keys").?.seq[1].scalar);
+    try std.testing.expectEqualStrings("c", par.get("m_Keys").?.seq[2].scalar);
+    try std.testing.expectEqualStrings("2", par.get("m_Values").?.seq[1].scalar);
+    try std.testing.expectEqualStrings("3", par.get("m_Values").?.seq[2].scalar);
 }

--- a/core/src/merge_value.zig
+++ b/core/src/merge_value.zig
@@ -688,3 +688,56 @@ test "value keyed first-second pairs and parallel keys merge by key" {
     try std.testing.expectEqualStrings("2", par.get("m_Values").?.seq[1].scalar);
     try std.testing.expectEqualStrings("3", par.get("m_Values").?.seq[2].scalar);
 }
+
+test "value keyed pairs report delete/edit when one side removes a changed key" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const yaml = @import("merge_yaml.zig");
+    const b = try yaml.parseValue(arena, "[{key: a, value: 1}]");
+    const o = try yaml.parseValue(arena, "[]");
+    const t = try yaml.parseValue(arena, "[{key: a, value: 2}]");
+    const plan = try build(arena, .{ .nodes = .{ .base = b, .ours = o, .theirs = t } });
+    // Taking Theirs would restore a key Ours deleted. The conflict has to stay
+    // explicit instead of auto-keeping the edited pair.
+    try std.testing.expectEqual(@as(usize, 1), plan.conflicts.len);
+    try std.testing.expectEqual(Reason.delete_edit, plan.conflicts[0].reason);
+    try std.testing.expectEqualStrings("[a]", plan.conflicts[0].path);
+}
+
+test "value keyed pairs keep the side that reorders shared keys" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const yaml = @import("merge_yaml.zig");
+    const b = try yaml.parseValue(arena, "[{key: a, value: 1}, {key: b, value: 2}]");
+    const o = try yaml.parseValue(arena, "[{key: a, value: 1}, {key: b, value: 2}]");
+    const t = try yaml.parseValue(arena, "[{key: b, value: 2}, {key: a, value: 1}]");
+    const plan = try build(arena, .{ .nodes = .{ .base = b, .ours = o, .theirs = t } });
+    try std.testing.expectEqual(@as(usize, 0), plan.conflicts.len);
+    const result = (try materialize(arena, plan, &.{})).?;
+    try std.testing.expectEqualStrings("b", model.findValue(result.seq[0].map, "key").?.scalar);
+    try std.testing.expectEqualStrings("a", model.findValue(result.seq[1].map, "key").?.scalar);
+}
+
+test "value keyed collections stay unresolved when YAML is malformed" {
+    var memory = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const yaml = @import("merge_yaml.zig");
+    const cases = [_][3][]const u8{
+        .{ "[{key: a, value: 1}]", "[{key: a, value: 1}, {key: a, value: 2}]", "[{key: a, value: 1}]" },
+        .{ "{m_Keys: [a], m_Values: [1]}", "{m_Keys: [a, b], m_Values: [1]}", "{m_Keys: [a], m_Values: [1]}" },
+    };
+    for (cases) |sides| {
+        const plan = try build(arena, .{ .nodes = .{
+            .base = try yaml.parseValue(arena, sides[0]),
+            .ours = try yaml.parseValue(arena, sides[1]),
+            .theirs = try yaml.parseValue(arena, sides[2]),
+        } });
+        // Duplicate keys and m_Keys/m_Values length mismatch cannot prove identity.
+        try std.testing.expectEqual(@as(usize, 1), plan.conflicts.len);
+        try std.testing.expectEqual(Reason.context_required, plan.conflicts[0].reason);
+        try std.testing.expectEqualStrings("", plan.conflicts[0].path);
+    }
+}

--- a/core/src/merge_yaml.zig
+++ b/core/src/merge_yaml.zig
@@ -230,10 +230,7 @@ pub fn replaceEntry(
                 break;
             }
             if (!preserved) {
-                try output.appendNTimes(arena, ' ', indent);
-                try output.appendSlice(arena, "- ");
-                try appendFlow(arena, &output, item, 0);
-                try output.appendSlice(arena, ending);
+                try appendReconstructedItem(arena, &output, item, indent, ending);
             }
         }
     } else {
@@ -249,6 +246,33 @@ pub fn replaceEntry(
         } else try output.appendSlice(arena, ours.bytes[value_span.end..span.end]);
     }
     return .{ .span = span, .bytes = try output.toOwnedSlice(arena) };
+}
+
+fn appendReconstructedItem(
+    arena: std.mem.Allocator,
+    output: *std.ArrayList(u8),
+    item: *const model.Node,
+    indent: usize,
+    ending: []const u8,
+) Error!void {
+    try output.appendNTimes(arena, ' ', indent);
+    try output.appendSlice(arena, "- ");
+    if (item.* == .map and item.map.len > 0) {
+        for (item.map, 0..) |entry, i| {
+            if (i != 0) {
+                try output.appendNTimes(arena, ' ', indent + 2);
+            }
+            try validatePlain(entry.key, true);
+            if (entry.key[0] == '"' or entry.key[0] == '\'') _ = try decodeScalar(arena, entry.key);
+            try output.appendSlice(arena, entry.key);
+            try output.appendSlice(arena, ": ");
+            try appendFlow(arena, output, entry.value, 0);
+            try output.appendSlice(arena, ending);
+        }
+        return;
+    }
+    try appendFlow(arena, output, item, 0);
+    try output.appendSlice(arena, ending);
 }
 
 fn lineEnd(bytes: []const u8, offset: usize) usize {
@@ -454,6 +478,20 @@ test "regression compact nested collection" {
     const merged = try std.fmt.allocPrint(al, "{s}{s}{s}", .{ f.bytes[0..patch.span.start], patch.bytes, f.bytes[patch.span.end..] });
     const parsed = try parser.parseSpanned(al, merged);
     try std.testing.expectEqual(@as(usize, 0), parsed.diagnostics.len);
+}
+test "collection YAML writes reconstructed dictionary pairs as block items" {
+    var memory = std.heap.ArenaAllocator.init(testing.allocator);
+    defer memory.deinit();
+    const arena = memory.allocator();
+    const parsed = try parser.parseSpanned(arena, "--- !u!114 &1\nMonoBehaviour:\n  m_Stats:\n  - key: Goblin\n    value: 3\n");
+    const stats = model.findValue(parsed.documents[0].body.map, "m_Stats").?;
+    const custom = try parseValue(arena, "key: Goblin\nvalue: 4");
+    var items = [_]*model.Node{@constCast(custom)};
+    const result = model.Node{ .seq = &items };
+    const patch = try replaceEntry(arena, parsed, stats, &result, &.{parsed});
+    // Custom pairs have no source item to copy. Flow `{key: Goblin, value: 4}` would
+    // restyle a block dictionary Unity wrote as two indented fields.
+    try testing.expectEqualStrings("  m_Stats:\n  - key: Goblin\n    value: 4\n", patch.bytes);
 }
 test "regression map key roundtrip" {
     var a = std.heap.ArenaAllocator.init(std.testing.allocator);

--- a/core/src/root.zig
+++ b/core/src/root.zig
@@ -93,4 +93,5 @@ test {
     _ = @import("merge_fixture_test.zig");
     _ = @import("fixture_test.zig");
     _ = @import("yaml_scalar.zig");
+    _ = @import("merge_dictionary.zig");
 }

--- a/docs/collection-merge.md
+++ b/docs/collection-merge.md
@@ -48,9 +48,45 @@ Competing source formatting can require a choice for the complete collection.
 Packed `int[]` values use the same collection rules.
 PrefabLens preserves their integer values and serialized format.
 
+## Dictionaries
+
+PrefabLens merges these YAML shapes by key, not by list position:
+
+- Pair sequences `{ key, value }` or `{ first, second }`
+- Parallel `SerializedDictionary` maps with `m_Keys` and `m_Values` of equal length
+
+Independent key insertions and removals combine.
+The same key with different values is an edit/edit conflict.
+A delete on one side and an edit on the other is a delete/edit conflict.
+Nested lists stay ordered. Nested dictionaries stay keyed.
+
+If only one side reorders shared keys, that side's order is kept.
+If both sides reorder shared keys differently, the field is an insertion-order conflict.
+Dictionaries do not offer **Both sides** mode.
+New keys land after the preceding shared key; extras already on the order-keeping side stay before extras from the other side.
+
+A C# schema of `Dictionary<,>` or `SerializedDictionary<,>` selects this path.
+Without a schema, the YAML shape is enough.
+A schema that marks a pair sequence `.ordered` still uses list merge.
+
+Unknown or malformed dictionary YAML, duplicate keys, and `m_Keys`/`m_Values` length mismatch stay a whole-collection conflict.
+
+Diff hides a pure reorder.
+Paths use the key, such as `Stats[Goblin]` or `Stats[Goblin].Hp`.
+
+## Prefab Variant collections
+
+When a source prefab is available, PrefabLens instantiates both sides of a modified Prefab Variant before display.
+`Array.size` runs first so later `Array.data[i]` rows can resolve.
+The diff then shows resolved item paths such as `Items[2].Speed` instead of the raw modification rows.
+
+Value-only `Array.data[i]` property overrides merge like other Prefab modifications, keyed by `target` and `propertyPath`.
+`Array.size` changes stay unsupported: a resize can retarget later indices, and PrefabLens does not yet re-encode resolved collections back into `m_Modifications`.
+Without the source prefab, collection overrides stay as modification rows.
+
 ## Unsupported collection shapes
 
-PrefabLens does not merge dictionary fields or collection overrides in Prefab Variants.
+Odin dictionaries and other unrecognized keyed shapes stay a whole-collection conflict.
 Use an explicit result for the whole collection or file when such a change needs resolution.
 
 ## Missing merge context


### PR DESCRIPTION
## Summary

Merge Unity YAML dictionaries by key, merge value-only Prefab Variant `Array.data` overrides, and keep the merge TUI open across remaining content files.

## Motivation

Pair sequences and `SerializedDictionary` maps were merged by list index, so independent keys conflicted and a Result value edit could write invalid Unity YAML. Completing one file restored the terminal before the next conflicted prefab.

Closes #402

## Changes

- Detect pair `{key,value}` / `{first,second}` sequences and parallel `m_Keys` / `m_Values` maps, then merge by key union.
- Keep source bytes for unchanged entries and reconstruct a custom scalar as the pair value field.
- Show `Stats[Goblin]` paths, Semantic Key/Value rows, and Raw pair YAML that applies without invalid indent.
- Instantiate Prefab Variant collection overrides for display. Merge value-only `Array.data[i]` edits. Leave `Array.size` unsupported.
- Reuse one vaxis App for remaining content conflicts in the native Git merge strategy.
- Treat `m_Keys` / `m_Values` length mismatch as malformed dictionary YAML. Do not offer Both sides for dictionary insertion-order conflicts.
- Keep tests at 80% necessity: drop overlapping TUI cases, add delete/edit, reorder, malformed YAML, and pure-reorder diff coverage.

## Testing

```
$ zig build lint --summary all
Build Summary: 2/2 steps succeeded
lint success
+- zig fmt --check success

$ zig test core/src/root.zig
All 243 tests passed.

$ zig build test-merge-tui --summary all
Build Summary: 8/8 steps succeeded; 49/49 tests passed
test-merge-tui success

$ zig build test --summary all
Build Summary: 30/30 steps succeeded; 409/409 tests passed
test success
```