### PR TITLE
feat: add skip chrome extension release option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
       version:
         description: 'Release version (X.Y.Z, no v prefix)'
         required: true
+      skip_chrome_extension:
+        description: 'Skip Chrome Web Store publish (GitHub Release still includes the extension zip)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -138,7 +142,10 @@ jobs:
   # Store and submits it for review; the store publishes it automatically on
   # approval. Independent from the release: safe to re-run in isolation, but
   # fails while a previous submission is still pending review.
+  # Skipped when skip_chrome_extension is true. The release job still builds
+  # and attaches the zip, so this job can run later on its own.
   publish-extension:
+    if: ${{ !inputs.skip_chrome_extension }}
     needs: release
     runs-on: ubuntu-latest
     env:

--- a/docs/extension.md
+++ b/docs/extension.md
@@ -346,13 +346,15 @@ Maintainers publish the extension through the Release workflow on `main`.
 
 1. Run [`.github/workflows/release.yml`](../.github/workflows/release.yml)
    with `workflow_dispatch` and a version `X.Y.Z` (no `v` prefix).
-2. Verify that the `CWS_*` repository secrets are set before you rely on
+2. Leave `skip_chrome_extension` unchecked to submit the extension to the Chrome Web Store.
+   Check it to skip that submission. The GitHub Release still includes the extension ZIP.
+3. Verify that the `CWS_*` repository secrets are set before you rely on
    `publish-extension`.
 
 The workflow updates the versions.
 It builds the CLI ZIP files and `prefablens-extension-$VERSION.zip`.
 The workflow commits the changes, tags `v$VERSION`, and creates the GitHub Release.
-The `publish-extension` job then downloads that ZIP file.
+Unless `skip_chrome_extension` is set, the `publish-extension` job then downloads that ZIP file.
 The job uploads the ZIP file to the Chrome Web Store and submits it for review.
 The store publishes the extension after approval.
 


### PR DESCRIPTION
## Summary

Add a `skip_chrome_extension` option to the Release workflow so a release can omit Chrome Web Store publish.

## Motivation

Chrome Web Store review takes time. Small patch releases should be able to skip that submission.

No tracking issue for this change.

## Changes

- Add `skip_chrome_extension` as a `workflow_dispatch` boolean. Default is `false`.
- Skip the `publish-extension` job when that input is `true`.
- Keep version bumps, the extension ZIP on the GitHub Release, and CLI package publish.
- Document the option in `docs/extension.md`.

## Testing

```
$ ruby -ryaml -e "YAML.load_file('.github/workflows/release.yml'); puts 'yaml ok'"
yaml ok
```

The Release workflow was not dispatched. Store publish remains unverified in this change.